### PR TITLE
Fix `bindConfig()` silently swallowing exceptions from `key` callbacks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -362,6 +362,10 @@ To be released.
     “CLI-provided”, which was causing `bindEnv(bindConfig(…))` to skip the
     environment-variable fallback even when the CLI option was absent.
 
+ -  Fixed `bindConfig()` silently swallowing exceptions thrown by `key`
+    callbacks.  Errors now propagate to the caller instead of being
+    treated as a missing config value.  [[#259], [#549]]
+
  -  Added config-source metadata support for `bindConfig()` key accessors.
     Accessor callbacks now receive a second `meta` argument, and single-file
     mode now provides default `ConfigMeta` values (`configPath`, `configDir`)
@@ -398,6 +402,8 @@ To be released.
 [#161]: https://github.com/dahlia/optique/issues/161
 [#162]: https://github.com/dahlia/optique/pull/162
 [#164]: https://github.com/dahlia/optique/pull/164
+[#259]: https://github.com/dahlia/optique/issues/259
+[#549]: https://github.com/dahlia/optique/pull/549
 
 ### @optique/env
 

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -982,7 +982,7 @@ describe("createConfigContext error paths", () => {
     }
   });
 
-  test("key accessor function that throws falls through to default", () => {
+  test("key accessor function that throws propagates the error", () => {
     const schema = z.object({
       nested: z.object({
         value: z.string(),
@@ -1002,9 +1002,34 @@ describe("createConfigContext error paths", () => {
       [context.id]: { data: { nested: undefined } },
     };
 
-    const result = parse(parser, [], { annotations });
-    assert.ok(result.success);
-    assert.equal(result.value, "fallback");
+    assert.throws(
+      () => parse(parser, [], { annotations }),
+      TypeError,
+    );
+  });
+
+  test("key callback exceptions are not swallowed", () => {
+    const schema = z.object({ host: z.string() });
+    const context = createConfigContext({ schema });
+    const parser = bindConfig(option("--host", string()), {
+      context,
+      key: () => {
+        throw new Error("Custom error from key callback.");
+      },
+      default: "fallback",
+    });
+
+    const annotations: Annotations = {
+      [context.id]: { data: { host: "example.com" } },
+    };
+
+    assert.throws(
+      () => parse(parser, [], { annotations }),
+      (err: Error) => {
+        assert.ok(err.message.includes("Custom error from key callback."));
+        return true;
+      },
+    );
   });
 
   test("Symbol.dispose clears active config registry", () => {

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -905,11 +905,7 @@ function getConfigOrDefault<T, TValue, TConfigMeta>(
   if (configData !== undefined && configData !== null) {
     // Extract value from config
     if (typeof options.key === "function") {
-      try {
-        configValue = options.key(configData, configMeta);
-      } catch {
-        configValue = undefined;
-      }
+      configValue = options.key(configData, configMeta);
     } else {
       configValue = configData[options.key] as TValue;
     }


### PR DESCRIPTION
## Summary

- Remove the bare `try-catch` in `getConfigOrDefault()` that caught all exceptions thrown by `key` callbacks and replaced them with `undefined`
- Exceptions from `key` functions now propagate naturally to the caller instead of being silently treated as a missing config value
- Update existing test and add regression test to verify exception propagation

Closes https://github.com/dahlia/optique/issues/259

## Test plan

- [x] Updated test: `key accessor function that throws propagates the error` verifies `TypeError` propagates when accessing a property on `undefined`
- [x] New test: `key callback exceptions are not swallowed` verifies a custom `Error` thrown from a `key` callback propagates with the correct message
- [x] `mise test` passes across all runtimes (Deno, Node.js, Bun)