### PR TITLE
Fix `runParser()` crash on `completion ... -- --help` payloads

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -418,6 +418,11 @@ To be released.
     inner option/argument documentation when called on a top-level `command()`
     parser with no arguments.  [[#200], [#595]]
 
+ -  Fixed `runParser()` crashing or showing help instead of handling completion
+    when help-option names (e.g., `--help`) appear inside completion payloads.
+    Help-option scanning now only checks the argument immediately after the
+    completion command name, not the entire `args` array.  [[#300], [#599]]
+
 [#110]: https://github.com/dahlia/optique/issues/110
 [#113]: https://github.com/dahlia/optique/issues/113
 [#115]: https://github.com/dahlia/optique/issues/115
@@ -454,6 +459,7 @@ To be released.
 [#248]: https://github.com/dahlia/optique/issues/248
 [#249]: https://github.com/dahlia/optique/issues/249
 [#296]: https://github.com/dahlia/optique/issues/296
+[#300]: https://github.com/dahlia/optique/issues/300
 [#307]: https://github.com/dahlia/optique/issues/307
 [#310]: https://github.com/dahlia/optique/issues/310
 [#315]: https://github.com/dahlia/optique/issues/315
@@ -512,6 +518,7 @@ To be released.
 [#590]: https://github.com/dahlia/optique/issues/590
 [#592]: https://github.com/dahlia/optique/pull/592
 [#595]: https://github.com/dahlia/optique/pull/595
+[#599]: https://github.com/dahlia/optique/pull/599
 
 ### @optique/config
 

--- a/packages/core/src/facade.test.ts
+++ b/packages/core/src/facade.test.ts
@@ -3128,6 +3128,106 @@ describe("Subcommand help edge cases (Issue #26 comprehensive coverage)", () => 
       assert.ok(helpOutput.includes("\n  Nushell:"));
     });
 
+    it("should not treat --help in completion payload as help request", () => {
+      const parser = object({});
+
+      let completionShown = false;
+      let helpShown = false;
+
+      runParser(
+        parser,
+        "myapp",
+        ["completion", "bash", "--", "--help"],
+        {
+          help: {
+            option: true,
+            onShow: () => {
+              helpShown = true;
+              return "help-shown";
+            },
+          },
+          completion: {
+            command: true,
+            option: true,
+            onShow: () => {
+              completionShown = true;
+              return "completion-shown";
+            },
+          },
+          stdout: () => {},
+        },
+      );
+
+      assert.ok(completionShown, "completion callback should be called");
+      assert.ok(!helpShown, "help callback should not be called");
+    });
+
+    it("should not treat --help after shell arg as help request", () => {
+      const parser = object({});
+
+      let completionShown = false;
+      let helpShown = false;
+
+      runParser(
+        parser,
+        "myapp",
+        ["completion", "bash", "git", "--help"],
+        {
+          help: {
+            option: true,
+            onShow: () => {
+              helpShown = true;
+              return "help-shown";
+            },
+          },
+          completion: {
+            command: true,
+            onShow: () => {
+              completionShown = true;
+              return "completion-shown";
+            },
+          },
+          stdout: () => {},
+        },
+      );
+
+      assert.ok(completionShown, "completion callback should be called");
+      assert.ok(!helpShown, "help callback should not be called");
+    });
+
+    it("should not treat custom help name in completion payload as help request", () => {
+      const parser = object({});
+
+      let completionShown = false;
+      let helpShown = false;
+
+      runParser(
+        parser,
+        "myapp",
+        ["completion", "bash", "--", "--assist"],
+        {
+          help: {
+            option: { names: ["--assist"] },
+            onShow: () => {
+              helpShown = true;
+              return "help-shown";
+            },
+          },
+          completion: {
+            command: true,
+            onShow: () => {
+              completionShown = true;
+              return "completion-shown";
+            },
+          },
+          stdout: () => {},
+        },
+      );
+
+      assert.ok(completionShown, "completion callback should be called");
+      assert.ok(!helpShown, "help callback should not be called");
+    });
+
     it("should support --completions (plural) option", () => {
       const parser = object({
         verbose: option("--verbose"),

--- a/packages/core/src/facade.ts
+++ b/packages/core/src/facade.ts
@@ -1361,11 +1361,15 @@ function classifyResult(
     const hasVersionOption = versionOptionNames.some((n) => args.includes(n));
     const hasVersionCommand = args.length > 0 &&
       versionCommandNames.includes(args[0]);
-    const hasHelpOption = helpOptionNames.some((n) => args.includes(n));
-    const hasHelpCommand = args.length > 0 &&
-      helpCommandNames.includes(args[0]);
     const hasCompletionCommand = args.length > 0 &&
       completionCommandNames.includes(args[0]);
+    const hasHelpOption = hasCompletionCommand
+      // Completion command detected: only check args[1] for help
+      ? helpOptionNames.length > 0 && args.length >= 2 &&
+        helpOptionNames.includes(args[1])
+      : helpOptionNames.some((n) => args.includes(n));
+    const hasHelpCommand = args.length > 0 &&
+      helpCommandNames.includes(args[0]);
 
     // Standard CLI behavior:
     // 1. `command --help` should show help for that command
@@ -1984,7 +1988,11 @@ export function runParser<
   // Exception: if a help option is present, let the parser handle it
   if (options.completion) {
     const hasHelpOption = helpOptionConfig
-      ? helpOptionNames.some((n) => args.includes(n))
+      ? (completionCommandConfig && completionCommandNames.includes(args[0]))
+        // Completion command detected: only check args[1] for help
+        ? args.length >= 2 && helpOptionNames.includes(args[1])
+        // No completion command: check all args
+        : helpOptionNames.some((n) => args.includes(n))
       : false;
 
     // Handle completion command format: "completion <shell> [args...]"


### PR DESCRIPTION
## Summary

`runParser()` checked for help-option names across the entire `args` array using `args.includes()`. This caused completion payloads containing help-option names to be misinterpreted as help requests instead of being treated as opaque completion input.

For example, all three of the following calls either crashed with `RunParserError: Completion should be handled by early return` or were hijacked into help output:

```typescript
// Crashed: --help after -- in completion payload
await runParser(object({}), "myapp", ["completion", "bash", "--", "--help"], {
  help: { option: true },
  completion: { command: true, option: true },
});

// Hijacked into help output instead of completion
await runParser(object({}), "myapp", ["completion", "bash", "git", "--help"], {
  help: { option: true },
  completion: { command: true },
});

// Crashed: custom help name in completion payload
await runParser(object({}), "myapp", ["completion", "bash", "--", "--assist"], {
  help: { option: { names: ["--assist"] } },
  completion: { command: true },
});
```

The completion command format is `completion <shell> [payload...]`, where everything after the shell name is the command line being completed. Help-option scanning should only detect help requests that target the completion command itself (e.g., `completion --help`), not tokens inside the payload.

The fix scopes help-option scanning in two places: the early-return path in `runParser()` and `classifyResult()`, both in *packages/core/src/facade.ts*. When `args[0]` matches a completion command name, only `args[1]` is checked for help options instead of the entire array. `completion --help` continues to show help for the completion command as before.

Closes https://github.com/dahlia/optique/issues/300

## Test plan

 - Regression tests added for all three reproduction cases from the issue
 - Existing `completion --help` test continues to pass (help for the completion command still works)
 - Full test suite passes across Deno, Node.js, and Bun (`mise test`)