### PR TITLE
Fix `email({ lowercase: true })` to only lowercase the domain part

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -435,6 +435,10 @@ To be released.
     containing multiple angle-bracket groups or bare `<email>` wrappers
     without a display name.  [[#338], [#611]]
 
+ -  Fixed `email({ lowercase: true })` lowercasing the entire address instead
+    of only the domain part; the local part (including quoted local parts)
+    is now preserved.  [[#352], [#614]]
+
  -  Fixed Bash completion scripts using `compgen -z` which is unsupported on
     macOS's default GNU Bash 3.2.  File and directory completions now use
     glob-based iteration instead, matching the pattern already used for
@@ -488,6 +492,7 @@ To be released.
 [#338]: https://github.com/dahlia/optique/issues/338
 [#341]: https://github.com/dahlia/optique/issues/341
 [#349]: https://github.com/dahlia/optique/issues/349
+[#352]: https://github.com/dahlia/optique/issues/352
 [#353]: https://github.com/dahlia/optique/issues/353
 [#362]: https://github.com/dahlia/optique/issues/362
 [#363]: https://github.com/dahlia/optique/issues/363
@@ -544,6 +549,7 @@ To be released.
 [#608]: https://github.com/dahlia/optique/pull/608
 [#610]: https://github.com/dahlia/optique/pull/610
 [#611]: https://github.com/dahlia/optique/pull/611
+[#614]: https://github.com/dahlia/optique/pull/614
 
 ### @optique/config
 

--- a/docs/concepts/valueparsers.md
+++ b/docs/concepts/valueparsers.md
@@ -1085,18 +1085,20 @@ Domain matching is case-insensitive.
 
 ### Lowercase conversion
 
-Convert email addresses to lowercase with the `lowercase` option:
+Normalize the domain part of email addresses to lowercase with
+the `lowercase` option.  The local part is preserved as-is, since it is
+technically case-sensitive per RFC 5321.
 
 ~~~~ typescript twoslash
 import { email } from "@optique/core/valueparser";
 import { option } from "@optique/core";
 // ---cut-before---
-// Normalize email to lowercase
+// Normalize email domain to lowercase
 const normalizedEmail = option("--email", email({ lowercase: true }));
 ~~~~
 
 ~~~~ bash
-$ example --email "User@Example.COM"  # Returns: "user@example.com"
+$ example --email "User@Example.COM"  # Returns: "User@example.com"
 ~~~~
 
 ### Quoted local parts

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -6714,16 +6714,28 @@ describe("email()", () => {
   });
 
   describe("lowercase option", () => {
-    it("should convert email to lowercase when lowercase is true", () => {
+    it("should lowercase only the domain when lowercase is true", () => {
       const parser = email({ lowercase: true });
 
       const result1 = parser.parse("User@Example.COM");
       assert.ok(result1.success);
-      assert.strictEqual(result1.value, "user@example.com");
+      assert.strictEqual(result1.value, "User@example.com");
 
       const result2 = parser.parse("ADMIN@COMPANY.NET");
       assert.ok(result2.success);
-      assert.strictEqual(result2.value, "admin@company.net");
+      assert.strictEqual(result2.value, "ADMIN@company.net");
+    });
+
+    it("should preserve local part case including quoted local parts", () => {
+      const parser = email({ lowercase: true });
+
+      const result1 = parser.parse("User.Name+Tag@Example.COM");
+      assert.ok(result1.success);
+      assert.strictEqual(result1.value, "User.Name+Tag@example.com");
+
+      const result2 = parser.parse('"Case.Sensitive"@Example.COM');
+      assert.ok(result2.success);
+      assert.strictEqual(result2.value, '"Case.Sensitive"@example.com');
     });
 
     it("should preserve case when lowercase is false", () => {
@@ -6740,8 +6752,8 @@ describe("email()", () => {
       const result = parser.parse("User1@Example.COM,User2@Example.ORG");
       assert.ok(result.success);
       assert.deepStrictEqual(result.value, [
-        "user1@example.com",
-        "user2@example.org",
+        "User1@example.com",
+        "User2@example.org",
       ]);
     });
   });
@@ -6941,8 +6953,8 @@ describe("email()", () => {
       const result = parser.parse("User1@Example.COM,User2@Example.COM");
       assert.ok(result.success);
       assert.deepStrictEqual(result.value, [
-        "user1@example.com",
-        "user2@example.com",
+        "User1@example.com",
+        "User2@example.com",
       ]);
     });
 

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -2769,7 +2769,9 @@ export interface EmailOptions {
   readonly allowDisplayName?: boolean;
 
   /**
-   * If `true`, converts email to lowercase.
+   * If `true`, converts the domain part of the email to lowercase.
+   * The local part is preserved as-is, since it is technically
+   * case-sensitive per RFC 5321.
    * @default false
    */
   readonly lowercase?: boolean;
@@ -2994,7 +2996,10 @@ export function email(
 
     // Return the email (preserve original form or extracted from display name)
     const resultEmail = emailAddr;
-    return lowercase ? resultEmail.toLowerCase() : resultEmail;
+    if (!lowercase) return resultEmail;
+    const lastAt = resultEmail.lastIndexOf("@");
+    return resultEmail.slice(0, lastAt) +
+      resultEmail.slice(lastAt).toLowerCase();
   }
 
   /**


### PR DESCRIPTION
`email({ lowercase: true })` was applying `.toLowerCase()` to the entire email address, including the local part and quoted local-part content. Per RFC 5321, only the domain portion of an email address is case-insensitive; the local part is technically case-sensitive and should be preserved as-is.

This is especially problematic because the parser explicitly supports quoted local parts (e.g., `"Case.Sensitive"@example.com`), where lowercasing silently changes the semantic meaning of the address.

Before this fix:

```typescript
const parser = email({ lowercase: true });
parser.parse("User.Name+Tag@Example.COM");     // "user.name+tag@example.com"
parser.parse('"Case.Sensitive"@Example.COM');   // "\"case.sensitive\"@example.com"
```

After this fix:

```typescript
const parser = email({ lowercase: true });
parser.parse("User.Name+Tag@Example.COM");     // "User.Name+Tag@example.com"
parser.parse('"Case.Sensitive"@Example.COM');   // "\"Case.Sensitive\"@example.com"
```

The fix is in *packages/core/src/valueparser.ts*: instead of calling `.toLowerCase()` on the whole address, it now splits at the last `@` and only lowercases the domain portion. Documentation in *docs/concepts/valueparsers.md* and *CHANGES.md* have been updated accordingly.

Closes https://github.com/dahlia/optique/issues/352