### PR TITLE
Fix `url()` suggestions for non-hierarchical URL schemes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -167,6 +167,12 @@ To be released.
     The method now uses `Intl.Locale.toString()` instead of `baseName` to
     preserve the full locale identifier.  [[#317], [#565]]
 
+ -  Fixed `url()` parser's `suggest()` emitting `://` for non-hierarchical URL
+    schemes like `mailto:` and `urn:`.  Suggestions now use `:` for
+    non-hierarchical schemes and `://` only for special schemes (`http`,
+    `https`, `ftp`, `ws`, `wss`, `file`) as defined by the WHATWG URL Standard.
+    [[#342], [#678]]
+
  -  Extended `hidden` visibility controls from `boolean` to
     `boolean | "usage" | "doc" | "help"` across primitive parsers:
     `option()`, `flag()`, `argument()`, `command()`, and `passThrough()`.
@@ -722,6 +728,7 @@ To be released.
 [#337]: https://github.com/dahlia/optique/issues/337
 [#338]: https://github.com/dahlia/optique/issues/338
 [#341]: https://github.com/dahlia/optique/issues/341
+[#342]: https://github.com/dahlia/optique/issues/342
 [#344]: https://github.com/dahlia/optique/issues/344
 [#345]: https://github.com/dahlia/optique/issues/345
 [#348]: https://github.com/dahlia/optique/issues/348
@@ -841,6 +848,7 @@ To be released.
 [#675]: https://github.com/dahlia/optique/pull/675
 [#676]: https://github.com/dahlia/optique/pull/676
 [#677]: https://github.com/dahlia/optique/pull/677
+[#678]: https://github.com/dahlia/optique/pull/678
 
 ### @optique/config
 

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -4816,6 +4816,45 @@ describe("ValueParser suggest() methods", () => {
 
       assert.deepEqual(texts, ["http://", "https://"]);
     });
+
+    it("should suggest non-hierarchical schemes with ':' not '://'", () => {
+      const parser = url({
+        allowedProtocols: ["mailto:", "urn:", "https:"],
+      });
+
+      const suggestions = Array.from(parser.suggest!("m"));
+      const texts = suggestions.map((s) =>
+        s.kind === "literal" ? s.text : s.pattern || ""
+      );
+      assert.deepEqual(texts, ["mailto:"]);
+
+      const suggestions2 = Array.from(parser.suggest!("u"));
+      const texts2 = suggestions2.map((s) =>
+        s.kind === "literal" ? s.text : s.pattern || ""
+      );
+      assert.deepEqual(texts2, ["urn:"]);
+
+      const suggestions3 = Array.from(parser.suggest!("h"));
+      const texts3 = suggestions3.map((s) =>
+        s.kind === "literal" ? s.text : s.pattern || ""
+      );
+      assert.deepEqual(texts3, ["https://"]);
+    });
+
+    it("should stop suggesting after prefix contains ':'", () => {
+      const parser = url({
+        allowedProtocols: ["mailto:", "https:"],
+      });
+
+      assert.deepEqual(
+        Array.from(parser.suggest!("mailto:someone")),
+        [],
+      );
+      assert.deepEqual(
+        Array.from(parser.suggest!("https:")),
+        [],
+      );
+    });
   });
 
   describe("locale parser", () => {

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -1236,6 +1236,20 @@ export function float(options: FloatOptions = {}): ValueParser<"sync", number> {
 }
 
 /**
+ * The set of URL schemes that are considered "special" by the WHATWG URL
+ * Standard.  These schemes always use the `://` authority syntax.
+ * Non-special schemes use only `:` (e.g., `mailto:`, `urn:`).
+ */
+const SPECIAL_URL_SCHEMES: ReadonlySet<string> = new Set([
+  "ftp",
+  "file",
+  "http",
+  "https",
+  "ws",
+  "wss",
+]);
+
+/**
  * Options for creating a {@link url} parser.
  */
 export interface UrlOptions {
@@ -1364,15 +1378,14 @@ export function url(options: UrlOptions = {}): ValueParser<"sync", URL> {
       return value.href;
     },
     *suggest(prefix: string): Iterable<Suggestion> {
-      if (allowedProtocols && prefix.length > 0 && !prefix.includes("://")) {
-        // Suggest protocol completions if prefix doesn't contain ://
+      if (allowedProtocols && prefix.length > 0 && !prefix.includes(":")) {
         for (const protocol of allowedProtocols) {
-          // Remove trailing colon if present, then add ://
           const cleanProtocol = protocol.replace(/:+$/, "");
           if (cleanProtocol.startsWith(prefix.toLowerCase())) {
+            const suffix = SPECIAL_URL_SCHEMES.has(cleanProtocol) ? "://" : ":";
             yield {
               kind: "literal",
-              text: `${cleanProtocol}://`,
+              text: `${cleanProtocol}${suffix}`,
             };
           }
         }


### PR DESCRIPTION
## Summary

Fixes https://github.com/dahlia/optique/issues/342

The `url()` value parser's `suggest()` function always appended `://` to protocol suggestions, producing syntactically incorrect completions for non-hierarchical URL schemes like `mailto:` and `urn:` (e.g., `mailto://` instead of `mailto:`).

## Changes

- Added a `SPECIAL_URL_SCHEMES` constant in *packages/core/src/valueparser.ts* listing the six WHATWG URL Standard special schemes (`ftp`, `file`, `http`, `https`, `ws`, `wss`) that use the `://` authority syntax.
- Changed `suggest()` to append `://` only for special schemes and `:` for all others.
- Tightened the suggestion guard from `!prefix.includes("://")` to `!prefix.includes(":")` so suggestions stop once the user has typed any colon, covering both hierarchical and non-hierarchical cases.
- Added tests for non-hierarchical scheme suggestions and for the colon-in-prefix guard.
- Documented the fix in *CHANGES.md*.

## Test plan

- Verified all existing suggestion tests still pass.
- Added a test asserting `mailto:` and `urn:` are suggested with `:` while `https:` is suggested with `://`.
- Added a test asserting no suggestions are returned when the prefix already contains `:`.
- Ran `mise test` — all tests pass across Deno, Node.js, and Bun.