### PR TITLE
Fix `--completion` option bypassing `--help`/`--version` precedence in `runParser()`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -704,6 +704,13 @@ To be released.
     `runWithSync()`.  Tokens after `--` are now correctly treated as positional
     data and no longer trigger meta-option early-exit paths.  [[#228], [#686]]
 
+ -  Fixed `--completion` option bypassing `--help`/`--version` precedence in
+    `runParser()`.  When `--help` or `--version` appears *before* the
+    `--completion` option (e.g., `--help --completion bash`), the help or
+    version path now correctly takes precedence.  Tokens *after* `--completion`
+    remain opaque completion payload and are not re-interpreted as meta flags.
+    [[#229], [#689]]
+
 [RFC 9562]: https://www.rfc-editor.org/rfc/rfc9562
 [#110]: https://github.com/dahlia/optique/issues/110
 [#113]: https://github.com/dahlia/optique/issues/113
@@ -734,6 +741,7 @@ To be released.
 [#224]: https://github.com/dahlia/optique/issues/224
 [#225]: https://github.com/dahlia/optique/issues/225
 [#228]: https://github.com/dahlia/optique/issues/228
+[#229]: https://github.com/dahlia/optique/issues/229
 [#235]: https://github.com/dahlia/optique/issues/235
 [#240]: https://github.com/dahlia/optique/issues/240
 [#241]: https://github.com/dahlia/optique/issues/241
@@ -901,6 +909,7 @@ To be released.
 [#684]: https://github.com/dahlia/optique/issues/684
 [#685]: https://github.com/dahlia/optique/pull/685
 [#686]: https://github.com/dahlia/optique/pull/686
+[#689]: https://github.com/dahlia/optique/pull/689
 
 ### @optique/config
 

--- a/packages/core/src/facade.test.ts
+++ b/packages/core/src/facade.test.ts
@@ -3841,6 +3841,470 @@ describe("Subcommand help edge cases (Issue #26 comprehensive coverage)", () => 
       assert.ok(!helpShown, "help callback should not be called");
     });
 
+    it("should treat --help after --completion as completion payload", () => {
+      const parser = object({});
+
+      let completionShown = false;
+      let helpShown = false;
+
+      runParser(
+        parser,
+        "myapp",
+        ["--completion", "bash", "--help"],
+        {
+          help: {
+            option: true,
+            onShow: () => {
+              helpShown = true;
+              return "help-shown";
+            },
+          },
+          completion: {
+            option: true,
+            command: true,
+            onShow: () => {
+              completionShown = true;
+              return "completion-shown";
+            },
+          },
+          stdout: () => {},
+        },
+      );
+
+      assert.ok(completionShown, "completion callback should be called");
+      assert.ok(!helpShown, "help callback should not be called");
+    });
+
+    it("should show help when --help precedes --completion", () => {
+      const parser = object({});
+
+      let completionShown = false;
+      let helpShown = false;
+
+      runParser(
+        parser,
+        "myapp",
+        ["--help", "--completion", "bash"],
+        {
+          help: {
+            option: true,
+            onShow: () => {
+              helpShown = true;
+              return "help-shown";
+            },
+          },
+          completion: {
+            option: true,
+            command: true,
+            onShow: () => {
+              completionShown = true;
+              return "completion-shown";
+            },
+          },
+          stdout: () => {},
+        },
+      );
+
+      assert.ok(helpShown, "help callback should be called");
+      assert.ok(!completionShown, "completion callback should not be called");
+    });
+
+    it("should ignore --version in completion payload when --help precedes --completion", () => {
+      const parser = object({});
+
+      let completionShown = false;
+      let helpShown = false;
+      let versionShown = false;
+
+      runParser(
+        parser,
+        "myapp",
+        ["--help", "--completion", "bash", "--version"],
+        {
+          help: {
+            option: true,
+            onShow: () => {
+              helpShown = true;
+              return "help-shown";
+            },
+          },
+          version: {
+            option: true,
+            value: "1.0.0",
+            onShow: () => {
+              versionShown = true;
+              return "version-shown";
+            },
+          },
+          completion: {
+            option: true,
+            command: true,
+            onShow: () => {
+              completionShown = true;
+              return "completion-shown";
+            },
+          },
+          stdout: () => {},
+        },
+      );
+
+      assert.ok(helpShown, "help callback should be called");
+      assert.ok(!versionShown, "version callback should not be called");
+      assert.ok(!completionShown, "completion callback should not be called");
+    });
+
+    it("should show help when --help follows other flags before --completion", () => {
+      const parser = object({
+        verbose: option("--verbose"),
+      });
+
+      let completionShown = false;
+      let helpShown = false;
+
+      runParser(
+        parser,
+        "myapp",
+        ["--verbose", "--help", "--completion", "bash"],
+        {
+          help: {
+            option: true,
+            onShow: () => {
+              helpShown = true;
+              return "help-shown";
+            },
+          },
+          completion: {
+            option: true,
+            command: true,
+            onShow: () => {
+              completionShown = true;
+              return "completion-shown";
+            },
+          },
+          stdout: () => {},
+        },
+      );
+
+      assert.ok(helpShown, "help callback should be called");
+      assert.ok(!completionShown, "completion callback should not be called");
+    });
+
+    it("should show version when --version follows other flags before --completion", () => {
+      const parser = object({
+        verbose: option("--verbose"),
+      });
+
+      let completionShown = false;
+      let versionShown = false;
+
+      runParser(
+        parser,
+        "myapp",
+        ["--verbose", "--version", "--completion", "bash"],
+        {
+          version: {
+            option: true,
+            value: "1.0.0",
+            onShow: () => {
+              versionShown = true;
+              return "version-shown";
+            },
+          },
+          completion: {
+            option: true,
+            command: true,
+            onShow: () => {
+              completionShown = true;
+              return "completion-shown";
+            },
+          },
+          stdout: () => {},
+        },
+      );
+
+      assert.ok(versionShown, "version callback should be called");
+      assert.ok(!completionShown, "completion callback should not be called");
+    });
+
+    it("should show help when help command precedes --completion", () => {
+      const parser = object({});
+
+      let completionShown = false;
+      let helpShown = false;
+
+      runParser(
+        parser,
+        "myapp",
+        ["help", "--completion", "bash"],
+        {
+          help: {
+            command: true,
+            option: true,
+            onShow: () => {
+              helpShown = true;
+              return "help-shown";
+            },
+          },
+          completion: {
+            option: true,
+            command: true,
+            onShow: () => {
+              completionShown = true;
+              return "completion-shown";
+            },
+          },
+          stdout: () => {},
+        },
+      );
+
+      assert.ok(helpShown, "help callback should be called");
+      assert.ok(!completionShown, "completion callback should not be called");
+    });
+
+    it("should show version when version command precedes --completion", () => {
+      const parser = object({});
+
+      let completionShown = false;
+      let versionShown = false;
+
+      runParser(
+        parser,
+        "myapp",
+        ["version", "--completion", "bash"],
+        {
+          version: {
+            command: true,
+            option: true,
+            value: "1.0.0",
+            onShow: () => {
+              versionShown = true;
+              return "version-shown";
+            },
+          },
+          completion: {
+            option: true,
+            command: true,
+            onShow: () => {
+              completionShown = true;
+              return "completion-shown";
+            },
+          },
+          stdout: () => {},
+        },
+      );
+
+      assert.ok(versionShown, "version callback should be called");
+      assert.ok(!completionShown, "completion callback should not be called");
+    });
+
+    it("should treat --help after --completion=bash as completion payload", () => {
+      const parser = object({});
+
+      let completionShown = false;
+      let helpShown = false;
+
+      runParser(
+        parser,
+        "myapp",
+        ["--completion=bash", "--help"],
+        {
+          help: {
+            option: true,
+            onShow: () => {
+              helpShown = true;
+              return "help-shown";
+            },
+          },
+          completion: {
+            option: true,
+            command: true,
+            onShow: () => {
+              completionShown = true;
+              return "completion-shown";
+            },
+          },
+          stdout: () => {},
+        },
+      );
+
+      assert.ok(completionShown, "completion callback should be called");
+      assert.ok(!helpShown, "help callback should not be called");
+    });
+
+    it("should show help when --help precedes --completion=bash", () => {
+      const parser = object({});
+
+      let completionShown = false;
+      let helpShown = false;
+
+      runParser(
+        parser,
+        "myapp",
+        ["--help", "--completion=bash"],
+        {
+          help: {
+            option: true,
+            onShow: () => {
+              helpShown = true;
+              return "help-shown";
+            },
+          },
+          completion: {
+            option: true,
+            command: true,
+            onShow: () => {
+              completionShown = true;
+              return "completion-shown";
+            },
+          },
+          stdout: () => {},
+        },
+      );
+
+      assert.ok(helpShown, "help callback should be called");
+      assert.ok(!completionShown, "completion callback should not be called");
+    });
+
+    it("should treat --version after --completion as completion payload", () => {
+      const parser = object({});
+
+      let completionShown = false;
+      let versionShown = false;
+
+      runParser(
+        parser,
+        "myapp",
+        ["--completion", "bash", "--version"],
+        {
+          version: {
+            option: true,
+            value: "1.0.0",
+            onShow: () => {
+              versionShown = true;
+              return "version-shown";
+            },
+          },
+          completion: {
+            option: true,
+            command: true,
+            onShow: () => {
+              completionShown = true;
+              return "completion-shown";
+            },
+          },
+          stdout: () => {},
+        },
+      );
+
+      assert.ok(completionShown, "completion callback should be called");
+      assert.ok(!versionShown, "version callback should not be called");
+    });
+
+    it("should show version when --version precedes --completion", () => {
+      const parser = object({});
+
+      let completionShown = false;
+      let versionShown = false;
+
+      runParser(
+        parser,
+        "myapp",
+        ["--version", "--completion", "bash"],
+        {
+          version: {
+            option: true,
+            value: "1.0.0",
+            onShow: () => {
+              versionShown = true;
+              return "version-shown";
+            },
+          },
+          completion: {
+            option: true,
+            command: true,
+            onShow: () => {
+              completionShown = true;
+              return "completion-shown";
+            },
+          },
+          stdout: () => {},
+        },
+      );
+
+      assert.ok(versionShown, "version callback should be called");
+      assert.ok(!completionShown, "completion callback should not be called");
+    });
+
+    it("should treat --version after --completion=bash as completion payload", () => {
+      const parser = object({});
+
+      let completionShown = false;
+      let versionShown = false;
+
+      runParser(
+        parser,
+        "myapp",
+        ["--completion=bash", "--version"],
+        {
+          version: {
+            option: true,
+            value: "1.0.0",
+            onShow: () => {
+              versionShown = true;
+              return "version-shown";
+            },
+          },
+          completion: {
+            option: true,
+            command: true,
+            onShow: () => {
+              completionShown = true;
+              return "completion-shown";
+            },
+          },
+          stdout: () => {},
+        },
+      );
+
+      assert.ok(completionShown, "completion callback should be called");
+      assert.ok(!versionShown, "version callback should not be called");
+    });
+
+    it("should show version when --version precedes --completion=bash", () => {
+      const parser = object({});
+
+      let completionShown = false;
+      let versionShown = false;
+
+      runParser(
+        parser,
+        "myapp",
+        ["--version", "--completion=bash"],
+        {
+          version: {
+            option: true,
+            value: "1.0.0",
+            onShow: () => {
+              versionShown = true;
+              return "version-shown";
+            },
+          },
+          completion: {
+            option: true,
+            command: true,
+            onShow: () => {
+              completionShown = true;
+              return "completion-shown";
+            },
+          },
+          stdout: () => {},
+        },
+      );
+
+      assert.ok(versionShown, "version callback should be called");
+      assert.ok(!completionShown, "completion callback should not be called");
+    });
+
     it("should support --completions (plural) option", () => {
       const parser = object({
         verbose: option("--verbose"),

--- a/packages/core/src/facade.ts
+++ b/packages/core/src/facade.ts
@@ -2234,6 +2234,45 @@ export function runParser<
     // The first --completion match is the meta option; everything after it
     // (including the shell name) is opaque completion payload and must not
     // be re-interpreted as another meta option.
+    // Exception: if a help or version option/command appears *before* the
+    // completion option, skip the early return and let the combined parser
+    // handle precedence — but only with args truncated at the completion
+    // option position so payload tokens stay opaque.
+    //
+    // This uses a naive token scan (matching raw argv strings against known
+    // meta option names).  The combined parser's lenient help/version parsers
+    // use the same naive approach: they scan the parse buffer for meta flag
+    // names and match regardless of whether a token is actually an option
+    // value.  So this early-return check is consistent with what the combined
+    // parser would do — both treat any token matching a meta flag name as
+    // that meta flag.
+    // Check whether any help/version meta entry (option or command form)
+    // appears in args before a given index.  Command-form entries are only
+    // checked at args[0] since commands are always the first token.
+    const hasMetaEntryBefore = (endIndex: number): boolean => {
+      const argsBefore = args.slice(0, endIndex);
+      if (
+        helpOptionConfig &&
+        helpOptionNames.some((n) => argsBefore.includes(n))
+      ) return true;
+      if (
+        versionOptionConfig &&
+        versionOptionNames.some((n) => argsBefore.includes(n))
+      ) return true;
+      if (endIndex > 0) {
+        if (
+          helpCommandConfig &&
+          helpCommandNames.includes(args[0])
+        ) return true;
+        if (
+          versionCommandConfig &&
+          versionCommandNames.includes(args[0])
+        ) return true;
+      }
+      return false;
+    };
+
+    let completionOptionIndex = -1;
     if (completionOptionConfig) {
       // Only scan args before the options terminator; reuse the index
       // already computed for the hasHelpOption check above.
@@ -2248,6 +2287,10 @@ export function runParser<
           arg.startsWith(n + "=")
         );
         if (equalsMatch) {
+          if (hasMetaEntryBefore(i)) {
+            completionOptionIndex = i;
+            break; // Fall through with truncated args
+          }
           const shell = arg.slice(equalsMatch.length + 1);
           const completionArgs = args.slice(i + 1);
           return handleCompletion<
@@ -2276,6 +2319,10 @@ export function runParser<
         // Check for "--completion <shell>" format (separate arg)
         const exactMatch = completionOptionNames.includes(arg);
         if (exactMatch) {
+          if (hasMetaEntryBefore(i)) {
+            completionOptionIndex = i;
+            break; // Fall through with truncated args
+          }
           const shell = i + 1 < args.length ? args[i + 1] : "";
           const completionArgs = i + 1 < args.length ? args.slice(i + 2) : [];
           return handleCompletion<
@@ -2301,6 +2348,14 @@ export function runParser<
           ) as ModeValue<InferMode<TParser>, InferValue<TParser>>;
         }
       }
+    }
+
+    // When help/version precedes --completion, truncate args so the combined
+    // parser and classifyResult only see tokens before the completion option.
+    // This keeps completion payload opaque — e.g., --version after
+    // --completion is not re-interpreted as a meta flag.
+    if (completionOptionIndex >= 0) {
+      args = args.slice(0, completionOptionIndex);
     }
   }
 


### PR DESCRIPTION
## Summary

The `--completion` option early-return scanner in `runParser()` bypassed help/version precedence checks. When `--help`, `--version`, `help`, or `version` appeared before `--completion` in the argument list, the completion path always won unconditionally. This was because the completion option path was handled by a separate early-return scanner that did not check for the presence of other meta entries, unlike the completion command path which already guarded against `--help`.

For example, all of the following incorrectly triggered completion output instead of showing help or version:

```typescript
runParser(parser, "myapp", ["--help", "--completion", "bash"], options);
runParser(parser, "myapp", ["--verbose", "--help", "--completion", "bash"], options);
runParser(parser, "myapp", ["help", "--completion", "bash"], options);
runParser(parser, "myapp", ["--version", "--completion", "bash"], options);
```

The fix scans all args before the matched `--completion` position for help/version meta entries, covering both option form (`--help`, `--version`) and command form (`help`, `version` at `args[0]`). When a meta entry is found before `--completion`, the early return is skipped and args are truncated at the completion option position so the combined parser handles precedence correctly. Tokens after `--completion` remain opaque completion payload and are never re-interpreted as meta flags. For instance, `--completion bash --help` still correctly triggers completion, because the `--help` there is part of what the user is trying to complete.

This token scan is consistent with the combined parser's existing lenient help/version parsers, which use the same approach: any token matching a meta flag name is treated as that meta flag regardless of position.

Closes https://github.com/dahlia/optique/issues/229

## Test plan

- Verify `--help`/`--version` before `--completion` (both separated and `=` form) triggers help/version instead of completion
- Verify `--help`/`--version` after `--completion` remains opaque payload (completion still triggers)
- Verify `help`/`version` command form before `--completion` triggers help/version
- Verify mixed flags like `--help --completion bash --version` show help (not version, since `--version` is payload)
- Verify `--verbose --help --completion bash` shows help (meta flag after other flags still detected)
- Verify all existing completion, help, and version tests continue to pass
- `mise test` passes across Deno, Node.js, and Bun