### PR TITLE
Fix `path()` applying `extensions` validation for `type: "directory"`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -491,13 +491,19 @@ interactive prompt fallback integration via Inquirer.js.  [[#87], [#137]]
     Previously, these were silently accepted as valid paths in
     non-`mustExist` modes.  [[#343], [#538]]
 
+ -  Fixed `path()` applying `extensions` validation even when
+    `type: "directory"` is set.  Extensions are now skipped for
+    directory-type paths.  [[#257], [#539]]
+
 [#112]: https://github.com/dahlia/optique/issues/112
 [#160]: https://github.com/dahlia/optique/issues/160
 [#163]: https://github.com/dahlia/optique/pull/163
+[#257]: https://github.com/dahlia/optique/issues/257
 [#309]: https://github.com/dahlia/optique/issues/309
 [#343]: https://github.com/dahlia/optique/issues/343
 [#530]: https://github.com/dahlia/optique/pull/530
 [#538]: https://github.com/dahlia/optique/pull/538
+[#539]: https://github.com/dahlia/optique/pull/539
 
 ### @optique/man
 

--- a/packages/run/src/valueparser.test.ts
+++ b/packages/run/src/valueparser.test.ts
@@ -545,6 +545,41 @@ describe("path", () => {
     });
   });
 
+  describe("extensions skipped for directory type", () => {
+    it("should ignore extensions when type is directory", () => {
+      const parser = path({ type: "directory", extensions: [".json"] });
+      const result = parser.parse("/some/directory");
+      assert.ok(result.success);
+    });
+
+    it("should ignore extensions for mustExist directory", () => {
+      const dir = createTempDir();
+      try {
+        const parser = path({
+          mustExist: true,
+          type: "directory",
+          extensions: [".json"],
+        });
+        const result = parser.parse(dir);
+        assert.ok(result.success);
+      } finally {
+        cleanupDir(dir);
+      }
+    });
+
+    it("should still validate extensions when type is file", () => {
+      const parser = path({ type: "file", extensions: [".json"] });
+      const result = parser.parse("config.txt");
+      assert.ok(!result.success);
+    });
+
+    it("should still validate extensions when type is either", () => {
+      const parser = path({ type: "either", extensions: [".json"] });
+      const result = parser.parse("config.txt");
+      assert.ok(!result.success);
+    });
+  });
+
   describe("extensions input validation", () => {
     it("should throw on extension without leading dot", () => {
       assert.throws(

--- a/packages/run/src/valueparser.ts
+++ b/packages/run/src/valueparser.ts
@@ -245,8 +245,8 @@ export function path(options: PathOptions = {}): ValueParser<"sync", string> {
         };
       }
 
-      // Extension validation
-      if (extensions && extensions.length > 0) {
+      // Extension validation (skip for directory type)
+      if (type !== "directory" && extensions && extensions.length > 0) {
         const base = /[/\\]$/.test(input) ? "" : basename(input);
         if (!extensions.some((ext) => base.endsWith(ext))) {
           const ext = extname(input);


### PR DESCRIPTION
## Summary

- `path()` was applying `extensions` validation even when `type: "directory"` was set, rejecting valid directory paths with a file-oriented error message like "Expected file with extension .json, got no extension."
- Extensions validation is now skipped when `type` is `"directory"`, matching the documented contract that `extensions` is "for files only."

Closes https://github.com/dahlia/optique/issues/257

## Test plan

- [x] Added regression tests for `type: "directory"` with `extensions` (both with and without `mustExist`)
- [x] Verified `type: "file"` and `type: "either"` still validate extensions as before
- [x] All tests pass across Deno, Node.js, and Bun (`mise test`)
- [x] Quality checks pass (`mise check`)