### PR TITLE
Fix `hostname()` to reject case variants and wildcard forms of `localhost`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -133,6 +133,14 @@ To be released.
     than DNS hostnames.  This also affects `socketAddress()` with
     `host: { type: "hostname" }`.  [[#376], [#657]]
 
+ -  Fixed `hostname()` accepting case variants of `localhost` (e.g.,
+    `LOCALHOST`, `LocalHost`) and wildcard-localhost forms (e.g.,
+    `*.localhost`) when `allowLocalhost` is set to `false`.  DNS hostnames
+    are case-insensitive, so all variants are now correctly rejected.
+    This also affects `socketAddress()` with
+    `host: { type: "hostname", hostname: { allowLocalhost: false } }`.
+    [[#321], [#659]]
+
  -  Fixed `locale()` value parser's `format()` method dropping Unicode
     extension subtags (e.g., `en-US-u-ca-buddhist` was formatted as `en-US`).
     The method now uses `Intl.Locale.toString()` instead of `baseName` to
@@ -626,6 +634,7 @@ To be released.
 [#315]: https://github.com/dahlia/optique/issues/315
 [#317]: https://github.com/dahlia/optique/issues/317
 [#320]: https://github.com/dahlia/optique/issues/320
+[#321]: https://github.com/dahlia/optique/issues/321
 [#323]: https://github.com/dahlia/optique/issues/323
 [#332]: https://github.com/dahlia/optique/issues/332
 [#338]: https://github.com/dahlia/optique/issues/338
@@ -729,6 +738,7 @@ To be released.
 [#653]: https://github.com/dahlia/optique/pull/653
 [#656]: https://github.com/dahlia/optique/pull/656
 [#657]: https://github.com/dahlia/optique/pull/657
+[#659]: https://github.com/dahlia/optique/pull/659
 
 ### @optique/config
 

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -6251,6 +6251,54 @@ describe("hostname()", () => {
       const result2 = parser.parse("my-localhost.com");
       assert.ok(result2.success);
     });
+
+    it("should reject case variants of localhost", () => {
+      const parser = hostname({ allowLocalhost: false });
+
+      for (const variant of ["LOCALHOST", "LocalHost", "Localhost"]) {
+        const result = parser.parse(variant);
+        assert.ok(!result.success, `expected ${variant} to be rejected`);
+        assert.deepStrictEqual(result.error, [
+          { type: "text", text: "Hostname 'localhost' is not allowed." },
+        ]);
+      }
+    });
+
+    it("should accept case variants when allowLocalhost is true", () => {
+      const parser = hostname({ allowLocalhost: true });
+
+      for (const variant of ["LOCALHOST", "LocalHost", "Localhost"]) {
+        const result = parser.parse(variant);
+        assert.ok(result.success, `expected ${variant} to be accepted`);
+      }
+    });
+
+    it("should reject wildcard localhost when allowLocalhost is false", () => {
+      const parser = hostname({
+        allowLocalhost: false,
+        allowWildcard: true,
+      });
+
+      for (
+        const variant of ["*.localhost", "*.LOCALHOST", "*.LocalHost"]
+      ) {
+        const result = parser.parse(variant);
+        assert.ok(!result.success, `expected ${variant} to be rejected`);
+        assert.deepStrictEqual(result.error, [
+          { type: "text", text: "Hostname 'localhost' is not allowed." },
+        ]);
+      }
+    });
+
+    it("should accept wildcard localhost when allowLocalhost is true", () => {
+      const parser = hostname({
+        allowLocalhost: true,
+        allowWildcard: true,
+      });
+
+      const result = parser.parse("*.localhost");
+      assert.ok(result.success);
+    });
   });
 
   describe("maxLength option", () => {

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -2663,7 +2663,7 @@ export function hostname(
       }
 
       // Check for localhost
-      if (!allowLocalhost && input === "localhost") {
+      if (!allowLocalhost && input.toLowerCase() === "localhost") {
         const errorMsg = options?.errors?.localhostNotAllowed;
         const msg = typeof errorMsg === "function"
           ? errorMsg(input)
@@ -2690,6 +2690,15 @@ export function hostname(
             ? errorMsg(input)
             : errorMsg ??
               message`Expected a valid hostname, but got ${input}.`;
+          return { success: false, error: msg };
+        }
+
+        // Check for wildcard localhost (e.g., *.localhost)
+        if (!allowLocalhost && rest.toLowerCase() === "localhost") {
+          const errorMsg = options?.errors?.localhostNotAllowed;
+          const msg = typeof errorMsg === "function"
+            ? errorMsg(input)
+            : errorMsg ?? message`Hostname 'localhost' is not allowed.`;
           return { success: false, error: msg };
         }
       }


### PR DESCRIPTION
`hostname({ allowLocalhost: false })` only blocked the exact lowercase string `"localhost"`. Because DNS hostnames are case-insensitive per RFC 1123, case variants like `"LOCALHOST"` and `"LocalHost"` should also be rejected. Additionally, wildcard forms rooted at localhost (e.g., `"*.localhost"`, `"*.LOCALHOST"`) bypassed the localhost check entirely since the wildcard validation runs in a separate code path.

This change makes the localhost comparison case-insensitive using `toLowerCase()` in *packages/core/src/valueparser.ts* and adds a dedicated check inside the wildcard validation block to reject `*.localhost` and its case variants when `allowLocalhost` is set to `false`. The fix also applies to `socketAddress()` since it delegates host validation to `hostname()`.

```typescript
const parser = hostname({ allowLocalhost: false, allowWildcard: true });

// All of these are now correctly rejected:
parser.parse("LOCALHOST");     // { success: false, ... }
parser.parse("LocalHost");     // { success: false, ... }
parser.parse("*.localhost");   // { success: false, ... }
parser.parse("*.LOCALHOST");   // { success: false, ... }
```

Closes https://github.com/dahlia/optique/issues/321