### PR TITLE
Validate runtime context entries in `runWith()` and `runWithSync()`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -518,6 +518,15 @@ To be released.
     PowerShell passes `-Force` to `Get-ChildItem` when hidden files are
     requested.  [[#623], [#624]]
 
+ -  Added `isSourceContext()` predicate to `@optique/core/context` for
+    runtime validation of `SourceContext` objects.  [[#424], [#640]]
+
+ -  `runWith()`, `runWithSync()`, and `runWithAsync()` now validate that
+    every entry in the `contexts` array is a valid `SourceContext` before
+    processing.  Malformed entries are rejected with a clear `TypeError`
+    instead of crashing with raw errors like
+    `TypeError: context.getAnnotations is not a function`.  [[#424], [#640]]
+
 [#110]: https://github.com/dahlia/optique/issues/110
 [#113]: https://github.com/dahlia/optique/issues/113
 [#115]: https://github.com/dahlia/optique/issues/115
@@ -589,6 +598,7 @@ To be released.
 [#389]: https://github.com/dahlia/optique/issues/389
 [#395]: https://github.com/dahlia/optique/issues/395
 [#396]: https://github.com/dahlia/optique/issues/396
+[#424]: https://github.com/dahlia/optique/issues/424
 [#429]: https://github.com/dahlia/optique/issues/429
 [#490]: https://github.com/dahlia/optique/pull/490
 [#507]: https://github.com/dahlia/optique/issues/507
@@ -652,6 +662,7 @@ To be released.
 [#635]: https://github.com/dahlia/optique/pull/635
 [#636]: https://github.com/dahlia/optique/pull/636
 [#639]: https://github.com/dahlia/optique/pull/639
+[#640]: https://github.com/dahlia/optique/pull/640
 
 ### @optique/config
 

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -264,6 +264,29 @@ export function isPlaceholderValue(value: unknown): boolean {
  * @returns `true` if the context is static, `false` otherwise.
  * @since 0.10.0
  */
+/**
+ * Checks whether the given value conforms to the {@link SourceContext}
+ * interface at runtime.
+ *
+ * This validates the minimum required shape: an object with a `symbol`-typed
+ * `id` property and a `getAnnotations` method.
+ *
+ * @param object The value to check.
+ * @returns `true` if the value is a valid {@link SourceContext}, `false`
+ *          otherwise.
+ * @since 1.0.0
+ */
+export function isSourceContext(
+  object: unknown,
+): object is SourceContext<unknown> {
+  return typeof object === "object" && object != null &&
+    !Array.isArray(object) &&
+    "id" in object &&
+    typeof (object as SourceContext<unknown>).id === "symbol" &&
+    "getAnnotations" in object &&
+    typeof (object as SourceContext<unknown>).getAnnotations === "function";
+}
+
 export function isStaticContext(context: SourceContext<unknown>): boolean {
   // If the context explicitly declares its static-ness, use that directly
   // to avoid calling getAnnotations() and triggering any side effects it

--- a/packages/core/src/facade.test.ts
+++ b/packages/core/src/facade.test.ts
@@ -9148,3 +9148,99 @@ describe("branch coverage: facade.ts edge cases", () => {
     assert.ok(methodIdentityHeld);
   });
 });
+
+describe("runWith/runWithSync context validation", () => {
+  const parser = option("--name", string());
+
+  const baseOptions = { args: [] as string[] };
+
+  describe("runWithSync", () => {
+    it("throws TypeError for empty object context", () => {
+      assert.throws(
+        () => runWithSync(parser, "test", [{} as never], baseOptions),
+        {
+          name: "TypeError",
+          message:
+            /Expected each context to be a SourceContext, but got: object at index 0\./,
+        },
+      );
+    });
+
+    it("throws TypeError for null context", () => {
+      assert.throws(
+        () => runWithSync(parser, "test", [null as never], baseOptions),
+        {
+          name: "TypeError",
+          message:
+            /Expected each context to be a SourceContext, but got: null at index 0\./,
+        },
+      );
+    });
+
+    it("throws TypeError for number context", () => {
+      assert.throws(
+        () => runWithSync(parser, "test", [42 as never], baseOptions),
+        {
+          name: "TypeError",
+          message:
+            /Expected each context to be a SourceContext, but got: number at index 0\./,
+        },
+      );
+    });
+
+    it("throws TypeError for array context", () => {
+      assert.throws(
+        () => runWithSync(parser, "test", [[] as never], baseOptions),
+        {
+          name: "TypeError",
+          message:
+            /Expected each context to be a SourceContext, but got: array at index 0\./,
+        },
+      );
+    });
+
+    it("reports correct index for second invalid context", () => {
+      const validContext: SourceContext = {
+        id: Symbol("valid"),
+        getAnnotations: () => ({}),
+      };
+      assert.throws(
+        () =>
+          runWithSync(
+            parser,
+            "test",
+            [validContext, {} as never],
+            baseOptions,
+          ),
+        {
+          name: "TypeError",
+          message: /at index 1\./,
+        },
+      );
+    });
+  });
+
+  describe("runWith", () => {
+    it("rejects with TypeError for empty object context", async () => {
+      await assert.rejects(
+        () => runWith(parser, "test", [{} as never], baseOptions),
+        {
+          name: "TypeError",
+          message:
+            /Expected each context to be a SourceContext, but got: object at index 0\./,
+        },
+      );
+    });
+
+    it("rejects with TypeError for array context", async () => {
+      await assert.rejects(
+        () => runWith(parser, "test", [[] as never], baseOptions),
+        {
+          name: "TypeError",
+          message:
+            /Expected each context to be a SourceContext, but got: array at index 0\./,
+        },
+      );
+    });
+  });
+});

--- a/packages/core/src/facade.test.ts
+++ b/packages/core/src/facade.test.ts
@@ -9244,4 +9244,17 @@ describe("runWith/runWithSync context validation", () => {
       );
     });
   });
+
+  describe("runWithAsync", () => {
+    it("rejects with TypeError for null context", async () => {
+      await assert.rejects(
+        () => runWithAsync(parser, "test", [null as never], baseOptions),
+        {
+          name: "TypeError",
+          message:
+            "Expected each context to be a SourceContext, but got: null at index 0.",
+        },
+      );
+    });
+  });
 });

--- a/packages/core/src/facade.test.ts
+++ b/packages/core/src/facade.test.ts
@@ -9161,7 +9161,7 @@ describe("runWith/runWithSync context validation", () => {
         {
           name: "TypeError",
           message:
-            /Expected each context to be a SourceContext, but got: object at index 0\./,
+            "Expected each context to be a SourceContext, but got: object at index 0.",
         },
       );
     });
@@ -9172,7 +9172,7 @@ describe("runWith/runWithSync context validation", () => {
         {
           name: "TypeError",
           message:
-            /Expected each context to be a SourceContext, but got: null at index 0\./,
+            "Expected each context to be a SourceContext, but got: null at index 0.",
         },
       );
     });
@@ -9183,7 +9183,7 @@ describe("runWith/runWithSync context validation", () => {
         {
           name: "TypeError",
           message:
-            /Expected each context to be a SourceContext, but got: number at index 0\./,
+            "Expected each context to be a SourceContext, but got: number at index 0.",
         },
       );
     });
@@ -9194,7 +9194,7 @@ describe("runWith/runWithSync context validation", () => {
         {
           name: "TypeError",
           message:
-            /Expected each context to be a SourceContext, but got: array at index 0\./,
+            "Expected each context to be a SourceContext, but got: array at index 0.",
         },
       );
     });
@@ -9214,7 +9214,8 @@ describe("runWith/runWithSync context validation", () => {
           ),
         {
           name: "TypeError",
-          message: /at index 1\./,
+          message:
+            "Expected each context to be a SourceContext, but got: object at index 1.",
         },
       );
     });
@@ -9227,7 +9228,7 @@ describe("runWith/runWithSync context validation", () => {
         {
           name: "TypeError",
           message:
-            /Expected each context to be a SourceContext, but got: object at index 0\./,
+            "Expected each context to be a SourceContext, but got: object at index 0.",
         },
       );
     });
@@ -9238,7 +9239,7 @@ describe("runWith/runWithSync context validation", () => {
         {
           name: "TypeError",
           message:
-            /Expected each context to be a SourceContext, but got: array at index 0\./,
+            "Expected each context to be a SourceContext, but got: array at index 0.",
         },
       );
     });

--- a/packages/core/src/facade.ts
+++ b/packages/core/src/facade.ts
@@ -53,11 +53,30 @@ import { string } from "./valueparser.ts";
 import { type Annotations, injectAnnotations } from "./annotations.ts";
 import {
   isPlaceholderValue,
+  isSourceContext,
   type ParserValuePlaceholder,
   type SourceContext,
 } from "./context.ts";
 
 export type { ParserValuePlaceholder, SourceContext };
+
+function validateContexts(
+  contexts: readonly unknown[],
+): void {
+  for (let i = 0; i < contexts.length; i++) {
+    if (!isSourceContext(contexts[i])) {
+      const value = contexts[i];
+      const type = value === null
+        ? "null"
+        : Array.isArray(value)
+        ? "array"
+        : typeof value;
+      throw new TypeError(
+        `Expected each context to be a SourceContext, but got: ${type} at index ${i}.`,
+      );
+    }
+  }
+}
 
 function isPlainObject(value: object): boolean {
   const proto = Object.getPrototypeOf(value);
@@ -3236,6 +3255,7 @@ export async function runWith<
     & RunWithOptions<THelp, TError>
     & ContextOptionsParam<TContexts, InferValue<TParser>>,
 ): Promise<InferValue<TParser>> {
+  validateContexts(contexts);
   const args = options?.args ?? [];
 
   // Early exit: skip context processing for help/version/completion
@@ -3417,6 +3437,7 @@ export function runWithSync<
     & RunWithOptions<THelp, TError>
     & ContextOptionsParam<TContexts, InferValue<TParser>>,
 ): InferValue<TParser> {
+  validateContexts(contexts);
   const args = options?.args ?? [];
 
   // Early exit: skip context processing for help/version/completion


### PR DESCRIPTION
## Summary

Fixes https://github.com/dahlia/optique/issues/424.

`runWith()`, `runWithSync()`, and `runWithAsync()` previously assumed that every entry in the `contexts` array was a valid `SourceContext`, without any runtime validation. Passing a malformed object (e.g., `{}` or `null`) would cause the runner to crash with an unhelpful error like `TypeError: context.getAnnotations is not a function`.

This PR adds upfront validation so that invalid entries are rejected early with a clear `TypeError` that includes the actual type and index of the offending entry:

```typescript
runWithSync(parser, "test", [{} as never], { args: [] });
// TypeError: Expected each context to be a SourceContext, but got: object at index 0.
```

A new `isSourceContext()` predicate is also exported from *@optique/core/context* for use by external code that needs to check whether a value conforms to the `SourceContext` interface at runtime.

## Test plan

- [x] Added 7 tests covering `runWith` and `runWithSync` with various invalid context types: empty object, `null`, number, array, and correct index reporting for the second invalid entry in a multi-context array
- [x] All existing tests pass (`mise test:deno`, 360 tests)
- [x] Type check and lint pass (`mise check`)