### PR TITLE
Reject contradictory `domain()` label constraints at construction time

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -457,6 +457,11 @@ To be released.
     `" example.com "`, or non-string values now throw a `TypeError`.
     [[#348], [#629]]
 
+ -  Fixed `domain()` accepting contradictory configuration such as
+    `allowSubdomains: false` with `minLabels: 3`.  This combination creates
+    an unsatisfiable parser, so it is now rejected at construction time with
+    a `TypeError`.  [[#350], [#630]]
+
  -  Fixed `__FILE__` completion transport unable to represent `pattern` values
     containing `:` (e.g., Windows drive-letter prefixes like `C:/...`).
     Colons in the pattern field are now percent-encoded (`%3A`) so that the
@@ -526,6 +531,7 @@ To be released.
 [#341]: https://github.com/dahlia/optique/issues/341
 [#348]: https://github.com/dahlia/optique/issues/348
 [#349]: https://github.com/dahlia/optique/issues/349
+[#350]: https://github.com/dahlia/optique/issues/350
 [#352]: https://github.com/dahlia/optique/issues/352
 [#353]: https://github.com/dahlia/optique/issues/353
 [#354]: https://github.com/dahlia/optique/issues/354
@@ -594,6 +600,7 @@ To be released.
 [#622]: https://github.com/dahlia/optique/pull/622
 [#626]: https://github.com/dahlia/optique/pull/626
 [#629]: https://github.com/dahlia/optique/pull/629
+[#630]: https://github.com/dahlia/optique/pull/630
 
 ### @optique/config
 

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -8795,6 +8795,36 @@ describe("domain()", () => {
         { type: "text", text: "." },
       ]);
     });
+
+    it("should throw TypeError when allowSubdomains is false and minLabels > 2", () => {
+      assert.throws(
+        () => domain({ allowSubdomains: false, minLabels: 3 }),
+        {
+          name: "TypeError",
+          message:
+            "allowSubdomains: false is incompatible with minLabels > 2, " +
+            "as non-subdomain domains have exactly 2 labels.",
+        },
+      );
+    });
+
+    it("should not throw when allowSubdomains is false and minLabels is 2", () => {
+      assert.doesNotThrow(
+        () => domain({ allowSubdomains: false, minLabels: 2 }),
+      );
+    });
+
+    it("should not throw when allowSubdomains is false and minLabels is 1", () => {
+      assert.doesNotThrow(
+        () => domain({ allowSubdomains: false, minLabels: 1 }),
+      );
+    });
+
+    it("should not throw when allowSubdomains is true and minLabels > 2", () => {
+      assert.doesNotThrow(
+        () => domain({ allowSubdomains: true, minLabels: 3 }),
+      );
+    });
   });
 
   describe("allowedTLDs option", () => {

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -4225,6 +4225,8 @@ export interface DomainOptions {
  *
  * @param options Parser options for domain validation.
  * @returns A parser that accepts valid domain names as strings.
+ * @throws {TypeError} If `allowSubdomains` is `false` and `minLabels` is
+ *   greater than 2, since non-subdomain domains have exactly 2 labels.
  *
  * @example
  * ``` typescript
@@ -4256,6 +4258,12 @@ export function domain(
     : undefined;
   const minLabels = options?.minLabels ?? 2;
   const lowercase = options?.lowercase ?? false;
+  if (!allowSubdomains && minLabels > 2) {
+    throw new TypeError(
+      "allowSubdomains: false is incompatible with minLabels > 2, " +
+        "as non-subdomain domains have exactly 2 labels.",
+    );
+  }
   const invalidDomain = options?.errors?.invalidDomain;
   const tooFewLabels = options?.errors?.tooFewLabels;
   const subdomainsNotAllowed = options?.errors?.subdomainsNotAllowed;


### PR DESCRIPTION
When `allowSubdomains: false` is combined with `minLabels > 2`, the resulting `domain()` parser is unsatisfiable. With `allowSubdomains: false`, any domain with more than 2 labels is rejected as a subdomain, so requiring 3 or more labels guarantees that every input fails one constraint or the other. For example:

```typescript
const parser = domain({
  allowSubdomains: false,
  minLabels: 3,
});

parser.parse("example.com");       // fails: "must have at least 3 labels"
parser.parse("a.b.c");             // fails: "subdomains are not allowed"
// No input can satisfy both constraints.
```

This change makes `domain()` throw a `TypeError` at construction time when it detects this contradictory configuration, rather than silently creating a parser that rejects all input. The validation is added in *packages/core/src/valueparser.ts*, with corresponding tests in *packages/core/src/valueparser.test.ts*.

Closes https://github.com/dahlia/optique/issues/350