### PR TITLE
Reject invalid runtime `type` values in `path()`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -503,6 +503,10 @@ interactive prompt fallback integration via Inquirer.js.  [[#87], [#137]]
     dotfile prefixes like `src/.` or `nested/path/.`.  Previously, only bare
     dot prefixes (e.g., `.`) set `includeHidden`.  [[#258], [#543]]
 
+ -  Fixed `path()` to reject invalid runtime `type` values.  Previously,
+    unsupported values like `"files"` were silently accepted, causing
+    inconsistent behavior between parsing and suggestions.  [[#361], [#545]]
+
 [#112]: https://github.com/dahlia/optique/issues/112
 [#160]: https://github.com/dahlia/optique/issues/160
 [#163]: https://github.com/dahlia/optique/pull/163
@@ -511,11 +515,13 @@ interactive prompt fallback integration via Inquirer.js.  [[#87], [#137]]
 [#309]: https://github.com/dahlia/optique/issues/309
 [#343]: https://github.com/dahlia/optique/issues/343
 [#358]: https://github.com/dahlia/optique/issues/358
+[#361]: https://github.com/dahlia/optique/issues/361
 [#530]: https://github.com/dahlia/optique/pull/530
 [#538]: https://github.com/dahlia/optique/pull/538
 [#539]: https://github.com/dahlia/optique/pull/539
 [#541]: https://github.com/dahlia/optique/pull/541
 [#543]: https://github.com/dahlia/optique/pull/543
+[#545]: https://github.com/dahlia/optique/pull/545
 
 ### @optique/man
 

--- a/packages/run/src/valueparser.test.ts
+++ b/packages/run/src/valueparser.test.ts
@@ -1166,6 +1166,30 @@ describe("path", () => {
     });
   });
 
+  describe("invalid type option", () => {
+    it("should throw TypeError for unsupported type values", () => {
+      assert.throws(
+        () => path({ type: "files" as never }),
+        {
+          name: "TypeError",
+          message: 'Unsupported path type: "files". ' +
+            'Expected "file", "directory", or "either".',
+        },
+      );
+    });
+
+    it("should throw TypeError for empty string type", () => {
+      assert.throws(
+        () => path({ type: "" as never }),
+        {
+          name: "TypeError",
+          message: 'Unsupported path type: "". ' +
+            'Expected "file", "directory", or "either".',
+        },
+      );
+    });
+  });
+
   describe("mutually exclusive options", () => {
     it("should throw TypeError when both mustExist and mustNotExist are set", () => {
       assert.throws(

--- a/packages/run/src/valueparser.ts
+++ b/packages/run/src/valueparser.ts
@@ -181,6 +181,8 @@ export type PathOptions =
  *
  * @param options Configuration options for path validation.
  * @returns A ValueParser that validates and returns string paths.
+ * @throws {TypeError} If {@link PathOptionsBase.type} is not one of
+ *   `"file"`, `"directory"`, or `"either"`.
  * @throws {TypeError} If any entry in {@link PathOptionsBase.extensions} does
  *   not start with a dot (e.g., `"json"` instead of `".json"`).
  * @throws {TypeError} If both {@link PathOptionsMustExist.mustExist} and
@@ -219,6 +221,12 @@ export function path(options: PathOptions = {}): ValueParser<"sync", string> {
     extensions,
   } = options;
   ensureNonEmptyString(metavar);
+  if (type !== "file" && type !== "directory" && type !== "either") {
+    throw new TypeError(
+      `Unsupported path type: ${JSON.stringify(type)}. ` +
+        `Expected "file", "directory", or "either".`,
+    );
+  }
   if (extensions) {
     for (const ext of extensions) {
       if (!ext.startsWith(".")) {


### PR DESCRIPTION
## Summary

- `path()` now throws `TypeError` at construction time when the `type` option is not `"file"`, `"directory"`, or `"either"`
- Previously, invalid values like `"files"` were silently accepted: parse fell back to `"either"` behavior while suggestions emitted the raw invalid string
- Follows the same validation pattern already used for `extensions` and `mustExist`/`mustNotExist`

Closes https://github.com/dahlia/optique/issues/361

## Test plan

- [x] Added tests for invalid `type` values (`"files"`, `""`)
- [x] All existing tests pass across Deno, Node.js, and Bun (`mise test`)
- [x] Type check, lint, and format check pass (`mise check`)