### PR TITLE
Fix `email({ allowedDomains: [] })` silently disabling domain filtering

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -426,6 +426,11 @@ To be released.
  -  Fixed `email()` with `allowMultiple` splitting on commas inside quoted
     local parts and quoted display names.  [[#320], [#606]]
 
+ -  Fixed `email({ allowedDomains: [] })` silently disabling domain filtering
+    instead of rejecting all domains, making it consistent with
+    `url({ allowedProtocols: [] })` and `domain({ allowedTLDs: [] })`.
+    [[#341], [#610]]
+
 [#110]: https://github.com/dahlia/optique/issues/110
 [#113]: https://github.com/dahlia/optique/issues/113
 [#115]: https://github.com/dahlia/optique/issues/115
@@ -470,6 +475,7 @@ To be released.
 [#320]: https://github.com/dahlia/optique/issues/320
 [#323]: https://github.com/dahlia/optique/issues/323
 [#332]: https://github.com/dahlia/optique/issues/332
+[#341]: https://github.com/dahlia/optique/issues/341
 [#349]: https://github.com/dahlia/optique/issues/349
 [#353]: https://github.com/dahlia/optique/issues/353
 [#362]: https://github.com/dahlia/optique/issues/362
@@ -524,6 +530,7 @@ To be released.
 [#595]: https://github.com/dahlia/optique/pull/595
 [#599]: https://github.com/dahlia/optique/pull/599
 [#606]: https://github.com/dahlia/optique/pull/606
+[#610]: https://github.com/dahlia/optique/pull/610
 
 ### @optique/config
 

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -6736,6 +6736,23 @@ describe("email()", () => {
       const result2 = parser.parse("user1@example.com,user2@other.com");
       assert.ok(!result2.success);
     });
+
+    it("should reject all emails when allowedDomains is empty", () => {
+      const parser = email({ allowedDomains: [] });
+
+      const result1 = parser.parse("user@example.com");
+      assert.ok(!result1.success);
+
+      const result2 = parser.parse("user@other.com");
+      assert.ok(!result2.success);
+    });
+
+    it("should reject all emails when allowedDomains is empty with allowMultiple", () => {
+      const parser = email({ allowedDomains: [], allowMultiple: true });
+
+      const result = parser.parse("user@example.com,user@other.com");
+      assert.ok(!result.success);
+    });
   });
 
   describe("custom error messages", () => {

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -3025,7 +3025,7 @@ export function email(
           }
 
           // Check domain restriction
-          if (allowedDomains && allowedDomains.length > 0) {
+          if (allowedDomains != null) {
             const atIndex = validated.indexOf("@");
             const domain = validated.substring(atIndex + 1).toLowerCase();
             const isAllowed = allowedDomains.some((allowed) =>
@@ -3070,7 +3070,7 @@ export function email(
         }
 
         // Check domain restriction
-        if (allowedDomains && allowedDomains.length > 0) {
+        if (allowedDomains != null) {
           const atIndex = validated.indexOf("@");
           const domain = validated.substring(atIndex + 1).toLowerCase();
           const isAllowed = allowedDomains.some((allowed) =>


### PR DESCRIPTION
## Summary

When `allowedDomains` is set to an empty array, `email()` silently accepts all domains instead of rejecting them. This happens because the domain restriction check in *packages/core/src/valueparser.ts* uses `allowedDomains && allowedDomains.length > 0`, which skips validation for empty arrays.

This is inconsistent with how other allow-list-based parsers behave. Both `url({ allowedProtocols: [] })` and `domain({ allowedTLDs: [] })` correctly reject all inputs when given an empty allow-list, because they check `!= null` or `!== undefined` rather than also checking `.length`.

```typescript
const parser = email({ allowedDomains: [] });

// Before: both succeed (bug)
// After: both fail, as expected
parser.parse("user@example.com");
parser.parse("user@anything.org");
```

The fix changes the condition from `allowedDomains && allowedDomains.length > 0` to `allowedDomains != null` in both the single-email and multi-email code paths, matching the pattern used by `url()` and `domain()`.

Closes https://github.com/dahlia/optique/issues/341

## Test plan

- Added a test that `email({ allowedDomains: [] })` rejects all emails in single-email mode
- Added a test that `email({ allowedDomains: [], allowMultiple: true })` rejects all emails in multi-email mode
- Verified all existing tests still pass across Deno, Node.js, and Bun (`mise test`)