### PR TITLE
Validate `seeAlso[].section` in `formatDocPageAsMan()`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -675,6 +675,12 @@ interactive prompt fallback integration via Inquirer.js.  [[#87], [#137]]
 
 ### @optique/man
 
+ -  Changed `ManPageOptions.seeAlso[].section` type from `number` to
+    `ManPageSection` and added runtime validation that rejects invalid section
+    numbers (must be integers 1–8).  Previously, fractional or negative numbers
+    were silently serialized into malformed `.BR` cross-references.
+    [[#380], [#578]]
+
  -  `generateManPageSync()`, `generateManPageAsync()`, and `generateManPage()`
     now validate that the input is a genuine Optique `Parser` or `Program`
     up front, instead of accepting malformed objects and crashing with an
@@ -774,6 +780,7 @@ interactive prompt fallback integration via Inquirer.js.  [[#87], [#137]]
 [#302]: https://github.com/dahlia/optique/issues/302
 [#303]: https://github.com/dahlia/optique/issues/303
 [#305]: https://github.com/dahlia/optique/issues/305
+[#380]: https://github.com/dahlia/optique/issues/380
 [#526]: https://github.com/dahlia/optique/pull/526
 [#529]: https://github.com/dahlia/optique/pull/529
 [#532]: https://github.com/dahlia/optique/pull/532
@@ -791,6 +798,7 @@ interactive prompt fallback integration via Inquirer.js.  [[#87], [#137]]
 [#564]: https://github.com/dahlia/optique/pull/564
 [#567]: https://github.com/dahlia/optique/pull/567
 [#574]: https://github.com/dahlia/optique/pull/574
+[#578]: https://github.com/dahlia/optique/pull/578
 
 
 Version 0.10.7

--- a/packages/man/src/compat.test.ts
+++ b/packages/man/src/compat.test.ts
@@ -134,8 +134,8 @@ It supports multiple options and arguments, and can be used as a reference for t
       author: message`Hong Minhee <hong@minhee.org>`,
       bugs: message`Report bugs at https://github.com/dahlia/optique/issues`,
       seeAlso: [
-        { name: "git", section: 1 },
-        { name: "make", section: 1 },
+        { name: "git", section: 1 as const },
+        { name: "make", section: 1 as const },
       ],
     };
 

--- a/packages/man/src/man.test.ts
+++ b/packages/man/src/man.test.ts
@@ -1663,4 +1663,22 @@ describe("formatDocPageAsMan()", () => {
       );
     }
   });
+
+  it("rejects invalid seeAlso section numbers", () => {
+    const page: DocPage = {
+      sections: [],
+    };
+
+    for (const section of [0, 9, -1, 99, 1.5] as never[]) {
+      assert.throws(
+        () =>
+          formatDocPageAsMan(page, {
+            name: "myapp",
+            section: 1,
+            seeAlso: [{ name: "git", section }],
+          }),
+        RangeError,
+      );
+    }
+  });
 });

--- a/packages/man/src/man.ts
+++ b/packages/man/src/man.ts
@@ -81,7 +81,7 @@ export interface ManPageOptions {
    * Cross-references to include in the SEE ALSO section.
    */
   readonly seeAlso?: ReadonlyArray<
-    { readonly name: string; readonly section: number }
+    { readonly name: string; readonly section: ManPageSection }
   >;
 
   /**
@@ -397,8 +397,8 @@ function formatDocSectionEntries(section: DocSection): string {
  * @param options The man page options.
  * @returns The complete man page in roff format.
  * @throws {TypeError} If the program name is empty.
- * @throws {RangeError} If the section number is not a valid man page section
- * (1–8).
+ * @throws {RangeError} If the section number or any `seeAlso` entry's section
+ * number is not a valid man page section (1–8).
  * @since 0.10.0
  */
 export function formatDocPageAsMan(
@@ -538,6 +538,24 @@ export function formatDocPageAsMan(
 
   // .SH SEE ALSO
   if (options.seeAlso && options.seeAlso.length > 0) {
+    for (const ref of options.seeAlso) {
+      if (
+        !Number.isInteger(ref.section) ||
+        ref.section < 1 ||
+        ref.section > 8
+      ) {
+        let repr: string;
+        try {
+          repr = JSON.stringify(ref.section);
+        } catch {
+          repr = String(typeof ref.section);
+        }
+        throw new RangeError(
+          `Invalid man page section number for seeAlso entry ` +
+            `${JSON.stringify(ref.name)} (must be 1–8): ${repr}`,
+        );
+      }
+    }
     lines.push(".SH SEE ALSO");
     const refs = options.seeAlso.map((ref, i) => {
       const suffix = i < options.seeAlso!.length - 1 ? "," : "";


### PR DESCRIPTION
## Summary

- Narrowed `ManPageOptions.seeAlso[].section` type from `number` to `ManPageSection` (integers 1–8)
- Added runtime validation that rejects invalid `seeAlso[].section` values with `RangeError`, matching the existing top-level `section` validation

Closes https://github.com/dahlia/optique/issues/380