### PR TITLE
Fix `email({ allowMultiple: true })` format/parse round-trip for quoted commas

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -447,6 +447,11 @@ To be released.
     (64-octet local-part maximum and 254-octet overall address maximum,
     measured in UTF-8).  [[#396], [#622]]
 
+ -  Fixed `email({ allowMultiple: true })` round-trip: `format()` now joins
+    addresses with `, ` (comma-space) instead of bare `,`, so quoted local
+    parts containing commas (e.g., `"Doe, John"@example.com`) survive a
+    `format()` → `parse()` cycle.  [[#354], [#626]]
+
  -  Fixed `__FILE__` completion transport unable to represent `pattern` values
     containing `:` (e.g., Windows drive-letter prefixes like `C:/...`).
     Colons in the pattern field are now percent-encoded (`%3A`) so that the
@@ -517,6 +522,7 @@ To be released.
 [#349]: https://github.com/dahlia/optique/issues/349
 [#352]: https://github.com/dahlia/optique/issues/352
 [#353]: https://github.com/dahlia/optique/issues/353
+[#354]: https://github.com/dahlia/optique/issues/354
 [#362]: https://github.com/dahlia/optique/issues/362
 [#363]: https://github.com/dahlia/optique/issues/363
 [#368]: https://github.com/dahlia/optique/issues/368
@@ -580,6 +586,7 @@ To be released.
 [#618]: https://github.com/dahlia/optique/issues/618
 [#619]: https://github.com/dahlia/optique/pull/619
 [#622]: https://github.com/dahlia/optique/pull/622
+[#626]: https://github.com/dahlia/optique/pull/626
 
 ### @optique/config
 

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -6992,13 +6992,33 @@ describe("email()", () => {
       assert.strictEqual(parser.format("user@example.com"), "user@example.com");
     });
 
-    it("should return multiple emails joined by comma", () => {
+    it("should return multiple emails joined by comma-space", () => {
       const parser = email({ allowMultiple: true });
 
       assert.strictEqual(
         parser.format(["user1@example.com", "user2@example.com"]),
-        "user1@example.com,user2@example.com",
+        "user1@example.com, user2@example.com",
       );
+    });
+
+    it("should round-trip emails with quoted commas in local part", () => {
+      const parser = email({ allowMultiple: true });
+      const value = ['"Doe, John"@example.com', "x@example.com"];
+
+      const formatted = parser.format(value);
+      const parsed = parser.parse(formatted);
+      assert.ok(parsed.success);
+      assert.deepStrictEqual(parsed.value, value);
+    });
+
+    it("should round-trip emails with escaped quotes and commas", () => {
+      const parser = email({ allowMultiple: true });
+      const value = ['"a\\",b"@example.com', "d@example.com"];
+
+      const formatted = parser.format(value);
+      const parsed = parser.parse(formatted);
+      assert.ok(parsed.success);
+      assert.deepStrictEqual(parsed.value, value);
     });
   });
 

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -3158,7 +3158,7 @@ export function email(
     },
     format(value: string | readonly string[]): string {
       if (Array.isArray(value)) {
-        return value.join(",");
+        return value.join(", ");
       }
       return value as string;
     },


### PR DESCRIPTION
## Summary

`email({ allowMultiple: true })` could not round-trip values whose local parts contained quoted commas. `format()` joined addresses with a bare `,`, producing output like `"Doe, John"@example.com,x@example.com`. While `splitEmails()` happened to handle this correctly due to its quote-tracking state machine, the bare comma join was fragile and not guaranteed to be unambiguous.

This PR changes `format()` to use `, ` (comma-space) as the separator instead. This is safe because email addresses cannot start with whitespace, and `parse()` already trims each split result. It also matches the RFC 5322 conventional separator for address lists.

```typescript
const parser = email({ allowMultiple: true });
const value = ['"Doe, John"@example.com', "x@example.com"];

// Before: "Doe, John"@example.com,x@example.com
// After:  "Doe, John"@example.com, x@example.com
parser.format(value);
```

Closes https://github.com/dahlia/optique/issues/354

## Test plan

- Added round-trip test for quoted commas in local parts (`"Doe, John"@example.com`)
- Added round-trip test for escaped quotes with commas (`"a\"b,c"@example.com`)
- Updated existing format test in *valueparser.test.ts* to expect comma-space separator
- `mise test` passes across Deno, Node.js, and Bun