### PR TITLE
Fix `formatUsageTermAsRoff()` and `formatDocPageAsMan()` dropping backslashes from metavar values

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -638,6 +638,11 @@ interactive prompt fallback integration via Inquirer.js.  [[#87], [#137]]
     group labels are now escaped so they render literally in the man page.
     [[#301], [#560]]
 
+ -  Fixed `formatUsageTermAsRoff()` and `formatDocPageAsMan()` dropping
+    backslashes from metavar values in usage and doc terms.  Roff consumed
+    sequences like `\T` as escapes, corrupting the rendered man page.
+    [[#298], [#563]]
+
 [#221]: https://github.com/dahlia/optique/issues/221
 [#222]: https://github.com/dahlia/optique/issues/222
 [#273]: https://github.com/dahlia/optique/issues/273
@@ -650,6 +655,7 @@ interactive prompt fallback integration via Inquirer.js.  [[#87], [#137]]
 [#286]: https://github.com/dahlia/optique/issues/286
 [#287]: https://github.com/dahlia/optique/issues/287
 [#297]: https://github.com/dahlia/optique/issues/297
+[#298]: https://github.com/dahlia/optique/issues/298
 [#301]: https://github.com/dahlia/optique/issues/301
 [#526]: https://github.com/dahlia/optique/pull/526
 [#529]: https://github.com/dahlia/optique/pull/529
@@ -664,6 +670,7 @@ interactive prompt fallback integration via Inquirer.js.  [[#87], [#137]]
 [#557]: https://github.com/dahlia/optique/pull/557
 [#559]: https://github.com/dahlia/optique/pull/559
 [#560]: https://github.com/dahlia/optique/pull/560
+[#563]: https://github.com/dahlia/optique/pull/563
 
 
 Version 0.10.7

--- a/packages/man/src/man.test.ts
+++ b/packages/man/src/man.test.ts
@@ -77,6 +77,23 @@ describe("formatUsageTermAsRoff()", () => {
     assert.equal(formatUsageTermAsRoff(term), "\\fBcmd\\\\arg\\fR");
   });
 
+  it("escapes backslashes in argument metavar", () => {
+    const term: UsageTerm = { type: "argument", metavar: "C:\\TMP" };
+    assert.equal(formatUsageTermAsRoff(term), "\\fIC:\\\\TMP\\fR");
+  });
+
+  it("escapes backslashes in option metavar", () => {
+    const term: UsageTerm = {
+      type: "option",
+      names: ["--dir"],
+      metavar: "C:\\TMP",
+    };
+    assert.equal(
+      formatUsageTermAsRoff(term),
+      "[\\fB\\-\\-dir\\fR \\fIC:\\\\TMP\\fR]",
+    );
+  });
+
   it("formats optional term", () => {
     const term: UsageTerm = {
       type: "optional",
@@ -464,6 +481,69 @@ describe("formatDocPageAsMan()", () => {
     const result = formatDocPageAsMan(page, minimalOptions);
 
     assert.ok(result.includes("\\&'quoted"));
+  });
+
+  it("escapes backslashes in argument metavar in SYNOPSIS", () => {
+    const page: DocPage = {
+      usage: [{ type: "argument", metavar: "C:\\TMP" }],
+      sections: [],
+    };
+
+    const result = formatDocPageAsMan(page, minimalOptions);
+
+    assert.ok(result.includes("\\fIC:\\\\TMP\\fR"));
+    assert.ok(!result.includes("\\fIC:\\TMP\\fR"));
+  });
+
+  it("escapes backslashes in option metavar in SYNOPSIS", () => {
+    const page: DocPage = {
+      usage: [{ type: "option", names: ["--dir"], metavar: "C:\\TMP" }],
+      sections: [],
+    };
+
+    const result = formatDocPageAsMan(page, minimalOptions);
+
+    assert.ok(result.includes("\\fIC:\\\\TMP\\fR"));
+  });
+
+  it("escapes backslashes in argument metavar in doc entry", () => {
+    const page: DocPage = {
+      sections: [
+        {
+          entries: [
+            {
+              term: { type: "argument", metavar: "C:\\TMP" },
+              description: message`a path`,
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = formatDocPageAsMan(page, minimalOptions);
+
+    assert.ok(result.includes(".TP"));
+    assert.ok(result.includes("\\fIC:\\\\TMP\\fR"));
+  });
+
+  it("escapes backslashes in option metavar in doc entry", () => {
+    const page: DocPage = {
+      sections: [
+        {
+          entries: [
+            {
+              term: { type: "option", names: ["--dir"], metavar: "C:\\TMP" },
+              description: message`a path`,
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = formatDocPageAsMan(page, minimalOptions);
+
+    assert.ok(result.includes(".TP"));
+    assert.ok(result.includes("\\fIC:\\\\TMP\\fR"));
   });
 
   it("escapes backslashes in section titles", () => {

--- a/packages/man/src/man.ts
+++ b/packages/man/src/man.ts
@@ -153,13 +153,15 @@ export function formatUsageTermAsRoff(term: UsageTerm): string {
 
   switch (term.type) {
     case "argument":
-      return `\\fI${term.metavar}\\fR`;
+      return `\\fI${escapeRoff(term.metavar)}\\fR`;
 
     case "option": {
       const names = term.names
         .map((name) => `\\fB${escapeHyphens(name)}\\fR`)
         .join(" | ");
-      const metavarPart = term.metavar ? ` \\fI${term.metavar}\\fR` : "";
+      const metavarPart = term.metavar
+        ? ` \\fI${escapeRoff(term.metavar)}\\fR`
+        : "";
       return `[${names}${metavarPart}]`;
     }
 
@@ -236,7 +238,9 @@ function formatDocEntryTerm(term: UsageTerm): string {
       const names = term.names
         .map((name) => `\\fB${escapeHyphens(name)}\\fR`)
         .join(", ");
-      const metavarPart = term.metavar ? ` \\fI${term.metavar}\\fR` : "";
+      const metavarPart = term.metavar
+        ? ` \\fI${escapeRoff(term.metavar)}\\fR`
+        : "";
       return `${names}${metavarPart}`;
     }
 
@@ -244,7 +248,7 @@ function formatDocEntryTerm(term: UsageTerm): string {
       return formatCommandNameAsRoff(term.name);
 
     case "argument":
-      return `\\fI${term.metavar}\\fR`;
+      return `\\fI${escapeRoff(term.metavar)}\\fR`;
 
     case "literal":
       return escapeRoff(term.value);
@@ -289,13 +293,15 @@ function formatDocUsageTermAsRoff(term: UsageTerm): string {
     }
 
     case "argument":
-      return `\\fI${term.metavar}\\fR`;
+      return `\\fI${escapeRoff(term.metavar)}\\fR`;
 
     case "option": {
       const names = term.names
         .map((name) => `\\fB${escapeHyphens(name)}\\fR`)
         .join(", ");
-      const metavarPart = term.metavar ? ` \\fI${term.metavar}\\fR` : "";
+      const metavarPart = term.metavar
+        ? ` \\fI${escapeRoff(term.metavar)}\\fR`
+        : "";
       return `${names}${metavarPart}`;
     }
 


### PR DESCRIPTION
## Summary

- `formatUsageTermAsRoff()`, `formatDocEntryTerm()`, and `formatDocUsageTermAsRoff()` interpolated `term.metavar` values into roff font-change sequences (`\fI...\fR`) without calling `escapeRoff()`, so roff consumed sequences like `\T` as escapes, corrupting the rendered man page (e.g., `C:\TMP` became `C:TMP`).
- Applied `escapeRoff()` to all 6 locations where metavar values were interpolated raw.

## Test plan

- [x] Added regression tests for `formatUsageTermAsRoff()` with backslashes in argument and option metavars
- [x] Added regression tests for `formatDocPageAsMan()` with backslashes in argument/option metavars in both SYNOPSIS and doc entry (`.TP`) contexts
- [x] All 6 new tests fail before the fix, pass after
- [x] Full test suite passes on Deno and Bun (Node failure is pre-existing, unrelated PowerShell completion test)

Closes https://github.com/dahlia/optique/issues/298