### PR TITLE
Treat empty `date`, `version`, and `manual` strings as absent in `formatDocPageAsMan()`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -643,6 +643,11 @@ interactive prompt fallback integration via Inquirer.js.  [[#87], [#137]]
     sequences like `\T` as escapes, corrupting the rendered man page.
     [[#298], [#563]]
 
+ -  Fixed `formatDocPageAsMan()` treating empty `date`, `version`, and
+    `manual` strings as present values, producing malformed `.TH` headers
+    with empty quoted fields.  Empty strings are now treated as absent.
+    [[#303], [#564]]
+
 [#221]: https://github.com/dahlia/optique/issues/221
 [#222]: https://github.com/dahlia/optique/issues/222
 [#273]: https://github.com/dahlia/optique/issues/273
@@ -657,6 +662,7 @@ interactive prompt fallback integration via Inquirer.js.  [[#87], [#137]]
 [#297]: https://github.com/dahlia/optique/issues/297
 [#298]: https://github.com/dahlia/optique/issues/298
 [#301]: https://github.com/dahlia/optique/issues/301
+[#303]: https://github.com/dahlia/optique/issues/303
 [#526]: https://github.com/dahlia/optique/pull/526
 [#529]: https://github.com/dahlia/optique/pull/529
 [#532]: https://github.com/dahlia/optique/pull/532
@@ -671,6 +677,7 @@ interactive prompt fallback integration via Inquirer.js.  [[#87], [#137]]
 [#559]: https://github.com/dahlia/optique/pull/559
 [#560]: https://github.com/dahlia/optique/pull/560
 [#563]: https://github.com/dahlia/optique/pull/563
+[#564]: https://github.com/dahlia/optique/pull/564
 
 
 Version 0.10.7

--- a/packages/man/src/man.test.ts
+++ b/packages/man/src/man.test.ts
@@ -399,6 +399,19 @@ describe("formatDocPageAsMan()", () => {
     );
   });
 
+  it("treats empty header strings as absent", () => {
+    const page: DocPage = { sections: [] };
+    const result = formatDocPageAsMan(page, {
+      name: "myapp",
+      section: 1,
+      date: "",
+      version: "",
+      manual: "",
+    });
+    const thLine = result.split("\n").find((l) => l.startsWith(".TH"))!;
+    assert.equal(thLine, ".TH MYAPP 1");
+  });
+
   it("uses brief in NAME section", () => {
     const page: DocPage = {
       brief: message`A sample CLI application`,

--- a/packages/man/src/man.ts
+++ b/packages/man/src/man.ts
@@ -430,9 +430,9 @@ export function formatDocPageAsMan(
   ];
   // .TH format: name section [date [source [manual]]]
   // Earlier positional args must be present (as "") if later ones are used.
-  const hasDate = options.date != null;
-  const hasVersion = options.version != null;
-  const hasManual = options.manual != null;
+  const hasDate = options.date != null && options.date !== "";
+  const hasVersion = options.version != null && options.version !== "";
+  const hasManual = options.manual != null && options.manual !== "";
 
   if (hasDate) {
     thParts.push(`"${escapeThField(formatDateForMan(options.date)!)}"`);


### PR DESCRIPTION
## Summary

- `formatDocPageAsMan()` treated empty strings for `date`, `version`, and `manual` as present values due to `!= null` checks, producing malformed `.TH` headers like `.TH MYAPP 1 "" "myapp " ""`.
- Empty strings are now treated as absent (equivalent to `undefined`), so they no longer emit empty quoted fields in the `.TH` header.

Closes https://github.com/dahlia/optique/issues/303

## Test plan

- [x] Added regression test confirming `formatDocPageAsMan()` with all three fields set to `""` produces `.TH MYAPP 1`
- [ ] Verify existing `.TH` header tests still pass
- [ ] Run `mise test` across all runtimes