### PR TITLE
Throw `TypeError` when `Temporal` API is unavailable instead of format errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2228,6 +2228,14 @@ Released on January 6, 2026.
  -  All temporal value parsers now validate that `metavar` is non-empty,
     throwing a `TypeError` if an empty string is provided.  [[#63]]
 
+ -  Temporal parsers now throw a `TypeError` when `globalThis.Temporal` is
+    unavailable, instead of silently returning an “invalid format” error.
+    This makes it clear that the runtime lacks Temporal support and a polyfill
+    is needed.  [[#282], [#561]]
+
+[#282]: https://github.com/dahlia/optique/issues/282
+[#561]: https://github.com/dahlia/optique/pull/561
+
 ### @optique/git
 
 The *@optique/git* package was introduced in this release, providing

--- a/packages/temporal/src/index.test.ts
+++ b/packages/temporal/src/index.test.ts
@@ -1136,3 +1136,40 @@ describe("async mode integration", () => {
     });
   });
 });
+
+describe("Temporal API unavailability", () => {
+  for (
+    const [name, factory, sample] of [
+      ["instant", instant, "2020-01-23T17:04:36Z"],
+      ["duration", duration, "PT1H"],
+      [
+        "zonedDateTime",
+        zonedDateTime,
+        "2020-01-23T17:04:36+01:00[Europe/Paris]",
+      ],
+      ["plainDate", plainDate, "2020-01-23"],
+      ["plainTime", plainTime, "17:04:36"],
+      ["plainDateTime", plainDateTime, "2020-01-23T17:04:36"],
+      ["plainYearMonth", plainYearMonth, "2020-01"],
+      ["plainMonthDay", plainMonthDay, "--01-23"],
+      ["timeZone", timeZone, "UTC"],
+    ] as const
+  ) {
+    it(`${name}().parse() should throw TypeError when Temporal is unavailable`, () => {
+      const saved = globalThis.Temporal;
+      (globalThis as Record<string, unknown>).Temporal = undefined;
+      try {
+        const parser = factory();
+        assert.throws(
+          () => parser.parse(sample),
+          {
+            name: "TypeError",
+            message: /Temporal API is not available/,
+          },
+        );
+      } finally {
+        globalThis.Temporal = saved;
+      }
+    });
+  }
+});

--- a/packages/temporal/src/index.ts
+++ b/packages/temporal/src/index.ts
@@ -6,6 +6,16 @@ import {
   type NonEmptyString,
 } from "@optique/core/nonempty";
 
+function ensureTemporal(): void {
+  if (typeof globalThis.Temporal === "undefined") {
+    throw new TypeError(
+      "Temporal API is not available. " +
+        "Use a runtime with Temporal support or install a polyfill " +
+        "like @js-temporal/polyfill.",
+    );
+  }
+}
+
 /**
  * IANA Time Zone Database identifier.
  *
@@ -272,6 +282,8 @@ export interface TimeZoneOptions {
  *
  * @param options Configuration options for the instant parser.
  * @returns A ValueParser that parses strings into Temporal.Instant values.
+ * @throws {TypeError} (from `parse()`) If the Temporal API is not available
+ *   at runtime.
  */
 export function instant(
   options: InstantOptions = {},
@@ -282,6 +294,7 @@ export function instant(
     $mode: "sync",
     metavar,
     parse(input: string): ValueParserResult<Temporal.Instant> {
+      ensureTemporal();
       try {
         const value = Temporal.Instant.from(input);
         return { success: true, value };
@@ -313,6 +326,8 @@ export function instant(
  *
  * @param options Configuration options for the duration parser.
  * @returns A ValueParser that parses strings into Temporal.Duration values.
+ * @throws {TypeError} (from `parse()`) If the Temporal API is not available
+ *   at runtime.
  */
 export function duration(
   options: DurationOptions = {},
@@ -323,6 +338,7 @@ export function duration(
     $mode: "sync",
     metavar,
     parse(input: string): ValueParserResult<Temporal.Duration> {
+      ensureTemporal();
       try {
         const value = Temporal.Duration.from(input);
         return { success: true, value };
@@ -353,6 +369,8 @@ export function duration(
  *
  * @param options Configuration options for the zoned datetime parser.
  * @returns A ValueParser that parses strings into Temporal.ZonedDateTime values.
+ * @throws {TypeError} (from `parse()`) If the Temporal API is not available
+ *   at runtime.
  */
 export function zonedDateTime(
   options: ZonedDateTimeOptions = {},
@@ -363,6 +381,7 @@ export function zonedDateTime(
     $mode: "sync",
     metavar,
     parse(input: string): ValueParserResult<Temporal.ZonedDateTime> {
+      ensureTemporal();
       try {
         const value = Temporal.ZonedDateTime.from(input);
         return { success: true, value };
@@ -393,6 +412,8 @@ export function zonedDateTime(
  *
  * @param options Configuration options for the plain date parser.
  * @returns A ValueParser that parses strings into Temporal.PlainDate values.
+ * @throws {TypeError} (from `parse()`) If the Temporal API is not available
+ *   at runtime.
  */
 export function plainDate(
   options: PlainDateOptions = {},
@@ -403,6 +424,7 @@ export function plainDate(
     $mode: "sync",
     metavar,
     parse(input: string): ValueParserResult<Temporal.PlainDate> {
+      ensureTemporal();
       try {
         const value = Temporal.PlainDate.from(input);
         return { success: true, value };
@@ -433,6 +455,8 @@ export function plainDate(
  *
  * @param options Configuration options for the plain time parser.
  * @returns A ValueParser that parses strings into Temporal.PlainTime values.
+ * @throws {TypeError} (from `parse()`) If the Temporal API is not available
+ *   at runtime.
  */
 export function plainTime(
   options: PlainTimeOptions = {},
@@ -443,6 +467,7 @@ export function plainTime(
     $mode: "sync",
     metavar,
     parse(input: string): ValueParserResult<Temporal.PlainTime> {
+      ensureTemporal();
       try {
         const value = Temporal.PlainTime.from(input);
         return { success: true, value };
@@ -473,6 +498,8 @@ export function plainTime(
  *
  * @param options Configuration options for the plain datetime parser.
  * @returns A ValueParser that parses strings into Temporal.PlainDateTime values.
+ * @throws {TypeError} (from `parse()`) If the Temporal API is not available
+ *   at runtime.
  */
 export function plainDateTime(
   options: PlainDateTimeOptions = {},
@@ -483,6 +510,7 @@ export function plainDateTime(
     $mode: "sync",
     metavar,
     parse(input: string): ValueParserResult<Temporal.PlainDateTime> {
+      ensureTemporal();
       try {
         const value = Temporal.PlainDateTime.from(input);
         return { success: true, value };
@@ -513,6 +541,8 @@ export function plainDateTime(
  *
  * @param options Configuration options for the plain year-month parser.
  * @returns A ValueParser that parses strings into Temporal.PlainYearMonth values.
+ * @throws {TypeError} (from `parse()`) If the Temporal API is not available
+ *   at runtime.
  */
 export function plainYearMonth(
   options: PlainYearMonthOptions = {},
@@ -523,6 +553,7 @@ export function plainYearMonth(
     $mode: "sync",
     metavar,
     parse(input: string): ValueParserResult<Temporal.PlainYearMonth> {
+      ensureTemporal();
       try {
         const value = Temporal.PlainYearMonth.from(input);
         return { success: true, value };
@@ -553,6 +584,8 @@ export function plainYearMonth(
  *
  * @param options Configuration options for the plain month-day parser.
  * @returns A ValueParser that parses strings into Temporal.PlainMonthDay values.
+ * @throws {TypeError} (from `parse()`) If the Temporal API is not available
+ *   at runtime.
  */
 export function plainMonthDay(
   options: PlainMonthDayOptions = {},
@@ -563,6 +596,7 @@ export function plainMonthDay(
     $mode: "sync",
     metavar,
     parse(input: string): ValueParserResult<Temporal.PlainMonthDay> {
+      ensureTemporal();
       try {
         const value = Temporal.PlainMonthDay.from(input);
         return { success: true, value };
@@ -595,6 +629,8 @@ export function plainMonthDay(
  *
  * @param options Configuration options for the timezone parser.
  * @returns A ValueParser that parses and validates timezone identifiers.
+ * @throws {TypeError} (from `parse()`) If the Temporal API is not available
+ *   at runtime.
  */
 export function timeZone(
   options: TimeZoneOptions = {},
@@ -605,6 +641,7 @@ export function timeZone(
     $mode: "sync",
     metavar,
     parse(input: string): ValueParserResult<TimeZone> {
+      ensureTemporal();
       try {
         // Validate by creating a ZonedDateTime with this timezone
         // This will throw if the timezone is invalid


### PR DESCRIPTION
## Summary

Fixes https://github.com/dahlia/optique/issues/282

When `globalThis.Temporal` is unavailable, all temporal parsers (`instant`, `duration`, `zonedDateTime`, `plainDate`, `plainTime`, `plainDateTime`, `plainYearMonth`, `plainMonthDay`, `timeZone`) caught the resulting `TypeError` and misreported it as an "invalid format" error, hiding the real cause from the caller.

Now each parser's `parse()` method calls an internal `ensureTemporal()` guard before the try/catch block. If `Temporal` is undefined, a `TypeError` is thrown with a clear message telling the caller to use a polyfill or a runtime with Temporal support.

## Changes

- Added `ensureTemporal()` internal helper in `packages/temporal/src/index.ts`
- Added the `ensureTemporal()` call to all 9 parsers' `parse()` methods, before the try/catch block
- Added `@throws` JSDoc tags to all 9 factory functions
- Added tests for all 9 parsers verifying `TypeError` is thrown when `Temporal` is unavailable
- Updated CHANGES.md

## Test plan

- [x] New tests pass: all 9 parsers throw `TypeError` with `/Temporal API is not available/` when `globalThis.Temporal` is `undefined`
- [x] Existing tests remain green (Temporal is available via polyfill or native support)
- [x] `mise test` passes across Deno, Node.js, and Bun
- [x] `mise check` passes (type check, lint, format, dry-run publish)