### PR TITLE
Flatten nested `optional()` wrappers in usage output

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1011,6 +1011,11 @@ To be released.
     values with a `TypeError`.  Previously, invalid names were only caught
     during help/error output formatting.  [[#428], [#743]]
 
+ -  Fixed nested `optional()` wrappers rendering double brackets (`[[...]]`)
+    in help usage output.  Parsers like `optional(optional(option(...)))` and
+    `withDefault(optional(option(...)), ...)` now correctly display single
+    brackets (`[...]`).  [[#290], [#745]]
+
 [RFC 9562]: https://www.rfc-editor.org/rfc/rfc9562
 [#110]: https://github.com/dahlia/optique/issues/110
 [#113]: https://github.com/dahlia/optique/issues/113
@@ -1063,6 +1068,7 @@ To be released.
 [#264]: https://github.com/dahlia/optique/issues/264
 [#275]: https://github.com/dahlia/optique/issues/275
 [#279]: https://github.com/dahlia/optique/issues/279
+[#290]: https://github.com/dahlia/optique/issues/290
 [#294]: https://github.com/dahlia/optique/issues/294
 [#296]: https://github.com/dahlia/optique/issues/296
 [#300]: https://github.com/dahlia/optique/issues/300
@@ -1286,6 +1292,7 @@ To be released.
 [#741]: https://github.com/dahlia/optique/pull/741
 [#742]: https://github.com/dahlia/optique/pull/742
 [#743]: https://github.com/dahlia/optique/pull/743
+[#745]: https://github.com/dahlia/optique/pull/745
 
 ### @optique/config
 

--- a/packages/core/src/usage.test.ts
+++ b/packages/core/src/usage.test.ts
@@ -219,7 +219,7 @@ describe("formatUsage", () => {
         },
       ];
       const result = formatUsage("test", usage);
-      assert.equal(result, "test [[FILE]]");
+      assert.equal(result, "test [FILE]");
     });
   });
 
@@ -1871,7 +1871,7 @@ describe("normalizeUsage", () => {
   });
 
   describe("optional terms", () => {
-    it("should normalize nested optional terms", () => {
+    it("should flatten nested optional terms", () => {
       const usage: Usage = [
         {
           type: "optional",
@@ -1887,7 +1887,55 @@ describe("normalizeUsage", () => {
       const expected: Usage = [
         {
           type: "optional",
+          terms: [{ type: "argument", metavar: "FILE" }],
+        },
+      ];
+      assert.deepEqual(result, expected);
+    });
+
+    it("should flatten deeply nested optional terms", () => {
+      const usage: Usage = [
+        {
+          type: "optional",
+          terms: [{
+            type: "optional",
+            terms: [{
+              type: "optional",
+              terms: [{ type: "argument", metavar: "FILE" }],
+            }],
+          }],
+        },
+      ];
+      const result = normalizeUsage(usage);
+      const expected: Usage = [
+        {
+          type: "optional",
+          terms: [{ type: "argument", metavar: "FILE" }],
+        },
+      ];
+      assert.deepEqual(result, expected);
+    });
+
+    it("should not flatten optional with multiple inner terms", () => {
+      const usage: Usage = [
+        {
+          type: "optional",
           terms: [
+            {
+              type: "optional",
+              terms: [{ type: "argument", metavar: "FILE" }],
+            },
+            { type: "option", names: ["--verbose"] },
+          ],
+        },
+      ];
+      const result = normalizeUsage(usage);
+      // normalizeUsage sorts: options before arguments
+      const expected: Usage = [
+        {
+          type: "optional",
+          terms: [
+            { type: "option", names: ["--verbose"] },
             {
               type: "optional",
               terms: [{ type: "argument", metavar: "FILE" }],

--- a/packages/core/src/usage.ts
+++ b/packages/core/src/usage.ts
@@ -595,6 +595,9 @@ export function formatUsage(
  *    nested exclusive terms into their parent exclusive term to avoid
  *    redundant nesting. For example, an exclusive term containing another
  *    exclusive term will have its nested terms flattened into the parent.
+ *    Similarly, nested optional terms are collapsed:
+ *    `optional(optional(X))` becomes `optional(X)` when the outer optional
+ *    contains only a single inner optional term.
  *
  * 3. *Sorting*: Reorders terms to improve readability by placing:
  *    - Commands (subcommands) first
@@ -607,8 +610,8 @@ export function formatUsage(
  *
  * @param usage The usage description to normalize.
  * @returns A normalized usage description with degenerate terms removed,
- *          nested exclusive terms flattened, and remaining terms sorted for
- *          optimal readability.
+ *          nested exclusive and optional terms flattened, and remaining
+ *          terms sorted for optimal readability.
  */
 export function normalizeUsage(usage: Usage): Usage {
   const terms = usage.map(normalizeUsageTerm).filter(isNonDegenerateTerm);
@@ -629,7 +632,11 @@ export function normalizeUsage(usage: Usage): Usage {
 
 function normalizeUsageTerm(term: UsageTerm): UsageTerm {
   if (term.type === "optional") {
-    return { type: "optional", terms: normalizeUsage(term.terms) };
+    const normalized = normalizeUsage(term.terms);
+    if (normalized.length === 1 && normalized[0].type === "optional") {
+      return normalized[0];
+    }
+    return { type: "optional", terms: normalized };
   } else if (term.type === "multiple") {
     return {
       type: "multiple",


### PR DESCRIPTION
Parsers like `optional(optional(option(...)))` or `withDefault(optional(option(...)), ...)` previously rendered double brackets in help usage output (e.g., `[[--name STRING]]`). This happened because both `optional()` and `withDefault()` unconditionally wrap their inner parser's usage in an `{ type: "optional" }` term, so nesting them produces a nested optional tree that the renderer emitted literally.

This PR fixes `normalizeUsageTerm()` in *packages/core/src/usage.ts* to collapse nested optional terms during normalization. When an outer optional contains exactly one inner optional term, the outer layer is stripped. Since normalization is recursive, this handles arbitrary nesting depth.

A real-world example of this issue already ships in `@optique/logtape`: `loggingOptions({ level: "option" })` renders `[[--log-output FILE]]` because `withDefault(logOutput(), { type: "console" })` wraps the already-optional `logOutput()` in a second optional layer. After this fix, it correctly renders `[--log-output FILE]`.

Before:

```text
Usage: myapp [[--name STRING]]
```

After:

```text
Usage: myapp [--name STRING]
```

Closes https://github.com/dahlia/optique/issues/290