### PR TITLE
Fix `path().suggest()` hidden-file completion for nested dotfile prefixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -499,10 +499,15 @@ interactive prompt fallback integration via Inquirer.js.  [[#87], [#137]]
     `mustNotExist` are set.  Previously, the contradictory configuration
     was silently accepted.  [[#358], [#541]]
 
+ -  Fixed `path().suggest()` not enabling hidden-file completion for nested
+    dotfile prefixes like `src/.` or `nested/path/.`.  Previously, only bare
+    dot prefixes (e.g., `.`) set `includeHidden`.  [[#258], [#543]]
+
 [#112]: https://github.com/dahlia/optique/issues/112
 [#160]: https://github.com/dahlia/optique/issues/160
 [#163]: https://github.com/dahlia/optique/pull/163
 [#257]: https://github.com/dahlia/optique/issues/257
+[#258]: https://github.com/dahlia/optique/issues/258
 [#309]: https://github.com/dahlia/optique/issues/309
 [#343]: https://github.com/dahlia/optique/issues/343
 [#358]: https://github.com/dahlia/optique/issues/358
@@ -510,6 +515,7 @@ interactive prompt fallback integration via Inquirer.js.  [[#87], [#137]]
 [#538]: https://github.com/dahlia/optique/pull/538
 [#539]: https://github.com/dahlia/optique/pull/539
 [#541]: https://github.com/dahlia/optique/pull/541
+[#543]: https://github.com/dahlia/optique/pull/543
 
 ### @optique/man
 

--- a/packages/run/src/valueparser.test.ts
+++ b/packages/run/src/valueparser.test.ts
@@ -1144,6 +1144,26 @@ describe("path", () => {
       assert.ok(Array.isArray(regularSuggestions));
       assert.ok(Array.isArray(dotSuggestions));
     });
+
+    it("should include hidden files when basename starts with dot", () => {
+      const parser = path();
+
+      const dot = Array.from(parser.suggest!("."))[0];
+      assert.equal(dot.kind, "file");
+      assert.equal(dot.kind === "file" && dot.includeHidden, true);
+
+      const nested = Array.from(parser.suggest!("src/."))[0];
+      assert.equal(nested.kind, "file");
+      assert.equal(nested.kind === "file" && nested.includeHidden, true);
+
+      const deep = Array.from(parser.suggest!("nested/path/."))[0];
+      assert.equal(deep.kind, "file");
+      assert.equal(deep.kind === "file" && deep.includeHidden, true);
+
+      const regular = Array.from(parser.suggest!("src/config"))[0];
+      assert.equal(regular.kind, "file");
+      assert.equal(regular.kind === "file" && regular.includeHidden, false);
+    });
   });
 
   describe("mutually exclusive options", () => {

--- a/packages/run/src/valueparser.ts
+++ b/packages/run/src/valueparser.ts
@@ -368,7 +368,7 @@ export function path(options: PathOptions = {}): ValueParser<"sync", string> {
         pattern: prefix,
         type: type === "either" ? "any" : type,
         extensions,
-        includeHidden: prefix.startsWith("."),
+        includeHidden: basename(prefix).startsWith("."),
         description: type === "directory"
           ? message`Directory`
           : type === "file"


### PR DESCRIPTION
## Summary

- Fixed `path().suggest()` not enabling hidden-file completion for nested dotfile prefixes like `src/.` or `nested/path/.`.
- Previously, `includeHidden` was only set to `true` when the entire prefix started with `.` (e.g., `.env`), so nested paths were incorrectly treated as non-hidden completions.
- The fix checks `basename(prefix)` instead of `prefix` itself, so `src/.gitignore` and `nested/path/.env` now correctly trigger hidden-file suggestions.

Closes https://github.com/dahlia/optique/issues/258

## Test plan

- Added a test verifying `includeHidden` is `true` for `.`, `src/.`, and `nested/path/.` prefixes, and `false` for `src/config`.
- All existing tests pass across Deno, Node.js, and Bun.