### PR TITLE
Fix `normalizeUsage()` to strip degenerate usage terms

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -805,8 +805,9 @@ To be released.
     preserving them unchanged.  Empty-named options, empty-named commands,
     empty-metavar arguments, and container terms (`optional`, `multiple`,
     `exclusive`) whose terms array is empty after recursive normalization
-    are now removed.  Semantically meaningful structures — empty branches
-    within exclusive terms and empty-value literals — are preserved.
+    are now removed.  Exclusive branches representing valid zero-token
+    alternatives and empty-value literals are preserved; branches that
+    become empty because all their content was malformed are removed.
     [[#485], [#716]]
 
 [RFC 9562]: https://www.rfc-editor.org/rfc/rfc9562

--- a/packages/core/src/usage.test.ts
+++ b/packages/core/src/usage.test.ts
@@ -2325,6 +2325,30 @@ describe("normalizeUsage", () => {
       ]);
     });
 
+    it("should preserve branch with valid empty containers", () => {
+      // e.g., or(optional(constant("x")), command("foo", ...))
+      // produces a branch [{ type: "optional", terms: [] }] which
+      // normalizes to [] but is a valid zero-token alternative
+      const result = normalizeUsage([
+        {
+          type: "exclusive",
+          terms: [
+            [{ type: "optional", terms: [] }],
+            [{ type: "option", names: ["--verbose"] }],
+          ],
+        },
+      ]);
+      assert.deepEqual(result, [
+        {
+          type: "exclusive",
+          terms: [
+            [],
+            [{ type: "option", names: ["--verbose"] }],
+          ],
+        },
+      ]);
+    });
+
     it("should strip exclusive when all branches normalize to empty", () => {
       const result = normalizeUsage([
         {

--- a/packages/core/src/usage.ts
+++ b/packages/core/src/usage.ts
@@ -505,10 +505,11 @@ export function formatUsage(
  *    malformed output, such as options with no names, commands with empty
  *    names, arguments with empty metavars, and container terms (`optional`,
  *    `multiple`, `exclusive`) whose top-level terms array is empty after
- *    recursive normalization.  Empty branches within exclusive terms and
- *    empty-value literals are preserved because they can carry semantic
- *    meaning (e.g., `conditional()` default branches or empty-string
- *    discriminator keys).
+ *    recursive normalization.  Exclusive branches representing valid
+ *    zero-token alternatives (e.g., `conditional()` default branches or
+ *    `optional(constant(...))`) and empty-value literals are preserved.
+ *    Only branches that become empty because all their content was
+ *    malformed are removed.
  *
  * 2. *Flattening*: Recursively processes all usage terms and merges any
  *    nested exclusive terms into their parent exclusive term to avoid
@@ -564,11 +565,12 @@ function normalizeUsageTerm(term: UsageTerm): UsageTerm {
         for (const subUsage of normalized[0].terms) {
           terms.push([...subUsage, ...rest]);
         }
-      } else if (normalized.length > 0 || usage.length === 0) {
-        // Keep the branch if it still has content, or if it was
-        // originally empty (intentional empty alternative, e.g.,
-        // conditional() default branches).  Drop branches that became
-        // empty solely because all their terms were degenerate.
+      } else if (normalized.length > 0 || !containsMalformedLeaf(usage)) {
+        // Keep the branch if it still has content, or if it became
+        // empty without any malformed terms (valid zero-token
+        // alternative, e.g., conditional() default branches or
+        // optional(constant(...))).  Drop branches that became empty
+        // solely because all their terms were malformed.
         terms.push(normalized);
       }
     }
@@ -589,6 +591,23 @@ function isNonDegenerateTerm(term: UsageTerm): boolean {
     return term.terms.length > 0;
   }
   return true;
+}
+
+function containsMalformedLeaf(usage: Usage): boolean {
+  for (const term of usage) {
+    if (term.type === "option" && term.names.length === 0) return true;
+    if (term.type === "command" && term.name === "") return true;
+    if (term.type === "argument" && term.metavar.length === 0) return true;
+    if (term.type === "optional" || term.type === "multiple") {
+      if (containsMalformedLeaf(term.terms)) return true;
+    }
+    if (term.type === "exclusive") {
+      for (const branch of term.terms) {
+        if (containsMalformedLeaf(branch)) return true;
+      }
+    }
+  }
+  return false;
 }
 
 /**


### PR DESCRIPTION
`normalizeUsage()` currently preserves degenerate (empty but type-valid) usage term structures unchanged. While `formatUsage()` and `formatUsageTerm()` are unaffected because they pre-filter via `filterUsageForDisplay()`, callers that consume the normalized tree directly (e.g., through `getDocPage().usage`) see malformed structures that render as broken output like `()`, `[]`, or `" X"`.

This PR adds a stripping pass to `normalizeUsage()` that removes terms which carry no meaningful content:

- Options with empty `names` arrays
- Commands with empty `name` strings
- Arguments with empty `metavar` strings
- Container terms (`optional`, `multiple`, `exclusive`) whose `terms` array is empty after recursive normalization

Exclusive branches that become empty solely because their content was stripped are also dropped. However, branches that were originally empty are preserved, since combinators like `conditional()` use them to represent alternatives that consume no CLI tokens. Similarly, empty-value literals are preserved because they can represent valid discriminator keys (e.g., `conditional(option("--mode", string()), { "": someParser })`).

For example, the following exclusive term has one branch with a degenerate option and one valid branch:

```typescript
normalizeUsage([{
  type: "exclusive",
  terms: [
    [{ type: "option", names: [] }],       // degenerate: stripped
    [{ type: "option", names: ["--verbose"] }],
  ],
}]);
// => [{ type: "exclusive", terms: [[{ type: "option", names: ["--verbose"] }]] }]
```

Whereas an intentionally empty branch from `conditional()` is kept:

```typescript
normalizeUsage([{
  type: "exclusive",
  terms: [
    [],                                     // intentional: preserved
    [{ type: "option", names: ["--verbose"] }],
  ],
}]);
// => [{ type: "exclusive", terms: [[], [{ type: "option", names: ["--verbose"] }]] }]
```

The distinction is made by checking whether the branch was originally empty (`usage.length === 0`) or became empty after normalization stripped all its degenerate terms. See *packages/core/src/usage.ts* `normalizeUsageTerm()` for the implementation.

Closes https://github.com/dahlia/optique/issues/485