### PR TITLE
Fix incorrect cookbook claim about `or()` flag conflicts

### DIFF
--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -254,7 +254,9 @@ The [`withDefault()`](./concepts/modifiers.md#withdefault-parser) wrapper
 handles the case where no flags are provided, giving you a fallback behavior.
 This is different from the previous pattern because:
 
- -  *No validation*: Multiple flags can be provided (last one wins)
+ -  *Conflict detection*: If multiple flags are provided, the parser rejects
+    them with an error (e.g., `--mode-a` and `--mode-b` cannot be used
+    together)
  -  *Simpler structure*: Returns a simple string rather than an object
  -  *Default handling*: Has a meaningful fallback when no options are given
 

--- a/packages/core/src/constructs.test.ts
+++ b/packages/core/src/constructs.test.ts
@@ -142,6 +142,24 @@ describe("or", () => {
     }
   });
 
+  // Regression test for https://github.com/dahlia/optique/issues/181
+  it("should detect conflicts with withDefault(or(map(...))) pattern", () => {
+    const modeParser = withDefault(
+      or(
+        map(option("-a", "--mode-a"), () => "a" as const),
+        map(option("-b", "--mode-b"), () => "b" as const),
+        map(option("-c", "--mode-c"), () => "c" as const),
+      ),
+      "default" as const,
+    );
+
+    const result = parseSync(modeParser, ["--mode-a", "--mode-b"]);
+    assert.ok(!result.success);
+    if (!result.success) {
+      assertErrorIncludes(result.error, "cannot be used together");
+    }
+  });
+
   it("should complete with successful parser result", () => {
     const parser1 = option("-a");
     const parser2 = option("-b");


### PR DESCRIPTION
## Summary

- The cookbook's *Mutually exclusive flags* section incorrectly claimed that `withDefault(or(...))` has "No validation" and that "Multiple flags can be provided (last one wins)". In reality, `or()` detects conflicting flags and rejects them with an error like `--mode-a and --mode-b cannot be used together.`
- Corrected the documentation to describe the actual conflict detection behavior.
- Added a regression test mirroring the exact cookbook pattern (`withDefault(or(map(option(...), ...), ...))`) to verify the behavior.

Closes #181

## Test plan

- [x] Regression test added in `packages/core/src/constructs.test.ts` passes with `deno test`
- [x] Documentation builds successfully with `pnpm build` in `docs/`
- [ ] Review the updated cookbook section reads naturally