### PR TITLE
Validate `prefix` in `createEnvContext()`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -840,6 +840,9 @@ environment variable integration via source contexts.  [[#86], [#135]]
  -  Added support for env-only values via `bindEnv(fail<T>(), ...)` when a
     value should not be exposed as a CLI option.
 
+ -  `createEnvContext()` now validates `prefix` at runtime, rejecting
+    non-string values with a `TypeError`.  [[#384], [#652]]
+
  -  `createEnvContext()` now throws a `TypeError` when `source` is not
     a function, instead of deferring the crash to environment lookup time.
     [[#390], [#600]]
@@ -859,6 +862,7 @@ environment variable integration via source contexts.  [[#86], [#135]]
 [#86]: https://github.com/dahlia/optique/issues/86
 [#135]: https://github.com/dahlia/optique/pull/135
 [#268]: https://github.com/dahlia/optique/issues/268
+[#384]: https://github.com/dahlia/optique/issues/384
 [#390]: https://github.com/dahlia/optique/issues/390
 [#399]: https://github.com/dahlia/optique/issues/399
 [#415]: https://github.com/dahlia/optique/issues/415
@@ -866,6 +870,7 @@ environment variable integration via source contexts.  [[#86], [#135]]
 [#600]: https://github.com/dahlia/optique/pull/600
 [#633]: https://github.com/dahlia/optique/pull/633
 [#637]: https://github.com/dahlia/optique/pull/637
+[#652]: https://github.com/dahlia/optique/pull/652
 
 ### @optique/git
 

--- a/packages/env/src/index.test.ts
+++ b/packages/env/src/index.test.ts
@@ -1485,6 +1485,51 @@ describe("createEnvContext defaults", () => {
     );
   });
 
+  it("throws TypeError when prefix is not a string", () => {
+    assert.throws(
+      () => createEnvContext({ prefix: 123 as never }),
+      {
+        name: "TypeError",
+        message: "Expected prefix to be a string, but got: number.",
+      },
+    );
+    assert.throws(
+      () => createEnvContext({ prefix: false as never }),
+      {
+        name: "TypeError",
+        message: "Expected prefix to be a string, but got: boolean.",
+      },
+    );
+    assert.throws(
+      () => createEnvContext({ prefix: { x: 1 } as never }),
+      {
+        name: "TypeError",
+        message: "Expected prefix to be a string, but got: object.",
+      },
+    );
+    assert.throws(
+      () => createEnvContext({ prefix: Symbol("P") as never }),
+      {
+        name: "TypeError",
+        message: "Expected prefix to be a string, but got: symbol.",
+      },
+    );
+    assert.throws(
+      () => createEnvContext({ prefix: null as never }),
+      {
+        name: "TypeError",
+        message: "Expected prefix to be a string, but got: null.",
+      },
+    );
+    assert.throws(
+      () => createEnvContext({ prefix: [] as never }),
+      {
+        name: "TypeError",
+        message: "Expected prefix to be a string, but got: array.",
+      },
+    );
+  });
+
   it("falls back to process.env when Deno.env.get is unavailable", () => {
     const originalDeno = Object.getOwnPropertyDescriptor(globalThis, "Deno");
     const originalProcess = Object.getOwnPropertyDescriptor(

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -119,6 +119,7 @@ function defaultEnvSource(key: string): string | undefined {
  *
  * @param options Environment context options.
  * @returns A context that provides environment source annotations.
+ * @throws {TypeError} If `prefix` is not a string.
  * @throws {TypeError} If `source` is not a function.
  * @since 1.0.0
  */
@@ -137,7 +138,19 @@ export function createEnvContext(options: EnvContextOptions = {}): EnvContext {
     );
   }
   const source = rawSource ?? defaultEnvSource;
-  const prefix = options.prefix ?? "";
+  const rawPrefix = options.prefix;
+  if (rawPrefix !== undefined && typeof rawPrefix !== "string") {
+    throw new TypeError(
+      `Expected prefix to be a string, but got: ${
+        rawPrefix === null
+          ? "null"
+          : Array.isArray(rawPrefix)
+          ? "array"
+          : typeof rawPrefix
+      }.`,
+    );
+  }
+  const prefix = rawPrefix ?? "";
 
   return {
     id: contextId,


### PR DESCRIPTION
## Summary

`createEnvContext()` now validates the `prefix` parameter at runtime, rejecting non-string values with a `TypeError`. Previously, malformed runtime values passed via `as never` or untyped JavaScript callers were silently accepted: numeric, boolean, and object prefixes were stringified into nonsensical environment variable names like `123FLAG` or `[object Object]FLAG`, while symbol prefixes crashed later during key construction with an unhelpful `TypeError: Cannot convert a Symbol value to a string`.

The new validation follows the same pattern already used for the `source` parameter in *packages/env/src/index.ts*, providing a clear error message that identifies the unexpected type:

```typescript
createEnvContext({ prefix: 123 as never });
// TypeError: Expected prefix to be a string, but got: number.
```

Closes https://github.com/dahlia/optique/issues/384

## Test plan

- Added a test case in *packages/env/src/index.test.ts* covering six malformed prefix types: number, boolean, object, symbol, null, and array
- Confirmed the test fails before the fix and passes after
- All existing tests pass across Deno, Node.js, and Bun (`mise test`)