### PR TITLE
Validate boolean options in `port()` and `portRange()`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -287,6 +287,16 @@ To be released.
     enabled case-insensitive matching due to JavaScript truthiness coercion.
     [[#389], [#548]]
 
+ -  Changed `port()` to reject non-boolean `disallowWellKnown` option values
+    at runtime.  Previously, truthy non-boolean values like `"no"` silently
+    enabled well-known port restrictions due to JavaScript truthiness coercion.
+    [[#370], [#573]]
+
+ -  Changed `portRange()` to reject non-boolean `disallowWellKnown` and
+    `allowSingle` option values at runtime.  Previously, truthy non-boolean
+    values like `"no"` silently enabled those behaviors due to JavaScript
+    truthiness coercion.  [[#370], [#573]]
+
  -  Changed `choice()` to throw `TypeError` when `NaN` is included in the
     number choices array.  Previously, `NaN` was silently filtered out but
     still advertised in suggestions and help output, creating an unsatisfiable
@@ -377,6 +387,7 @@ To be released.
 [#332]: https://github.com/dahlia/optique/issues/332
 [#353]: https://github.com/dahlia/optique/issues/353
 [#363]: https://github.com/dahlia/optique/issues/363
+[#370]: https://github.com/dahlia/optique/issues/370
 [#371]: https://github.com/dahlia/optique/issues/371
 [#385]: https://github.com/dahlia/optique/issues/385
 [#388]: https://github.com/dahlia/optique/issues/388
@@ -407,6 +418,7 @@ To be released.
 [#566]: https://github.com/dahlia/optique/pull/566
 [#568]: https://github.com/dahlia/optique/pull/568
 [#572]: https://github.com/dahlia/optique/pull/572
+[#573]: https://github.com/dahlia/optique/pull/573
 
 ### @optique/config
 

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -5227,6 +5227,54 @@ describe("port", () => {
     });
   });
 
+  describe("boolean option validation", () => {
+    it("should reject non-boolean disallowWellKnown option", () => {
+      assert.throws(
+        () => port({ disallowWellKnown: "no" as never }),
+        TypeError,
+      );
+      assert.throws(
+        () => port({ disallowWellKnown: 1 as never }),
+        TypeError,
+      );
+      assert.throws(
+        () => port({ disallowWellKnown: "true" as never }),
+        TypeError,
+      );
+      assert.throws(
+        () => port({ disallowWellKnown: 0 as never }),
+        TypeError,
+      );
+      assert.throws(
+        () => port({ disallowWellKnown: null as never }),
+        TypeError,
+      );
+    });
+
+    it("should reject non-boolean disallowWellKnown option (bigint)", () => {
+      assert.throws(
+        () => port({ type: "bigint", disallowWellKnown: "no" as never }),
+        TypeError,
+      );
+      assert.throws(
+        () => port({ type: "bigint", disallowWellKnown: 1 as never }),
+        TypeError,
+      );
+      assert.throws(
+        () => port({ type: "bigint", disallowWellKnown: "true" as never }),
+        TypeError,
+      );
+      assert.throws(
+        () => port({ type: "bigint", disallowWellKnown: 0 as never }),
+        TypeError,
+      );
+      assert.throws(
+        () => port({ type: "bigint", disallowWellKnown: null as never }),
+        TypeError,
+      );
+    });
+  });
+
   describe("ipv4()", () => {
     describe("basic validation", () => {
       it("should accept valid IPv4 addresses", () => {
@@ -6938,6 +6986,100 @@ describe("portRange()", () => {
       // Well-known port rejected
       const result3 = parser.parse("80-443");
       assert.ok(!result3.success);
+    });
+  });
+
+  describe("boolean option validation", () => {
+    it("should reject non-boolean disallowWellKnown option", () => {
+      assert.throws(
+        () => portRange({ disallowWellKnown: "no" as never }),
+        TypeError,
+      );
+      assert.throws(
+        () => portRange({ disallowWellKnown: 1 as never }),
+        TypeError,
+      );
+      assert.throws(
+        () => portRange({ disallowWellKnown: "true" as never }),
+        TypeError,
+      );
+      assert.throws(
+        () => portRange({ disallowWellKnown: 0 as never }),
+        TypeError,
+      );
+      assert.throws(
+        () => portRange({ disallowWellKnown: null as never }),
+        TypeError,
+      );
+    });
+
+    it("should reject non-boolean disallowWellKnown option (bigint)", () => {
+      assert.throws(
+        () => portRange({ type: "bigint", disallowWellKnown: "no" as never }),
+        TypeError,
+      );
+      assert.throws(
+        () => portRange({ type: "bigint", disallowWellKnown: 1 as never }),
+        TypeError,
+      );
+      assert.throws(
+        () => portRange({ type: "bigint", disallowWellKnown: "true" as never }),
+        TypeError,
+      );
+      assert.throws(
+        () => portRange({ type: "bigint", disallowWellKnown: 0 as never }),
+        TypeError,
+      );
+      assert.throws(
+        () => portRange({ type: "bigint", disallowWellKnown: null as never }),
+        TypeError,
+      );
+    });
+
+    it("should reject non-boolean allowSingle option", () => {
+      assert.throws(
+        () => portRange({ allowSingle: "no" as never }),
+        TypeError,
+      );
+      assert.throws(
+        () => portRange({ allowSingle: 1 as never }),
+        TypeError,
+      );
+      assert.throws(
+        () => portRange({ allowSingle: "true" as never }),
+        TypeError,
+      );
+      assert.throws(
+        () => portRange({ allowSingle: 0 as never }),
+        TypeError,
+      );
+      assert.throws(
+        () => portRange({ allowSingle: null as never }),
+        TypeError,
+      );
+    });
+
+    it("should reject non-boolean allowSingle option (bigint)", () => {
+      assert.throws(
+        () => portRange({ type: "bigint", allowSingle: "no" as never }),
+        TypeError,
+      );
+      assert.throws(
+        () => portRange({ type: "bigint", allowSingle: 1 as never }),
+        TypeError,
+      );
+      assert.throws(
+        () => portRange({ type: "bigint", allowSingle: "true" as never }),
+        TypeError,
+      );
+      assert.throws(
+        () => portRange({ type: "bigint", allowSingle: 0 as never }),
+        TypeError,
+      );
+      assert.throws(
+        () => portRange({ type: "bigint", allowSingle: null as never }),
+        TypeError,
+      );
     });
   });
 });

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -1969,6 +1969,16 @@ export function port(
 export function port(
   options?: PortOptionsNumber | PortOptionsBigInt,
 ): ValueParser<"sync", number> | ValueParser<"sync", bigint> {
+  if (
+    options?.disallowWellKnown !== undefined &&
+    typeof options.disallowWellKnown !== "boolean"
+  ) {
+    throw new TypeError(
+      `Expected disallowWellKnown to be a boolean, but got ` +
+        `${typeof options.disallowWellKnown}: ` +
+        `${String(options.disallowWellKnown)}.`,
+    );
+  }
   if (options?.type === "bigint") {
     const metavar = options.metavar ?? "PORT";
     ensureNonEmptyString(metavar);
@@ -3501,6 +3511,26 @@ export function portRange(
 export function portRange(
   options?: PortRangeOptionsNumber | PortRangeOptionsBigInt,
 ): ValueParser<"sync", PortRangeValueNumber | PortRangeValueBigInt> {
+  if (
+    options?.disallowWellKnown !== undefined &&
+    typeof options.disallowWellKnown !== "boolean"
+  ) {
+    throw new TypeError(
+      `Expected disallowWellKnown to be a boolean, but got ` +
+        `${typeof options.disallowWellKnown}: ` +
+        `${String(options.disallowWellKnown)}.`,
+    );
+  }
+  if (
+    options?.allowSingle !== undefined &&
+    typeof options.allowSingle !== "boolean"
+  ) {
+    throw new TypeError(
+      `Expected allowSingle to be a boolean, but got ` +
+        `${typeof options.allowSingle}: ` +
+        `${String(options.allowSingle)}.`,
+    );
+  }
   const metavar: NonEmptyString = options?.metavar ?? "PORT-PORT";
   ensureNonEmptyString(metavar);
 


### PR DESCRIPTION
## Summary

- `port()` now throws `TypeError` when `disallowWellKnown` receives a non-boolean value at runtime
- `portRange()` now throws `TypeError` when `disallowWellKnown` or `allowSingle` receives a non-boolean value at runtime
- Previously, truthy non-boolean values like `"no"` silently enabled those behaviors due to JavaScript truthiness coercion

Closes https://github.com/dahlia/optique/issues/370

## Test plan

- [x] Added regression tests for `port()` with non-boolean `disallowWellKnown` (both number and bigint variants)
- [x] Added regression tests for `portRange()` with non-boolean `disallowWellKnown` (both number and bigint variants)
- [x] Added regression tests for `portRange()` with non-boolean `allowSingle` (both number and bigint variants)
- [x] All existing tests pass across Deno, Node.js, and Bun
- [x] Type check, lint, and format check pass