### PR TITLE
Fix `locale().format()` dropping Unicode extension subtags

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -103,6 +103,11 @@ To be released.
     annotation object).  This affects annotation-enabled parse/run paths,
     including `runWith()` and `runWithSync()`.  [[#146]]
 
+ -  Fixed `locale()` value parser's `format()` method dropping Unicode
+    extension subtags (e.g., `en-US-u-ca-buddhist` was formatted as `en-US`).
+    The method now uses `Intl.Locale.toString()` instead of `baseName` to
+    preserve the full locale identifier.  [[#317], [#565]]
+
  -  Extended `hidden` visibility controls from `boolean` to
     `boolean | "usage" | "doc" | "help"` across primitive parsers:
     `option()`, `flag()`, `argument()`, `command()`, and `passThrough()`.
@@ -337,6 +342,7 @@ To be released.
 [#242]: https://github.com/dahlia/optique/issues/242
 [#248]: https://github.com/dahlia/optique/issues/248
 [#310]: https://github.com/dahlia/optique/issues/310
+[#317]: https://github.com/dahlia/optique/issues/317
 [#332]: https://github.com/dahlia/optique/issues/332
 [#353]: https://github.com/dahlia/optique/issues/353
 [#363]: https://github.com/dahlia/optique/issues/363
@@ -364,6 +370,7 @@ To be released.
 [#553]: https://github.com/dahlia/optique/pull/553
 [#554]: https://github.com/dahlia/optique/pull/554
 [#555]: https://github.com/dahlia/optique/pull/555
+[#565]: https://github.com/dahlia/optique/pull/565
 
 ### @optique/config
 

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -9239,6 +9239,14 @@ describe("branch coverage regressions", () => {
     });
     assert.ok(!localeParser.parse("xyz-INVALID-123").success);
     assert.equal(localeParser.format(new Intl.Locale("en-US")), "en-US");
+    assert.equal(
+      localeParser.format(new Intl.Locale("en-US-u-ca-buddhist")),
+      "en-US-u-ca-buddhist",
+    );
+    assert.equal(
+      localeParser.format(new Intl.Locale("zh-Hant-TW-u-nu-hanidec")),
+      "zh-Hant-TW-u-nu-hanidec",
+    );
 
     const uuidParser = uuid({
       allowedVersions: [4],

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -1359,7 +1359,7 @@ export function locale(
       return { success: true, value: locale };
     },
     format(value: Intl.Locale): string {
-      return value.baseName;
+      return value.toString();
     },
     *suggest(prefix: string): Iterable<Suggestion> {
       // Since Intl.supportedValuesOf doesn't support 'locale', we use a curated list


### PR DESCRIPTION
## Summary

- `locale()` value parser's `format()` method used `Intl.Locale.baseName`, which strips Unicode extension subtags (e.g., `en-US-u-ca-buddhist` was formatted as `en-US`)
- Changed to use `Intl.Locale.toString()` to preserve the full locale identifier, fixing round-tripping of locale values

Closes https://github.com/dahlia/optique/issues/317

## Test plan

- [x] Added regression tests for `format()` with Unicode extension subtags (`en-US-u-ca-buddhist`, `zh-Hant-TW-u-nu-hanidec`)
- [x] All existing locale tests still pass
- [x] Verified across Deno, Node.js, and Bun runtimes (`mise test`)