### PR TITLE
Add regression tests for `portRange({ type: "bigint" })` input validation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -332,10 +332,11 @@ To be released.
     allowing private field access to work correctly through the sanitized
     view.  [[#307], [#558]]
 
- -  Fixed `integer({ type: "bigint" })` and `port({ type: "bigint" })` to
-    reject empty strings, whitespace, signed-plus strings, and non-decimal
-    literals (`0x`, `0b`, `0o`) that the `BigInt()` constructor would
-    otherwise accept.  [[#245], [#566]]
+ -  Fixed `integer({ type: "bigint" })`, `port({ type: "bigint" })`, and
+    `portRange({ type: "bigint" })` to reject empty strings, whitespace,
+    signed-plus strings, and non-decimal literals (`0x`, `0b`, `0o`) that
+    the `BigInt()` constructor would otherwise accept.
+    [[#245], [#249], [#566], [#572]]
 
 [#110]: https://github.com/dahlia/optique/issues/110
 [#113]: https://github.com/dahlia/optique/issues/113
@@ -368,6 +369,7 @@ To be released.
 [#242]: https://github.com/dahlia/optique/issues/242
 [#245]: https://github.com/dahlia/optique/issues/245
 [#248]: https://github.com/dahlia/optique/issues/248
+[#249]: https://github.com/dahlia/optique/issues/249
 [#307]: https://github.com/dahlia/optique/issues/307
 [#310]: https://github.com/dahlia/optique/issues/310
 [#315]: https://github.com/dahlia/optique/issues/315
@@ -404,6 +406,7 @@ To be released.
 [#565]: https://github.com/dahlia/optique/pull/565
 [#566]: https://github.com/dahlia/optique/pull/566
 [#568]: https://github.com/dahlia/optique/pull/568
+[#572]: https://github.com/dahlia/optique/pull/572
 
 ### @optique/config
 

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -6612,6 +6612,31 @@ describe("portRange()", () => {
         { type: "text", text: "." },
       ]);
     });
+
+    it("should reject non-decimal literals in ranges", () => {
+      const parser = portRange({ type: "bigint" });
+
+      // Plus-signed
+      assert.ok(!parser.parse("+80-81").success);
+
+      // Hex literals
+      assert.ok(!parser.parse("0x50-0x51").success);
+
+      // Binary literals
+      assert.ok(!parser.parse("0b1010000-0b1010001").success);
+
+      // Octal literals
+      assert.ok(!parser.parse("0o120-0o121").success);
+    });
+
+    it("should reject non-decimal literals in single port mode", () => {
+      const parser = portRange({ type: "bigint", allowSingle: true });
+
+      assert.ok(!parser.parse("+80").success);
+      assert.ok(!parser.parse("0x50").success);
+      assert.ok(!parser.parse("0b1010000").success);
+      assert.ok(!parser.parse("0o120").success);
+    });
   });
 
   describe("allowSingle option", () => {


### PR DESCRIPTION
## Summary

- Added regression tests confirming `portRange({ type: "bigint" })` rejects non-decimal BigInt literals (`+80-81`, `0x50-0x51`, `0b1010000-0b1010001`, `0o120-0o121`) in both range and single-port modes
- Updated CHANGES.md to mention `portRange({ type: "bigint" })` alongside the existing `integer()`/`port()` fix entry from #566, and linked #249

## Context

The root cause was already fixed by #566 (for #245), which added `/^-?\d+$/` regex validation to `port()`'s bigint branch. Since `portRange()` delegates port validation to `port()`, the fix extends to it automatically. However, there were no dedicated regression tests for `portRange()`, and CHANGES.md did not mention it.

Closes #249