### PR TITLE
Fix `optique-man` inferring empty program name for extensionless input files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -583,11 +583,16 @@ interactive prompt fallback integration via Inquirer.js.  [[#87], [#137]]
     `value()` and `values()` terms, which produced malformed roff output.
     [[#273], [#544]]
 
+ -  Fixed `optique-man` inferring an empty program name for extensionless
+    input files.  `inferNameFromPath()` returned an empty string because
+    `base.slice(0, -0)` yields `""` in JavaScript.  [[#277], [#551]]
+
 [#221]: https://github.com/dahlia/optique/issues/221
 [#222]: https://github.com/dahlia/optique/issues/222
 [#273]: https://github.com/dahlia/optique/issues/273
 [#274]: https://github.com/dahlia/optique/issues/274
 [#276]: https://github.com/dahlia/optique/issues/276
+[#277]: https://github.com/dahlia/optique/issues/277
 [#280]: https://github.com/dahlia/optique/issues/280
 [#283]: https://github.com/dahlia/optique/issues/283
 [#526]: https://github.com/dahlia/optique/pull/526
@@ -597,6 +602,7 @@ interactive prompt fallback integration via Inquirer.js.  [[#87], [#137]]
 [#542]: https://github.com/dahlia/optique/pull/542
 [#544]: https://github.com/dahlia/optique/pull/544
 [#547]: https://github.com/dahlia/optique/pull/547
+[#551]: https://github.com/dahlia/optique/pull/551
 
 
 Version 0.10.7

--- a/packages/man/src/cli.test.ts
+++ b/packages/man/src/cli.test.ts
@@ -183,6 +183,29 @@ describe("optique-man CLI", { skip: !hasReliableSubprocess }, () => {
       }
     });
 
+    it("infers program name from extensionless input file", async () => {
+      const sourceFile = join(fixturesDir, "parser.ts");
+      const tempDir = await mkdtemp(
+        join(fixturesDir, "tmp-optique-man-extless-"),
+      );
+      const parserFile = join(tempDir, "myapp");
+
+      try {
+        await writeFile(parserFile, await readFile(sourceFile, "utf-8"));
+
+        const result = await runCli([
+          parserFile,
+          "-s",
+          "1",
+        ]);
+
+        assert.equal(result.exitCode, 0);
+        assert.ok(result.stdout.includes(".TH MYAPP 1"));
+      } finally {
+        await rm(tempDir, { recursive: true });
+      }
+    });
+
     it("generates man page from named export", async () => {
       const namedFile = join(fixturesDir, "named-export.ts");
       const result = await runCli([namedFile, "-s", "1", "-e", "myProgram"]);

--- a/packages/man/src/cli.ts
+++ b/packages/man/src/cli.ts
@@ -498,7 +498,7 @@ function isParser(
 function inferNameFromPath(filePath: string): string {
   const base = basename(filePath);
   const ext = extname(base);
-  return base.slice(0, -ext.length);
+  return ext.length > 0 ? base.slice(0, -ext.length) : base;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Fix `inferNameFromPath()` returning an empty string when the input file has no extension (e.g., `myapp` instead of `myapp.ts`)
- `base.slice(0, -ext.length)` yields `""` when `ext` is `""`, because `-0 === 0` in JavaScript
- Add a guard so extensionless filenames are returned as-is
- Add a regression test that copies `parser.ts` to a temp file without an extension and verifies the inferred name appears in the `.TH` header

Fixes https://github.com/dahlia/optique/issues/277

## Test plan

- [x] New test `"infers program name from extensionless input file"` passes on Deno
- [x] All 175 existing `@optique/man` tests pass on Node.js
- [x] `mise check` passes (type check, lint, format, dry-run publish)