### PR TITLE
Fix `deduplicateSuggestions()` treating extension order as semantically significant

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -739,6 +739,11 @@ To be released.
     Duplicates are now merged with `includeHidden: true` preferred, since
     it is a superset of the non-hidden variant.  [[#518], [#693]]
 
+ -  Fixed `deduplicateSuggestions()` treating file suggestions with the same
+    `extensions` in different order as distinct.  Extensions are now compared
+    as a set, so `[".json", ".yaml"]` and `[".yaml", ".json"]` correctly
+    deduplicate to one suggestion.  [[#519], [#695]]
+
 [RFC 9562]: https://www.rfc-editor.org/rfc/rfc9562
 [#110]: https://github.com/dahlia/optique/issues/110
 [#113]: https://github.com/dahlia/optique/issues/113
@@ -850,6 +855,7 @@ To be released.
 [#513]: https://github.com/dahlia/optique/issues/513
 [#516]: https://github.com/dahlia/optique/issues/516
 [#518]: https://github.com/dahlia/optique/issues/518
+[#519]: https://github.com/dahlia/optique/issues/519
 [#520]: https://github.com/dahlia/optique/pull/520
 [#522]: https://github.com/dahlia/optique/pull/522
 [#523]: https://github.com/dahlia/optique/pull/523
@@ -946,6 +952,7 @@ To be released.
 [#690]: https://github.com/dahlia/optique/pull/690
 [#692]: https://github.com/dahlia/optique/pull/692
 [#693]: https://github.com/dahlia/optique/pull/693
+[#695]: https://github.com/dahlia/optique/pull/695
 
 ### @optique/config
 

--- a/packages/core/src/modifiers.ts
+++ b/packages/core/src/modifiers.ts
@@ -1280,7 +1280,9 @@ export function multiple<M extends Mode, TValue, TState>(
           suggestion.type,
           suggestion.pattern ?? "",
           suggestion.includeHidden === true,
-          suggestion.extensions == null ? "" : suggestion.extensions.join("\0"),
+          suggestion.extensions == null
+            ? ""
+            : suggestion.extensions.toSorted().join("\0"),
           description,
         ]);
       };

--- a/packages/core/src/suggestion.test.ts
+++ b/packages/core/src/suggestion.test.ts
@@ -763,6 +763,26 @@ describe("property-based tests", () => {
     });
   });
 
+  it("deduplicateSuggestions should treat extension order as insignificant", () => {
+    const suggestions: readonly Suggestion[] = [
+      {
+        kind: "file",
+        type: "file",
+        extensions: [".json", ".yaml"],
+        pattern: "x",
+      },
+      {
+        kind: "file",
+        type: "file",
+        extensions: [".yaml", ".json"],
+        pattern: "x",
+      },
+    ];
+    const result = deduplicateSuggestions(suggestions);
+    assert.equal(result.length, 1);
+    assert.deepEqual(result[0], suggestions[0]);
+  });
+
   it("deduplicateSuggestions should be idempotent and stable", () => {
     const literalSuggestionArbitrary = safeStringArbitrary.map(
       (text: string): Suggestion => ({ kind: "literal", text }),
@@ -795,7 +815,7 @@ describe("property-based tests", () => {
         return suggestion.text;
       }
       return `__FILE__:${suggestion.type}:${
-        suggestion.extensions?.join(",") ?? ""
+        suggestion.extensions?.toSorted().join(",") ?? ""
       }:${suggestion.pattern ?? ""}`;
     };
 

--- a/packages/core/src/suggestion.ts
+++ b/packages/core/src/suggestion.ts
@@ -333,7 +333,7 @@ function getSuggestionKey(suggestion: Suggestion): string {
   // File suggestion: create a composite key (excludes includeHidden,
   // which is merged separately in deduplicateSuggestions)
   return `__FILE__:${suggestion.type}:${
-    suggestion.extensions?.join(",") ?? ""
+    suggestion.extensions?.toSorted().join(",") ?? ""
   }:${suggestion.pattern ?? ""}`;
 }
 


### PR DESCRIPTION
## Summary

`deduplicateSuggestions()` uses `extensions?.join(",")` to build its deduplication key, which means two file suggestions with the same set of extensions in a different array order produce different keys and survive deduplication. For example, `[".json", ".yaml"]` and `[".yaml", ".json"]` are treated as distinct suggestions even though they describe the same file extension filter.

This fix sorts the extensions array before joining it into the key, so that order no longer affects deduplication. The same fix is applied to the local `suggestionKey()` helper in *modifiers.ts*, which has the same issue.

```typescript
const suggestions = [
  { kind: "file", type: "file", extensions: [".json", ".yaml"], pattern: "x" },
  { kind: "file", type: "file", extensions: [".yaml", ".json"], pattern: "x" },
];

// Before: returns both suggestions (length 2)
// After:  returns only the first suggestion (length 1)
deduplicateSuggestions(suggestions);
```

## Test plan

- Added a unit test that verifies file suggestions with the same extensions in different order are deduplicated to one suggestion
- Updated the property-based test's `keyOf` helper to use sorted extensions, ensuring idempotency and stability properties hold with the new key function
- All existing tests continue to pass across Deno, Node.js, and Bun (`mise test`)

Closes https://github.com/dahlia/optique/issues/519