### PR TITLE
Fix `prompt()` sharing a single completion cache across concurrent parses

### DIFF
--- a/packages/inquirer/src/index.test.ts
+++ b/packages/inquirer/src/index.test.ts
@@ -3777,6 +3777,46 @@ describe("prompt()", () => {
       assert.equal(promptCalls, 0);
     });
 
+    it("does not duplicate prompts under concurrent object() parses", async () => {
+      let promptCount = 0;
+      let release!: () => void;
+      const gate = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+
+      const parser = object({
+        name: prompt(fail<string>(), {
+          type: "input",
+          message: "name?",
+          prompter: async () => {
+            promptCount++;
+            if (promptCount === 1) {
+              await gate;
+              return "first";
+            }
+            return `value-${promptCount}`;
+          },
+        }),
+      });
+
+      const p1 = parseAsync(parser, []);
+      const p2 = parseAsync(parser, []);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      release();
+
+      const [r1, r2] = await Promise.all([p1, p2]);
+
+      // Each parse should trigger exactly one prompt execution (total 2).
+      assert.equal(promptCount, 2);
+      assert.ok(r1.success);
+      assert.ok(r2.success);
+      if (r1.success && r2.success) {
+        // Values should not be mixed up across parses.
+        const values = new Set([r1.value.name, r2.value.name]);
+        assert.equal(values.size, 2);
+      }
+    });
+
     it("keeps concurrent non-plain prompt annotations isolated", async () => {
       const marker = Symbol.for("@test/prompt-concurrent-class-state");
 

--- a/packages/inquirer/src/index.ts
+++ b/packages/inquirer/src/index.ts
@@ -673,14 +673,13 @@ export function prompt<M extends Mode, TValue, TState>(
   // 1. completability check (inside object.parse): sets this cache
   // 2. actual complete (inside object.complete): reads and clears this cache
   //
-  // The cache is scoped to a specific sentinel state instance so values from
-  // one completion cycle are never replayed for another parse invocation.
-  let promptCache:
-    | {
-      readonly state: InstanceType<typeof PromptBindInitialStateClass>;
-      readonly result: Promise<ValueParserResult<TValue>>;
-    }
-    | null = null;
+  // Uses a WeakMap keyed by sentinel state instance so concurrent parse
+  // invocations maintain independent caches.  WeakMap ensures entries are
+  // garbage-collected if phase 2 never fires (e.g., after a parse failure).
+  const promptCache = new WeakMap<
+    InstanceType<typeof PromptBindInitialStateClass>,
+    Promise<ValueParserResult<TValue>>
+  >();
 
   function shouldAttemptInnerCompletion(
     cliState: unknown,
@@ -1019,10 +1018,10 @@ export function prompt<M extends Mode, TValue, TState>(
       // was provided, avoiding unnecessary interactive prompts.  The cache
       // deduplicates the two calls so the prompt (or inner complete) runs once.
       if (state instanceof PromptBindInitialStateClass) {
-        if (promptCache?.state === state) {
+        if (promptCache.has(state)) {
           // Second call (real complete phase): consume the cache.
-          const cached = promptCache.result;
-          promptCache = null;
+          const cached = promptCache.get(state)!;
+          promptCache.delete(state);
           return cached;
         }
         // First call: try inner parser, fall back to prompt if it fails.
@@ -1066,7 +1065,7 @@ export function prompt<M extends Mode, TValue, TState>(
             : usePromptOrDeferSentinel(
               annotatedR as ValueParserResult<TValue>,
             );
-          promptCache = { state, result: cachedResult };
+          promptCache.set(state, cachedResult);
           return cachedResult;
         }
 
@@ -1175,7 +1174,7 @@ export function prompt<M extends Mode, TValue, TState>(
         const cachedResult = simParseR instanceof Promise
           ? (simParseR as Promise<ParserResult<TState>>).then(decideFromParse)
           : decideFromParse(simParseR as ParserResult<TState>);
-        promptCache = { state, result: cachedResult };
+        promptCache.set(state, cachedResult);
         return cachedResult;
       }
 


### PR DESCRIPTION
## Summary

`prompt()` stored its two-phase completion cache in a single closure variable (`let promptCache`), so concurrent `parseAsync()` calls on the same parser instance could overwrite each other's cache entry. This caused extra prompt executions (3 instead of 2) and potential value mix-ups between parses.

The fix replaces the single-slot variable with a `WeakMap` keyed by the sentinel state instance that `object()` creates per parse. Each concurrent parse now maintains its own independent cache entry. Using a `WeakMap` (rather than a plain `Map`) ensures that entries are garbage-collected if phase 2 of the completion cycle never fires, for example when `object()` parse fails after phase 1 succeeds for one field.

```typescript
// Before: single slot, last writer wins
let promptCache: { readonly state: ...; readonly result: ... } | null = null;

// After: one slot per sentinel, concurrent-safe
const promptCache = new WeakMap<..., Promise<ValueParserResult<TValue>>>();
```

## Reproduction

When two `parseAsync()` calls run concurrently on the same `object({ name: prompt(fail(), { ... }) })` parser, the prompter is invoked 3 times instead of the expected 2, and the first parse may receive a value from the third invocation rather than the first.

Closes https://github.com/dahlia/optique/issues/313

## Test plan

- Added a regression test in *packages/inquirer/src/index.test.ts* that runs two concurrent `parseAsync()` calls on an `object()` containing a `prompt(fail<string>(), ...)` field, asserts the prompter runs exactly twice, and verifies each parse receives a distinct value.
- All existing tests pass across Deno, Node.js, and Bun (`mise test`).