### PR TITLE
Reject empty choices array in `choice()`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -258,6 +258,10 @@ To be released.
     and multiple choices normalize to the same lowercase value (e.g., `"JSON"`
     and `"json"`).  Previously the first match won silently.  [[#310], [#533]]
 
+ -  Changed `choice()` to throw `TypeError` when the choices array is empty.
+    Previously `choice([])` created an unsatisfiable parser with a malformed
+    error message.  [[#332], [#536]]
+
 [#110]: https://github.com/dahlia/optique/issues/110
 [#113]: https://github.com/dahlia/optique/issues/113
 [#115]: https://github.com/dahlia/optique/issues/115
@@ -288,6 +292,7 @@ To be released.
 [#242]: https://github.com/dahlia/optique/issues/242
 [#248]: https://github.com/dahlia/optique/issues/248
 [#310]: https://github.com/dahlia/optique/issues/310
+[#332]: https://github.com/dahlia/optique/issues/332
 [#388]: https://github.com/dahlia/optique/issues/388
 [#490]: https://github.com/dahlia/optique/pull/490
 [#512]: https://github.com/dahlia/optique/pull/512
@@ -299,6 +304,7 @@ To be released.
 [#528]: https://github.com/dahlia/optique/pull/528
 [#531]: https://github.com/dahlia/optique/pull/531
 [#533]: https://github.com/dahlia/optique/pull/533
+[#536]: https://github.com/dahlia/optique/pull/536
 
 ### @optique/config
 

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -714,14 +714,11 @@ describe("choice", () => {
       assert.ok(!result4.success);
     });
 
-    it("should work with empty choice list", () => {
-      const parser = choice([]);
-
-      const result1 = parser.parse("anything");
-      assert.ok(!result1.success);
-
-      const result2 = parser.parse("");
-      assert.ok(!result2.success);
+    it("should throw TypeError for empty choice list", () => {
+      assert.throws(
+        () => choice([]),
+        TypeError,
+      );
     });
 
     it("should handle choices with special characters", () => {
@@ -945,22 +942,11 @@ describe("choice", () => {
       }
     });
 
-    it("should provide structured error messages for empty choice list", () => {
-      const parser = choice([]);
-      const result = parser.parse("anything");
-
-      assert.ok(!result.success);
-      if (!result.success) {
-        assert.deepEqual(
-          result.error,
-          [
-            { type: "text", text: "Expected one of " },
-            { type: "text", text: ", but got " },
-            { type: "value", value: "anything" },
-            { type: "text", text: "." },
-          ] as const,
-        );
-      }
+    it("should throw TypeError for empty choice list", () => {
+      assert.throws(
+        () => choice([] as string[]),
+        TypeError,
+      );
     });
 
     it("should provide structured error messages for case insensitive parser", () => {
@@ -1481,11 +1467,11 @@ describe("choice", () => {
       }
     });
 
-    it("should work with empty number choice list", () => {
-      const parser = choice([] as number[]);
-
-      const result = parser.parse("1");
-      assert.ok(!result.success);
+    it("should throw TypeError for empty number choice list", () => {
+      assert.throws(
+        () => choice([] as number[]),
+        TypeError,
+      );
     });
 
     it("should reject hex, binary, octal, and scientific notation", () => {
@@ -1775,9 +1761,11 @@ describe("choice", () => {
       assert.deepEqual(parser.choices, ["JSON", "YAML"]);
     });
 
-    it("should expose empty array for empty choices", () => {
-      const parser = choice([] as string[]);
-      assert.deepEqual(parser.choices, []);
+    it("should throw TypeError for empty choices", () => {
+      assert.throws(
+        () => choice([] as string[]),
+        TypeError,
+      );
     });
 
     it("should expose single-element array for single choice", () => {

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -249,6 +249,7 @@ export function isValueParser<M extends Mode, T>(
  * @param options Configuration options for the choice parser.
  * @returns A {@link ValueParser} that checks if the input matches one of the
  *          specified values.
+ * @throws {TypeError} If the choices array is empty.
  * @throws {TypeError} If `caseInsensitive` is `true` and multiple choices
  *         normalize to the same lowercase value.
  */
@@ -268,6 +269,7 @@ export function choice<const T extends string>(
  * @param options Configuration options for the choice parser.
  * @returns A {@link ValueParser} that checks if the input matches one of the
  *          specified values.
+ * @throws {TypeError} If the choices array is empty.
  * @since 0.9.0
  */
 export function choice<const T extends number>(
@@ -282,6 +284,11 @@ export function choice<const T extends string | number>(
   choices: readonly T[],
   options: ChoiceOptionsString | ChoiceOptionsNumber = {},
 ): ValueParser<"sync", T> {
+  if (choices.length < 1) {
+    throw new TypeError(
+      "Expected at least one choice, but got an empty array.",
+    );
+  }
   const metavar = options.metavar ?? "TYPE";
   ensureNonEmptyString(metavar);
 


### PR DESCRIPTION
## Summary

- `choice([])` now throws `TypeError` at construction time instead of creating an unsatisfiable parser with a malformed error message (`Expected one of , but got x.`).
- Updated JSDoc on both string and number overloads to document the new `@throws {TypeError}`.
- Updated existing tests to expect `TypeError` for empty choices arrays (both string and number).

Closes https://github.com/dahlia/optique/issues/332

## Test plan

- `mise test` passes across all runtimes (Deno, Node.js, Bun).
- `mise check` passes (type check, lint, format, dry-run publish).