### PR TITLE
Fix number `choice()` accepting `Number()` coercion forms

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -785,9 +785,10 @@ Released on February 15, 2026.
  -  Fixed number `choice()` accepting hex (`0x10`), binary (`0b10`), octal
     (`0o10`), scientific notation (`2e0`), empty strings, and whitespace-only
     strings via JavaScript's `Number()` coercion.  Number choices now accept
-    only the canonical string representation and mathematically equivalent
-    decimal or scientific-notation spellings of each choice value.
-    [[#315], [#523]]
+    the canonical string representation and equivalent decimal spellings
+    (e.g., `"8.0"` for `8`).  Alternate scientific-notation spellings are
+    only accepted for values whose canonical form uses scientific notation
+    (e.g., `"1e21"` for `1e+21`).  [[#315], [#523]]
 
  -  Added `@optique/core/program` module with `Program` and `ProgramMetadata`
     interfaces. These provide a structured way to bundle a parser with its

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -784,9 +784,10 @@ Released on February 15, 2026.
 
  -  Fixed number `choice()` accepting hex (`0x10`), binary (`0b10`), octal
     (`0o10`), scientific notation (`2e0`), empty strings, and whitespace-only
-    strings via JavaScript's `Number()` coercion.  Number choices now match
-    input strictly against the canonical string representation of each choice
-    value. [[#315], [#523]]
+    strings via JavaScript's `Number()` coercion.  Number choices now accept
+    only the canonical string representation and mathematically equivalent
+    decimal or scientific-notation spellings of each choice value.
+    [[#315], [#523]]
 
  -  Added `@optique/core/program` module with `Program` and `ProgramMetadata`
     interfaces. These provide a structured way to bundle a parser with its

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -782,6 +782,12 @@ Released on February 15, 2026.
       zsh:  ${commandLine(`eval "$(mycli completion zsh)"`)}`;
     ~~~~
 
+ -  Fixed number `choice()` accepting hex (`0x10`), binary (`0b10`), octal
+    (`0o10`), scientific notation (`2e0`), empty strings, and whitespace-only
+    strings via JavaScript's `Number()` coercion.  Number choices now match
+    input strictly against the canonical string representation of each choice
+    value. [[#315], [#523]]
+
  -  Added `@optique/core/program` module with `Program` and `ProgramMetadata`
     interfaces. These provide a structured way to bundle a parser with its
     metadata (name, version, description, etc.), creating a single source of
@@ -1250,6 +1256,8 @@ Released on February 15, 2026.
 [#99]: https://github.com/dahlia/optique/issues/99
 [#106]: https://github.com/dahlia/optique/issues/106
 [#107]: https://github.com/dahlia/optique/issues/107
+[#315]: https://github.com/dahlia/optique/issues/315
+[#523]: https://github.com/dahlia/optique/pull/523
 
 ### @optique/config
 

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -1299,9 +1299,12 @@ describe("choice", () => {
       const result3 = parser.parse("");
       assert.ok(!result3.success);
 
-      // "8.0" is not in the choice list as a string representation
+      // "8.0" is an alternate decimal spelling of 8, which is in the list
       const result4 = parser.parse("8.0");
-      assert.ok(!result4.success);
+      assert.ok(result4.success);
+      if (result4.success) {
+        assert.equal(result4.value, 8);
+      }
     });
 
     it("should work with single number choice", () => {
@@ -1473,6 +1476,43 @@ describe("choice", () => {
       // Whitespace-only should not be accepted as 0
       const space = parser.parse("   ");
       assert.ok(!space.success);
+    });
+
+    it("should accept alternate decimal spellings for large/small numbers", () => {
+      const parser = choice([1e21, 1e-7, 42]);
+
+      // Decimal spelling of 1e21
+      const big = parser.parse("1000000000000000000000");
+      assert.ok(big.success);
+      if (big.success) {
+        assert.equal(big.value, 1e21);
+      }
+
+      // Canonical form should also work
+      const bigCanon = parser.parse("1e+21");
+      assert.ok(bigCanon.success);
+      if (bigCanon.success) {
+        assert.equal(bigCanon.value, 1e21);
+      }
+
+      // Decimal spelling of 1e-7
+      const small = parser.parse("0.0000001");
+      assert.ok(small.success);
+      if (small.success) {
+        assert.equal(small.value, 1e-7);
+      }
+
+      // Canonical form should also work
+      const smallCanon = parser.parse("1e-7");
+      assert.ok(smallCanon.success);
+      if (smallCanon.success) {
+        assert.equal(smallCanon.value, 1e-7);
+      }
+
+      // But scientific notation for a value whose canonical form is plain
+      // decimal should still be rejected
+      const sci = parser.parse("4.2e1");
+      assert.ok(!sci.success);
     });
 
     it("should reject Infinity and -Infinity literals", () => {

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -1478,7 +1478,7 @@ describe("choice", () => {
       assert.ok(!space.success);
     });
 
-    it("should accept alternate decimal spellings for large/small numbers", () => {
+    it("should accept alternate decimal and scientific spellings for large/small numbers", () => {
       const parser = choice([1e21, 1e-7, 42]);
 
       // Decimal spelling of 1e21

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -1691,9 +1691,9 @@ describe("choice", () => {
       const result = parser.parse("NaN");
       assert.ok(!result.success);
 
-      // The internal sentinel must not be matchable either
-      const sentinel = parser.parse("\0");
-      assert.ok(!sentinel.success);
+      // No hidden literal should parse to NaN
+      const nul = parser.parse("\0");
+      assert.ok(!nul.success);
 
       // Other values should still work
       const result2 = parser.parse("1");

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -1498,6 +1498,36 @@ describe("choice", () => {
       assert.ok(!plusInf.success);
     });
 
+    it("should preserve negative zero as a valid choice", () => {
+      const parser = choice([-0, 1]);
+
+      const result = parser.parse("-0");
+      assert.ok(result.success);
+      if (result.success) {
+        assert.ok(Object.is(result.value, -0));
+      }
+
+      // "0" should not match -0
+      const result2 = parser.parse("0");
+      assert.ok(!result2.success);
+    });
+
+    it("should distinguish 0 and -0 when both are in choices", () => {
+      const parser = choice([0, -0]);
+
+      const pos = parser.parse("0");
+      assert.ok(pos.success);
+      if (pos.success) {
+        assert.ok(Object.is(pos.value, 0));
+      }
+
+      const neg = parser.parse("-0");
+      assert.ok(neg.success);
+      if (neg.success) {
+        assert.ok(Object.is(neg.value, -0));
+      }
+    });
+
     it("should handle duplicate number values", () => {
       const parser = choice([1, 1, 2]);
 

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -1299,12 +1299,9 @@ describe("choice", () => {
       const result3 = parser.parse("");
       assert.ok(!result3.success);
 
-      // Note: "8.0" parses to 8, which is in the choice list
+      // "8.0" is not in the choice list as a string representation
       const result4 = parser.parse("8.0");
-      assert.ok(result4.success);
-      if (result4.success) {
-        assert.equal(result4.value, 8);
-      }
+      assert.ok(!result4.success);
     });
 
     it("should work with single number choice", () => {
@@ -1444,6 +1441,61 @@ describe("choice", () => {
 
       const result = parser.parse("1");
       assert.ok(!result.success);
+    });
+
+    it("should reject hex, binary, octal, and scientific notation", () => {
+      const parser = choice([0, 2, 8, 16]);
+
+      // Hex notation "0x10" should not be accepted as 16
+      const hex = parser.parse("0x10");
+      assert.ok(!hex.success);
+
+      // Binary notation "0b10" should not be accepted as 2
+      const bin = parser.parse("0b10");
+      assert.ok(!bin.success);
+
+      // Octal notation "0o10" should not be accepted as 8
+      const oct = parser.parse("0o10");
+      assert.ok(!oct.success);
+
+      // Scientific notation "2e0" should not be accepted as 2
+      const sci = parser.parse("2e0");
+      assert.ok(!sci.success);
+    });
+
+    it("should reject empty and whitespace-only strings", () => {
+      const parser = choice([0, 1, 2]);
+
+      // Empty string should not be accepted as 0
+      const empty = parser.parse("");
+      assert.ok(!empty.success);
+
+      // Whitespace-only should not be accepted as 0
+      const space = parser.parse("   ");
+      assert.ok(!space.success);
+    });
+
+    it("should reject Infinity and -Infinity literals", () => {
+      const parser = choice([Infinity, -Infinity, 0]);
+
+      // Even though Infinity is in the list, the string "Infinity"
+      // cannot match because String(Infinity) = "Infinity" but we
+      // need to verify it works correctly with the string comparison
+      const inf = parser.parse("Infinity");
+      assert.ok(inf.success);
+      if (inf.success) {
+        assert.equal(inf.value, Infinity);
+      }
+
+      const negInf = parser.parse("-Infinity");
+      assert.ok(negInf.success);
+      if (negInf.success) {
+        assert.equal(negInf.value, -Infinity);
+      }
+
+      // But alternate forms should not work
+      const plusInf = parser.parse("+Infinity");
+      assert.ok(!plusInf.success);
     });
 
     it("should handle duplicate number values", () => {

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -1507,9 +1507,23 @@ describe("choice", () => {
         assert.ok(Object.is(result.value, -0));
       }
 
-      // "0" should not match -0
+      // "0" should not match -0, and the error should show "-0" not "0"
       const result2 = parser.parse("0");
       assert.ok(!result2.success);
+      if (!result2.success) {
+        assert.deepEqual(
+          result2.error,
+          [
+            { type: "text", text: "Expected one of " },
+            { type: "value", value: "-0" },
+            { type: "text", text: " and " },
+            { type: "value", value: "1" },
+            { type: "text", text: ", but got " },
+            { type: "value", value: "0" },
+            { type: "text", text: "." },
+          ] as const,
+        );
+      }
     });
 
     it("should distinguish 0 and -0 when both are in choices", () => {

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -1691,6 +1691,10 @@ describe("choice", () => {
       const result = parser.parse("NaN");
       assert.ok(!result.success);
 
+      // The internal sentinel must not be matchable either
+      const sentinel = parser.parse("\0");
+      assert.ok(!sentinel.success);
+
       // Other values should still work
       const result2 = parser.parse("1");
       assert.ok(result2.success);

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -1509,6 +1509,26 @@ describe("choice", () => {
         assert.equal(smallCanon.value, 1e-7);
       }
 
+      // Alternate scientific notation spellings should work for
+      // values whose canonical form uses scientific notation
+      const altSci1 = parser.parse("1e21");
+      assert.ok(altSci1.success);
+      if (altSci1.success) {
+        assert.equal(altSci1.value, 1e21);
+      }
+
+      const altSci2 = parser.parse("1.0e-7");
+      assert.ok(altSci2.success);
+      if (altSci2.success) {
+        assert.equal(altSci2.value, 1e-7);
+      }
+
+      const altSci3 = parser.parse("10e20");
+      assert.ok(altSci3.success);
+      if (altSci3.success) {
+        assert.equal(altSci3.value, 1e21);
+      }
+
       // But scientific notation for a value whose canonical form is plain
       // decimal should still be rejected
       const sci = parser.parse("4.2e1");

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -1629,6 +1629,31 @@ describe("choice", () => {
       }
     });
 
+    it("should accept -0 spellings when only 0 is in the choice list", () => {
+      const parser = choice([0, 1, 2]);
+
+      // "-0" should match 0 when -0 is not explicitly in the list
+      const neg = parser.parse("-0");
+      assert.ok(neg.success);
+      if (neg.success) {
+        assert.equal(neg.value, 0);
+      }
+
+      // "-0.0" should also match 0
+      const negAlt = parser.parse("-0.0");
+      assert.ok(negAlt.success);
+      if (negAlt.success) {
+        assert.equal(negAlt.value, 0);
+      }
+
+      // "-000" should also match 0
+      const negZeros = parser.parse("-000");
+      assert.ok(negZeros.success);
+      if (negZeros.success) {
+        assert.equal(negZeros.value, 0);
+      }
+    });
+
     it("should handle duplicate number values", () => {
       const parser = choice([1, 1, 2]);
 

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -1654,6 +1654,17 @@ describe("choice", () => {
       }
     });
 
+    it("should reject NaN even when it appears in the choice list", () => {
+      const parser = choice([NaN, 1, 2]);
+
+      const result = parser.parse("NaN");
+      assert.ok(!result.success);
+
+      // Other values should still work
+      const result2 = parser.parse("1");
+      assert.ok(result2.success);
+    });
+
     it("should handle duplicate number values", () => {
       const parser = choice([1, 1, 2]);
 

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -1596,12 +1596,9 @@ describe("choice", () => {
       assert.ok(zeroAlt3.success);
     });
 
-    it("should reject Infinity and -Infinity literals", () => {
+    it("should accept Infinity and -Infinity when in the choice list", () => {
       const parser = choice([Infinity, -Infinity, 0]);
 
-      // Even though Infinity is in the list, the string "Infinity"
-      // cannot match because String(Infinity) = "Infinity" but we
-      // need to verify it works correctly with the string comparison
       const inf = parser.parse("Infinity");
       assert.ok(inf.success);
       if (inf.success) {
@@ -1614,7 +1611,7 @@ describe("choice", () => {
         assert.equal(negInf.value, -Infinity);
       }
 
-      // But alternate forms should not work
+      // Alternate forms like "+Infinity" should not work
       const plusInf = parser.parse("+Infinity");
       assert.ok(!plusInf.success);
     });

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -1698,6 +1698,9 @@ describe("choice", () => {
       // Other values should still work
       const result2 = parser.parse("1");
       assert.ok(result2.success);
+
+      // NaN should be excluded from choices metadata
+      assert.deepEqual(parser.choices, [1, 2]);
     });
 
     it("should handle duplicate number values", () => {

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -1529,6 +1529,20 @@ describe("choice", () => {
         assert.equal(altSci3.value, 1e21);
       }
 
+      // Leading + sign should work
+      const altSci4 = parser.parse("+1e21");
+      assert.ok(altSci4.success);
+      if (altSci4.success) {
+        assert.equal(altSci4.value, 1e21);
+      }
+
+      // Leading-dot mantissa should work
+      const altSci5 = parser.parse(".1e-6");
+      assert.ok(altSci5.success);
+      if (altSci5.success) {
+        assert.equal(altSci5.value, 1e-7);
+      }
+
       // But scientific notation for a value whose canonical form is plain
       // decimal should still be rejected
       const sci = parser.parse("4.2e1");

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -1515,6 +1515,24 @@ describe("choice", () => {
       assert.ok(!sci.success);
     });
 
+    it("should reject decimals that only round to a choice value", () => {
+      // "1000000000000000000001" rounds to 1e21 in IEEE-754 but is
+      // mathematically different
+      const parser1 = choice([1e21]);
+      const rounded = parser1.parse("1000000000000000000001");
+      assert.ok(!rounded.success);
+
+      // "0.10000000000000001" rounds to 0.1 in IEEE-754 but is
+      // mathematically different
+      const parser2 = choice([0.1]);
+      const rounded2 = parser2.parse("0.10000000000000001");
+      assert.ok(!rounded2.success);
+
+      // But exact alternate spellings should still work
+      const exact = parser1.parse("1000000000000000000000");
+      assert.ok(exact.success);
+    });
+
     it("should reject overflowed and underflowed decimal inputs", () => {
       const parser = choice([Infinity, -Infinity, 0]);
 

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -1515,6 +1515,35 @@ describe("choice", () => {
       assert.ok(!sci.success);
     });
 
+    it("should reject overflowed and underflowed decimal inputs", () => {
+      const parser = choice([Infinity, -Infinity, 0]);
+
+      // A 400-digit decimal should not overflow to Infinity
+      const bigOverflow = parser.parse("9".repeat(400));
+      assert.ok(!bigOverflow.success);
+
+      // A negative 400-digit decimal should not overflow to -Infinity
+      const negOverflow = parser.parse("-" + "9".repeat(400));
+      assert.ok(!negOverflow.success);
+
+      // An extremely small decimal should not underflow to 0
+      const tinyUnderflow = parser.parse("0." + "0".repeat(400) + "1");
+      assert.ok(!tinyUnderflow.success);
+
+      // But legitimate alternate zero spellings should still work
+      const zeroAlt = parser.parse("0.0");
+      assert.ok(zeroAlt.success);
+      if (zeroAlt.success) {
+        assert.equal(zeroAlt.value, 0);
+      }
+
+      const zeroAlt2 = parser.parse("0.00");
+      assert.ok(zeroAlt2.success);
+
+      const zeroAlt3 = parser.parse(".0");
+      assert.ok(zeroAlt3.success);
+    });
+
     it("should reject Infinity and -Infinity literals", () => {
       const parser = choice([Infinity, -Infinity, 0]);
 

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -390,7 +390,7 @@ export function choice<const T extends string | number>(
           success: false,
           error: formatNumberChoiceError(
             input,
-            validNumberChoices,
+            numberChoices,
             numberOptions,
           ),
         };

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -329,6 +329,25 @@ export function choice<const T extends string | number>(
                 };
               }
             }
+            // When parsed is -0 but only 0 is in the list (or vice
+            // versa), the normalization above won't match because
+            // "-0" normalizes differently from "0". Treat -0 and 0
+            // as interchangeable when the list does not distinguish
+            // them (i.e., does not contain both 0 and -0).
+            if (
+              parsed === 0 &&
+              normalizedInput.replace(/^-/, "") === "0" &&
+              !numberChoices.some((v) => Object.is(v, -0))
+            ) {
+              // Use indexOf (===) which treats -0 and 0 as equal
+              const zeroIndex = numberChoices.indexOf(0);
+              if (zeroIndex >= 0) {
+                return {
+                  success: true,
+                  value: numberChoices[zeroIndex] as T,
+                };
+              }
+            }
           }
         }
         return {

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -298,14 +298,28 @@ export function choice<const T extends string | number>(
       metavar,
       choices: choices as readonly T[],
       parse(input: string): ValueParserResult<T> {
+        // Exact match against canonical String() representations
         const index = numberStrings.indexOf(input);
-        if (index < 0) {
-          return {
-            success: false,
-            error: formatNumberChoiceError(input, numberChoices, numberOptions),
-          };
+        if (index >= 0) {
+          return { success: true, value: numberChoices[index] as T };
         }
-        return { success: true, value: numberChoices[index] as T };
+        // Fall back to strict decimal parsing for alternate spellings
+        // (e.g., "1000000000000000000000" for 1e21, or "8.0" for 8).
+        // Rejects hex, binary, octal, scientific notation, empty, and
+        // whitespace inputs.
+        if (/^[+-]?(\d+\.?\d*|\.\d+)$/.test(input)) {
+          const parsed = Number(input);
+          const fallbackIndex = numberChoices.findIndex((v) =>
+            Object.is(v, parsed)
+          );
+          if (fallbackIndex >= 0) {
+            return { success: true, value: numberChoices[fallbackIndex] as T };
+          }
+        }
+        return {
+          success: false,
+          error: formatNumberChoiceError(input, numberChoices, numberOptions),
+        };
       },
       format(value: T): string {
         return Object.is(value, -0) ? "-0" : String(value);

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -290,16 +290,17 @@ export function choice<const T extends string | number>(
     // Number choice implementation
     const numberChoices = choices as readonly number[];
     const numberOptions = options as ChoiceOptionsNumber;
-    const validNumberChoices = numberChoices.filter((v) => !Number.isNaN(v));
+    const hasNaN = numberChoices.some((v) => Number.isNaN(v));
+    const validNumberChoices = hasNaN
+      ? numberChoices.filter((v) => !Number.isNaN(v))
+      : numberChoices;
     const numberStrings = numberChoices.map((v) =>
       Object.is(v, -0) ? "-0" : String(v)
     );
     return {
       $mode: "sync",
       metavar,
-      choices: choices.filter((c) =>
-        typeof c === "string" || !Number.isNaN(c)
-      ) as readonly T[],
+      choices: (hasNaN ? validNumberChoices : numberChoices) as readonly T[],
       parse(input: string): ValueParserResult<T> {
         // Exact match against canonical string representations
         // (String(value) for most values, "-0" for negative zero).

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -290,19 +290,13 @@ export function choice<const T extends string | number>(
     // Number choice implementation
     const numberChoices = choices as readonly number[];
     const numberOptions = options as ChoiceOptionsNumber;
+    const numberStrings = numberChoices.map((v) => String(v));
     return {
       $mode: "sync",
       metavar,
       choices: choices as readonly T[],
       parse(input: string): ValueParserResult<T> {
-        const parsed = Number(input);
-        if (Number.isNaN(parsed)) {
-          return {
-            success: false,
-            error: formatNumberChoiceError(input, numberChoices, numberOptions),
-          };
-        }
-        const index = numberChoices.indexOf(parsed);
+        const index = numberStrings.indexOf(input);
         if (index < 0) {
           return {
             success: false,

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -390,6 +390,7 @@ export function choice<const T extends string | number>(
           success: false,
           error: formatNumberChoiceError(
             input,
+            validNumberChoices,
             numberChoices,
             numberOptions,
           ),
@@ -526,15 +527,16 @@ function formatStringChoiceError(
  */
 function formatNumberChoiceError(
   input: string,
-  choices: readonly number[],
+  validChoices: readonly number[],
+  allChoices: readonly number[],
   options: ChoiceOptionsNumber,
 ): Message {
   if (options.errors?.invalidChoice) {
     return typeof options.errors.invalidChoice === "function"
-      ? options.errors.invalidChoice(input, choices)
+      ? options.errors.invalidChoice(input, validChoices)
       : options.errors.invalidChoice;
   }
-  return formatDefaultChoiceError(input, choices);
+  return formatDefaultChoiceError(input, allChoices);
 }
 
 /**

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -291,7 +291,10 @@ export function choice<const T extends string | number>(
     const numberChoices = choices as readonly number[];
     const numberOptions = options as ChoiceOptionsNumber;
     const numberStrings = numberChoices.map((v) =>
-      Object.is(v, -0) ? "-0" : String(v)
+      // NaN is never a valid CLI literal (consistent with float()
+      // requiring explicit allowNaN), so map it to a string that
+      // can never match any input.
+      Number.isNaN(v) ? "\0" : Object.is(v, -0) ? "-0" : String(v)
     );
     return {
       $mode: "sync",
@@ -360,7 +363,9 @@ export function choice<const T extends string | number>(
       },
       suggest(prefix: string) {
         return numberStrings
-          .filter((valueStr) => valueStr.startsWith(prefix))
+          .filter((valueStr) =>
+            valueStr !== "\0" && valueStr.startsWith(prefix)
+          )
           .map((valueStr) => ({ kind: "literal" as const, text: valueStr }));
       },
     };

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -290,7 +290,9 @@ export function choice<const T extends string | number>(
     // Number choice implementation
     const numberChoices = choices as readonly number[];
     const numberOptions = options as ChoiceOptionsNumber;
-    const numberStrings = numberChoices.map((v) => String(v));
+    const numberStrings = numberChoices.map((v) =>
+      Object.is(v, -0) ? "-0" : String(v)
+    );
     return {
       $mode: "sync",
       metavar,
@@ -306,11 +308,10 @@ export function choice<const T extends string | number>(
         return { success: true, value: numberChoices[index] as T };
       },
       format(value: T): string {
-        return String(value);
+        return Object.is(value, -0) ? "-0" : String(value);
       },
       suggest(prefix: string) {
-        return numberChoices
-          .map((value) => String(value))
+        return numberStrings
           .filter((valueStr) => valueStr.startsWith(prefix))
           .map((valueStr) => ({ kind: "literal" as const, text: valueStr }));
       },

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -353,6 +353,35 @@ export function choice<const T extends string | number>(
             }
           }
         }
+        // Fall back to scientific notation parsing for alternate exponent
+        // spellings (e.g., "1e21" for canonical "1e+21", "1.0e-7" for
+        // "1e-7"). Only accepted when the canonical form also uses
+        // scientific notation, so "2e0" for choice([2]) stays rejected.
+        if (/^[+-]?(\d+\.?\d*|\.\d+)[eE][+-]?\d+$/.test(input)) {
+          const parsed = Number(input);
+          if (Number.isFinite(parsed)) {
+            const canonical = Object.is(parsed, -0) ? "-0" : String(parsed);
+            if (/[eE]/.test(canonical)) {
+              const normalizedInput = normalizeDecimal(
+                expandScientific(input),
+              );
+              const normalizedCanonical = normalizeDecimal(
+                expandScientific(canonical),
+              );
+              if (normalizedInput === normalizedCanonical) {
+                const fallbackIndex = numberChoices.findIndex((v) =>
+                  Object.is(v, parsed)
+                );
+                if (fallbackIndex >= 0) {
+                  return {
+                    success: true,
+                    value: numberChoices[fallbackIndex] as T,
+                  };
+                }
+              }
+            }
+          }
+        }
         return {
           success: false,
           error: formatNumberChoiceError(input, numberChoices, numberOptions),

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -296,7 +296,9 @@ export function choice<const T extends string | number>(
     return {
       $mode: "sync",
       metavar,
-      choices: choices as readonly T[],
+      choices: choices.filter((c) =>
+        typeof c === "string" || !Number.isNaN(c)
+      ) as readonly T[],
       parse(input: string): ValueParserResult<T> {
         // Exact match against canonical String() representations.
         // NaN is never a valid CLI literal (consistent with float()

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -535,7 +535,9 @@ function formatDefaultChoiceError(
   input: string,
   choices: readonly (string | number)[],
 ): Message {
-  const choiceStrings = choices.map((c) => Object.is(c, -0) ? "-0" : String(c));
+  const choiceStrings = choices
+    .filter((c) => typeof c === "string" || !Number.isNaN(c))
+    .map((c) => Object.is(c, -0) ? "-0" : String(c));
   return message`Expected one of ${
     valueSet(choiceStrings, { locale: "en-US" })
   }, but got ${input}.`;

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -300,7 +300,8 @@ export function choice<const T extends string | number>(
         typeof c === "string" || !Number.isNaN(c)
       ) as readonly T[],
       parse(input: string): ValueParserResult<T> {
-        // Exact match against canonical String() representations.
+        // Exact match against canonical string representations
+        // (String(value) for most values, "-0" for negative zero).
         // NaN is never a valid CLI literal (consistent with float()
         // requiring explicit allowNaN), so skip NaN entries.
         const index = numberStrings.indexOf(input);

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -449,9 +449,10 @@ export function choice<const T extends string | number>(
  * Returns the input unchanged if it does not contain scientific notation.
  */
 function expandScientific(s: string): string {
-  const match = /^(-?)(\d+\.?\d*)[eE]([+-]?\d+)$/.exec(s);
+  const match = /^([+-]?)(\d+\.?\d*|\.\d+)[eE]([+-]?\d+)$/.exec(s);
   if (!match) return s;
-  const [, sign, mantissa, expStr] = match;
+  const [, rawSign, mantissa, expStr] = match;
+  const sign = rawSign === "-" ? "-" : "";
   const exp = parseInt(expStr);
   const dotPos = mantissa.indexOf(".");
   const digits = mantissa.replace(".", "");

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -400,7 +400,7 @@ function formatDefaultChoiceError(
   input: string,
   choices: readonly (string | number)[],
 ): Message {
-  const choiceStrings = choices.map((c) => String(c));
+  const choiceStrings = choices.map((c) => Object.is(c, -0) ? "-0" : String(c));
   return message`Expected one of ${
     valueSet(choiceStrings, { locale: "en-US" })
   }, but got ${input}.`;

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -309,20 +309,25 @@ export function choice<const T extends string | number>(
         // whitespace inputs.
         if (/^[+-]?(\d+\.?\d*|\.\d+)$/.test(input)) {
           const parsed = Number(input);
-          // Accept only if the conversion is lossless: reject overflow
-          // (finite decimal → Infinity) and underflow (nonzero decimal → 0)
-          const overflowed = !Number.isFinite(parsed);
-          const underflowed = parsed === 0 &&
-            !/^[+-]?0*(\.0*)?$/.test(input);
-          if (!overflowed && !underflowed) {
-            const fallbackIndex = numberChoices.findIndex((v) =>
-              Object.is(v, parsed)
+          if (Number.isFinite(parsed)) {
+            // Verify exact decimal equivalence: the input must normalize
+            // to the same string as the canonical form, not merely round
+            // to the same IEEE-754 double.
+            const canonical = Object.is(parsed, -0) ? "-0" : String(parsed);
+            const normalizedInput = normalizeDecimal(input);
+            const normalizedCanonical = normalizeDecimal(
+              expandScientific(canonical),
             );
-            if (fallbackIndex >= 0) {
-              return {
-                success: true,
-                value: numberChoices[fallbackIndex] as T,
-              };
+            if (normalizedInput === normalizedCanonical) {
+              const fallbackIndex = numberChoices.findIndex((v) =>
+                Object.is(v, parsed)
+              );
+              if (fallbackIndex >= 0) {
+                return {
+                  success: true,
+                  value: numberChoices[fallbackIndex] as T,
+                };
+              }
             }
           }
         }
@@ -383,6 +388,58 @@ export function choice<const T extends string | number>(
         .map((value) => ({ kind: "literal" as const, text: value }));
     },
   };
+}
+
+/**
+ * Expands a canonical `String(number)` representation that uses scientific
+ * notation (e.g., `"1e+21"`, `"1.5e-3"`) into plain decimal form.
+ * Returns the input unchanged if it does not contain scientific notation.
+ */
+function expandScientific(s: string): string {
+  const match = /^(-?)(\d+\.?\d*)[eE]([+-]?\d+)$/.exec(s);
+  if (!match) return s;
+  const [, sign, mantissa, expStr] = match;
+  const exp = parseInt(expStr);
+  const dotPos = mantissa.indexOf(".");
+  const digits = mantissa.replace(".", "");
+  const intLen = dotPos >= 0 ? dotPos : digits.length;
+  const newIntLen = intLen + exp;
+  let result: string;
+  if (newIntLen >= digits.length) {
+    result = digits + "0".repeat(newIntLen - digits.length);
+  } else if (newIntLen <= 0) {
+    result = "0." + "0".repeat(-newIntLen) + digits;
+  } else {
+    result = digits.slice(0, newIntLen) + "." + digits.slice(newIntLen);
+  }
+  return sign + result;
+}
+
+/**
+ * Normalizes a plain decimal string by stripping leading zeros from the
+ * integer part and trailing zeros from the fractional part, so that two
+ * strings representing the same mathematical value compare as equal.
+ */
+function normalizeDecimal(s: string): string {
+  let sign = "";
+  let str = s;
+  if (str.startsWith("-") || str.startsWith("+")) {
+    if (str[0] === "-") sign = "-";
+    str = str.slice(1);
+  }
+  const dot = str.indexOf(".");
+  let int: string;
+  let frac: string;
+  if (dot >= 0) {
+    int = str.slice(0, dot);
+    frac = str.slice(dot + 1);
+  } else {
+    int = str;
+    frac = "";
+  }
+  int = int.replace(/^0+/, "") || "0";
+  frac = frac.replace(/0+$/, "");
+  return sign + (frac ? int + "." + frac : int);
 }
 
 /**

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -291,19 +291,18 @@ export function choice<const T extends string | number>(
     const numberChoices = choices as readonly number[];
     const numberOptions = options as ChoiceOptionsNumber;
     const numberStrings = numberChoices.map((v) =>
-      // NaN is never a valid CLI literal (consistent with float()
-      // requiring explicit allowNaN), so map it to a string that
-      // can never match any input.
-      Number.isNaN(v) ? "\0" : Object.is(v, -0) ? "-0" : String(v)
+      Object.is(v, -0) ? "-0" : String(v)
     );
     return {
       $mode: "sync",
       metavar,
       choices: choices as readonly T[],
       parse(input: string): ValueParserResult<T> {
-        // Exact match against canonical String() representations
+        // Exact match against canonical String() representations.
+        // NaN is never a valid CLI literal (consistent with float()
+        // requiring explicit allowNaN), so skip NaN entries.
         const index = numberStrings.indexOf(input);
-        if (index >= 0) {
+        if (index >= 0 && !Number.isNaN(numberChoices[index])) {
           return { success: true, value: numberChoices[index] as T };
         }
         // Fall back to strict decimal parsing for alternate spellings
@@ -392,8 +391,8 @@ export function choice<const T extends string | number>(
       },
       suggest(prefix: string) {
         return numberStrings
-          .filter((valueStr) =>
-            valueStr !== "\0" && valueStr.startsWith(prefix)
+          .filter((valueStr, i) =>
+            !Number.isNaN(numberChoices[i]) && valueStr.startsWith(prefix)
           )
           .map((valueStr) => ({ kind: "literal" as const, text: valueStr }));
       },

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -290,6 +290,7 @@ export function choice<const T extends string | number>(
     // Number choice implementation
     const numberChoices = choices as readonly number[];
     const numberOptions = options as ChoiceOptionsNumber;
+    const validNumberChoices = numberChoices.filter((v) => !Number.isNaN(v));
     const numberStrings = numberChoices.map((v) =>
       Object.is(v, -0) ? "-0" : String(v)
     );
@@ -386,7 +387,11 @@ export function choice<const T extends string | number>(
         }
         return {
           success: false,
-          error: formatNumberChoiceError(input, numberChoices, numberOptions),
+          error: formatNumberChoiceError(
+            input,
+            validNumberChoices,
+            numberOptions,
+          ),
         };
       },
       format(value: T): string {

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -546,6 +546,9 @@ function formatDefaultChoiceError(
   const choiceStrings = choices
     .filter((c) => typeof c === "string" || !Number.isNaN(c))
     .map((c) => Object.is(c, -0) ? "-0" : String(c));
+  if (choiceStrings.length === 0 && choices.length > 0) {
+    return message`No valid choices are configured, but got ${input}.`;
+  }
   return message`Expected one of ${
     valueSet(choiceStrings, { locale: "en-US" })
   }, but got ${input}.`;

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -309,11 +309,21 @@ export function choice<const T extends string | number>(
         // whitespace inputs.
         if (/^[+-]?(\d+\.?\d*|\.\d+)$/.test(input)) {
           const parsed = Number(input);
-          const fallbackIndex = numberChoices.findIndex((v) =>
-            Object.is(v, parsed)
-          );
-          if (fallbackIndex >= 0) {
-            return { success: true, value: numberChoices[fallbackIndex] as T };
+          // Accept only if the conversion is lossless: reject overflow
+          // (finite decimal → Infinity) and underflow (nonzero decimal → 0)
+          const overflowed = !Number.isFinite(parsed);
+          const underflowed = parsed === 0 &&
+            !/^[+-]?0*(\.0*)?$/.test(input);
+          if (!overflowed && !underflowed) {
+            const fallbackIndex = numberChoices.findIndex((v) =>
+              Object.is(v, parsed)
+            );
+            if (fallbackIndex >= 0) {
+              return {
+                success: true,
+                value: numberChoices[fallbackIndex] as T,
+              };
+            }
           }
         }
         return {

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -443,8 +443,9 @@ export function choice<const T extends string | number>(
 }
 
 /**
- * Expands a canonical `String(number)` representation that uses scientific
- * notation (e.g., `"1e+21"`, `"1.5e-3"`) into plain decimal form.
+ * Expands a numeric string in scientific notation (e.g., `"1e+21"`,
+ * `"1.5e-3"`, `".1e-6"`) into plain decimal form for normalization.
+ * Used for both canonical `String(number)` output and user input.
  * Returns the input unchanged if it does not contain scientific notation.
  */
 function expandScientific(s: string): string {

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -452,7 +452,7 @@ function expandScientific(s: string): string {
   if (!match) return s;
   const [, rawSign, mantissa, expStr] = match;
   const sign = rawSign === "-" ? "-" : "";
-  const exp = parseInt(expStr);
+  const exp = parseInt(expStr, 10);
   const dotPos = mantissa.indexOf(".");
   const digits = mantissa.replace(".", "");
   const intLen = dotPos >= 0 ? dotPos : digits.length;


### PR DESCRIPTION
## Summary

- Number `choice()` no longer accepts hex (`0x10`), binary (`0b10`), octal (`0o10`), empty strings, or whitespace-only strings via JavaScript's `Number()` coercion.
- Alternate decimal spellings (e.g., `"8.0"` for `8`, `"1000000000000000000000"` for `1e21`) are accepted via normalization-based equivalence checking, not `Number()` rounding.
- Alternate scientific notation spellings (e.g., `"1e21"` for canonical `"1e+21"`, `".1e-6"` for `"1e-7"`) are accepted only when the choice value's canonical `String()` form itself uses scientific notation, so `"2e0"` for `choice([2])` stays rejected.
- Inputs that merely round to an IEEE-754 double matching a choice value (e.g., `"1000000000000000000001"` rounding to `1e21`) are rejected.
- Overflow (huge decimals → `Infinity`) and underflow (tiny decimals → `0`) are rejected.
- `-0` is preserved as a distinct choice when explicitly listed; `-0` spellings like `"-0.0"` fall back to `0` when only `0` is in the list.
- `NaN` is rejected even when it appears in the choice list, consistent with `float()` requiring explicit `allowNaN`.
- Error messages correctly render `-0` instead of `0` when `-0` is in the choice list.

## Test plan

- [x] Regression tests for all original reproduction cases from the issue (hex, binary, octal, scientific notation, empty string, whitespace)
- [x] Tests for alternate decimal spellings of large/small numbers
- [x] Tests for alternate scientific notation spellings
- [x] Tests for IEEE-754 rounding rejection
- [x] Tests for overflow and underflow rejection
- [x] Tests for `-0` preservation, `-0`/`0` distinction, and `-0` error message rendering
- [x] Tests for `NaN` rejection
- [x] Tests for `-0` fallback to `0` when `-0` is not explicitly listed
- [x] All existing tests pass across Deno, Node.js, and Bun

Closes https://github.com/dahlia/optique/issues/315