### PR TITLE
Reject non-positive `domain()` and `hostname()` structural constraints

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -462,9 +462,10 @@ To be released.
     an unsatisfiable parser, so it is now rejected at construction time with
     a `TypeError`.  [[#350], [#630]]
 
- -  Fixed `domain()` and `hostname()` accepting non-positive structural
-    constraints such as `minLabels: 0` or `maxLength: -1`.  These values
-    are now rejected at construction time with a `RangeError`.  [[#351], [#631]]
+ -  Fixed `domain()` and `hostname()` accepting invalid structural
+    constraints such as `minLabels: 0`, `maxLength: -1`, `minLabels: NaN`,
+    or `maxLength: 1.5`.  These values are now rejected at construction
+    time with a `RangeError`.  [[#351], [#631]]
 
  -  Fixed `__FILE__` completion transport unable to represent `pattern` values
     containing `:` (e.g., Windows drive-letter prefixes like `C:/...`).

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -6198,7 +6198,7 @@ describe("hostname()", () => {
         () => hostname({ maxLength: 0 }),
         {
           name: "RangeError",
-          message: "maxLength must be at least 1.",
+          message: "maxLength must be an integer greater than or equal to 1.",
         },
       );
     });
@@ -6208,7 +6208,27 @@ describe("hostname()", () => {
         () => hostname({ maxLength: -1 }),
         {
           name: "RangeError",
-          message: "maxLength must be at least 1.",
+          message: "maxLength must be an integer greater than or equal to 1.",
+        },
+      );
+    });
+
+    it("should throw RangeError when maxLength is NaN", () => {
+      assert.throws(
+        () => hostname({ maxLength: NaN }),
+        {
+          name: "RangeError",
+          message: "maxLength must be an integer greater than or equal to 1.",
+        },
+      );
+    });
+
+    it("should throw RangeError when maxLength is fractional", () => {
+      assert.throws(
+        () => hostname({ maxLength: 1.5 }),
+        {
+          name: "RangeError",
+          message: "maxLength must be an integer greater than or equal to 1.",
         },
       );
     });
@@ -8857,7 +8877,7 @@ describe("domain()", () => {
         () => domain({ minLabels: 0 }),
         {
           name: "RangeError",
-          message: "minLabels must be at least 1.",
+          message: "minLabels must be an integer greater than or equal to 1.",
         },
       );
     });
@@ -8867,7 +8887,27 @@ describe("domain()", () => {
         () => domain({ minLabels: -1 }),
         {
           name: "RangeError",
-          message: "minLabels must be at least 1.",
+          message: "minLabels must be an integer greater than or equal to 1.",
+        },
+      );
+    });
+
+    it("should throw RangeError when minLabels is NaN", () => {
+      assert.throws(
+        () => domain({ minLabels: NaN }),
+        {
+          name: "RangeError",
+          message: "minLabels must be an integer greater than or equal to 1.",
+        },
+      );
+    });
+
+    it("should throw RangeError when minLabels is fractional", () => {
+      assert.throws(
+        () => domain({ minLabels: 1.5 }),
+        {
+          name: "RangeError",
+          message: "minLabels must be an integer greater than or equal to 1.",
         },
       );
     });

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -2585,7 +2585,7 @@ export interface HostnameOptions {
  *
  * @param options - Options for hostname validation.
  * @returns A value parser for hostnames.
- * @throws {RangeError} If `maxLength` is less than 1.
+ * @throws {RangeError} If `maxLength` is not a positive integer.
  * @since 0.10.0
  *
  * @example
@@ -2612,8 +2612,10 @@ export function hostname(
   const allowUnderscore = options?.allowUnderscore ?? false;
   const allowLocalhost = options?.allowLocalhost ?? true;
   const maxLength = options?.maxLength ?? 253;
-  if (maxLength < 1) {
-    throw new RangeError("maxLength must be at least 1.");
+  if (!Number.isInteger(maxLength) || maxLength < 1) {
+    throw new RangeError(
+      "maxLength must be an integer greater than or equal to 1.",
+    );
   }
 
   return {
@@ -4229,7 +4231,7 @@ export interface DomainOptions {
  *
  * @param options Parser options for domain validation.
  * @returns A parser that accepts valid domain names as strings.
- * @throws {RangeError} If `minLabels` is less than 1.
+ * @throws {RangeError} If `minLabels` is not a positive integer.
  * @throws {TypeError} If `allowSubdomains` is `false` and `minLabels` is
  *   greater than 2, since non-subdomain domains have exactly 2 labels.
  *
@@ -4263,8 +4265,10 @@ export function domain(
     : undefined;
   const minLabels = options?.minLabels ?? 2;
   const lowercase = options?.lowercase ?? false;
-  if (minLabels < 1) {
-    throw new RangeError("minLabels must be at least 1.");
+  if (!Number.isInteger(minLabels) || minLabels < 1) {
+    throw new RangeError(
+      "minLabels must be an integer greater than or equal to 1.",
+    );
   }
   if (!allowSubdomains && minLabels > 2) {
     throw new TypeError(


### PR DESCRIPTION
Fixes https://github.com/dahlia/optique/issues/351

`domain()` and `hostname()` previously accepted structurally invalid configuration without any error. For example, `domain({ minLabels: 0 })` would silently allow single-label values like `localhost`, and `hostname({ maxLength: -1 })` would produce impossible runtime errors like "maximum -1 characters". These non-positive values are never meaningful as structural constraints, so they should be caught early.

Both functions now validate their respective options at construction time and throw a `RangeError` if the value is less than 1:

```typescript
domain({ minLabels: 0 });   // RangeError: minLabels must be at least 1.
domain({ minLabels: -1 });  // RangeError: minLabels must be at least 1.

hostname({ maxLength: 0 });  // RangeError: maxLength must be at least 1.
hostname({ maxLength: -1 }); // RangeError: maxLength must be at least 1.
```

This is in the same family of configuration-validation fixes as #350 (contradictory label constraints) and #348 (malformed `allowedDomains` entries).

### Changed files

- *packages/core/src/valueparser.ts*: Added `minLabels < 1` validation in `domain()` and `maxLength < 1` validation in `hostname()`, both throwing `RangeError` at construction time.
- *packages/core/src/valueparser.test.ts*: Added tests for non-positive values (0 and -1) and boundary value (1) for both `domain()` `minLabels` and `hostname()` `maxLength`.
- *CHANGES.md*: Documented the fix.