### PR TITLE
Fix `encodeSuggestions()` not escaping tabs or newlines in completion descriptions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -207,6 +207,12 @@ To be released.
     instead of expanding the variable, so extension filtering (e.g.,
     `*.json`, `*.yaml`) now works correctly.  [[#256], [#639]]
 
+ -  Fixed `encodeSuggestions()` for zsh, fish, Nushell, and PowerShell not
+    escaping tabs and newlines in completion descriptions.  Descriptions
+    containing `lineBreak()` terms or tab characters now have those
+    characters replaced with spaces so the shell completion protocol is not
+    corrupted.  [[#247], [#642]]
+
  -  Fixed duplicate detection for equals-joined option syntax in `option()`
     when the value parser produces deferred or dependency-source state
     (for example, `DerivedValueParser` or `DependencySource`).  Repeated
@@ -563,6 +569,7 @@ To be released.
 [#241]: https://github.com/dahlia/optique/issues/241
 [#242]: https://github.com/dahlia/optique/issues/242
 [#245]: https://github.com/dahlia/optique/issues/245
+[#247]: https://github.com/dahlia/optique/issues/247
 [#248]: https://github.com/dahlia/optique/issues/248
 [#249]: https://github.com/dahlia/optique/issues/249
 [#250]: https://github.com/dahlia/optique/issues/250
@@ -668,6 +675,7 @@ To be released.
 [#638]: https://github.com/dahlia/optique/pull/638
 [#639]: https://github.com/dahlia/optique/pull/639
 [#641]: https://github.com/dahlia/optique/pull/641
+[#642]: https://github.com/dahlia/optique/pull/642
 
 ### @optique/config
 

--- a/packages/core/src/completion.test.ts
+++ b/packages/core/src/completion.test.ts
@@ -14,7 +14,7 @@ import {
   zsh,
 } from "./completion.ts";
 import type { Suggestion } from "./parser.ts";
-import { message } from "./message.ts";
+import { lineBreak, message, text } from "./message.ts";
 
 // Helper functions for shell availability and testing
 function getStdoutFromExecError(error: unknown): string | undefined {
@@ -1546,6 +1546,19 @@ _nohidden_cli 2>/dev/null
         rmSync(tempDir, { recursive: true, force: true });
       }
     });
+
+    it("should sanitize tabs and newlines in descriptions", () => {
+      const suggestions: Suggestion[] = [
+        {
+          kind: "literal",
+          text: "--opt",
+          description: [text("Line 1"), lineBreak(), text("Line\t2")],
+        },
+      ];
+
+      const encoded = Array.from(zsh.encodeSuggestions(suggestions));
+      deepStrictEqual(encoded, ["--opt\0Line 1 Line 2\0"]);
+    });
   });
 
   describe("pwsh shell completion", () => {
@@ -1742,6 +1755,19 @@ _nohidden_cli 2>/dev/null
       deepStrictEqual(encoded[0].includes("Enable verbose mode"), true);
       // Should not contain ANSI color codes
       deepStrictEqual(encoded[0].includes("\x1b["), false);
+    });
+
+    it("should sanitize tabs and newlines in descriptions", () => {
+      const suggestions: Suggestion[] = [
+        {
+          kind: "literal",
+          text: "--opt",
+          description: [text("Line 1"), lineBreak(), text("Line\t2")],
+        },
+      ];
+
+      const encoded = Array.from(pwsh.encodeSuggestions(suggestions));
+      deepStrictEqual(encoded, ["--opt\t--opt\tLine 1 Line 2"]);
     });
 
     it("should strip tab-delimited metadata before parsing __FILE__ directive", () => {
@@ -2134,6 +2160,19 @@ printf '__FILE__:file::src/:0\\n'
       deepStrictEqual(encoded[0].includes("\x1b["), false);
     });
 
+    it("should sanitize tabs and newlines in descriptions", () => {
+      const suggestions: Suggestion[] = [
+        {
+          kind: "literal",
+          text: "--opt",
+          description: [text("Line 1"), lineBreak(), text("Line\t2")],
+        },
+      ];
+
+      const encoded = Array.from(fish.encodeSuggestions(suggestions));
+      deepStrictEqual(encoded, ["--opt\tLine 1 Line 2"]);
+    });
+
     it("should sanitize program names with special characters", () => {
       const script = fish.generateScript("my-app.js");
 
@@ -2492,6 +2531,19 @@ ${functionName}
       deepStrictEqual(encoded[0].includes("Enable verbose mode"), true);
       // Should not contain ANSI color codes
       deepStrictEqual(encoded[0].includes("\x1b["), false);
+    });
+
+    it("should sanitize tabs and newlines in descriptions", () => {
+      const suggestions: Suggestion[] = [
+        {
+          kind: "literal",
+          text: "--opt",
+          description: [text("Line 1"), lineBreak(), text("Line\t2")],
+        },
+      ];
+
+      const encoded = Array.from(nu.encodeSuggestions(suggestions));
+      deepStrictEqual(encoded, ["--opt\tLine 1 Line 2"]);
     });
 
     it("should use 2-space indentation in generated script", () => {

--- a/packages/core/src/completion.ts
+++ b/packages/core/src/completion.ts
@@ -51,6 +51,18 @@ function encodePattern(pattern: string): string {
 }
 
 /**
+ * Replaces control characters that would corrupt shell completion protocols.
+ * Shell completion formats use tabs as field delimiters and newlines as record
+ * delimiters.  Null bytes are used as delimiters in zsh's format.
+ * @param description The description string to sanitize.
+ * @returns The sanitized description with control characters replaced by spaces.
+ * @internal
+ */
+function sanitizeDescription(description: string): string {
+  return description.replace(/[\t\n\r\0]/g, " ");
+}
+
+/**
  * A shell completion generator.
  * @since 0.6.0
  */
@@ -360,7 +372,9 @@ compdef _${programName.replace(/[^a-zA-Z0-9]/g, "_")} ${programName}
       if (suggestion.kind === "literal") {
         const description = suggestion.description == null
           ? ""
-          : formatMessage(suggestion.description, { colors: false });
+          : sanitizeDescription(
+            formatMessage(suggestion.description, { colors: false }),
+          );
         yield `${suggestion.text}\0${description}\0`;
       } else {
         // Emit special marker for native file completion
@@ -368,7 +382,9 @@ compdef _${programName.replace(/[^a-zA-Z0-9]/g, "_")} ${programName}
         const hidden = suggestion.includeHidden ? "1" : "0";
         const description = suggestion.description == null
           ? ""
-          : formatMessage(suggestion.description, { colors: false });
+          : sanitizeDescription(
+            formatMessage(suggestion.description, { colors: false }),
+          );
         const pattern = encodePattern(suggestion.pattern ?? "");
         yield `__FILE__:${suggestion.type}:${extensions}:${pattern}:${hidden}\0${description}\0`;
       }
@@ -542,7 +558,9 @@ complete -c ${programName} -f -a '(${functionName})'
       if (suggestion.kind === "literal") {
         const description = suggestion.description == null
           ? ""
-          : formatMessage(suggestion.description, { colors: false });
+          : sanitizeDescription(
+            formatMessage(suggestion.description, { colors: false }),
+          );
         // Format: value\tdescription
         yield `${suggestion.text}\t${description}`;
       } else {
@@ -551,7 +569,9 @@ complete -c ${programName} -f -a '(${functionName})'
         const hidden = suggestion.includeHidden ? "1" : "0";
         const description = suggestion.description == null
           ? ""
-          : formatMessage(suggestion.description, { colors: false });
+          : sanitizeDescription(
+            formatMessage(suggestion.description, { colors: false }),
+          );
         const pattern = encodePattern(suggestion.pattern ?? "");
         yield `__FILE__:${suggestion.type}:${extensions}:${pattern}:${hidden}\t${description}`;
       }
@@ -799,7 +819,9 @@ ${functionName}-external
       if (suggestion.kind === "literal") {
         const description = suggestion.description == null
           ? ""
-          : formatMessage(suggestion.description, { colors: false });
+          : sanitizeDescription(
+            formatMessage(suggestion.description, { colors: false }),
+          );
         // Format: value\tdescription
         yield `${suggestion.text}\t${description}`;
       } else {
@@ -808,7 +830,9 @@ ${functionName}-external
         const hidden = suggestion.includeHidden ? "1" : "0";
         const description = suggestion.description == null
           ? ""
-          : formatMessage(suggestion.description, { colors: false });
+          : sanitizeDescription(
+            formatMessage(suggestion.description, { colors: false }),
+          );
         const pattern = encodePattern(suggestion.pattern ?? "");
         yield `__FILE__:${suggestion.type}:${extensions}:${pattern}:${hidden}\t${description}`;
       }
@@ -981,7 +1005,9 @@ ${
       if (suggestion.kind === "literal") {
         const description = suggestion.description == null
           ? ""
-          : formatMessage(suggestion.description, { colors: false });
+          : sanitizeDescription(
+            formatMessage(suggestion.description, { colors: false }),
+          );
         // Format: text\tlistItemText\tdescription
         yield `${suggestion.text}\t${suggestion.text}\t${description}`;
       } else {
@@ -990,7 +1016,9 @@ ${
         const hidden = suggestion.includeHidden ? "1" : "0";
         const description = suggestion.description == null
           ? ""
-          : formatMessage(suggestion.description, { colors: false });
+          : sanitizeDescription(
+            formatMessage(suggestion.description, { colors: false }),
+          );
         const pattern = encodePattern(suggestion.pattern ?? "");
         yield `__FILE__:${suggestion.type}:${extensions}:${pattern}:${hidden}\t[file]\t${description}`;
       }


### PR DESCRIPTION
## Summary

Shell completion encoding in `encodeSuggestions()` for zsh, fish, Nushell, and PowerShell passed `formatMessage()` output directly into delimiter-separated payloads without sanitizing control characters. When a suggestion description contained a `lineBreak()` term or a tab character, the resulting newline or tab would corrupt the shell completion protocol by injecting extra records or extra fields.

For example, a suggestion like this:

```typescript
const suggestions = [{
  kind: "literal" as const,
  text: "--opt",
  description: [text("Line 1"), lineBreak(), text("Line\t2")],
}];
```

would produce output containing raw `\n` and `\t` inside the description field, breaking fish's tab-separated format, Nushell's tab-separated format, PowerShell's three-field tab-delimited format, and zsh's line-based `read` loop (despite its null-byte delimiters).

This patch adds a `sanitizeDescription()` helper in *packages/core/src/completion.ts* that replaces tabs, newlines, carriage returns, and null bytes with spaces, and applies it to all 8 `formatMessage()` call sites across the four affected shells. Bash is unaffected because it does not emit descriptions.

Fixes https://github.com/dahlia/optique/issues/247

## Test plan

- Added regression tests in *packages/core/src/completion.test.ts* for all four shells (zsh, fish, nu, pwsh) verifying that descriptions containing `lineBreak()` and tab characters are sanitized to spaces in the encoded output
- All existing completion tests continue to pass
- Full cross-runtime test suite (`mise test`) passes