### PR TITLE
Validate non-string `extensions` entries in `path()`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1052,6 +1052,11 @@ interactive prompt fallback integration via Inquirer.js.  [[#87], [#137]]
     JavaScript truthiness silently coerced invalid values like `"no"` into
     `true`.  [[#383], [#591]]
 
+ -  Fixed `path()` to reject non-string extension entries at construction
+    time.  Previously, non-string values (e.g., numbers) bypassed the
+    leading-dot validation and leaked into error messages and completion
+    payloads.  [[#346], [#651]]
+
 [#112]: https://github.com/dahlia/optique/issues/112
 [#160]: https://github.com/dahlia/optique/issues/160
 [#163]: https://github.com/dahlia/optique/pull/163
@@ -1059,6 +1064,7 @@ interactive prompt fallback integration via Inquirer.js.  [[#87], [#137]]
 [#258]: https://github.com/dahlia/optique/issues/258
 [#309]: https://github.com/dahlia/optique/issues/309
 [#343]: https://github.com/dahlia/optique/issues/343
+[#346]: https://github.com/dahlia/optique/issues/346
 [#358]: https://github.com/dahlia/optique/issues/358
 [#361]: https://github.com/dahlia/optique/issues/361
 [#383]: https://github.com/dahlia/optique/issues/383
@@ -1069,6 +1075,7 @@ interactive prompt fallback integration via Inquirer.js.  [[#87], [#137]]
 [#543]: https://github.com/dahlia/optique/pull/543
 [#545]: https://github.com/dahlia/optique/pull/545
 [#591]: https://github.com/dahlia/optique/pull/591
+[#651]: https://github.com/dahlia/optique/pull/651
 
 ### @optique/man
 

--- a/packages/run/src/valueparser.test.ts
+++ b/packages/run/src/valueparser.test.ts
@@ -594,6 +594,36 @@ describe("path", () => {
         { name: "TypeError" },
       );
     });
+
+    it("should throw on non-string extension (number)", () => {
+      assert.throws(
+        () => path({ extensions: [123 as never] }),
+        {
+          name: "TypeError",
+          message: /must start with a dot/,
+        },
+      );
+    });
+
+    it("should throw on non-string extension (null)", () => {
+      assert.throws(
+        () => path({ extensions: [null as never] }),
+        {
+          name: "TypeError",
+          message: /must start with a dot/,
+        },
+      );
+    });
+
+    it("should throw on non-string extension mixed with valid entries", () => {
+      assert.throws(
+        () => path({ extensions: [".json", 456 as never] }),
+        {
+          name: "TypeError",
+          message: /must start with a dot/,
+        },
+      );
+    });
   });
 
   describe("combined validations", () => {

--- a/packages/run/src/valueparser.ts
+++ b/packages/run/src/valueparser.ts
@@ -234,7 +234,7 @@ export function path(options: PathOptions = {}): ValueParser<"sync", string> {
   }
   if (extensions) {
     for (const ext of extensions) {
-      if (!ext.startsWith(".")) {
+      if (typeof ext !== "string" || !ext.startsWith(".")) {
         throw new TypeError(
           `Each extension must start with a dot, got: ${JSON.stringify(ext)}`,
         );


### PR DESCRIPTION
Closes https://github.com/dahlia/optique/issues/346

The `path()` value parser validates that each entry in the `extensions` array starts with a leading dot, but this check calls `.startsWith(".")` directly on the entry without first verifying that it is a string. When a non-string value (e.g., a number or `null`) is passed at runtime via a type assertion like `as never`, the call throws an unhelpful `TypeError: ext.startsWith is not a function` instead of the intended validation message.

This PR adds a `typeof ext !== "string"` guard before the `.startsWith()` call in *packages/run/src/valueparser.ts* so that all malformed entries are rejected with the same clear error:

```
TypeError: Each extension must start with a dot, got: 123
```

Three regression tests are included in *packages/run/src/valueparser.test.ts* for non-string entries (number, `null`, and a mixed array with one valid and one invalid entry).