### PR TITLE
Escape `literal` usage terms in roff output to prevent control-line interpretation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -616,6 +616,11 @@ interactive prompt fallback integration via Inquirer.js.  [[#87], [#137]]
     a `RangeError` when `section` is not a valid man page section number
     (1–8), instead of generating malformed man page output.  [[#287], [#557]]
 
+ -  Fixed `formatDocPageAsMan()` emitting `literal` usage/doc terms without
+    roff line-start escaping.  Values starting with `.` or `'` (e.g., `.env`)
+    were interpreted by roff as requests instead of visible text.
+    [[#297], [#559]]
+
 [#221]: https://github.com/dahlia/optique/issues/221
 [#222]: https://github.com/dahlia/optique/issues/222
 [#273]: https://github.com/dahlia/optique/issues/273
@@ -627,6 +632,7 @@ interactive prompt fallback integration via Inquirer.js.  [[#87], [#137]]
 [#283]: https://github.com/dahlia/optique/issues/283
 [#286]: https://github.com/dahlia/optique/issues/286
 [#287]: https://github.com/dahlia/optique/issues/287
+[#297]: https://github.com/dahlia/optique/issues/297
 [#526]: https://github.com/dahlia/optique/pull/526
 [#529]: https://github.com/dahlia/optique/pull/529
 [#532]: https://github.com/dahlia/optique/pull/532
@@ -638,6 +644,7 @@ interactive prompt fallback integration via Inquirer.js.  [[#87], [#137]]
 [#552]: https://github.com/dahlia/optique/pull/552
 [#556]: https://github.com/dahlia/optique/pull/556
 [#557]: https://github.com/dahlia/optique/pull/557
+[#559]: https://github.com/dahlia/optique/pull/559
 
 
 Version 0.10.7

--- a/packages/man/src/man.test.ts
+++ b/packages/man/src/man.test.ts
@@ -122,6 +122,16 @@ describe("formatUsageTermAsRoff()", () => {
     assert.equal(formatUsageTermAsRoff(term), "debug");
   });
 
+  it("escapes literal term starting with period", () => {
+    const term: UsageTerm = { type: "literal", value: ".env" };
+    assert.equal(formatUsageTermAsRoff(term), "\\&.env");
+  });
+
+  it("escapes literal term starting with single quote", () => {
+    const term: UsageTerm = { type: "literal", value: "'quoted" };
+    assert.equal(formatUsageTermAsRoff(term), "\\&'quoted");
+  });
+
   it("formats passthrough term", () => {
     const term: UsageTerm = { type: "passthrough" };
     assert.equal(formatUsageTermAsRoff(term), "[...]");
@@ -401,6 +411,59 @@ describe("formatDocPageAsMan()", () => {
     assert.ok(result.includes(".B myapp"));
     assert.ok(result.includes("\\fB\\-\\-verbose\\fR"));
     assert.ok(result.includes("\\fIFILE\\fR"));
+  });
+
+  it("escapes literal usage term starting with period in SYNOPSIS", () => {
+    const page: DocPage = {
+      usage: [{ type: "literal", value: ".env" }],
+      sections: [],
+    };
+
+    const result = formatDocPageAsMan(page, minimalOptions);
+
+    assert.ok(result.includes(".SH SYNOPSIS"));
+    assert.ok(result.includes("\\&.env"));
+    assert.ok(!result.includes("\n.env\n"));
+  });
+
+  it("escapes literal doc entry term starting with period", () => {
+    const page: DocPage = {
+      sections: [
+        {
+          entries: [
+            {
+              term: { type: "literal", value: ".env" },
+              description: message`hidden env file`,
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = formatDocPageAsMan(page, minimalOptions);
+
+    assert.ok(result.includes(".TP"));
+    assert.ok(result.includes("\\&.env"));
+    assert.ok(!result.split("\n").some((l) => l === ".env"));
+  });
+
+  it("escapes literal doc entry term starting with single quote", () => {
+    const page: DocPage = {
+      sections: [
+        {
+          entries: [
+            {
+              term: { type: "literal", value: "'quoted" },
+              description: message`quoted term`,
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = formatDocPageAsMan(page, minimalOptions);
+
+    assert.ok(result.includes("\\&'quoted"));
   });
 
   it("generates DESCRIPTION section", () => {

--- a/packages/man/src/man.ts
+++ b/packages/man/src/man.ts
@@ -186,7 +186,7 @@ export function formatUsageTermAsRoff(term: UsageTerm): string {
     }
 
     case "literal":
-      return term.value;
+      return escapeRoff(term.value);
 
     case "passthrough":
       return "[...]";
@@ -242,7 +242,7 @@ function formatDocEntryTerm(term: UsageTerm): string {
       return `\\fI${term.metavar}\\fR`;
 
     case "literal":
-      return term.value;
+      return escapeRoff(term.value);
 
     default:
       return formatDocUsageTermAsRoff(term);
@@ -298,7 +298,7 @@ function formatDocUsageTermAsRoff(term: UsageTerm): string {
       return formatCommandNameAsRoff(term.name);
 
     case "literal":
-      return term.value;
+      return escapeRoff(term.value);
 
     case "passthrough":
       return "[...]";


### PR DESCRIPTION
## Summary

- `formatUsageTermAsRoff()`, `formatDocEntryTerm()`, and `formatDocUsageTermAsRoff()` emitted `literal` term values without calling `escapeRoff()`, so values starting with `.` or `'` (e.g., `.env`) were interpreted by roff as requests instead of visible text.
- Applied `escapeRoff()` to the `literal` case in all three functions so that leading `.` and `'` are escaped with `\&`.
- Added regression tests for period and single-quote escaping in both `formatUsageTermAsRoff()` and `formatDocPageAsMan()`.

Fixes https://github.com/dahlia/optique/issues/297

## Test plan

- [x] New tests for `formatUsageTermAsRoff()` with `.env` and `'quoted` literals
- [x] New tests for `formatDocPageAsMan()` verifying SYNOPSIS and `.TP` terms escape leading `.` and `'`
- [x] All existing tests pass (`mise test:deno`)