### PR TITLE
Reject empty `name` in `formatDocPageAsMan()` and `generateManPage*()` APIs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -608,6 +608,10 @@ interactive prompt fallback integration via Inquirer.js.  [[#87], [#137]]
     `isParser()`.  Both guards also catch exceptions from throwing
     accessors.  [[#278], [#552]]
 
+ -  `formatDocPageAsMan()` and the `generateManPage*()` functions now throw
+    a `TypeError` when `name` is an empty string, instead of generating
+    malformed man page output.  [[#286], [#556]]
+
 [#221]: https://github.com/dahlia/optique/issues/221
 [#222]: https://github.com/dahlia/optique/issues/222
 [#273]: https://github.com/dahlia/optique/issues/273
@@ -617,6 +621,7 @@ interactive prompt fallback integration via Inquirer.js.  [[#87], [#137]]
 [#278]: https://github.com/dahlia/optique/issues/278
 [#280]: https://github.com/dahlia/optique/issues/280
 [#283]: https://github.com/dahlia/optique/issues/283
+[#286]: https://github.com/dahlia/optique/issues/286
 [#526]: https://github.com/dahlia/optique/pull/526
 [#529]: https://github.com/dahlia/optique/pull/529
 [#532]: https://github.com/dahlia/optique/pull/532
@@ -626,6 +631,7 @@ interactive prompt fallback integration via Inquirer.js.  [[#87], [#137]]
 [#547]: https://github.com/dahlia/optique/pull/547
 [#551]: https://github.com/dahlia/optique/pull/551
 [#552]: https://github.com/dahlia/optique/pull/552
+[#556]: https://github.com/dahlia/optique/pull/556
 
 
 Version 0.10.7

--- a/packages/man/src/generator.test.ts
+++ b/packages/man/src/generator.test.ts
@@ -244,6 +244,14 @@ describe("generateManPageSync()", () => {
     assert.ok(result.includes(".TH MYAPP 1"));
   });
 
+  it("rejects empty name", () => {
+    const parser = object({});
+    assert.throws(
+      () => generateManPageSync(parser, { name: "", section: 1 }),
+      TypeError,
+    );
+  });
+
   it("falls back to empty doc page when getDocPageSync returns undefined", () => {
     const parser: Parser<"sync", string, null> = {
       $mode: "sync",
@@ -292,6 +300,14 @@ describe("generateManPageAsync()", () => {
 
     assert.ok(typeof result === "string");
     assert.ok(result.includes(".TH MYAPP 1"));
+  });
+
+  it("rejects empty name", async () => {
+    const parser = object({});
+    await assert.rejects(
+      () => generateManPageAsync(parser, { name: "", section: 1 }),
+      TypeError,
+    );
   });
 
   it("falls back to empty doc page when getDocPageAsync returns undefined", async () => {
@@ -508,6 +524,25 @@ describe("Program-based API", () => {
 
     assert.ok(result.includes(".SH EXAMPLES"));
     assert.ok(result.includes("Basic usage:"));
+  });
+
+  it("rejects empty name from parser options", () => {
+    const parser = object({});
+    assert.throws(
+      () => generateManPage(parser, { name: "", section: 1 }),
+      TypeError,
+    );
+  });
+
+  it("rejects empty name from Program metadata", () => {
+    const prog = defineProgram({
+      parser: object({}),
+      metadata: { name: "" },
+    });
+    assert.throws(
+      () => generateManPage(prog, { section: 1 }),
+      TypeError,
+    );
   });
 
   it("keeps hidden: 'doc' option in SYNOPSIS but omits from OPTIONS", () => {

--- a/packages/man/src/man.test.ts
+++ b/packages/man/src/man.test.ts
@@ -1363,4 +1363,15 @@ describe("formatDocPageAsMan()", () => {
 
     assert.ok(result.includes(".BR app\\\\bin (1)"));
   });
+
+  it("rejects empty name", () => {
+    const page: DocPage = {
+      sections: [],
+    };
+
+    assert.throws(
+      () => formatDocPageAsMan(page, { name: "", section: 1 }),
+      TypeError,
+    );
+  });
 });

--- a/packages/man/src/man.ts
+++ b/packages/man/src/man.ts
@@ -383,12 +383,16 @@ function formatDocSectionEntries(section: DocSection): string {
  * @param page The documentation page to format.
  * @param options The man page options.
  * @returns The complete man page in roff format.
+ * @throws {TypeError} If the program name is empty.
  * @since 0.10.0
  */
 export function formatDocPageAsMan(
   page: DocPage,
   options: ManPageOptions,
 ): string {
+  if (options.name === "") {
+    throw new TypeError("Program name must not be empty.");
+  }
   const lines: string[] = [];
 
   // .TH - Title heading


### PR DESCRIPTION
## Summary

- `formatDocPageAsMan()` now throws a `TypeError` when `options.name` is an empty string, instead of silently generating malformed man page output (e.g., `.TH  1`, empty `.B` lines).
- Since all `generateManPage*()` functions delegate to `formatDocPageAsMan()`, the validation covers `generateManPage()`, `generateManPageSync()`, and `generateManPageAsync()` as well.

Closes https://github.com/dahlia/optique/issues/286

## Test plan

- [x] `formatDocPageAsMan()` throws `TypeError` on empty name
- [x] `generateManPage()` throws `TypeError` on empty name (direct options)
- [x] `generateManPage()` throws `TypeError` on empty name (via Program metadata)
- [x] `generateManPageSync()` throws `TypeError` on empty name
- [x] `generateManPageAsync()` rejects with `TypeError` on empty name