### PR TITLE
Add regression tests for `contextOptions` collision with runner option names

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,7 +28,8 @@ To be released.
  -  Context-required options passed to `runWith()`, `runWithSync()`, and
     `runWithAsync()` must now be wrapped in a `contextOptions` property
     instead of being passed as top-level keys.  This prevents name collisions
-    with runner options such as `args`, `help`, and `colors`.  [[#240], [#575]]
+    with runner options such as `args`, `help`, and `colors`.
+    [[#240], [#241], [#575], [#581]]
 
  -  Added `fail<T>()` parser: always fails without consuming input, declared
     to produce a value of type `T`.  Its primary use is as the inner parser
@@ -393,6 +394,7 @@ To be released.
 [#225]: https://github.com/dahlia/optique/issues/225
 [#235]: https://github.com/dahlia/optique/issues/235
 [#240]: https://github.com/dahlia/optique/issues/240
+[#241]: https://github.com/dahlia/optique/issues/241
 [#242]: https://github.com/dahlia/optique/issues/242
 [#245]: https://github.com/dahlia/optique/issues/245
 [#248]: https://github.com/dahlia/optique/issues/248
@@ -441,6 +443,7 @@ To be released.
 [#575]: https://github.com/dahlia/optique/pull/575
 [#576]: https://github.com/dahlia/optique/pull/576
 [#579]: https://github.com/dahlia/optique/pull/579
+[#581]: https://github.com/dahlia/optique/pull/581
 
 ### @optique/config
 
@@ -682,7 +685,8 @@ interactive prompt fallback integration via Inquirer.js.  [[#87], [#137]]
  -  Context-required options passed to `run()`, `runSync()`, and `runAsync()`
     must now be wrapped in a `contextOptions` property instead of being
     passed as top-level keys.  This prevents name collisions with runner
-    options such as `help`, `programName`, and `version`.  [[#240], [#575]]
+    options such as `help`, `programName`, and `version`.
+    [[#240], [#241], [#575], [#581]]
 
 [#112]: https://github.com/dahlia/optique/issues/112
 [#160]: https://github.com/dahlia/optique/issues/160

--- a/packages/core/src/facade.test.ts
+++ b/packages/core/src/facade.test.ts
@@ -4685,6 +4685,35 @@ describe("runWith", () => {
       );
     });
 
+    it("should forward contextOptions.help without collision with runner help config", async () => {
+      let receivedOptions: unknown;
+      const key = Symbol.for("@test/contextOptions-help-collision");
+
+      const context: SourceContext<{ help: string; programName: string }> = {
+        id: key,
+        getAnnotations(_parsed?: unknown, options?: unknown) {
+          receivedOptions = options;
+          return {};
+        },
+      };
+
+      const parser = object({
+        name: withDefault(option("--name", string()), "default"),
+      });
+
+      await runWith(parser, "test", [context], {
+        args: [],
+        help: { option: true, onShow: () => undefined },
+        contextOptions: { help: "from-context", programName: "my-program" },
+      });
+
+      // Context should receive contextOptions, not runner help config
+      assert.ok(receivedOptions != null);
+      const opts = receivedOptions as Record<string, unknown>;
+      assert.equal(opts.help, "from-context");
+      assert.equal(opts.programName, "my-program");
+    });
+
     it("should not require contextOptions for SourceContext<{}>", async () => {
       const key = Symbol.for("@test/empty-object-context");
 
@@ -5255,6 +5284,35 @@ describe("runWithSync", () => {
         (receivedOptions as Record<string, unknown>).custom,
         "sync-value",
       );
+    });
+
+    it("should forward contextOptions without collision with runner option keys", () => {
+      let receivedOptions: unknown;
+      const key = Symbol.for("@test/sync-contextOptions-collision");
+
+      const context: SourceContext<{ help: string; programName: string }> = {
+        id: key,
+        getAnnotations(_parsed?: unknown, options?: unknown) {
+          receivedOptions = options;
+          return {};
+        },
+      };
+
+      const parser = object({
+        name: withDefault(option("--name", string()), "default"),
+      });
+
+      runWithSync(parser, "test", [context], {
+        args: [],
+        help: { option: true, onShow: () => undefined },
+        contextOptions: { help: "ctx-help", programName: "ctx-program" },
+      });
+
+      // Context should receive contextOptions, not runner options
+      assert.ok(receivedOptions != null);
+      const opts = receivedOptions as Record<string, unknown>;
+      assert.equal(opts.help, "ctx-help");
+      assert.equal(opts.programName, "ctx-program");
     });
   });
 });


### PR DESCRIPTION
## Summary

- Add regression tests for the exact scenario described in #241: contexts declaring required options with names like `help` and `programName` that collide with built-in runner option names.
- Cover both `runWith()` and `runWithSync()` in `@optique/core/facade`.
- Reference #241 in the existing `contextOptions` entries in CHANGES.md.

The underlying fix was already shipped in #575 (for #240), which introduced the `contextOptions` namespace. This PR adds test coverage for the specific collision case described in #241 and attributes it properly.

Closes #241