### PR TITLE
Fix `formatDocPageAsMan()` mislabeling untitled sections as OPTIONS

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -904,11 +904,17 @@ interactive prompt fallback integration via Inquirer.js.  [[#87], [#137]]
     so they can also be passed as explicit overrides in both the parser-based
     and program-based APIs.  [[#260], [#598]]
 
+ -  Fixed `formatDocPageAsMan()` labeling untitled sections as `OPTIONS`
+    regardless of entry kinds.  Untitled command-only sections now render
+    as `COMMANDS`, and untitled argument-only sections render as `ARGUMENTS`.
+    [[#261], [#601]]
+
 [#197]: https://github.com/dahlia/optique/issues/197
 [#221]: https://github.com/dahlia/optique/issues/221
 [#222]: https://github.com/dahlia/optique/issues/222
 [#237]: https://github.com/dahlia/optique/issues/237
 [#260]: https://github.com/dahlia/optique/issues/260
+[#261]: https://github.com/dahlia/optique/issues/261
 [#273]: https://github.com/dahlia/optique/issues/273
 [#274]: https://github.com/dahlia/optique/issues/274
 [#276]: https://github.com/dahlia/optique/issues/276
@@ -948,6 +954,7 @@ interactive prompt fallback integration via Inquirer.js.  [[#87], [#137]]
 [#586]: https://github.com/dahlia/optique/pull/586
 [#593]: https://github.com/dahlia/optique/pull/593
 [#598]: https://github.com/dahlia/optique/pull/598
+[#601]: https://github.com/dahlia/optique/pull/601
 
 
 Version 0.10.7

--- a/packages/man/src/man.test.ts
+++ b/packages/man/src/man.test.ts
@@ -892,6 +892,83 @@ describe("formatDocPageAsMan()", () => {
     assert.ok(!result.includes('.SH "EMPTY"'));
   });
 
+  it("infers COMMANDS heading for untitled command-only sections", () => {
+    const page: DocPage = {
+      sections: [{
+        entries: [
+          {
+            term: { type: "command", name: "build" },
+            description: message`Build the project.`,
+          },
+          {
+            term: { type: "command", name: "test" },
+            description: message`Run tests.`,
+          },
+        ],
+      }],
+    };
+
+    const result = formatDocPageAsMan(page, minimalOptions);
+
+    assert.ok(result.includes('.SH "COMMANDS"'));
+    assert.ok(!result.includes('.SH "OPTIONS"'));
+  });
+
+  it("infers ARGUMENTS heading for untitled argument-only sections", () => {
+    const page: DocPage = {
+      sections: [{
+        entries: [
+          {
+            term: { type: "argument", metavar: "INPUT" },
+          },
+        ],
+      }],
+    };
+
+    const result = formatDocPageAsMan(page, minimalOptions);
+
+    assert.ok(result.includes('.SH "ARGUMENTS"'));
+    assert.ok(!result.includes('.SH "OPTIONS"'));
+  });
+
+  it("infers OPTIONS heading for untitled option-only sections", () => {
+    const page: DocPage = {
+      sections: [{
+        entries: [
+          {
+            term: { type: "option", names: ["--verbose"] },
+            description: message`Enable verbose output.`,
+          },
+        ],
+      }],
+    };
+
+    const result = formatDocPageAsMan(page, minimalOptions);
+
+    assert.ok(result.includes('.SH "OPTIONS"'));
+  });
+
+  it("falls back to OPTIONS for untitled mixed sections", () => {
+    const page: DocPage = {
+      sections: [{
+        entries: [
+          {
+            term: { type: "option", names: ["--verbose"] },
+            description: message`Enable verbose output.`,
+          },
+          {
+            term: { type: "command", name: "build" },
+            description: message`Build the project.`,
+          },
+        ],
+      }],
+    };
+
+    const result = formatDocPageAsMan(page, minimalOptions);
+
+    assert.ok(result.includes('.SH "OPTIONS"'));
+  });
+
   it("generates AUTHOR section", () => {
     const page: DocPage = {
       sections: [],

--- a/packages/man/src/man.ts
+++ b/packages/man/src/man.ts
@@ -1,4 +1,4 @@
-import type { DocPage, DocSection } from "@optique/core/doc";
+import type { DocEntry, DocPage, DocSection } from "@optique/core/doc";
 import type { Message } from "@optique/core/message";
 import {
   isDocHidden,
@@ -444,6 +444,27 @@ function formatDocUsageAsRoff(usage: Usage): string {
 }
 
 /**
+ * Infers the section title from entry kinds when no explicit title is given.
+ * Returns `"COMMANDS"` for command-only sections, `"ARGUMENTS"` for
+ * argument-only sections, and `"OPTIONS"` otherwise.
+ *
+ * @param entries The entries in the section.
+ * @returns The inferred section title in uppercase.
+ */
+function inferSectionTitle(entries: readonly DocEntry[]): string {
+  const kinds = new Set<string>();
+  for (const entry of entries) {
+    if ("hidden" in entry.term && isDocHidden(entry.term.hidden)) continue;
+    kinds.add(entry.term.type);
+  }
+  if (kinds.size === 1) {
+    if (kinds.has("command")) return "COMMANDS";
+    if (kinds.has("argument")) return "ARGUMENTS";
+  }
+  return "OPTIONS";
+}
+
+/**
  * Formats a {@link DocSection} as roff markup with .TP macros.
  *
  * @param section The section to format.
@@ -598,7 +619,8 @@ export function formatDocPageAsMan(
     const content = formatDocSectionEntries(section);
     if (content === "") continue;
 
-    const title = section.title?.toUpperCase() ?? "OPTIONS";
+    const title = section.title?.toUpperCase() ??
+      inferSectionTitle(section.entries);
     lines.push(`.SH "${escapeRequestArg(title)}"`);
     lines.push(content);
   }


### PR DESCRIPTION
## Summary

`formatDocPageAsMan()` used `section.title?.toUpperCase() ?? "OPTIONS"` as the fallback heading for untitled sections, so sections containing only commands or only arguments were still labeled `.SH OPTIONS`. This patch adds an `inferSectionTitle()` helper in *packages/man/src/man.ts* that inspects entry kinds before choosing the fallback: untitled command-only sections now render as `COMMANDS`, untitled argument-only sections render as `ARGUMENTS`, and mixed or option-only sections keep the existing `OPTIONS` label.

For example, a parser with two subcommands and no explicit section title previously produced:

```
.SH OPTIONS
.TP
\fBbuild\fR
Build project.
.TP
\fBtest\fR
Run tests.
```

After this fix, the same parser produces:

```
.SH COMMANDS
.TP
\fBbuild\fR
Build project.
.TP
\fBtest\fR
Run tests.
```

Fixes https://github.com/dahlia/optique/issues/261

## Test plan

- Added tests in *packages/man/src/man.test.ts* for untitled command-only, argument-only, option-only, and mixed sections
- Verified all existing man page tests still pass