### PR TITLE
Fix missing-shell help for `--completion` rendering in command form

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -262,6 +262,14 @@ To be released.
     PowerShell) now use the transported pattern as the glob base when it is
     non-empty.  [[#251], [#656]]
 
+ -  Fixed `runParser()` missing-shell help for `--completion` rendering
+    in command form (`myapp completion [SHELL] [ARG...]`) instead of
+    option form.  When the user invokes `--completion` without a shell name,
+    the error message now shows option-form usage and respects custom option
+    names (e.g., `--completions`).  Previously, option-only mode showed no
+    follow-up help at all, and both-mode showed only the command form.
+    [[#275], [#668]]
+
  -  Fixed duplicate detection for equals-joined option syntax in `option()`
     when the value parser produces deferred or dependency-source state
     (for example, `DerivedValueParser` or `DependencySource`).  Repeated
@@ -652,6 +660,7 @@ To be released.
 [#255]: https://github.com/dahlia/optique/issues/255
 [#256]: https://github.com/dahlia/optique/issues/256
 [#262]: https://github.com/dahlia/optique/issues/262
+[#275]: https://github.com/dahlia/optique/issues/275
 [#294]: https://github.com/dahlia/optique/issues/294
 [#296]: https://github.com/dahlia/optique/issues/296
 [#300]: https://github.com/dahlia/optique/issues/300
@@ -773,6 +782,7 @@ To be released.
 [#661]: https://github.com/dahlia/optique/pull/661
 [#663]: https://github.com/dahlia/optique/pull/663
 [#664]: https://github.com/dahlia/optique/pull/664
+[#668]: https://github.com/dahlia/optique/pull/668
 
 ### @optique/config
 

--- a/packages/core/src/facade.test.ts
+++ b/packages/core/src/facade.test.ts
@@ -3338,6 +3338,109 @@ describe("Subcommand help edge cases (Issue #26 comprehensive coverage)", () => 
       assert.ok(errorOutput.includes("zsh"));
     });
 
+    it("should show option-form help when --completion is missing shell in option-only mode", () => {
+      const parser = object({
+        verbose: option("--verbose"),
+      });
+
+      let errorOutput = "";
+      let errorResult: unknown;
+
+      runParser(parser, "myapp", ["--completion"], {
+        completion: {
+          option: true,
+        },
+        onError: (exitCode) => {
+          errorResult = `error-${exitCode}`;
+          return errorResult;
+        },
+        stderr: (text) => {
+          errorOutput += text;
+        },
+      });
+
+      assert.equal(errorResult, "error-1");
+      assert.ok(errorOutput.includes("Missing shell name"));
+      // Should show option-form usage, not command-form
+      assert.ok(
+        errorOutput.includes("--completion"),
+        "Should include '--completion' in help output",
+      );
+      assert.ok(
+        !errorOutput.includes("Usage: myapp completion "),
+        "Should not show command-form usage",
+      );
+    });
+
+    it("should show option-form help when --completion is missing shell in both mode", () => {
+      const parser = object({
+        verbose: option("--verbose"),
+      });
+
+      let errorOutput = "";
+      let errorResult: unknown;
+
+      runParser(parser, "myapp", ["--completion"], {
+        completion: {
+          command: true,
+          option: true,
+        },
+        onError: (exitCode) => {
+          errorResult = `error-${exitCode}`;
+          return errorResult;
+        },
+        stderr: (text) => {
+          errorOutput += text;
+        },
+      });
+
+      assert.equal(errorResult, "error-1");
+      assert.ok(errorOutput.includes("Missing shell name"));
+      // Should show option-form usage since --completion was used
+      assert.ok(
+        errorOutput.includes("--completion"),
+        "Should include '--completion' in help output",
+      );
+      assert.ok(
+        !errorOutput.includes("Usage: myapp completion "),
+        "Should not show command-form usage",
+      );
+    });
+
+    it("should show custom option name in help when missing shell", () => {
+      const parser = object({
+        verbose: option("--verbose"),
+      });
+
+      let errorOutput = "";
+      let errorResult: unknown;
+
+      runParser(parser, "myapp", ["--completions"], {
+        completion: {
+          option: { names: ["--completions"] },
+        },
+        onError: (exitCode) => {
+          errorResult = `error-${exitCode}`;
+          return errorResult;
+        },
+        stderr: (text) => {
+          errorOutput += text;
+        },
+      });
+
+      assert.equal(errorResult, "error-1");
+      assert.ok(errorOutput.includes("Missing shell name"));
+      // Should use the custom option name
+      assert.ok(
+        errorOutput.includes("--completions"),
+        "Should include custom option name '--completions' in help output",
+      );
+      assert.ok(
+        !errorOutput.includes("Usage: myapp completion "),
+        "Should not show command-form usage",
+      );
+    });
+
     it("should support both command and option modes", () => {
       const parser = object({
         verbose: option("--verbose"),

--- a/packages/core/src/facade.ts
+++ b/packages/core/src/facade.ts
@@ -1686,7 +1686,9 @@ function handleCompletion<M extends Mode, THelp, TError>(
 
     // Show help for completion command if parser is available
     if (completionParser) {
-      const displayName = completionCommandDisplayName ?? "completion";
+      const displayName = isOptionMode
+        ? (completionOptionDisplayName ?? "--completion")
+        : (completionCommandDisplayName ?? "completion");
       const doc = getDocPage(completionParser, [displayName]);
       if (doc) {
         stderr(
@@ -2216,7 +2218,7 @@ export function runParser<
             [shell, ...completionArgs],
             programName,
             parser,
-            completionParsers.completionCommand,
+            completionParsers.completionOption,
             stdout,
             stderr,
             onCompletionResult,
@@ -2244,7 +2246,7 @@ export function runParser<
             [shell, ...completionArgs],
             programName,
             parser,
-            completionParsers.completionCommand,
+            completionParsers.completionOption,
             stdout,
             stderr,
             onCompletionResult,


### PR DESCRIPTION
When a user invokes `--completion` without providing a shell name, the error help was incorrectly rendered in command form (e.g., `Usage: myapp completion [SHELL] [ARG...]`) instead of option form. This happened in two scenarios:

1. In both-mode (`completion: { command: true, option: true }`), the help showed the command form even though the user used `--completion`.
2. In option-only mode (`completion: { option: true }`), no follow-up help was shown at all because `completionParsers.completionCommand` was `null`.

The root cause was that `handleCompletion()` always used `completionCommandDisplayName` for the display name and the callers in `runParser()` always passed `completionParsers.completionCommand` as the parser, regardless of whether the request came from option mode.

For example, with the following configuration:

```typescript
runParser(parser, "myapp", ["--completion"], {
  completion: { command: true, option: true },
  onError: () => "ERR" as never,
  stderr: (text) => console.error(text),
});
```

Before this fix, the stderr output was:

```
Error: Missing shell name for completion.
Generate shell completion script or provide completions.
Usage: myapp completion [SHELL] [ARG...]
...
  Bash:       eval "$(myapp completion bash)"
```

After this fix, the output correctly reflects the option form the user actually invoked. Custom option names (e.g., `--completions`) are also respected in the help output.

This fix changes two things in *packages/core/src/facade.ts*:

- `handleCompletion()` now checks `isOptionMode` to choose between `completionOptionDisplayName` and `completionCommandDisplayName` when rendering missing-shell help.
- The option-mode call sites in `runParser()` now pass `completionParsers.completionOption` instead of `completionParsers.completionCommand`.

Closes https://github.com/dahlia/optique/issues/275