### PR TITLE
Fix falsy parsed values in `createConfigContext()`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -270,11 +270,19 @@ To be released.
     `TConfigMeta | undefined`, and `ConfigLoadResult.meta` is typed as
     `TConfigMeta | undefined` to match runtime behavior.  [[#155]]
 
+ -  Fixed `createConfigContext()` treating falsy first-pass parse results
+    such as `0`, `false`, and `""` as the phase-one sentinel.  Dynamic
+    config loading now skips only when the parsed value is actually
+    `undefined`, so top-level primitive parsers still reach the second
+    config-loading phase correctly.  [[#161], [#164]]
+
 [#111]: https://github.com/dahlia/optique/issues/111
 [#136]: https://github.com/dahlia/optique/issues/136
 [#155]: https://github.com/dahlia/optique/issues/155
 [#159]: https://github.com/dahlia/optique/issues/159
+[#161]: https://github.com/dahlia/optique/issues/161
 [#162]: https://github.com/dahlia/optique/pull/162
+[#164]: https://github.com/dahlia/optique/pull/164
 
 ### @optique/env
 

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -77,6 +77,49 @@ describe("createConfigContext", () => {
     assert.ok(annotations);
     assert.deepEqual(Object.getOwnPropertySymbols(annotations).length, 0);
   });
+
+  for (
+    const [parsed, expectedHost, label] of [
+      [0, "zero-host", "0"],
+      [false, "false-host", "false"],
+      ["", "empty-string-host", '""'],
+    ] as const
+  ) {
+    test(
+      `treats ${label} as a valid phase-two parsed value`,
+      async () => {
+        const schema = z.object({
+          host: z.string(),
+        });
+
+        const context = createConfigContext({ schema });
+        let receivedParsed: unknown;
+
+        const annotations = await context.getAnnotations(
+          parsed,
+          {
+            load: (value: unknown) => {
+              receivedParsed = value;
+              return {
+                config: { host: expectedHost },
+                meta: {
+                  configDir: "/app",
+                  configPath: "/app/config.json",
+                } satisfies ConfigMeta,
+              };
+            },
+          },
+        );
+
+        assert.equal(receivedParsed, parsed);
+        const contextAnnotation = annotations[context.id] as
+          | { readonly data: unknown; readonly meta?: unknown }
+          | undefined;
+        assert.ok(contextAnnotation != null);
+        assert.deepEqual(contextAnnotation.data, { host: expectedHost });
+      },
+    );
+  }
 });
 
 describe("bindConfig", () => {

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -290,7 +290,7 @@ export function createConfigContext<T, TConfigMeta = ConfigMeta>(
       runtimeOptions?: unknown,
     ): Promise<Annotations> | Annotations {
       // Phase 1 (no parsed result): return empty — this is a dynamic context
-      if (!parsed) {
+      if (parsed === undefined) {
         return {};
       }
 

--- a/packages/config/src/run.test.ts
+++ b/packages/config/src/run.test.ts
@@ -419,6 +419,97 @@ describe("run with config context", { concurrency: false }, () => {
     assert.equal(result, 0);
   });
 
+  for (
+    const [parserName, configValue, cliArgs, label] of [
+      [
+        "number",
+        9,
+        [] as readonly string[],
+        "0 as the initial parsed result",
+      ],
+      [
+        "boolean",
+        true,
+        [] as readonly string[],
+        "false as the initial parsed result",
+      ],
+      [
+        "string",
+        "config-name",
+        [] as readonly string[],
+        '"" as the initial parsed result',
+      ],
+    ] as const
+  ) {
+    test(
+      `runs phase-two config loading when the top-level parser returns ${label}`,
+      async () => {
+        if (parserName === "number") {
+          const schema = z.number();
+          const context = createConfigContext({ schema });
+          const parser = bindConfig(
+            withDefault(option("--count", integer()), 0),
+            {
+              context,
+              key: (config) => config,
+              default: 0,
+            },
+          );
+
+          const result = await runWith(parser, "test", [context], {
+            load: (parsed: number) => {
+              assert.equal(parsed, 0);
+              return { config: configValue, meta: undefined };
+            },
+            args: cliArgs,
+          });
+
+          assert.equal(result, configValue);
+          return;
+        }
+
+        if (parserName === "boolean") {
+          const schema = z.boolean();
+          const context = createConfigContext({ schema });
+          const parser = bindConfig(withDefault(flag("--enabled"), false), {
+            context,
+            key: (config) => config,
+            default: false,
+          });
+
+          const result = await runWith(parser, "test", [context], {
+            load: (parsed: boolean) => {
+              assert.equal(parsed, false);
+              return { config: configValue, meta: undefined };
+            },
+            args: cliArgs,
+          });
+
+          assert.equal(result, configValue);
+          return;
+        }
+
+        const schema = z.string();
+        const context = createConfigContext({ schema });
+        const parser = bindConfig(withDefault(option("--name", string()), ""), {
+          context,
+          key: (config) => config,
+          default: "",
+        });
+
+        const result = await runWith(parser, "test", [context], {
+          load: (parsed: string) => {
+            assert.equal(parsed, "");
+            return { config: configValue, meta: undefined };
+          },
+          args: cliArgs,
+        });
+
+        assert.equal(result, configValue);
+      },
+    );
+  }
+
   test("works with nested config values", async () => {
     await mkdir(TEST_DIR, { recursive: true });
     const configPath = join(TEST_DIR, "test-config-nested.json");


### PR DESCRIPTION
## Summary
Fix `createConfigContext()` so it treats only `undefined` as the phase-one sentinel and still performs phase-two config loading when the first-pass parse result is `0`, `false`, or `""`.

## Changes
- Narrow the phase-one check in *packages/config/src/index.ts* from a generic falsy check to an explicit `parsed === undefined` check.
- Add regression tests in *packages/config/src/index.test.ts* to verify `getAnnotations()` still loads config for falsy primitive parsed values.
- Add end-to-end tests in *packages/config/src/run.test.ts* to verify `runWith()` performs the second config-loading phase for top-level number, boolean, and string parsers that initially resolve to falsy values.
- Document the fix in *CHANGES.md*.

## Testing
- `mise test`

Fixes https://github.com/dahlia/optique/issues/161