### PR TITLE
Reject async parsers in `generateManPageSync()` at runtime

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -799,6 +799,11 @@ interactive prompt fallback integration via Inquirer.js.  [[#87], [#137]]
     spaces, backslashes, or quotes were corrupted by the renderer because
     roff parsed them as macro syntax.  [[#302], [#574]]
 
+ -  `generateManPageSync()` now throws `TypeError` at runtime when given an
+    async parser or program.  Previously it silently produced output; now
+    callers must use `generateManPageAsync()` or `generateManPage()` for async
+    parsers.  [[#291], [#584]]
+
 [#221]: https://github.com/dahlia/optique/issues/221
 [#222]: https://github.com/dahlia/optique/issues/222
 [#273]: https://github.com/dahlia/optique/issues/273
@@ -810,6 +815,7 @@ interactive prompt fallback integration via Inquirer.js.  [[#87], [#137]]
 [#283]: https://github.com/dahlia/optique/issues/283
 [#286]: https://github.com/dahlia/optique/issues/286
 [#287]: https://github.com/dahlia/optique/issues/287
+[#291]: https://github.com/dahlia/optique/issues/291
 [#297]: https://github.com/dahlia/optique/issues/297
 [#298]: https://github.com/dahlia/optique/issues/298
 [#301]: https://github.com/dahlia/optique/issues/301
@@ -835,6 +841,7 @@ interactive prompt fallback integration via Inquirer.js.  [[#87], [#137]]
 [#567]: https://github.com/dahlia/optique/pull/567
 [#574]: https://github.com/dahlia/optique/pull/574
 [#578]: https://github.com/dahlia/optique/pull/578
+[#584]: https://github.com/dahlia/optique/pull/584
 
 
 Version 0.10.7

--- a/packages/man/src/generator.test.ts
+++ b/packages/man/src/generator.test.ts
@@ -385,6 +385,78 @@ describe("generateManPageSync()", () => {
     assert.ok(result.includes('.TH "FALLBACK" 1'));
     assert.ok(result.includes(".SH NAME"));
   });
+
+  it("rejects an async parser at runtime", () => {
+    const asyncParser: Parser<"async", string, null> = {
+      $mode: "async",
+      $valueType: [] as readonly string[],
+      $stateType: [] as readonly null[],
+      priority: 0,
+      usage: [],
+      initialState: null,
+      parse() {
+        return Promise.resolve({
+          success: false as const,
+          consumed: 0,
+          error: message`stop.`,
+        });
+      },
+      complete() {
+        return Promise.resolve({ success: true as const, value: "ok" });
+      },
+      async *suggest() {},
+      getDocFragments() {
+        return { fragments: [] };
+      },
+    };
+
+    assert.throws(
+      () =>
+        generateManPageSync(asyncParser as never, {
+          name: "myapp",
+          section: 1,
+        }),
+      { name: "TypeError", message: /async/ },
+    );
+  });
+
+  it("rejects an async program at runtime", () => {
+    const asyncParser: Parser<"async", string, null> = {
+      $mode: "async",
+      $valueType: [] as readonly string[],
+      $stateType: [] as readonly null[],
+      priority: 0,
+      usage: [],
+      initialState: null,
+      parse() {
+        return Promise.resolve({
+          success: false as const,
+          consumed: 0,
+          error: message`stop.`,
+        });
+      },
+      complete() {
+        return Promise.resolve({ success: true as const, value: "ok" });
+      },
+      async *suggest() {},
+      getDocFragments() {
+        return { fragments: [] };
+      },
+    };
+
+    const asyncProgram = defineProgram({
+      parser: asyncParser,
+      metadata: { name: "myapp" },
+    });
+
+    assert.throws(
+      () =>
+        generateManPageSync(asyncProgram as never, {
+          section: 1,
+        }),
+      { name: "TypeError", message: /async/ },
+    );
+  });
 });
 
 describe("generateManPageAsync()", () => {

--- a/packages/man/src/generator.ts
+++ b/packages/man/src/generator.ts
@@ -177,6 +177,12 @@ export function generateManPageSync(
     parserOrProgram,
     options,
   );
+  if ((parser as { readonly $mode: string }).$mode === "async") {
+    throw new TypeError(
+      "Cannot use an async parser with generateManPageSync(). " +
+        "Use generateManPageAsync() or generateManPage() instead.",
+    );
+  }
   const docPage = getDocPageSync(parser) ?? { sections: [] };
   return formatDocPageAsMan(docPage, mergedOptions);
 }


### PR DESCRIPTION
## Summary

- `generateManPageSync()` now throws `TypeError` when given an async parser or program at runtime, instead of silently producing output.
- This is analogous to https://github.com/dahlia/optique/issues/279 but for the man-page generation layer.

Closes https://github.com/dahlia/optique/issues/291

## Test plan

- [x] Added test: rejects async parser passed directly to `generateManPageSync()`
- [x] Added test: rejects async program (via `defineProgram()`) passed to `generateManPageSync()`
- [x] All existing tests pass on Deno, Node.js, and Bun
- [x] Type check, lint, and format check pass (`mise check`)