### PR TITLE
Snapshot `caseInsensitive` at construction time in `choice()`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -281,6 +281,10 @@ To be released.
     still advertised in suggestions and help output, creating an unsatisfiable
     parser with contradictory diagnostics.  [[#363], [#553]]
 
+ -  Fixed `choice()` to snapshot `caseInsensitive` at construction time,
+    preventing post-construction option mutation from causing `parse()` and
+    `suggest()` to diverge.  [[#508], [#554]]
+
  -  Fixed `optional()`, `withDefault()`, and `group()` dropping the
     config-prompt deferral hook (`@optique/config/deferPromptUntilResolved`)
     from inner parsers.  These combinators now forward the hook so that
@@ -331,6 +335,7 @@ To be released.
 [#388]: https://github.com/dahlia/optique/issues/388
 [#389]: https://github.com/dahlia/optique/issues/389
 [#490]: https://github.com/dahlia/optique/pull/490
+[#508]: https://github.com/dahlia/optique/issues/508
 [#512]: https://github.com/dahlia/optique/pull/512
 [#520]: https://github.com/dahlia/optique/pull/520
 [#522]: https://github.com/dahlia/optique/pull/522
@@ -346,6 +351,7 @@ To be released.
 [#546]: https://github.com/dahlia/optique/pull/546
 [#548]: https://github.com/dahlia/optique/pull/548
 [#553]: https://github.com/dahlia/optique/pull/553
+[#554]: https://github.com/dahlia/optique/pull/554
 
 ### @optique/config
 

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -1897,6 +1897,24 @@ describe("choice", () => {
       ]);
     });
 
+    it("should not change behavior after post-construction caseInsensitive mutation", () => {
+      const options: { caseInsensitive: boolean } = {
+        caseInsensitive: false,
+      };
+      const parser = choice(["Foo", "Bar"], options);
+
+      // Before mutation: case-sensitive, "foo" doesn't match "Foo"
+      assert.ok(!parser.parse("foo").success);
+      assert.deepEqual([...parser.suggest!("f")], []);
+
+      // Mutate options after construction
+      options.caseInsensitive = true;
+
+      // After mutation: behavior should NOT change (still case-sensitive)
+      assert.ok(!parser.parse("foo").success);
+      assert.deepEqual([...parser.suggest!("f")], []);
+    });
+
     it("should work with all-duplicate list", () => {
       const parser = choice(["a", "a"]);
       assert.deepEqual(parser.choices, ["a"]);

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -478,10 +478,11 @@ export function choice<const T extends string | number>(
         `${String(stringOptions.caseInsensitive)}.`,
     );
   }
-  const normalizedValues = stringOptions.caseInsensitive
+  const caseInsensitive = stringOptions.caseInsensitive ?? false;
+  const normalizedValues = caseInsensitive
     ? stringChoices.map((v) => v.toLowerCase())
     : stringChoices;
-  if (stringOptions.caseInsensitive) {
+  if (caseInsensitive) {
     const seen = new Map<string, string>();
     for (let i = 0; i < stringChoices.length; i++) {
       const nv = normalizedValues[i];
@@ -502,9 +503,7 @@ export function choice<const T extends string | number>(
     metavar,
     choices: stringChoices as readonly T[],
     parse(input: string): ValueParserResult<T> {
-      const normalizedInput = stringOptions.caseInsensitive
-        ? input.toLowerCase()
-        : input;
+      const normalizedInput = caseInsensitive ? input.toLowerCase() : input;
       const index = normalizedValues.indexOf(normalizedInput);
       if (index < 0) {
         return {
@@ -518,15 +517,11 @@ export function choice<const T extends string | number>(
       return String(value);
     },
     suggest(prefix: string) {
-      const normalizedPrefix = stringOptions.caseInsensitive
-        ? prefix.toLowerCase()
-        : prefix;
+      const normalizedPrefix = caseInsensitive ? prefix.toLowerCase() : prefix;
 
       return stringChoices
         .filter((value) => {
-          const normalizedValue = stringOptions.caseInsensitive
-            ? value.toLowerCase()
-            : value;
+          const normalizedValue = caseInsensitive ? value.toLowerCase() : value;
           return normalizedValue.startsWith(normalizedPrefix);
         })
         .map((value) => ({ kind: "literal" as const, text: value }));


### PR DESCRIPTION
## Summary

- Fixed `choice()` to snapshot `caseInsensitive` into a local `const` at construction time, so that `parse()` and `suggest()` both use the snapshotted value instead of reading the mutable options object dynamically.
- Previously, mutating `options.caseInsensitive` after construction caused `parse()` to keep using the precomputed normalization table (snapshotted) while `suggest()` read the flag live, making the two methods diverge.

Closes https://github.com/dahlia/optique/issues/508

## Test plan

- [x] Added regression test that mutates `caseInsensitive` after construction and asserts both `parse()` and `suggest()` remain unchanged.
- [x] All existing `choice()` tests pass.
- [x] Full cross-runtime test suite passes (`mise test`).