### PR TITLE
Fix `formatDocPageAsMan()` to fall back to `DocPage` metadata for examples, author, and bugs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -801,6 +801,12 @@ interactive prompt fallback integration via Inquirer.js.  [[#87], [#137]]
 
 ### @optique/man
 
+ -  Fixed `formatDocPageAsMan()` to fall back to `DocPage.examples`,
+    `DocPage.author`, and `DocPage.bugs` when the corresponding
+    `ManPageOptions` fields are absent.  Previously, those page-level
+    metadata fields were silently ignored unless duplicated in the options.
+    [[#263], [#602]]
+
  -  Fixed `formatDocPageAsMan()` to respect command `usageLine` overrides
     in the SYNOPSIS section.  Previously, the man page formatter always
     rendered the default command usage, ignoring custom `usageLine` values.
@@ -922,6 +928,7 @@ interactive prompt fallback integration via Inquirer.js.  [[#87], [#137]]
 [#237]: https://github.com/dahlia/optique/issues/237
 [#260]: https://github.com/dahlia/optique/issues/260
 [#261]: https://github.com/dahlia/optique/issues/261
+[#263]: https://github.com/dahlia/optique/issues/263
 [#273]: https://github.com/dahlia/optique/issues/273
 [#274]: https://github.com/dahlia/optique/issues/274
 [#276]: https://github.com/dahlia/optique/issues/276
@@ -962,6 +969,7 @@ interactive prompt fallback integration via Inquirer.js.  [[#87], [#137]]
 [#593]: https://github.com/dahlia/optique/pull/593
 [#598]: https://github.com/dahlia/optique/pull/598
 [#601]: https://github.com/dahlia/optique/pull/601
+[#602]: https://github.com/dahlia/optique/pull/602
 
 
 Version 0.10.7

--- a/packages/man/src/man.test.ts
+++ b/packages/man/src/man.test.ts
@@ -985,6 +985,35 @@ describe("formatDocPageAsMan()", () => {
     assert.ok(result.includes("Hong Minhee <hong@minhee.org>"));
   });
 
+  it("falls back to page.author when options.author is absent", () => {
+    const page: DocPage = {
+      sections: [],
+      author: message`Page Author`,
+    };
+
+    const result = formatDocPageAsMan(page, minimalOptions);
+
+    assert.ok(result.includes(".SH AUTHOR"));
+    assert.ok(result.includes("Page Author"));
+  });
+
+  it("prefers options.author over page.author", () => {
+    const page: DocPage = {
+      sections: [],
+      author: message`Page Author`,
+    };
+
+    const options: ManPageOptions = {
+      ...minimalOptions,
+      author: message`Options Author`,
+    };
+
+    const result = formatDocPageAsMan(page, options);
+
+    assert.ok(result.includes("Options Author"));
+    assert.ok(!result.includes("Page Author"));
+  });
+
   it("generates BUGS section", () => {
     const page: DocPage = {
       sections: [],
@@ -1005,6 +1034,35 @@ describe("formatDocPageAsMan()", () => {
     );
   });
 
+  it("falls back to page.bugs when options.bugs is absent", () => {
+    const page: DocPage = {
+      sections: [],
+      bugs: message`Page Bugs`,
+    };
+
+    const result = formatDocPageAsMan(page, minimalOptions);
+
+    assert.ok(result.includes(".SH BUGS"));
+    assert.ok(result.includes("Page Bugs"));
+  });
+
+  it("prefers options.bugs over page.bugs", () => {
+    const page: DocPage = {
+      sections: [],
+      bugs: message`Page Bugs`,
+    };
+
+    const options: ManPageOptions = {
+      ...minimalOptions,
+      bugs: message`Options Bugs`,
+    };
+
+    const result = formatDocPageAsMan(page, options);
+
+    assert.ok(result.includes("Options Bugs"));
+    assert.ok(!result.includes("Page Bugs"));
+  });
+
   it("generates EXAMPLES section", () => {
     const page: DocPage = {
       sections: [],
@@ -1019,6 +1077,35 @@ describe("formatDocPageAsMan()", () => {
 
     assert.ok(result.includes(".SH EXAMPLES"));
     assert.ok(result.includes("Run with verbose output:"));
+  });
+
+  it("falls back to page.examples when options.examples is absent", () => {
+    const page: DocPage = {
+      sections: [],
+      examples: message`Page Examples`,
+    };
+
+    const result = formatDocPageAsMan(page, minimalOptions);
+
+    assert.ok(result.includes(".SH EXAMPLES"));
+    assert.ok(result.includes("Page Examples"));
+  });
+
+  it("prefers options.examples over page.examples", () => {
+    const page: DocPage = {
+      sections: [],
+      examples: message`Page Examples`,
+    };
+
+    const options: ManPageOptions = {
+      ...minimalOptions,
+      examples: message`Options Examples`,
+    };
+
+    const result = formatDocPageAsMan(page, options);
+
+    assert.ok(result.includes("Options Examples"));
+    assert.ok(!result.includes("Page Examples"));
   });
 
   it("generates SEE ALSO section", () => {

--- a/packages/man/src/man.ts
+++ b/packages/man/src/man.ts
@@ -653,15 +653,17 @@ export function formatDocPageAsMan(
   }
 
   // .SH EXAMPLES
-  if (options.examples) {
+  const examples = options.examples ?? page.examples;
+  if (examples) {
     lines.push(".SH EXAMPLES");
-    lines.push(formatMessageAsRoff(options.examples));
+    lines.push(formatMessageAsRoff(examples));
   }
 
   // .SH BUGS
-  if (options.bugs) {
+  const bugs = options.bugs ?? page.bugs;
+  if (bugs) {
     lines.push(".SH BUGS");
-    lines.push(formatMessageAsRoff(options.bugs));
+    lines.push(formatMessageAsRoff(bugs));
   }
 
   // .SH SEE ALSO
@@ -695,9 +697,10 @@ export function formatDocPageAsMan(
   }
 
   // .SH AUTHOR
-  if (options.author) {
+  const author = options.author ?? page.author;
+  if (author) {
     lines.push(".SH AUTHOR");
-    lines.push(formatMessageAsRoff(options.author));
+    lines.push(formatMessageAsRoff(author));
   }
 
   // Footer (if present, add at the end)


### PR DESCRIPTION
## Summary

`formatDocPageAsMan()` already falls back from `ManPageOptions` to `DocPage` for `brief`, `description`, and `footer`, but it did not do the same for `examples`, `author`, and `bugs`. This meant a fully populated `DocPage` carrying those fields would silently drop them unless they were redundantly duplicated in `ManPageOptions`.

This PR applies the same `options.* ?? page.*` pattern to the three missing fields in *packages/man/src/man.ts*, so they are now treated consistently with the rest of the page-level metadata.

For example, the following code now correctly renders EXAMPLES, AUTHOR, and BUGS sections without needing to pass them through `ManPageOptions`:

```typescript
import { formatDocPageAsMan } from "@optique/man/man";
import { message } from "@optique/core/message";

const page = {
  sections: [],
  examples: message`Example text.`,
  author: message`Author text.`,
  bugs: message`Bugs text.`,
};

// Previously, this would not render EXAMPLES, AUTHOR, or BUGS sections.
// Now it does.
console.log(formatDocPageAsMan(page as never, { name: "myapp", section: 1 }));
```

Closes https://github.com/dahlia/optique/issues/263

## Test plan

- Added tests in *packages/man/src/man.test.ts* verifying that `page.examples`, `page.author`, and `page.bugs` are rendered when the corresponding `ManPageOptions` fields are absent
- Added tests verifying that `options.*` takes precedence over `page.*` when both are present
- All existing tests continue to pass