### PR TITLE
Fix shell completion extension filters to handle dot-prefixed extensions like `.json`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -238,6 +238,14 @@ To be released.
     (as produced by `path()`) are now normalized to `["ts", "json"]` before
     encoding.  [[#647], [#650]]
 
+ -  Fixed generated shell completion scripts not stripping leading dots from
+    extension filters, so that dot-prefixed extensions (e.g., `.json`) in the
+    transport protocol are handled correctly in Bash, fish, Nushell, and
+    PowerShell.  Also fixed a `Split-Path` error in PowerShell that caused
+    extension filtering to silently fail when the completion prefix was empty,
+    and rewrote the PowerShell extension matching to use the `-in` operator
+    instead of nested `ForEach-Object` pipelines.  [[#255], [#660]]
+
  -  Fixed shell completion scripts ignoring `Suggestion.file.pattern`, which
     caused file completions to enumerate the current directory instead of the
     pattern-specified path.  All five shell backends (Bash, zsh, fish, Nushell,
@@ -624,6 +632,7 @@ To be released.
 [#252]: https://github.com/dahlia/optique/issues/252
 [#253]: https://github.com/dahlia/optique/issues/253
 [#254]: https://github.com/dahlia/optique/issues/254
+[#255]: https://github.com/dahlia/optique/issues/255
 [#256]: https://github.com/dahlia/optique/issues/256
 [#262]: https://github.com/dahlia/optique/issues/262
 [#294]: https://github.com/dahlia/optique/issues/294
@@ -739,6 +748,7 @@ To be released.
 [#656]: https://github.com/dahlia/optique/pull/656
 [#657]: https://github.com/dahlia/optique/pull/657
 [#659]: https://github.com/dahlia/optique/pull/659
+[#660]: https://github.com/dahlia/optique/pull/660
 
 ### @optique/config
 

--- a/packages/core/src/completion.test.ts
+++ b/packages/core/src/completion.test.ts
@@ -1545,6 +1545,85 @@ printf "%s\\n" "\${COMPREPLY[@]}"
       );
     });
 
+    it("should filter files by dot-prefixed extensions in bash", (t) => {
+      if (!isShellAvailable("bash")) {
+        t.skip("bash not available");
+        return;
+      }
+
+      const tempDir = mkdtempSync(
+        join(tmpdir(), "bash-ext-dot-filter-"),
+      );
+
+      try {
+        // CLI emits __FILE__ with dot-prefixed extensions (.json,.yaml)
+        const cliScript = `#!/bin/bash
+printf '__FILE__:file:.json,.yaml::0\\n'
+`;
+        const cliPath = join(tempDir, "extapp");
+        writeFileSync(cliPath, cliScript, { mode: 0o755 });
+
+        // Create test files
+        writeFileSync(join(tempDir, "data.json"), "");
+        writeFileSync(join(tempDir, "config.yaml"), "");
+        writeFileSync(join(tempDir, "readme.txt"), "");
+        const subDir = join(tempDir, "subdir");
+        mkdirSync(subDir);
+
+        const script = bash.generateScript("extapp");
+
+        const testScript = `
+export PATH="${tempDir}:$PATH"
+source /dev/stdin <<'COMPLETION_SCRIPT'
+${script}
+COMPLETION_SCRIPT
+cd "${tempDir}"
+COMP_WORDS=("extapp" "")
+COMP_CWORD=1
+_extapp 2>&1
+if [ \${#COMPREPLY[@]} -gt 0 ]; then
+  printf "%s\\n" "\${COMPREPLY[@]}"
+else
+  echo "__NO_COMPLETIONS__"
+fi
+`;
+
+        const result = runCommand("bash", ["-c", testScript], {
+          cwd: tempDir,
+        });
+        const completions = result.trim().split("\n").filter((l) =>
+          l.length > 0
+        );
+
+        ok(
+          completions.some((c) => c.includes("data.json")),
+          `Expected data.json in completions, got: ${
+            JSON.stringify(completions)
+          }`,
+        );
+        ok(
+          completions.some((c) => c.includes("config.yaml")),
+          `Expected config.yaml in completions, got: ${
+            JSON.stringify(completions)
+          }`,
+        );
+        ok(
+          !completions.some((c) => c.includes("readme.txt")),
+          `Should not include readme.txt in completions, got: ${
+            JSON.stringify(completions)
+          }`,
+        );
+        ok(
+          completions.some((c) => c.includes("subdir")),
+          `Expected subdir/ in completions for navigation, got: ${
+            JSON.stringify(completions)
+          }`,
+        );
+      } finally {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
+    });
+
     it("should include directories for navigation in file type completion with extensions", () => {
       const script = bash.generateScript("fileext-cli");
 
@@ -2362,6 +2441,87 @@ printf '__FILE__:file::src/:0\\n'
       }
     });
 
+    it("should filter files by dot-prefixed extensions in pwsh", {
+      skip: process.platform === "win32" || !isShellAvailable("pwsh"),
+    }, () => {
+      // Bun ignores the skip option, so we need an early return as well:
+      if (process.platform === "win32") return;
+      if (!isShellAvailable("pwsh")) return;
+
+      const tempDir = mkdtempSync(
+        join(tmpdir(), "pwsh-ext-dot-filter-"),
+      );
+
+      try {
+        // CLI emits __FILE__ with dot-prefixed extensions (.json,.yaml)
+        const cliScript = `#!/bin/bash
+printf '__FILE__:file:.json,.yaml::0\\n'
+`;
+        const cliPath = join(tempDir, "extapp");
+        writeFileSync(cliPath, cliScript, { mode: 0o755 });
+
+        // Create test files
+        writeFileSync(join(tempDir, "data.json"), "");
+        writeFileSync(join(tempDir, "config.yaml"), "");
+        writeFileSync(join(tempDir, "readme.txt"), "");
+        const subDir = join(tempDir, "subdir");
+        mkdirSync(subDir);
+
+        const script = pwsh.generateScript("extapp");
+
+        const scriptPath = join(tempDir, "completion.ps1");
+        writeFileSync(scriptPath, script);
+
+        const testScriptPath = join(tempDir, "test.ps1");
+        writeFileSync(
+          testScriptPath,
+          `$env:PATH = "${tempDir}:" + $env:PATH\n` +
+            `. "${scriptPath}"\n` +
+            `$result = TabExpansion2 -inputScript 'extapp ' ` +
+            `-cursorColumn 7\n` +
+            `$result.CompletionMatches | ` +
+            `ForEach-Object { $_.CompletionText }\n`,
+        );
+
+        const result = runCommand(
+          "pwsh",
+          ["-NoProfile", "-NonInteractive", "-File", testScriptPath],
+          { cwd: tempDir },
+        );
+
+        const completions = result.trim().split("\n").filter((l) =>
+          l.length > 0
+        );
+
+        ok(
+          completions.some((c) => c.includes("data.json")),
+          `Expected data.json in completions, got: ${
+            JSON.stringify(completions)
+          }`,
+        );
+        ok(
+          completions.some((c) => c.includes("config.yaml")),
+          `Expected config.yaml in completions, got: ${
+            JSON.stringify(completions)
+          }`,
+        );
+        ok(
+          !completions.some((c) => c.includes("readme.txt")),
+          `Should not include readme.txt in completions, got: ${
+            JSON.stringify(completions)
+          }`,
+        );
+        ok(
+          completions.some((c) => c.includes("subdir")),
+          `Expected subdir/ in completions for navigation, got: ${
+            JSON.stringify(completions)
+          }`,
+        );
+      } finally {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
+    });
+
     it("should include directories for navigation in file type completion", () => {
       const script = pwsh.generateScript("filedir-cli");
 
@@ -3036,6 +3196,91 @@ ${functionName}
       }
     });
 
+    it("should filter files by dot-prefixed extensions in fish", (t) => {
+      if (!isShellAvailable("fish")) {
+        t.skip("fish not available");
+        return;
+      }
+
+      const tempDir = mkdtempSync(
+        join(tmpdir(), "fish-ext-dot-filter-"),
+      );
+
+      try {
+        // CLI emits __FILE__ with dot-prefixed extensions (.json,.yaml)
+        const cliScript = `#!/bin/bash
+printf '__FILE__:file:.json,.yaml::0\\tFile\\n'
+`;
+        const cliPath = join(tempDir, "extapp");
+        writeFileSync(cliPath, cliScript, { mode: 0o755 });
+
+        // Create test files
+        writeFileSync(join(tempDir, "data.json"), "");
+        writeFileSync(join(tempDir, "config.yaml"), "");
+        writeFileSync(join(tempDir, "readme.txt"), "");
+        const subDir = join(tempDir, "subdir");
+        mkdirSync(subDir);
+
+        const script = fish.generateScript("extapp");
+        const scriptPath = join(tempDir, "completion.fish");
+        writeFileSync(scriptPath, script);
+
+        const functionMatch = script.match(/function ([^\s]+)/);
+        const functionName = functionMatch
+          ? functionMatch[1]
+          : "__extapp_complete";
+        const testScript = `
+set -x PATH "${tempDir}" $PATH
+source "${scriptPath}"
+cd "${tempDir}"
+
+function commandline
+    switch $argv[1]
+        case '-poc'
+            echo "extapp"
+        case '-ct'
+            echo ""
+    end
+end
+
+${functionName}
+`;
+        const testScriptPath = join(tempDir, "test.fish");
+        writeFileSync(testScriptPath, testScript);
+        const result = runCommand("fish", [testScriptPath], { cwd: tempDir });
+        const completions = result.trim().split("\n").filter((l) =>
+          l.length > 0
+        );
+
+        ok(
+          completions.some((c) => c.includes("data.json")),
+          `Expected data.json in completions, got: ${
+            JSON.stringify(completions)
+          }`,
+        );
+        ok(
+          completions.some((c) => c.includes("config.yaml")),
+          `Expected config.yaml in completions, got: ${
+            JSON.stringify(completions)
+          }`,
+        );
+        ok(
+          !completions.some((c) => c.includes("readme.txt")),
+          `Should not include readme.txt in completions, got: ${
+            JSON.stringify(completions)
+          }`,
+        );
+        ok(
+          completions.some((c) => c.includes("subdir")),
+          `Expected subdir/ in completions for navigation, got: ${
+            JSON.stringify(completions)
+          }`,
+        );
+      } finally {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
+    });
+
     it("should include directories for navigation in file type completion", () => {
       const script = fish.generateScript("filedir-cli");
 
@@ -3619,6 +3864,103 @@ printf '__FILE__:file:::1\\tConfiguration file\\n'
           // With hidden=1, hidden files must be included even without dot prefix
           ok(completions.some((c) => c.includes(".hidden")));
           ok(completions.some((c) => c.includes("visible.txt")));
+        }
+      } finally {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
+    });
+
+    it("should filter files by dot-prefixed extensions in nu", {
+      skip: process.platform === "win32",
+    }, (t) => {
+      // Bun ignores the skip option, so we need an early return as well:
+      if (process.platform === "win32") return;
+      if (!isShellAvailable("nu")) {
+        t.skip("nu not available");
+        return;
+      }
+
+      const tempDir = mkdtempSync(
+        join(tmpdir(), "nu-ext-dot-filter-"),
+      );
+
+      try {
+        // CLI emits __FILE__ with dot-prefixed extensions (.json,.yaml)
+        const cliScript = `#!/bin/bash
+printf '__FILE__:file:.json,.yaml::0\\n'
+`;
+        const cliPath = join(tempDir, "extapp");
+        writeFileSync(cliPath, cliScript, { mode: 0o755 });
+
+        // Create test files
+        writeFileSync(join(tempDir, "data.json"), "");
+        writeFileSync(join(tempDir, "config.yaml"), "");
+        writeFileSync(join(tempDir, "readme.txt"), "");
+        const subDir = join(tempDir, "subdir");
+        mkdirSync(subDir);
+
+        const script = nu.generateScript("extapp");
+
+        const nuTempDir = mkdtempSync(
+          join(tmpdir(), "nu-ext-dot-test-"),
+        );
+        try {
+          const scriptPath = join(nuTempDir, "completion.nu");
+          writeFileSync(scriptPath, script);
+
+          const safeName = "extapp".replace(/[^a-zA-Z0-9]+/g, "-");
+          const functionName = `nu-complete-${safeName}`;
+          const testScript = `
+$env.PATH = ($env.PATH | prepend "${tempDir}")
+source ${scriptPath}
+
+do { ${functionName} "extapp " }
+`;
+          const testScriptPath = join(nuTempDir, "test.nu");
+          writeFileSync(testScriptPath, testScript);
+
+          const result = runCommand("nu", [testScriptPath], {
+            cwd: tempDir,
+          });
+
+          const lines = result.trim().split("\n");
+          const completions: string[] = [];
+          for (const line of lines) {
+            const match = line.match(
+              /│\s*\d+\s*│\s*([^│]+)\s*│/,
+            );
+            if (match) {
+              const value = match[1]?.trim();
+              if (value) completions.push(value);
+            }
+          }
+
+          ok(
+            completions.some((c) => c.includes("data.json")),
+            `Expected data.json in completions, got: ${
+              JSON.stringify(completions)
+            }`,
+          );
+          ok(
+            completions.some((c) => c.includes("config.yaml")),
+            `Expected config.yaml in completions, got: ${
+              JSON.stringify(completions)
+            }`,
+          );
+          ok(
+            !completions.some((c) => c.includes("readme.txt")),
+            `Should not include readme.txt in completions, got: ${
+              JSON.stringify(completions)
+            }`,
+          );
+          ok(
+            completions.some((c) => c.includes("subdir")),
+            `Expected subdir/ in completions for navigation, got: ${
+              JSON.stringify(completions)
+            }`,
+          );
+        } finally {
+          rmSync(nuTempDir, { recursive: true, force: true });
         }
       } finally {
         rmSync(tempDir, { recursive: true, force: true });

--- a/packages/core/src/completion.ts
+++ b/packages/core/src/completion.ts
@@ -115,6 +115,7 @@ function _${programName} () {
     if [[ "$line" == __FILE__:* ]]; then
       # Parse file completion directive: __FILE__:type:extensions:pattern:hidden
       IFS=':' read -r _ type extensions pattern hidden <<< "$line"
+      extensions="\${extensions//,\\./,}"; extensions="\${extensions#.}"
       pattern="\${pattern//%3A/:}"; pattern="\${pattern//%25/%}"
 
       # Save and adjust glob/shell options for safe file completion
@@ -721,7 +722,7 @@ ${
             # Filter by extensions if specified
             if test -n "$extensions" -a "$type" != directory
                 set -l filtered
-                set -l ext_list (string split ',' -- $extensions)
+                set -l ext_list (string replace -r '^\\.' '' -- (string split ',' -- $extensions))
                 for item in $items
                     # Skip directories, they don't have extensions
                     if string match -q '*/' -- $item
@@ -1002,7 +1003,7 @@ ${
             if ($extensions | is-empty) {
               (if $hidden { ls -a $ls_pattern } else { ls $ls_pattern }) | where type == file or type == dir
             } else {
-              let ext_list = ($extensions | split row ',')
+              let ext_list = ($extensions | split row ',' | each {|e| $e | str replace -r '^\\.' '' })
               let all_items = (if $hidden { ls -a $ls_pattern } else { ls $ls_pattern })
               let dirs = $all_items | where type == dir
               let files = $all_items | where type == file | where {|f|
@@ -1019,7 +1020,7 @@ ${
             if ($extensions | is-empty) {
               if $hidden { ls -a $ls_pattern } else { ls $ls_pattern }
             } else {
-              let ext_list = ($extensions | split row ',')
+              let ext_list = ($extensions | split row ',' | each {|e| $e | str replace -r '^\\.' '' })
               let all_items = (if $hidden { ls -a $ls_pattern } else { ls $ls_pattern })
               let dirs = $all_items | where type == dir
               let files = $all_items | where type == file | where {|f|
@@ -1253,7 +1254,7 @@ ${
 
                 # Use -Force to include hidden files when requested, or when
                 # the prefix basename targets dotfiles (e.g., src/.e)
-                \$prefixBasename = Split-Path -Leaf \$prefix 2>\$null
+                \$prefixBasename = if (\$prefix) { Split-Path -Leaf \$prefix } else { '' }
                 \$forceParam = if (\$hidden -or (\$prefixBasename -and \$prefixBasename.StartsWith('.'))) { @{Force = \$true} } else { @{} }
 
                 # If prefix is a directory without trailing slash, append
@@ -1272,12 +1273,10 @@ ${
                     'file' {
                         if (\$extensions) {
                             # Filter by extensions, always include directories
-                            \$extList = \$extensions -split ','
+                            \$extList = (\$extensions -split ',') -replace '^\\.',''
                             \$items = Get-ChildItem @forceParam -Path \$globPath -ErrorAction SilentlyContinue |
                                 Where-Object {
-                                    if (\$_.PSIsContainer) { return \$true }
-                                    \$ext = \$_.Extension
-                                    \$extList | ForEach-Object { if (\$ext -eq ".\$_") { return \$true } }
+                                    \$_.PSIsContainer -or ((\$_.Extension -replace '^\\.','' ) -in \$extList)
                                 }
                         } else {
                             \$items = Get-ChildItem @forceParam -Path \$globPath -ErrorAction SilentlyContinue
@@ -1289,12 +1288,10 @@ ${
                     'any' {
                         if (\$extensions) {
                             # Filter by extensions, always include directories
-                            \$extList = \$extensions -split ','
+                            \$extList = (\$extensions -split ',') -replace '^\\.',''
                             \$items = Get-ChildItem @forceParam -Path \$globPath -ErrorAction SilentlyContinue |
                                 Where-Object {
-                                    if (\$_.PSIsContainer) { return \$true }
-                                    \$ext = \$_.Extension
-                                    \$extList | ForEach-Object { if (\$ext -eq ".\$_") { return \$true } }
+                                    \$_.PSIsContainer -or ((\$_.Extension -replace '^\\.','' ) -in \$extList)
                                 }
                         } else {
                             \$items = Get-ChildItem @forceParam -Path \$globPath -ErrorAction SilentlyContinue


### PR DESCRIPTION
## Summary

The generated shell completion scripts did not defensively strip leading dots from extension filters parsed from `__FILE__` directives. While `encodeExtensions()` already normalizes extensions on the TypeScript side (#647, #650), the shell scripts themselves would silently break if dot-prefixed extensions (e.g., `.json` instead of `json`) ever reached them through the transport protocol.

This PR adds defense-in-depth by making each shell's generated script strip leading dots from extensions after parsing. It also fixes two pre-existing PowerShell bugs that were discovered during testing.

## Changes

**Bash:** After parsing the `__FILE__` directive, the extensions variable is now cleaned with `${extensions//,\./,}` and `${extensions#.}` to strip dots from each comma-separated entry.

**Fish:** The `ext_list` is now built with `string replace -r '^\.' '' --` to strip leading dots from each extension after splitting.

**Nushell:** The `ext_list` pipeline now includes `each {|e| $e | str replace -r '^\.' '' }` to normalize extensions.

**PowerShell:** The extension matching logic was rewritten. The original code used nested `ForEach-Object` pipelines inside `Where-Object` for matching, but this pattern silently failed when running inside `TabExpansion2`. The new code uses the `-in` operator instead:

```powershell
# Before (broken inside TabExpansion2):
$extList = $extensions -split ','
$items = Get-ChildItem ... | Where-Object {
    if ($_.PSIsContainer) { return $true }
    $ext = $_.Extension
    $extList | ForEach-Object { if ($ext -eq ".$_") { return $true } }
}

# After:
$extList = ($extensions -split ',') -replace '^\.',''
$items = Get-ChildItem ... | Where-Object {
    $_.PSIsContainer -or (($_.Extension -replace '^\.','' ) -in $extList)
}
```

Additionally, `Split-Path -Leaf $prefix` threw a terminating error when `$prefix` was an empty string, which the `2>$null` redirect could not suppress. This caused the entire completion function to abort silently on every invocation where no prefix was typed. The fix guards the call with an `if ($prefix)` check.

## Test plan

- [ ] Added integration tests for all four shells (Bash, Fish, Nushell, PowerShell) that emit `__FILE__:file:.json,.yaml::0` with dot-prefixed extensions and verify that only matching files and directories appear in completions
- [ ] `mise test` passes across Deno, Node.js, and Bun

Closes #255