### PR TITLE
Add `validate` support to `select`, `rawlist`, `expand`, and `checkbox` prompt configs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -795,6 +795,11 @@ interactive prompt fallback integration via Inquirer.js.  [[#87], [#137]]
     to enforce equivalent constraints on prompted values.
     [[#392], [#613], [#615], [#621]]
 
+ -  Added `validate` support to `SelectConfig`, `RawlistConfig`,
+    `ExpandConfig`, and `CheckboxConfig` prompt configurations.  Return
+    `true` to accept, or a string error message to reject and re-prompt.
+    [[#620], [#625]]
+
 [#87]: https://github.com/dahlia/optique/issues/87
 [#137]: https://github.com/dahlia/optique/pull/137
 [#151]: https://github.com/dahlia/optique/issues/151
@@ -807,7 +812,9 @@ interactive prompt fallback integration via Inquirer.js.  [[#87], [#137]]
 [#612]: https://github.com/dahlia/optique/pull/612
 [#613]: https://github.com/dahlia/optique/pull/613
 [#615]: https://github.com/dahlia/optique/issues/615
+[#620]: https://github.com/dahlia/optique/issues/620
 [#621]: https://github.com/dahlia/optique/pull/621
+[#625]: https://github.com/dahlia/optique/pull/625
 
 ### @optique/temporal
 


### PR DESCRIPTION
Closes #620.

After #615 decoupled the CLI path and the prompt path into independent value sources, prompted values no longer pass through the inner parser's constraint pipeline. This meant that for prompt types without a `validate` callback (`select`, `rawlist`, `expand`, `checkbox`), there was no way to enforce runtime constraints on prompted values at all.

This PR adds an optional `validate` property to `SelectConfig`, `RawlistConfig`, `ExpandConfig`, and `CheckboxConfig`, following the same signature as `InputConfig.validate`:

```typescript
// For select, rawlist, expand (single-value prompts):
validate?: (value: string) => boolean | string | Promise<boolean | string>;

// For checkbox (multi-value prompt):
validate?: (value: readonly string[]) => boolean | string | Promise<boolean | string>;
```

Return `true` to accept the value, or a string error message to reject it and re-prompt the user. For example, enforcing a minimum selection count on a checkbox prompt:

```typescript
prompt(multiple(option("--tag", "Tags", string())), {
  type: "checkbox",
  message: "Select at least two tags:",
  choices: ["bug", "feature", "docs", "refactor"],
  validate: (values) => values.length >= 2 || "Please select at least two tags.",
});
```

Since Inquirer.js does not natively support `validate` for `select`, `rawlist`, or `expand` prompts, the validation loop is implemented at the Optique layer: after each prompt execution, the `validate` function is called and, if it rejects, the error message is logged to stderr and the user is re-prompted.

## Test plan

- [x] Tests for all four prompt types verifying that invalid values trigger re-prompting
- [x] Tests verifying that valid values pass through without re-prompting
- [x] Test for async `validate` functions
- [x] Full test suite passes across Deno, Node.js, and Bun (`mise test`)
- [x] Type check, lint, and format check pass (`mise check`)