### PR TITLE
Preserve nested IP validation errors in `cidr()`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -664,6 +664,10 @@ To be released.
     minimum `maxWidth` to account for all fixed-width labels actually in
     use.  [[#672], [#677]]
 
+ -  Fixed `cidr()` discarding specific nested IPv4/IPv6 validation errors
+    (e.g., private network, loopback, multicast restrictions) behind a
+    generic “Expected a valid CIDR notation” error message.  [[#333]]
+
 [RFC 9562]: https://www.rfc-editor.org/rfc/rfc9562
 [#110]: https://github.com/dahlia/optique/issues/110
 [#113]: https://github.com/dahlia/optique/issues/113
@@ -723,6 +727,7 @@ To be released.
 [#321]: https://github.com/dahlia/optique/issues/321
 [#323]: https://github.com/dahlia/optique/issues/323
 [#332]: https://github.com/dahlia/optique/issues/332
+[#333]: https://github.com/dahlia/optique/issues/333
 [#334]: https://github.com/dahlia/optique/issues/334
 [#336]: https://github.com/dahlia/optique/issues/336
 [#337]: https://github.com/dahlia/optique/issues/337

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -666,7 +666,11 @@ To be released.
 
  -  Fixed `cidr()` discarding specific nested IPv4/IPv6 validation errors
     (e.g., private network, loopback, multicast restrictions) behind a
-    generic “Expected a valid CIDR notation” error message.  [[#333]]
+    generic “Expected a valid CIDR notation” error message.  Added
+    `privateNotAllowed`, `loopbackNotAllowed`, `linkLocalNotAllowed`,
+    `multicastNotAllowed`, `broadcastNotAllowed`, `zeroNotAllowed`, and
+    `uniqueLocalNotAllowed` error hooks to `CidrOptions.errors` so callers
+    can customize these diagnostics.  [[#333], [#679]]
 
 [RFC 9562]: https://www.rfc-editor.org/rfc/rfc9562
 [#110]: https://github.com/dahlia/optique/issues/110
@@ -854,6 +858,7 @@ To be released.
 [#676]: https://github.com/dahlia/optique/pull/676
 [#677]: https://github.com/dahlia/optique/pull/677
 [#678]: https://github.com/dahlia/optique/pull/678
+[#679]: https://github.com/dahlia/optique/pull/679
 
 ### @optique/config
 

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -11367,6 +11367,23 @@ describe("cidr()", () => {
         { type: "text", text: "Unique local denied." },
       ]);
     });
+
+    it("should not misclassify custom error containing 'Expected'", () => {
+      const parser = cidr({
+        ipv4: { allowPrivate: false },
+        errors: {
+          privateNotAllowed: (ip) =>
+            message`Expected a public IP, but got ${ip}.`,
+        },
+      });
+      const result = parser.parse("192.168.0.0/24");
+      assert.ok(!result.success);
+      assert.deepStrictEqual(result.error, [
+        { type: "text", text: "Expected a public IP, but got " },
+        { type: "value", value: "192.168.0.0" },
+        { type: "text", text: "." },
+      ]);
+    });
   });
 });
 

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -11384,6 +11384,79 @@ describe("cidr()", () => {
         { type: "text", text: "." },
       ]);
     });
+
+    it("should report invalidPrefix over private restriction for IPv4", () => {
+      const parser = cidr({ ipv4: { allowPrivate: false } });
+      const result = parser.parse("192.168.0.0/33");
+      assert.ok(!result.success);
+      assert.deepStrictEqual(result.error, [
+        {
+          type: "text",
+          text: "Expected a prefix length between 0 and ",
+        },
+        { type: "text", text: "32" },
+        { type: "text", text: " for IPv4, but got " },
+        { type: "text", text: "33" },
+        { type: "text", text: "." },
+      ]);
+    });
+
+    it("should report invalidPrefix over loopback restriction for IPv6", () => {
+      const parser = cidr({
+        version: 6,
+        ipv6: { allowLoopback: false },
+      });
+      const result = parser.parse("::1/129");
+      assert.ok(!result.success);
+      assert.deepStrictEqual(result.error, [
+        {
+          type: "text",
+          text: "Expected a prefix length between 0 and ",
+        },
+        { type: "text", text: "128" },
+        { type: "text", text: " for IPv6, but got " },
+        { type: "text", text: "129" },
+        { type: "text", text: "." },
+      ]);
+    });
+
+    it("should report prefixBelowMinimum over restriction error", () => {
+      const parser = cidr({
+        ipv4: { allowPrivate: false },
+        minPrefix: 16,
+      });
+      const result = parser.parse("192.168.0.0/8");
+      assert.ok(!result.success);
+      assert.deepStrictEqual(result.error, [
+        {
+          type: "text",
+          text: "Expected a prefix length greater than or equal to ",
+        },
+        { type: "text", text: "16" },
+        { type: "text", text: ", but got " },
+        { type: "text", text: "8" },
+        { type: "text", text: "." },
+      ]);
+    });
+
+    it("should report prefixAboveMaximum over restriction error", () => {
+      const parser = cidr({
+        ipv4: { allowLoopback: false },
+        maxPrefix: 24,
+      });
+      const result = parser.parse("127.0.0.0/32");
+      assert.ok(!result.success);
+      assert.deepStrictEqual(result.error, [
+        {
+          type: "text",
+          text: "Expected a prefix length less than or equal to ",
+        },
+        { type: "text", text: "24" },
+        { type: "text", text: ", but got " },
+        { type: "text", text: "32" },
+        { type: "text", text: "." },
+      ]);
+    });
   });
 });
 

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -11238,6 +11238,73 @@ describe("cidr()", () => {
       );
     });
   });
+
+  describe("nested IP validation error propagation", () => {
+    it("should preserve private IP error from IPv4", () => {
+      const parser = cidr({ ipv4: { allowPrivate: false } });
+      const result = parser.parse("192.168.0.0/24");
+      assert.ok(!result.success);
+      assert.deepStrictEqual(result.error, [
+        { type: "value", value: "192.168.0.0" },
+        { type: "text", text: " is a private IP address." },
+      ]);
+    });
+
+    it("should preserve loopback error from IPv4", () => {
+      const parser = cidr({ ipv4: { allowLoopback: false } });
+      const result = parser.parse("127.0.0.0/8");
+      assert.ok(!result.success);
+      assert.deepStrictEqual(result.error, [
+        { type: "value", value: "127.0.0.0" },
+        { type: "text", text: " is a loopback address." },
+      ]);
+    });
+
+    it("should preserve multicast error from IPv6", () => {
+      const parser = cidr({
+        version: 6,
+        ipv6: { allowMulticast: false },
+      });
+      const result = parser.parse("ff00::/8");
+      assert.ok(!result.success);
+      assert.deepStrictEqual(result.error, [
+        { type: "value", value: "ff00::" },
+        { type: "text", text: " is a multicast address." },
+      ]);
+    });
+
+    it("should preserve loopback error from IPv6", () => {
+      const parser = cidr({ ipv6: { allowLoopback: false } });
+      const result = parser.parse("::1/128");
+      assert.ok(!result.success);
+      assert.deepStrictEqual(result.error, [
+        { type: "value", value: "::1" },
+        { type: "text", text: " is a loopback address." },
+      ]);
+    });
+
+    it("should return generic CIDR error for structurally invalid IP", () => {
+      const parser = cidr({ ipv4: { allowPrivate: false } });
+      const result = parser.parse("not-an-ip/24");
+      assert.ok(!result.success);
+      assert.deepStrictEqual(result.error, [
+        { type: "text", text: "Expected a valid CIDR notation, but got " },
+        { type: "value", value: "not-an-ip/24" },
+        { type: "text", text: "." },
+      ]);
+    });
+
+    it("should still succeed when no restrictions are violated", () => {
+      const parser = cidr({ version: 4 });
+      const result = parser.parse("192.168.0.0/24");
+      assert.ok(result.success);
+      assert.deepStrictEqual(result.value, {
+        address: "192.168.0.0",
+        prefix: 24,
+        version: 4,
+      });
+    });
+  });
 });
 
 describe("branch coverage regressions", () => {

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -11368,6 +11368,48 @@ describe("cidr()", () => {
       ]);
     });
 
+    it("should use custom linkLocalNotAllowed error", () => {
+      const parser = cidr({
+        ipv4: { allowLinkLocal: false },
+        errors: {
+          linkLocalNotAllowed: message`Link-local denied.`,
+        },
+      });
+      const result = parser.parse("169.254.1.0/24");
+      assert.ok(!result.success);
+      assert.deepStrictEqual(result.error, [
+        { type: "text", text: "Link-local denied." },
+      ]);
+    });
+
+    it("should use custom broadcastNotAllowed error", () => {
+      const parser = cidr({
+        ipv4: { allowBroadcast: false },
+        errors: {
+          broadcastNotAllowed: message`Broadcast denied.`,
+        },
+      });
+      const result = parser.parse("255.255.255.255/32");
+      assert.ok(!result.success);
+      assert.deepStrictEqual(result.error, [
+        { type: "text", text: "Broadcast denied." },
+      ]);
+    });
+
+    it("should use custom zeroNotAllowed error", () => {
+      const parser = cidr({
+        ipv4: { allowZero: false },
+        errors: {
+          zeroNotAllowed: message`Zero denied.`,
+        },
+      });
+      const result = parser.parse("0.0.0.0/32");
+      assert.ok(!result.success);
+      assert.deepStrictEqual(result.error, [
+        { type: "text", text: "Zero denied." },
+      ]);
+    });
+
     it("should not misclassify custom error containing 'Expected'", () => {
       const parser = cidr({
         ipv4: { allowPrivate: false },

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -11304,6 +11304,69 @@ describe("cidr()", () => {
         version: 4,
       });
     });
+
+    it("should use custom privateNotAllowed error", () => {
+      const parser = cidr({
+        ipv4: { allowPrivate: false },
+        errors: {
+          privateNotAllowed: (ip) =>
+            message`Private IP ${ip} not allowed in CIDR.`,
+        },
+      });
+      const result = parser.parse("192.168.0.0/24");
+      assert.ok(!result.success);
+      assert.deepStrictEqual(result.error, [
+        { type: "text", text: "Private IP " },
+        { type: "value", value: "192.168.0.0" },
+        { type: "text", text: " not allowed in CIDR." },
+      ]);
+    });
+
+    it("should use custom loopbackNotAllowed error", () => {
+      const parser = cidr({
+        ipv4: { allowLoopback: false },
+        errors: {
+          loopbackNotAllowed: message`Loopback denied.`,
+        },
+      });
+      const result = parser.parse("127.0.0.0/8");
+      assert.ok(!result.success);
+      assert.deepStrictEqual(result.error, [
+        { type: "text", text: "Loopback denied." },
+      ]);
+    });
+
+    it("should use custom multicastNotAllowed error for IPv6", () => {
+      const parser = cidr({
+        version: 6,
+        ipv6: { allowMulticast: false },
+        errors: {
+          multicastNotAllowed: (ip) => message`Multicast ${ip} rejected.`,
+        },
+      });
+      const result = parser.parse("ff00::/8");
+      assert.ok(!result.success);
+      assert.deepStrictEqual(result.error, [
+        { type: "text", text: "Multicast " },
+        { type: "value", value: "ff00::" },
+        { type: "text", text: " rejected." },
+      ]);
+    });
+
+    it("should use custom uniqueLocalNotAllowed error for IPv6", () => {
+      const parser = cidr({
+        version: 6,
+        ipv6: { allowUniqueLocal: false },
+        errors: {
+          uniqueLocalNotAllowed: message`Unique local denied.`,
+        },
+      });
+      const result = parser.parse("fd00::/8");
+      assert.ok(!result.success);
+      assert.deepStrictEqual(result.error, [
+        { type: "text", text: "Unique local denied." },
+      ]);
+    });
   });
 });
 

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -5364,6 +5364,50 @@ export interface CidrOptions {
      * Can be a static message or a function that receives the prefix and maximum.
      */
     prefixAboveMaximum?: Message | ((prefix: number, max: number) => Message);
+
+    /**
+     * Custom error message when a private IPv4 address is used but disallowed.
+     * Can be a static message or a function that receives the IP.
+     */
+    privateNotAllowed?: Message | ((ip: string) => Message);
+
+    /**
+     * Custom error message when a loopback address is used but disallowed.
+     * Can be a static message or a function that receives the IP.
+     */
+    loopbackNotAllowed?: Message | ((ip: string) => Message);
+
+    /**
+     * Custom error message when a link-local address is used but disallowed.
+     * Can be a static message or a function that receives the IP.
+     */
+    linkLocalNotAllowed?: Message | ((ip: string) => Message);
+
+    /**
+     * Custom error message when a multicast address is used but disallowed.
+     * Can be a static message or a function that receives the IP.
+     */
+    multicastNotAllowed?: Message | ((ip: string) => Message);
+
+    /**
+     * Custom error message when the broadcast address is used but disallowed
+     * (IPv4 only).
+     * Can be a static message or a function that receives the IP.
+     */
+    broadcastNotAllowed?: Message | ((ip: string) => Message);
+
+    /**
+     * Custom error message when the zero address is used but disallowed.
+     * Can be a static message or a function that receives the IP.
+     */
+    zeroNotAllowed?: Message | ((ip: string) => Message);
+
+    /**
+     * Custom error message when a unique local address is used but disallowed
+     * (IPv6 only).
+     * Can be a static message or a function that receives the IP.
+     */
+    uniqueLocalNotAllowed?: Message | ((ip: string) => Message);
   };
 }
 
@@ -5441,13 +5485,33 @@ export function cidr(
   const errors = options?.errors;
   const metavar = options?.metavar ?? "CIDR";
 
-  // Create IP parsers for address validation
+  // Create IP parsers for address validation, forwarding restriction
+  // error hooks from CidrOptions.errors to the nested parsers
   const ipv4Parser = (version === 4 || version === "both")
-    ? ipv4(options?.ipv4)
+    ? ipv4({
+      ...options?.ipv4,
+      errors: {
+        privateNotAllowed: errors?.privateNotAllowed,
+        loopbackNotAllowed: errors?.loopbackNotAllowed,
+        linkLocalNotAllowed: errors?.linkLocalNotAllowed,
+        multicastNotAllowed: errors?.multicastNotAllowed,
+        broadcastNotAllowed: errors?.broadcastNotAllowed,
+        zeroNotAllowed: errors?.zeroNotAllowed,
+      },
+    })
     : null;
 
   const ipv6Parser = (version === 6 || version === "both")
-    ? ipv6(options?.ipv6)
+    ? ipv6({
+      ...options?.ipv6,
+      errors: {
+        loopbackNotAllowed: errors?.loopbackNotAllowed,
+        linkLocalNotAllowed: errors?.linkLocalNotAllowed,
+        multicastNotAllowed: errors?.multicastNotAllowed,
+        zeroNotAllowed: errors?.zeroNotAllowed,
+        uniqueLocalNotAllowed: errors?.uniqueLocalNotAllowed,
+      },
+    })
     : null;
 
   return {

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -5493,6 +5493,8 @@ export function cidr(
       // Try to parse as IPv4 first
       let ipVersion: 4 | 6 | null = null;
       let normalizedIp: string | null = null;
+      let ipv4Error: ValueParserResult<string> | null = null;
+      let ipv6Error: ValueParserResult<string> | null = null;
 
       if (ipv4Parser !== null) {
         const result = ipv4Parser.parse(ipPart);
@@ -5518,6 +5520,8 @@ export function cidr(
             ] as Message;
             return { success: false, error: msg };
           }
+        } else {
+          ipv4Error = result;
         }
       }
 
@@ -5546,11 +5550,25 @@ export function cidr(
             ] as Message;
             return { success: false, error: msg };
           }
+        } else {
+          ipv6Error = result;
         }
       }
 
       // Neither IPv4 nor IPv6 worked
       if (ipVersion === null || normalizedIp === null) {
+        // Prefer specific (non-generic) errors from nested IP parsers.
+        // Generic errors contain "Expected" text; specific restriction
+        // errors (private, loopback, multicast, etc.) do not.
+        for (const err of [ipv4Error, ipv6Error]) {
+          if (err !== null && !err.success) {
+            const isGeneric = err.error.some((term) =>
+              term.type === "text" && term.text.includes("Expected")
+            );
+            if (!isGeneric) return err;
+          }
+        }
+
         const errorMsg = errors?.invalidCidr;
         if (typeof errorMsg === "function") {
           return { success: false, error: errorMsg(input) };

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -5485,12 +5485,20 @@ export function cidr(
   const errors = options?.errors;
   const metavar = options?.metavar ?? "CIDR";
 
+  // Sentinel message passed as the invalidIpv4/invalidIpv6 error hook.
+  // When ipv4()/ipv6() return a structural parse failure they return this
+  // exact object, so we can distinguish generic failures from specific
+  // restriction errors (private, loopback, etc.) via reference equality
+  // instead of fragile text-content heuristics.
+  const genericIpSentinel: Message = [] as unknown as Message;
+
   // Create IP parsers for address validation, forwarding restriction
   // error hooks from CidrOptions.errors to the nested parsers
   const ipv4Parser = (version === 4 || version === "both")
     ? ipv4({
       ...options?.ipv4,
       errors: {
+        invalidIpv4: genericIpSentinel,
         privateNotAllowed: errors?.privateNotAllowed,
         loopbackNotAllowed: errors?.loopbackNotAllowed,
         linkLocalNotAllowed: errors?.linkLocalNotAllowed,
@@ -5505,6 +5513,7 @@ export function cidr(
     ? ipv6({
       ...options?.ipv6,
       errors: {
+        invalidIpv6: genericIpSentinel,
         loopbackNotAllowed: errors?.loopbackNotAllowed,
         linkLocalNotAllowed: errors?.linkLocalNotAllowed,
         multicastNotAllowed: errors?.multicastNotAllowed,
@@ -5621,15 +5630,13 @@ export function cidr(
 
       // Neither IPv4 nor IPv6 worked
       if (ipVersion === null || normalizedIp === null) {
-        // Prefer specific (non-generic) errors from nested IP parsers.
-        // Generic errors contain "Expected" text; specific restriction
-        // errors (private, loopback, multicast, etc.) do not.
+        // Prefer specific restriction errors (private, loopback, multicast,
+        // etc.) over the generic CIDR error.  Structural parse failures are
+        // identified by reference equality with genericIpSentinel, which was
+        // injected as the invalidIpv4/invalidIpv6 error hook above.
         for (const err of [ipv4Error, ipv6Error]) {
-          if (err !== null && !err.success) {
-            const isGeneric = err.error.some((term) =>
-              term.type === "text" && term.text.includes("Expected")
-            );
-            if (!isGeneric) return err;
+          if (err !== null && !err.success && err.error !== genericIpSentinel) {
+            return err;
           }
         }
 

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -5368,24 +5368,28 @@ export interface CidrOptions {
     /**
      * Custom error message when a private IPv4 address is used but disallowed.
      * Can be a static message or a function that receives the IP.
+     * @since 1.0.0
      */
     privateNotAllowed?: Message | ((ip: string) => Message);
 
     /**
      * Custom error message when a loopback address is used but disallowed.
      * Can be a static message or a function that receives the IP.
+     * @since 1.0.0
      */
     loopbackNotAllowed?: Message | ((ip: string) => Message);
 
     /**
      * Custom error message when a link-local address is used but disallowed.
      * Can be a static message or a function that receives the IP.
+     * @since 1.0.0
      */
     linkLocalNotAllowed?: Message | ((ip: string) => Message);
 
     /**
      * Custom error message when a multicast address is used but disallowed.
      * Can be a static message or a function that receives the IP.
+     * @since 1.0.0
      */
     multicastNotAllowed?: Message | ((ip: string) => Message);
 
@@ -5393,12 +5397,14 @@ export interface CidrOptions {
      * Custom error message when the broadcast address is used but disallowed
      * (IPv4 only).
      * Can be a static message or a function that receives the IP.
+     * @since 1.0.0
      */
     broadcastNotAllowed?: Message | ((ip: string) => Message);
 
     /**
      * Custom error message when the zero address is used but disallowed.
      * Can be a static message or a function that receives the IP.
+     * @since 1.0.0
      */
     zeroNotAllowed?: Message | ((ip: string) => Message);
 
@@ -5406,6 +5412,7 @@ export interface CidrOptions {
      * Custom error message when a unique local address is used but disallowed
      * (IPv6 only).
      * Can be a static message or a function that receives the IP.
+     * @since 1.0.0
      */
     uniqueLocalNotAllowed?: Message | ((ip: string) => Message);
   };
@@ -5490,7 +5497,7 @@ export function cidr(
   // exact object, so we can distinguish generic failures from specific
   // restriction errors (private, loopback, etc.) via reference equality
   // instead of fragile text-content heuristics.
-  const genericIpSentinel: Message = [] as unknown as Message;
+  const genericIpSentinel: Message = [];
 
   // Create IP parsers for address validation, forwarding restriction
   // error hooks from CidrOptions.errors to the nested parsers

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -5631,11 +5631,70 @@ export function cidr(
       // Neither IPv4 nor IPv6 worked
       if (ipVersion === null || normalizedIp === null) {
         // Prefer specific restriction errors (private, loopback, multicast,
-        // etc.) over the generic CIDR error.  Structural parse failures are
-        // identified by reference equality with genericIpSentinel, which was
-        // injected as the invalidIpv4/invalidIpv6 error hook above.
-        for (const err of [ipv4Error, ipv6Error]) {
+        // etc.) over the generic CIDR error, but only when the prefix is
+        // also valid for the implied IP version.  Structural parse failures
+        // are identified by reference equality with genericIpSentinel.
+        const candidates: readonly [
+          ValueParserResult<string> | null,
+          4 | 6,
+          number,
+        ][] = [[ipv4Error, 4, 32], [ipv6Error, 6, 128]];
+        for (const [err, ver, maxPfx] of candidates) {
           if (err !== null && !err.success && err.error !== genericIpSentinel) {
+            // The IP was structurally valid but violated a restriction.
+            // Validate the prefix before surfacing the restriction error,
+            // so prefix errors take precedence over restriction diagnostics.
+            if (prefix > maxPfx) {
+              const errorMsg = errors?.invalidPrefix;
+              if (typeof errorMsg === "function") {
+                return { success: false, error: errorMsg(prefix, ver) };
+              }
+              const msg = errorMsg ?? [
+                {
+                  type: "text",
+                  text: "Expected a prefix length between 0 and ",
+                },
+                { type: "text", text: maxPfx.toString() },
+                { type: "text", text: ` for IPv${ver}, but got ` },
+                { type: "text", text: prefix.toString() },
+                { type: "text", text: "." },
+              ] as Message;
+              return { success: false, error: msg };
+            }
+            if (minPrefix !== undefined && prefix < minPrefix) {
+              const errorMsg = errors?.prefixBelowMinimum;
+              if (typeof errorMsg === "function") {
+                return { success: false, error: errorMsg(prefix, minPrefix) };
+              }
+              const msg = errorMsg ?? [
+                {
+                  type: "text",
+                  text: "Expected a prefix length greater than or equal to ",
+                },
+                { type: "text", text: minPrefix.toString() },
+                { type: "text", text: ", but got " },
+                { type: "text", text: prefix.toString() },
+                { type: "text", text: "." },
+              ] as Message;
+              return { success: false, error: msg };
+            }
+            if (maxPrefix !== undefined && prefix > maxPrefix) {
+              const errorMsg = errors?.prefixAboveMaximum;
+              if (typeof errorMsg === "function") {
+                return { success: false, error: errorMsg(prefix, maxPrefix) };
+              }
+              const msg = errorMsg ?? [
+                {
+                  type: "text",
+                  text: "Expected a prefix length less than or equal to ",
+                },
+                { type: "text", text: maxPrefix.toString() },
+                { type: "text", text: ", but got " },
+                { type: "text", text: prefix.toString() },
+                { type: "text", text: "." },
+              ] as Message;
+              return { success: false, error: msg };
+            }
             return err;
           }
         }


### PR DESCRIPTION
## Summary

Fixes https://github.com/dahlia/optique/issues/333.

`cidr()` delegates address validation to `ipv4()`/`ipv6()`, but when those nested parsers reject the address for a specific reason (e.g., private network, loopback, multicast), `cidr()` discarded that diagnostic and returned the generic "Expected a valid CIDR notation" error instead. This PR makes `cidr()` surface those specific restriction errors so users can tell what actually went wrong.

## Changes

- When both nested IP parsers fail, `cidr()` now checks whether either returned a specific restriction error (as opposed to a structural parse failure) and surfaces it instead of the generic CIDR error.
- Structural vs. restriction errors are distinguished via reference equality against a sentinel `Message` object injected as the *invalidIpv4*/*invalidIpv6* error hook, avoiding fragile text-content heuristics.
- Added *privateNotAllowed*, *loopbackNotAllowed*, *linkLocalNotAllowed*, *multicastNotAllowed*, *broadcastNotAllowed*, *zeroNotAllowed*, and *uniqueLocalNotAllowed* error hooks to *CidrOptions.errors*, following the same pattern as *IpOptions.errors*. These are forwarded to the nested parsers so callers can customize the newly exposed diagnostics.
- When a restriction error is detected, prefix validation (*invalidPrefix*, *prefixBelowMinimum*, *prefixAboveMaximum*) still runs first, so malformed CIDRs like `192.168.0.0/33` with *allowPrivate: false* correctly report the prefix error rather than the restriction error.

## Test plan

- Added 15 test cases covering:
  - Default restriction error propagation (IPv4 private/loopback, IPv6 multicast/loopback)
  - Generic CIDR error for structurally invalid IPs
  - No-regression success case
  - Custom restriction error hooks (*privateNotAllowed*, *loopbackNotAllowed*, *multicastNotAllowed*, *uniqueLocalNotAllowed*)
  - Custom error messages containing the word "Expected" are not misclassified as generic
  - Prefix errors (*invalidPrefix*, *prefixBelowMinimum*, *prefixAboveMaximum*) take precedence over restriction errors
- All tests pass across Deno, Node.js, and Bun (`mise test`)