### PR TITLE
Keep annotated state transparent in `argument()` and `command()`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -224,7 +224,7 @@ To be released.
     primitives, so positional arguments, subcommands, and top-level
     value-suggestion flows behave the same way they do without annotations.
     Wrapper compositions that forward primitive state directly, such as
-    `group(argument(...))`, inherit the fix as well.  [[#187]]
+    `group(argument(...))`, inherit the fix as well.  [[#187], [#781]]
 
  -  Expanded `or()`'s fully inferred overloads from 10 to 15 parser
     arguments, so large alternative sets keep precise union inference without
@@ -1614,6 +1614,7 @@ To be released.
 [#778]: https://github.com/dahlia/optique/pull/778
 [#779]: https://github.com/dahlia/optique/pull/779
 [#780]: https://github.com/dahlia/optique/pull/780
+[#781]: https://github.com/dahlia/optique/pull/781
 
 ### @optique/config
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -217,6 +217,15 @@ To be released.
     `runSync()`) either select a branch normally or return an ordinary parse
     failure instead of throwing.  [[#183]]
 
+ -  Fixed `argument()` and `command()` misinterpreting annotation-injected
+    initial state as real parser-local state.  Annotated calls through
+    `parse()`, `suggest()`, `runWith()`, `runWithSync()`, `run()`, and
+    `runSync()` now treat annotations as transparent runtime context for these
+    primitives, so positional arguments, subcommands, and top-level
+    value-suggestion flows behave the same way they do without annotations.
+    Wrapper compositions that forward primitive state directly, such as
+    `group(argument(...))`, inherit the fix as well.  [[#187]]
+
  -  Expanded `or()`'s fully inferred overloads from 10 to 15 parser
     arguments, so large alternative sets keep precise union inference without
     collapsing to `unknown` at 11+ arguments.  [[#142], [#143]]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1313,6 +1313,7 @@ To be released.
 [#180]: https://github.com/dahlia/optique/issues/180
 [#183]: https://github.com/dahlia/optique/issues/183
 [#186]: https://github.com/dahlia/optique/issues/186
+[#187]: https://github.com/dahlia/optique/issues/187
 [#200]: https://github.com/dahlia/optique/issues/200
 [#223]: https://github.com/dahlia/optique/issues/223
 [#224]: https://github.com/dahlia/optique/issues/224

--- a/packages/core/src/annotation-state.test.ts
+++ b/packages/core/src/annotation-state.test.ts
@@ -1,0 +1,104 @@
+import {
+  type Annotations,
+  getAnnotations,
+  injectAnnotations,
+} from "@optique/core/annotations";
+import { message } from "@optique/core/message";
+import {
+  defineInheritedAnnotationParser,
+  type Parser,
+} from "@optique/core/parser";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  getWrappedChildParseState,
+  getWrappedChildState,
+  normalizeInjectedAnnotationState,
+} from "./annotation-state.ts";
+
+function createInheritedTestParser(): Parser<"sync", unknown, unknown> {
+  const parser: Parser<"sync", unknown, unknown> = {
+    $mode: "sync",
+    $valueType: [] as readonly unknown[],
+    $stateType: [] as readonly unknown[],
+    priority: 1,
+    usage: [],
+    leadingNames: new Set(),
+    acceptingAnyToken: false,
+    initialState: undefined,
+    parse(context) {
+      return {
+        success: false as const,
+        consumed: 0,
+        error: message`unused parse: ${String(context.state)}`,
+      };
+    },
+    complete() {
+      return { success: true as const, value: undefined };
+    },
+    suggest() {
+      return [];
+    },
+    getDocFragments() {
+      return { fragments: [] };
+    },
+  };
+  defineInheritedAnnotationParser(parser);
+  return parser;
+}
+
+describe("annotation-state", () => {
+  it(
+    "getWrappedChildParseState() preserves nullish sentinels when inheriting annotations",
+    () => {
+      const marker = Symbol.for(
+        "@test/getWrappedChildParseState-nullish-sentinel",
+      );
+      const annotations = { [marker]: true } satisfies Annotations;
+      const parentState = injectAnnotations(undefined, annotations);
+      const parser = createInheritedTestParser();
+
+      for (const childState of [undefined, null] as const) {
+        const wrapped = getWrappedChildParseState(
+          parentState,
+          childState,
+          parser,
+        );
+
+        assert.equal(
+          normalizeInjectedAnnotationState(wrapped),
+          childState,
+          "the wrapped state should normalize back to the original sentinel",
+        );
+        assert.equal(getAnnotations(wrapped)?.[marker], true);
+      }
+    },
+  );
+
+  it(
+    "getWrappedChildState() preserves nullish sentinels when inheriting annotations",
+    () => {
+      const marker = Symbol.for(
+        "@test/getWrappedChildState-nullish-sentinel",
+      );
+      const annotations = { [marker]: true } satisfies Annotations;
+      const parentState = injectAnnotations(undefined, annotations);
+      const parser = createInheritedTestParser();
+
+      for (const childState of [undefined, null] as const) {
+        const wrapped = getWrappedChildState(
+          parentState,
+          childState,
+          parser,
+        );
+
+        assert.equal(
+          normalizeInjectedAnnotationState(wrapped),
+          childState,
+          "the wrapped state should normalize back to the original sentinel",
+        );
+        assert.equal(getAnnotations(wrapped)?.[marker], true);
+      }
+    },
+  );
+});

--- a/packages/core/src/annotation-state.test.ts
+++ b/packages/core/src/annotation-state.test.ts
@@ -70,7 +70,7 @@ describe("annotation-state", () => {
           childState,
           "the wrapped state should normalize back to the original sentinel",
         );
-        assert.equal(getAnnotations(wrapped)?.[marker], true);
+        assert.ok(getAnnotations(wrapped)?.[marker]);
       }
     },
   );
@@ -97,7 +97,7 @@ describe("annotation-state", () => {
           childState,
           "the wrapped state should normalize back to the original sentinel",
         );
-        assert.equal(getAnnotations(wrapped)?.[marker], true);
+        assert.ok(getAnnotations(wrapped)?.[marker]);
       }
     },
   );

--- a/packages/core/src/annotation-state.ts
+++ b/packages/core/src/annotation-state.ts
@@ -1,0 +1,145 @@
+import {
+  annotationKey,
+  type Annotations,
+  getAnnotations,
+  injectAnnotations,
+  unwrapInjectedAnnotationWrapper,
+} from "./annotations.ts";
+import {
+  inheritParentAnnotationsKey,
+  type Mode,
+  type Parser,
+} from "./parser.ts";
+
+/**
+ * Shared targets for annotation-view proxies.
+ *
+ * @internal
+ */
+export const annotationViewTargets = new WeakMap<object, object>();
+
+/**
+ * Unwraps an annotation-view proxy to its original target object.
+ *
+ * @internal
+ */
+export function unwrapAnnotationView<T>(value: T): T {
+  if (value == null || typeof value !== "object") {
+    return value;
+  }
+  return (annotationViewTargets.get(value as object) as T | undefined) ?? value;
+}
+
+/**
+ * Creates a proxy that exposes annotations without changing the target shape.
+ *
+ * @internal
+ */
+export function withAnnotationView<T extends object>(
+  state: T,
+  annotations: Annotations,
+): T {
+  const target = unwrapAnnotationView(state) as T;
+  const view = new Proxy(target, {
+    get(target, key) {
+      if (key === annotationKey) {
+        return annotations;
+      }
+      const value = Reflect.get(target, key, target);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+    has(target, key) {
+      return key === annotationKey || Reflect.has(target, key);
+    },
+  });
+  annotationViewTargets.set(view, target);
+  return view;
+}
+
+/**
+ * Removes Optique's internal primitive-state annotation wrapper when present.
+ *
+ * @internal
+ */
+export function normalizeInjectedAnnotationState<T>(state: T): T {
+  return unwrapInjectedAnnotationWrapper(state);
+}
+
+/**
+ * Returns whether a state is still the annotation-wrapped initial sentinel.
+ *
+ * @internal
+ */
+export function isAnnotationWrappedInitialState(state: unknown): boolean {
+  return normalizeInjectedAnnotationState(state) === undefined;
+}
+
+/**
+ * Propagates parent annotations into a child parse state when the child parser
+ * explicitly opts into parent annotation inheritance.
+ *
+ * @internal
+ */
+export function getWrappedChildParseState<TState>(
+  parentState: unknown,
+  childState: TState,
+  parser: Parser<Mode, unknown, unknown>,
+): TState {
+  const annotations = getAnnotations(parentState);
+  const shouldInheritAnnotations =
+    Reflect.get(parser, inheritParentAnnotationsKey) === true;
+  if (childState == null) {
+    if (annotations !== undefined && shouldInheritAnnotations) {
+      return injectAnnotations({}, annotations) as TState;
+    }
+    return childState;
+  }
+  if (
+    annotations === undefined ||
+    typeof childState !== "object" ||
+    getAnnotations(childState) === annotations ||
+    !shouldInheritAnnotations
+  ) {
+    return childState;
+  }
+  const injectedState = injectAnnotations(childState, annotations);
+  return getAnnotations(injectedState) === annotations
+    ? injectedState as TState
+    : childState;
+}
+
+/**
+ * Propagates parent annotations into a child state while preserving the child
+ * state's shape for parsers that do not opt into full wrapper injection.
+ *
+ * @internal
+ */
+export function getWrappedChildState<TState>(
+  parentState: unknown,
+  childState: TState,
+  parser: Parser<Mode, unknown, unknown>,
+): TState {
+  const annotations = getAnnotations(parentState);
+  const shouldInheritAnnotations =
+    Reflect.get(parser, inheritParentAnnotationsKey) === true;
+  if (childState == null) {
+    if (annotations !== undefined && shouldInheritAnnotations) {
+      return injectAnnotations({}, annotations) as TState;
+    }
+    return childState;
+  }
+  if (
+    annotations === undefined ||
+    typeof childState !== "object" ||
+    getAnnotations(childState) === annotations
+  ) {
+    return childState;
+  }
+  if (shouldInheritAnnotations) {
+    const injectedState = injectAnnotations(childState, annotations);
+    if (getAnnotations(injectedState) === annotations) {
+      return injectedState as TState;
+    }
+  }
+  return withAnnotationView(childState, annotations) as TState;
+}

--- a/packages/core/src/annotation-state.ts
+++ b/packages/core/src/annotation-state.ts
@@ -15,6 +15,9 @@ import {
 /**
  * Shared targets for annotation-view proxies.
  *
+ * Maps a proxy returned by {@link withAnnotationView} back to its original
+ * target object.
+ *
  * @internal
  */
 export const annotationViewTargets = new WeakMap<object, object>();
@@ -22,6 +25,9 @@ export const annotationViewTargets = new WeakMap<object, object>();
 /**
  * Unwraps an annotation-view proxy to its original target object.
  *
+ * @param value The candidate value that may be an annotation-view proxy.
+ * @returns The original target object when the input is a tracked
+ *          annotation-view proxy; otherwise the input value unchanged.
  * @internal
  */
 export function unwrapAnnotationView<T>(value: T): T {
@@ -34,6 +40,10 @@ export function unwrapAnnotationView<T>(value: T): T {
 /**
  * Creates a proxy that exposes annotations without changing the target shape.
  *
+ * @param state The object state to expose through an annotation-aware view.
+ * @param annotations The annotations to surface through the proxy.
+ * @returns A proxy over the unwrapped target object that reports the supplied
+ *          annotations while preserving the target's structural behavior.
  * @internal
  */
 export function withAnnotationView<T extends object>(
@@ -60,6 +70,9 @@ export function withAnnotationView<T extends object>(
 /**
  * Removes Optique's internal primitive-state annotation wrapper when present.
  *
+ * @param state The parser state to normalize.
+ * @returns The wrapped primitive sentinel when the input is an injected
+ *          annotation wrapper; otherwise the original input unchanged.
  * @internal
  */
 export function normalizeInjectedAnnotationState<T>(state: T): T {
@@ -72,6 +85,9 @@ export function normalizeInjectedAnnotationState<T>(state: T): T {
  *
  * This treats plain `undefined` and annotation-wrapped `undefined` the same.
  *
+ * @param state The parser state to inspect.
+ * @returns `true` when the normalized state is still `undefined`;
+ *          otherwise `false`.
  * @internal
  */
 export function isAnnotationWrappedInitialState(state: unknown): boolean {
@@ -82,6 +98,14 @@ export function isAnnotationWrappedInitialState(state: unknown): boolean {
  * Propagates parent annotations into a child parse state when the child parser
  * explicitly opts into parent annotation inheritance.
  *
+ * @param parentState The parent parser state that may carry annotations.
+ * @param childState The child parse state that may receive inherited
+ *                   annotations.
+ * @param parser The child parser whose inheritance marker controls whether
+ *               wrapper injection is allowed.
+ * @returns The original child state when no injection is needed or possible,
+ *          or an annotation-injected child state that preserves the original
+ *          sentinel or object shape when inheritance applies.
  * @internal
  */
 export function getWrappedChildParseState<TState>(
@@ -116,6 +140,13 @@ export function getWrappedChildParseState<TState>(
  * Propagates parent annotations into a child state while preserving the child
  * state's shape for parsers that do not opt into full wrapper injection.
  *
+ * @param parentState The parent parser state that may carry annotations.
+ * @param childState The child state that may receive inherited annotations.
+ * @param parser The child parser whose inheritance marker controls whether
+ *               full wrapper injection is allowed.
+ * @returns The original child state when no wrapping is needed, an
+ *          annotation-injected child state when inheritance applies, or an
+ *          annotation-view proxy that preserves the child's object shape.
  * @internal
  */
 export function getWrappedChildState<TState>(
@@ -152,6 +183,11 @@ export function getWrappedChildState<TState>(
  * Reconciles object-owned child state with parent annotations using the same
  * shared object-state inheritance rule across parser families.
  *
+ * @param parentState The parent parser state that may carry annotations.
+ * @param childState The object-owned child state to reconcile.
+ * @returns The original child state when no reconciliation is needed, or a
+ *          child state with inherited annotations when the object state should
+ *          carry the parent's annotations.
  * @internal
  */
 export function reconcileObjectChildState<TState>(

--- a/packages/core/src/annotation-state.ts
+++ b/packages/core/src/annotation-state.ts
@@ -67,7 +67,10 @@ export function normalizeInjectedAnnotationState<T>(state: T): T {
 }
 
 /**
- * Returns whether a state is still the annotation-wrapped initial sentinel.
+ * Returns whether a state is still at the initial sentinel after normalizing
+ * Optique's injected annotation wrapper.
+ *
+ * This treats plain `undefined` and annotation-wrapped `undefined` the same.
  *
  * @internal
  */

--- a/packages/core/src/annotation-state.ts
+++ b/packages/core/src/annotation-state.ts
@@ -91,7 +91,7 @@ export function getWrappedChildParseState<TState>(
     Reflect.get(parser, inheritParentAnnotationsKey) === true;
   if (childState == null) {
     if (annotations !== undefined && shouldInheritAnnotations) {
-      return injectAnnotations({}, annotations) as TState;
+      return injectAnnotations(childState, annotations);
     }
     return childState;
   }
@@ -125,7 +125,7 @@ export function getWrappedChildState<TState>(
     Reflect.get(parser, inheritParentAnnotationsKey) === true;
   if (childState == null) {
     if (annotations !== undefined && shouldInheritAnnotations) {
-      return injectAnnotations({}, annotations) as TState;
+      return injectAnnotations(childState, annotations);
     }
     return childState;
   }

--- a/packages/core/src/annotation-state.ts
+++ b/packages/core/src/annotation-state.ts
@@ -2,6 +2,7 @@ import {
   annotationKey,
   type Annotations,
   getAnnotations,
+  inheritAnnotations,
   injectAnnotations,
   unwrapInjectedAnnotationWrapper,
 } from "./annotations.ts";
@@ -142,4 +143,26 @@ export function getWrappedChildState<TState>(
     }
   }
   return withAnnotationView(childState, annotations) as TState;
+}
+
+/**
+ * Reconciles object-owned child state with parent annotations using the same
+ * shared object-state inheritance rule across parser families.
+ *
+ * @internal
+ */
+export function reconcileObjectChildState<TState>(
+  parentState: unknown,
+  childState: TState,
+): TState {
+  const annotations = getAnnotations(parentState);
+  if (
+    annotations === undefined ||
+    childState == null ||
+    typeof childState !== "object" ||
+    getAnnotations(childState) === annotations
+  ) {
+    return childState;
+  }
+  return inheritAnnotations(parentState, childState);
 }

--- a/packages/core/src/constructs.ts
+++ b/packages/core/src/constructs.ts
@@ -1,4 +1,10 @@
 import {
+  annotationViewTargets,
+  getWrappedChildParseState as getParseChildState,
+  getWrappedChildState as getAnnotatedChildState,
+  unwrapAnnotationView,
+} from "./annotation-state.ts";
+import {
   createDependencySourceState,
   dependencyId,
   isDependencySourceState,
@@ -21,11 +27,8 @@ import {
 } from "./dependency-runtime.ts";
 import {
   annotateFreshArray,
-  annotationKey,
-  type Annotations,
   getAnnotations,
   inheritAnnotations,
-  injectAnnotations,
 } from "./annotations.ts";
 import { dispatchByMode, dispatchIterableByMode } from "./mode-dispatch.ts";
 import {
@@ -64,7 +67,6 @@ import type {
 import {
   defineInheritedAnnotationParser,
   getParserSuggestRuntimeNodes,
-  inheritParentAnnotationsKey,
   unmatchedNonCliDependencySourceStateMarker,
 } from "./parser.ts";
 import type { ParserDependencyMetadata } from "./dependency-metadata.ts";
@@ -307,13 +309,6 @@ const fieldParsersKey: unique symbol = Symbol("fieldParsers");
  * to consume results from parsers that still return `DependencySourceState`.
  * @internal
  */
-function unwrapAnnotationView<T>(value: T): T {
-  if (value == null || typeof value !== "object") {
-    return value;
-  }
-  return (annotationViewTargets.get(value as object) as T | undefined) ?? value;
-}
-
 function containsAnnotationView(
   value: unknown,
   seen = new WeakSet<object>(),
@@ -611,62 +606,11 @@ function getAnnotatedFieldState(
   return getAnnotatedChildState(parentState, sourceState, parser);
 }
 
-const annotationViewTargets = new WeakMap<object, object>();
-
-function withAnnotationView<T extends object>(
-  state: T,
-  annotations: Annotations,
-): T {
-  const target = unwrapAnnotationView(state) as T;
-  const view = new Proxy(target, {
-    get(target, key) {
-      if (key === annotationKey) {
-        return annotations;
-      }
-      const value = Reflect.get(target, key, target);
-      return typeof value === "function" ? value.bind(target) : value;
-    },
-    has(target, key) {
-      return key === annotationKey || Reflect.has(target, key);
-    },
-  });
-  annotationViewTargets.set(view, target);
-  return view;
-}
-
-function getParseChildState(
+function getObjectParseChildState<TState>(
   parentState: unknown,
-  childState: unknown,
-  parser: Parser<Mode, unknown, unknown>,
-): unknown {
-  const annotations = getAnnotations(parentState);
-  const shouldInheritAnnotations =
-    Reflect.get(parser, inheritParentAnnotationsKey) === true;
-  if (childState == null) {
-    if (annotations !== undefined && shouldInheritAnnotations) {
-      return injectAnnotations({}, annotations);
-    }
-    return childState;
-  }
-  if (
-    annotations === undefined ||
-    typeof childState !== "object" ||
-    getAnnotations(childState) === annotations ||
-    !shouldInheritAnnotations
-  ) {
-    return childState;
-  }
-  const injectedState = injectAnnotations(childState, annotations);
-  return getAnnotations(injectedState) === annotations
-    ? injectedState
-    : childState;
-}
-
-function getObjectParseChildState(
-  parentState: unknown,
-  childState: unknown,
+  childState: TState,
   _parser: Parser<Mode, unknown, unknown>,
-): unknown {
+): TState {
   const annotations = getAnnotations(parentState);
   if (
     annotations === undefined ||
@@ -677,37 +621,6 @@ function getObjectParseChildState(
     return childState;
   }
   return inheritAnnotations(parentState, childState);
-}
-
-function getAnnotatedChildState(
-  parentState: unknown,
-  childState: unknown,
-  parser: Parser<Mode, unknown, unknown>,
-): unknown {
-  const annotations = getAnnotations(parentState);
-  const shouldInheritAnnotations =
-    Reflect.get(parser, inheritParentAnnotationsKey) === true;
-  if (childState == null) {
-    if (annotations !== undefined && shouldInheritAnnotations) {
-      return injectAnnotations({}, annotations);
-    }
-    return childState;
-  }
-  if (typeof childState !== "object") {
-    return childState;
-  }
-  if (
-    annotations === undefined || getAnnotations(childState) === annotations
-  ) {
-    return childState;
-  }
-  if (shouldInheritAnnotations) {
-    const injectedState = injectAnnotations(childState, annotations);
-    if (getAnnotations(injectedState) === annotations) {
-      return injectedState;
-    }
-  }
-  return withAnnotationView(childState, annotations);
 }
 
 function buildSuggestRuntimeNodesFromPairs(

--- a/packages/core/src/constructs.ts
+++ b/packages/core/src/constructs.ts
@@ -2,6 +2,7 @@ import {
   annotationViewTargets,
   getWrappedChildParseState as getParseChildState,
   getWrappedChildState as getAnnotatedChildState,
+  reconcileObjectChildState,
   unwrapAnnotationView,
 } from "./annotation-state.ts";
 import {
@@ -611,16 +612,7 @@ function getObjectParseChildState<TState>(
   childState: TState,
   _parser: Parser<Mode, unknown, unknown>,
 ): TState {
-  const annotations = getAnnotations(parentState);
-  if (
-    annotations === undefined ||
-    childState == null ||
-    typeof childState !== "object" ||
-    getAnnotations(childState) === annotations
-  ) {
-    return childState;
-  }
-  return inheritAnnotations(parentState, childState);
+  return reconcileObjectChildState(parentState, childState);
 }
 
 function buildSuggestRuntimeNodesFromPairs(

--- a/packages/core/src/facade.test.ts
+++ b/packages/core/src/facade.test.ts
@@ -6659,6 +6659,43 @@ describe("runWithSync", () => {
     assert.equal(result, "ok");
   });
 
+  it("should keep argument parsing transparent for static contexts", () => {
+    const annotation = Symbol.for("@test/issue-187/runwithsync-argument");
+    const context: SourceContext = {
+      id: annotation,
+      mode: "static",
+      getAnnotations() {
+        return { [annotation]: true };
+      },
+    };
+
+    const result = runWithSync(argument(string()), "test", [context], {
+      args: ["value"],
+    });
+
+    assert.equal(result, "value");
+  });
+
+  it("should keep command parsing transparent for static contexts", () => {
+    const annotation = Symbol.for("@test/issue-187/runwithsync-command");
+    const context: SourceContext = {
+      id: annotation,
+      mode: "static",
+      getAnnotations() {
+        return { [annotation]: true };
+      },
+    };
+
+    const result = runWithSync(
+      command("go", object({ silent: option("--silent") })),
+      "test",
+      [context],
+      { args: ["go", "--silent"] },
+    );
+
+    assert.deepEqual(result, { silent: true });
+  });
+
   it("should preserve array parser state shape with annotations", () => {
     const envKey = Symbol.for("@test/env-array");
     const envContext: SourceContext = {

--- a/packages/core/src/primitives.test.ts
+++ b/packages/core/src/primitives.test.ts
@@ -47,6 +47,7 @@ import {
   type Parser,
   type ParserContext,
   parseSync,
+  suggest,
   type Suggestion,
 } from "@optique/core/parser";
 import type { Usage } from "@optique/core/usage";
@@ -1795,6 +1796,26 @@ describe("flag() error customization", () => {
 });
 
 describe("argument", () => {
+  it("should treat annotations as transparent during top-level parsing", () => {
+    const annotation = Symbol.for("@test/issue-187/argument-parse");
+    const result = parse(argument(string()), ["value"], {
+      annotations: { [annotation]: true },
+    });
+
+    assert.deepEqual(result, { success: true, value: "value" });
+  });
+
+  it("should keep top-level suggestions when annotations are present", () => {
+    const annotation = Symbol.for("@test/issue-187/argument-suggest");
+    const suggestions = suggest(
+      argument(choice(["alpha", "beta"] as const)),
+      ["a"],
+      { annotations: { [annotation]: true } },
+    );
+
+    assert.deepEqual(suggestions, [{ kind: "literal", text: "alpha" }]);
+  });
+
   it("should create a parser that expects a single argument", () => {
     const parser = argument(string({ metavar: "FILE" }));
 
@@ -2045,6 +2066,27 @@ describe("primitives additional branch coverage", () => {
       assert.deepEqual(resolved.consumed, ["--count", "42"]);
       assert.deepEqual(resolved.next.buffer, []);
     }
+  });
+
+  it("option suggest keeps top-level value suggestions under annotations", () => {
+    const annotation = Symbol.for("@test/issue-187/option-suggest");
+    const suggestions = suggest(
+      option("--env", choice(["alpha", "beta"] as const)),
+      ["a"],
+      { annotations: { [annotation]: true } },
+    );
+
+    assert.deepEqual(suggestions, [{ kind: "literal", text: "alpha" }]);
+  });
+
+  it("group(argument()) stays annotation-transparent", () => {
+    const annotation = Symbol.for("@test/issue-187/group-argument");
+    const parser = group("Arguments", argument(string()));
+    const result = parse(parser, ["value"], {
+      annotations: { [annotation]: true },
+    });
+
+    assert.deepEqual(result, { success: true, value: "value" });
   });
 
   it("option parse rejects instead of throwing when async value parsing throws synchronously", async () => {
@@ -2406,6 +2448,30 @@ describe("command", () => {
       },
     };
   }
+
+  it("should treat annotations as transparent during top-level parsing", () => {
+    const annotation = Symbol.for("@test/issue-187/command-parse");
+    const parser = command("go", object({ silent: option("--silent") }));
+
+    const result = parse(parser, ["go", "--silent"], {
+      annotations: { [annotation]: true },
+    });
+
+    assert.deepEqual(result, {
+      success: true,
+      value: { silent: true },
+    });
+  });
+
+  it("should keep top-level suggestions when annotations are present", () => {
+    const annotation = Symbol.for("@test/issue-187/command-suggest");
+    const parser = command("go", object({ silent: option("--silent") }));
+    const suggestions = suggest(parser, ["g"], {
+      annotations: { [annotation]: true },
+    });
+
+    assert.deepEqual(suggestions, [{ kind: "literal", text: "go" }]);
+  });
 
   it("should create a parser that matches a subcommand and applies inner parser", () => {
     const showParser = command(

--- a/packages/core/src/primitives.test.ts
+++ b/packages/core/src/primitives.test.ts
@@ -2089,6 +2089,16 @@ describe("primitives additional branch coverage", () => {
     assert.deepEqual(result, { success: true, value: "value" });
   });
 
+  it("map(argument()) stays annotation-transparent", () => {
+    const annotation = Symbol.for("@test/issue-187/map-argument");
+    const parser = map(argument(string()), (value) => value.toUpperCase());
+    const result = parse(parser, ["value"], {
+      annotations: { [annotation]: true },
+    });
+
+    assert.deepEqual(result, { success: true, value: "VALUE" });
+  });
+
   it("option parse rejects instead of throwing when async value parsing throws synchronously", async () => {
     const throwingParser: ValueParser<"async", string> = {
       $mode: "async",
@@ -2471,6 +2481,22 @@ describe("command", () => {
     });
 
     assert.deepEqual(suggestions, [{ kind: "literal", text: "go" }]);
+  });
+
+  it("group(command()) stays annotation-transparent", () => {
+    const annotation = Symbol.for("@test/issue-187/group-command");
+    const parser = group(
+      "Commands",
+      command("go", object({ silent: option("--silent") })),
+    );
+    const result = parse(parser, ["go", "--silent"], {
+      annotations: { [annotation]: true },
+    });
+
+    assert.deepEqual(result, {
+      success: true,
+      value: { silent: true },
+    });
   });
 
   it("should create a parser that matches a subcommand and applies inner parser", () => {

--- a/packages/core/src/primitives.ts
+++ b/packages/core/src/primitives.ts
@@ -6,7 +6,14 @@ import {
   isDerivedValueParser,
   suggestWithDependency,
 } from "./dependency.ts";
-import { annotateFreshArray, getAnnotations } from "./annotations.ts";
+import {
+  annotateFreshArray,
+  annotationKey,
+  type Annotations,
+  getAnnotations,
+  injectAnnotations,
+  unwrapInjectedAnnotationWrapper,
+} from "./annotations.ts";
 import { extractDependencyMetadata } from "./dependency-metadata.ts";
 import {
   replayDerivedParser,
@@ -83,6 +90,103 @@ function withChildContext<TState>(
       }
       : {}),
   };
+}
+
+const annotationViewTargets = new WeakMap<object, object>();
+
+function unwrapAnnotationView<T>(value: T): T {
+  if (value == null || typeof value !== "object") {
+    return value;
+  }
+  return (annotationViewTargets.get(value as object) as T | undefined) ??
+    value;
+}
+
+function withAnnotationView<T extends object>(
+  state: T,
+  annotations: Annotations,
+): T {
+  const target = unwrapAnnotationView(state) as T;
+  const view = new Proxy(target, {
+    get(target, key) {
+      if (key === annotationKey) {
+        return annotations;
+      }
+      const value = Reflect.get(target, key, target);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+    has(target, key) {
+      return key === annotationKey || Reflect.has(target, key);
+    },
+  });
+  annotationViewTargets.set(view, target);
+  return view;
+}
+
+function normalizeInjectedAnnotationState<T>(state: T): T {
+  return unwrapInjectedAnnotationWrapper(state);
+}
+
+function isAnnotationWrappedInitialState(state: unknown): boolean {
+  return normalizeInjectedAnnotationState(state) === undefined;
+}
+
+function getWrappedChildParseState<TState>(
+  parentState: unknown,
+  childState: TState,
+  parser: Parser<Mode, unknown, unknown>,
+): TState {
+  const annotations = getAnnotations(parentState);
+  const shouldInheritAnnotations =
+    Reflect.get(parser, inheritParentAnnotationsKey) === true;
+  if (childState == null) {
+    if (annotations !== undefined && shouldInheritAnnotations) {
+      return injectAnnotations({}, annotations) as TState;
+    }
+    return childState;
+  }
+  if (
+    annotations === undefined ||
+    typeof childState !== "object" ||
+    getAnnotations(childState) === annotations ||
+    !shouldInheritAnnotations
+  ) {
+    return childState;
+  }
+  const injectedState = injectAnnotations(childState, annotations);
+  return getAnnotations(injectedState) === annotations
+    ? injectedState as TState
+    : childState;
+}
+
+function getWrappedChildState<TState>(
+  parentState: unknown,
+  childState: TState,
+  parser: Parser<Mode, unknown, unknown>,
+): TState {
+  const annotations = getAnnotations(parentState);
+  const shouldInheritAnnotations =
+    Reflect.get(parser, inheritParentAnnotationsKey) === true;
+  if (childState == null) {
+    if (annotations !== undefined && shouldInheritAnnotations) {
+      return injectAnnotations({}, annotations) as TState;
+    }
+    return childState;
+  }
+  if (
+    annotations === undefined ||
+    typeof childState !== "object" ||
+    getAnnotations(childState) === annotations
+  ) {
+    return childState;
+  }
+  if (shouldInheritAnnotations) {
+    const injectedState = injectAnnotations(childState, annotations);
+    if (getAnnotations(injectedState) === annotations) {
+      return injectedState as TState;
+    }
+  }
+  return withAnnotationView(childState, annotations) as TState;
 }
 
 /** @internal */
@@ -260,6 +364,7 @@ import type {
   ParserResult,
   Suggestion,
 } from "./parser.ts";
+import { inheritParentAnnotationsKey } from "./parser.ts";
 import {
   createErrorWithSuggestions,
   createSuggestionMessage,
@@ -601,7 +706,7 @@ function* suggestOptionSync<T>(
       } // Scenario 2: Empty buffer, state is undefined, and the prefix is
       // not itself starting an option token.
       else if (
-        context.state === undefined &&
+        isAnnotationWrappedInitialState(context.state) &&
         context.buffer.length === 0 &&
         (context.exec?.path?.length ?? 0) === 0 &&
         !(prefix.startsWith("--") || prefix.startsWith("-") ||
@@ -781,7 +886,7 @@ async function* suggestOptionAsync<T>(
       } // Scenario 2: Empty buffer, state is undefined, and the prefix is
       // not itself starting an option token.
       else if (
-        context.state === undefined &&
+        isAnnotationWrappedInitialState(context.state) &&
         context.buffer.length === 0 &&
         (context.exec?.path?.length ?? 0) === 0 &&
         !(prefix.startsWith("--") || prefix.startsWith("-") ||
@@ -2006,6 +2111,7 @@ export function argument<M extends Mode, T>(
         ValueParserResult<T> | undefined
       >,
     ) {
+      const localState = normalizeInjectedAnnotationState(context.state);
       if (context.buffer.length < 1) {
         return {
           success: false,
@@ -2042,7 +2148,7 @@ export function argument<M extends Mode, T>(
         };
       }
 
-      if (context.state != null) {
+      if (localState != null) {
         return {
           success: false,
           consumed: i,
@@ -2153,7 +2259,7 @@ export function argument<M extends Mode, T>(
       >,
       prefix: string,
     ) {
-      if (context.state != null) {
+      if (normalizeInjectedAnnotationState(context.state) != null) {
         return dispatchIterableByMode<M, Suggestion>(
           valueParser.$mode,
           function* () {},
@@ -2402,6 +2508,41 @@ type CommandState<TState> =
   | ["matched", string] // Command matched but inner parser not started
   | ["parsing", TState]; // Command matched and inner parser active
 
+function normalizeCommandState<TState>(
+  state: CommandState<TState>,
+): CommandState<TState> {
+  return normalizeInjectedAnnotationState(state);
+}
+
+function getCommandParseChildState<TState>(
+  commandState: CommandState<TState>,
+  childState: TState,
+  parser: Parser<Mode, unknown, unknown>,
+): TState {
+  return getWrappedChildParseState(commandState, childState, parser);
+}
+
+function getCommandChildState<TState>(
+  commandState: CommandState<TState>,
+  childState: TState,
+  parser: Parser<Mode, unknown, unknown>,
+): TState {
+  return getWrappedChildState(commandState, childState, parser);
+}
+
+function createCommandState<TState>(
+  sourceState: unknown,
+  state: Exclude<CommandState<TState>, undefined>,
+): Exclude<CommandState<TState>, undefined> {
+  return annotateFreshArray(
+    sourceState,
+    state as readonly unknown[],
+  ) as Exclude<
+    CommandState<TState>,
+    undefined
+  >;
+}
+
 function* suggestCommandSync<T, TState>(
   context: ParserContext<CommandState<TState>>,
   prefix: string,
@@ -2413,8 +2554,10 @@ function* suggestCommandSync<T, TState>(
     return;
   }
 
+  const state = normalizeCommandState(context.state);
+
   // Handle different command states
-  if (context.state === undefined) {
+  if (state === undefined) {
     // Command not yet matched - suggest command name if it matches prefix
     if (name.startsWith(prefix)) {
       yield {
@@ -2423,16 +2566,26 @@ function* suggestCommandSync<T, TState>(
         ...(options.description && { description: options.description }),
       };
     }
-  } else if (context.state[0] === "matched") {
+  } else if (state[0] === "matched") {
     // Command matched but inner parser not started - delegate to inner parser
     yield* parser.suggest(
-      withChildContext(context, name, parser.initialState, parser.usage),
+      withChildContext(
+        context,
+        name,
+        getCommandChildState(context.state, parser.initialState, parser),
+        parser.usage,
+      ),
       prefix,
     );
-  } else if (context.state[0] === "parsing") {
+  } else if (state[0] === "parsing") {
     // Command in parsing state - delegate to inner parser
     yield* parser.suggest(
-      withChildContext(context, name, context.state[1], parser.usage),
+      withChildContext(
+        context,
+        name,
+        getCommandChildState(context.state, state[1], parser),
+        parser.usage,
+      ),
       prefix,
     );
   }
@@ -2449,8 +2602,10 @@ async function* suggestCommandAsync<T, TState>(
     return;
   }
 
+  const state = normalizeCommandState(context.state);
+
   // Handle different command states
-  if (context.state === undefined) {
+  if (state === undefined) {
     // Command not yet matched - suggest command name if it matches prefix
     if (name.startsWith(prefix)) {
       yield {
@@ -2459,19 +2614,29 @@ async function* suggestCommandAsync<T, TState>(
         ...(options.description && { description: options.description }),
       };
     }
-  } else if (context.state[0] === "matched") {
+  } else if (state[0] === "matched") {
     // Command matched but inner parser not started - delegate to inner parser
     const suggestions = parser.suggest(
-      withChildContext(context, name, parser.initialState, parser.usage),
+      withChildContext(
+        context,
+        name,
+        getCommandChildState(context.state, parser.initialState, parser),
+        parser.usage,
+      ),
       prefix,
     ) as AsyncIterable<Suggestion>;
     for await (const s of suggestions) {
       yield s;
     }
-  } else if (context.state[0] === "parsing") {
+  } else if (state[0] === "parsing") {
     // Command in parsing state - delegate to inner parser
     const suggestions = parser.suggest(
-      withChildContext(context, name, context.state[1], parser.usage),
+      withChildContext(
+        context,
+        name,
+        getCommandChildState(context.state, state[1], parser),
+        parser.usage,
+      ),
       prefix,
     ) as AsyncIterable<Suggestion>;
     for await (const s of suggestions) {
@@ -2529,12 +2694,13 @@ export function command<M extends Mode, T, TState>(
       state: CommandState<TState>,
       path: readonly PropertyKey[],
     ) {
-      if (state === undefined) {
+      const normalizedState = normalizeCommandState(state);
+      if (normalizedState === undefined) {
         return [];
       }
-      const childState = state[0] === "matched"
-        ? parser.initialState
-        : state[1];
+      const childState = normalizedState[0] === "matched"
+        ? getCommandChildState(state, parser.initialState, parser)
+        : getCommandChildState(state, normalizedState[1], parser);
       const childPath = [...path, name];
       return parser.getSuggestRuntimeNodes?.(childState, childPath) ??
         (parser.dependencyMetadata?.source != null
@@ -2542,8 +2708,9 @@ export function command<M extends Mode, T, TState>(
           : []);
     },
     parse(context: ParserContext<CommandState<TState>>) {
+      const state = normalizeCommandState(context.state);
       // Handle different states
-      if (context.state === undefined) {
+      if (state === undefined) {
         // Check if buffer starts with our command name
         if (context.buffer.length < 1 || context.buffer[0] !== name) {
           const actual = context.buffer.length > 0 ? context.buffer[0] : null;
@@ -2600,19 +2767,26 @@ export function command<M extends Mode, T, TState>(
           next: {
             ...context,
             buffer: context.buffer.slice(1),
-            state: ["matched", name] as ["matched", string],
+            state: createCommandState(
+              context.state,
+              ["matched", name] as ["matched", string],
+            ),
           },
           consumed: context.buffer.slice(0, 1),
         };
       } else if (
-        context.state[0] === "matched" ||
-        context.state[0] === "parsing"
+        state[0] === "matched" ||
+        state[0] === "parsing"
       ) {
         // "matched": command was matched, start the inner parser
         // "parsing": delegate to inner parser with existing state
-        const innerState = context.state[0] === "matched"
-          ? parser.initialState
-          : context.state[1];
+        const innerState = state[0] === "matched"
+          ? getCommandParseChildState(
+            context.state,
+            parser.initialState,
+            parser,
+          )
+          : getCommandParseChildState(context.state, state[1], parser);
 
         const wrapState = (
           parseResult: ParserResult<TState>,
@@ -2626,10 +2800,13 @@ export function command<M extends Mode, T, TState>(
               success: true as const,
               next: {
                 ...parseResult.next,
-                state: ["parsing", parseResult.next.state] as [
-                  "parsing",
-                  TState,
-                ],
+                state: createCommandState(
+                  context.state,
+                  ["parsing", parseResult.next.state] as [
+                    "parsing",
+                    TState,
+                  ],
+                ),
                 ...(mergedExec != null
                   ? {
                     exec: mergedExec,
@@ -2667,13 +2844,14 @@ export function command<M extends Mode, T, TState>(
       };
     },
     complete(state: CommandState<TState>, exec?: ExecutionContext) {
-      if (typeof state === "undefined") {
+      const normalizedState = normalizeCommandState(state);
+      if (typeof normalizedState === "undefined") {
         return {
           success: false,
           error: options.errors?.notFound ??
             message`Command ${eOptionName(name)} was not matched.`,
         };
-      } else if (state[0] === "matched") {
+      } else if (normalizedState[0] === "matched") {
         // Command matched but inner parser never started.
         // First give the inner parser a chance to run with empty buffer,
         // then complete with the resulting state.
@@ -2682,7 +2860,7 @@ export function command<M extends Mode, T, TState>(
           buffer: [],
           optionsTerminated: false,
           usage: parser.usage,
-          state: parser.initialState,
+          state: getCommandParseChildState(state, parser.initialState, parser),
           ...(childExec != null
             ? {
               exec: childExec,
@@ -2700,8 +2878,12 @@ export function command<M extends Mode, T, TState>(
               : childExec;
             return syncInnerParser.complete(
               parseResult.success
-                ? parseResult.next.state
-                : syncInnerParser.initialState,
+                ? getCommandChildState(state, parseResult.next.state, parser)
+                : getCommandChildState(
+                  state,
+                  syncInnerParser.initialState,
+                  parser,
+                ),
               nextExec,
             );
           },
@@ -2712,19 +2894,27 @@ export function command<M extends Mode, T, TState>(
               : childExec;
             return asyncInnerParser.complete(
               parseResult.success
-                ? parseResult.next.state
-                : parser.initialState,
+                ? getCommandChildState(state, parseResult.next.state, parser)
+                : getCommandChildState(state, parser.initialState, parser),
               nextExec,
             );
           },
         );
-      } else if (state[0] === "parsing") {
+      } else if (normalizedState[0] === "parsing") {
         // Delegate to inner parser
         const childExec = withChildExecPath(exec, name);
         return dispatchByMode(
           parser.$mode,
-          () => syncInnerParser.complete(state[1], childExec),
-          async () => await asyncInnerParser.complete(state[1], childExec),
+          () =>
+            syncInnerParser.complete(
+              getCommandChildState(state, normalizedState[1], parser),
+              childExec,
+            ),
+          async () =>
+            await asyncInnerParser.complete(
+              getCommandChildState(state, normalizedState[1], parser),
+              childExec,
+            ),
         );
       }
       // Should never reach here
@@ -2738,16 +2928,17 @@ export function command<M extends Mode, T, TState>(
       state: CommandState<TState>,
       exec?: ExecutionContext,
     ) {
-      if (typeof state === "undefined") {
+      const normalizedState = normalizeCommandState(state);
+      if (typeof normalizedState === "undefined") {
         return wrapForMode(parser.$mode, null);
       }
-      if (state[0] === "matched") {
+      if (normalizedState[0] === "matched") {
         const childExec = withChildExecPath(exec, name);
         const childContext = {
           buffer: [],
           optionsTerminated: false,
           usage: parser.usage,
-          state: parser.initialState,
+          state: getCommandParseChildState(state, parser.initialState, parser),
           ...(childExec != null
             ? {
               exec: childExec,
@@ -2766,8 +2957,12 @@ export function command<M extends Mode, T, TState>(
             return completeOrExtractPhase2Seed(
               syncInnerParser,
               parseResult.success
-                ? parseResult.next.state
-                : syncInnerParser.initialState,
+                ? getCommandChildState(state, parseResult.next.state, parser)
+                : getCommandChildState(
+                  state,
+                  syncInnerParser.initialState,
+                  parser,
+                ),
               nextExec,
             );
           },
@@ -2779,17 +2974,17 @@ export function command<M extends Mode, T, TState>(
             return await completeOrExtractPhase2Seed(
               asyncInnerParser,
               parseResult.success
-                ? parseResult.next.state
-                : parser.initialState,
+                ? getCommandChildState(state, parseResult.next.state, parser)
+                : getCommandChildState(state, parser.initialState, parser),
               nextExec,
             );
           },
         );
       }
-      if (state[0] === "parsing") {
+      if (normalizedState[0] === "parsing") {
         return completeOrExtractPhase2Seed(
           parser,
-          state[1],
+          getCommandChildState(state, normalizedState[1], parser),
           withChildExecPath(exec, name),
         );
       }
@@ -2817,7 +3012,10 @@ export function command<M extends Mode, T, TState>(
       );
     },
     getDocFragments(state: DocState<CommandState<TState>>, defaultValue?: T) {
-      if (state.kind === "unavailable" || typeof state.state === "undefined") {
+      const commandState = state.kind === "available"
+        ? normalizeCommandState(state.state)
+        : undefined;
+      if (state.kind === "unavailable" || typeof commandState === "undefined") {
         // When the command is not matched (showing in a list), apply hidden option
         if (isDocHidden(options.hidden)) {
           return { fragments: [], description: options.description };
@@ -2837,9 +3035,19 @@ export function command<M extends Mode, T, TState>(
       }
       // When the command is matched and executing, show inner parser documentation
       // regardless of hidden status
-      const innerState: DocState<TState> = state.state[0] === "parsing"
-        ? { kind: "available", state: state.state[1] }
-        : { kind: "available", state: parser.initialState };
+      const innerState: DocState<TState> = commandState[0] === "parsing"
+        ? {
+          kind: "available",
+          state: getCommandChildState(state.state, commandState[1], parser),
+        }
+        : {
+          kind: "available",
+          state: getCommandChildState(
+            state.state,
+            parser.initialState,
+            parser,
+          ),
+        };
       const innerFragments = parser.getDocFragments(
         innerState,
         defaultValue,

--- a/packages/core/src/primitives.ts
+++ b/packages/core/src/primitives.ts
@@ -1,4 +1,10 @@
 import {
+  getWrappedChildParseState,
+  getWrappedChildState,
+  isAnnotationWrappedInitialState,
+  normalizeInjectedAnnotationState,
+} from "./annotation-state.ts";
+import {
   type DerivedValueParser,
   getDefaultValuesFunction,
   getDependencyIds,
@@ -6,14 +12,7 @@ import {
   isDerivedValueParser,
   suggestWithDependency,
 } from "./dependency.ts";
-import {
-  annotateFreshArray,
-  annotationKey,
-  type Annotations,
-  getAnnotations,
-  injectAnnotations,
-  unwrapInjectedAnnotationWrapper,
-} from "./annotations.ts";
+import { annotateFreshArray, getAnnotations } from "./annotations.ts";
 import { extractDependencyMetadata } from "./dependency-metadata.ts";
 import {
   replayDerivedParser,
@@ -90,103 +89,6 @@ function withChildContext<TState>(
       }
       : {}),
   };
-}
-
-const annotationViewTargets = new WeakMap<object, object>();
-
-function unwrapAnnotationView<T>(value: T): T {
-  if (value == null || typeof value !== "object") {
-    return value;
-  }
-  return (annotationViewTargets.get(value as object) as T | undefined) ??
-    value;
-}
-
-function withAnnotationView<T extends object>(
-  state: T,
-  annotations: Annotations,
-): T {
-  const target = unwrapAnnotationView(state) as T;
-  const view = new Proxy(target, {
-    get(target, key) {
-      if (key === annotationKey) {
-        return annotations;
-      }
-      const value = Reflect.get(target, key, target);
-      return typeof value === "function" ? value.bind(target) : value;
-    },
-    has(target, key) {
-      return key === annotationKey || Reflect.has(target, key);
-    },
-  });
-  annotationViewTargets.set(view, target);
-  return view;
-}
-
-function normalizeInjectedAnnotationState<T>(state: T): T {
-  return unwrapInjectedAnnotationWrapper(state);
-}
-
-function isAnnotationWrappedInitialState(state: unknown): boolean {
-  return normalizeInjectedAnnotationState(state) === undefined;
-}
-
-function getWrappedChildParseState<TState>(
-  parentState: unknown,
-  childState: TState,
-  parser: Parser<Mode, unknown, unknown>,
-): TState {
-  const annotations = getAnnotations(parentState);
-  const shouldInheritAnnotations =
-    Reflect.get(parser, inheritParentAnnotationsKey) === true;
-  if (childState == null) {
-    if (annotations !== undefined && shouldInheritAnnotations) {
-      return injectAnnotations({}, annotations) as TState;
-    }
-    return childState;
-  }
-  if (
-    annotations === undefined ||
-    typeof childState !== "object" ||
-    getAnnotations(childState) === annotations ||
-    !shouldInheritAnnotations
-  ) {
-    return childState;
-  }
-  const injectedState = injectAnnotations(childState, annotations);
-  return getAnnotations(injectedState) === annotations
-    ? injectedState as TState
-    : childState;
-}
-
-function getWrappedChildState<TState>(
-  parentState: unknown,
-  childState: TState,
-  parser: Parser<Mode, unknown, unknown>,
-): TState {
-  const annotations = getAnnotations(parentState);
-  const shouldInheritAnnotations =
-    Reflect.get(parser, inheritParentAnnotationsKey) === true;
-  if (childState == null) {
-    if (annotations !== undefined && shouldInheritAnnotations) {
-      return injectAnnotations({}, annotations) as TState;
-    }
-    return childState;
-  }
-  if (
-    annotations === undefined ||
-    typeof childState !== "object" ||
-    getAnnotations(childState) === annotations
-  ) {
-    return childState;
-  }
-  if (shouldInheritAnnotations) {
-    const injectedState = injectAnnotations(childState, annotations);
-    if (getAnnotations(injectedState) === annotations) {
-      return injectedState as TState;
-    }
-  }
-  return withAnnotationView(childState, annotations) as TState;
 }
 
 /** @internal */
@@ -364,7 +266,6 @@ import type {
   ParserResult,
   Suggestion,
 } from "./parser.ts";
-import { inheritParentAnnotationsKey } from "./parser.ts";
 import {
   createErrorWithSuggestions,
   createSuggestionMessage,

--- a/packages/run/src/run.test.ts
+++ b/packages/run/src/run.test.ts
@@ -164,6 +164,47 @@ describe("run", () => {
       assert.deepEqual(result, { tag: "a", silent: true });
     });
 
+    it("should parse arguments with annotated static contexts in runSync()", () => {
+      const annotation = Symbol.for("@test/issue-187/run-runSync");
+      const context: SourceContext = {
+        id: annotation,
+        mode: "static",
+        getAnnotations() {
+          return { [annotation]: true };
+        },
+      };
+
+      const result = runSync(argument(string()), {
+        args: ["value"],
+        programName: "test",
+        contexts: [context],
+      });
+
+      assert.equal(result, "value");
+    });
+
+    it("should parse commands with annotated static contexts in run()", async () => {
+      const annotation = Symbol.for("@test/issue-187/run-run");
+      const context: SourceContext = {
+        id: annotation,
+        mode: "static",
+        getAnnotations() {
+          return { [annotation]: true };
+        },
+      };
+
+      const result = await run(
+        command("go", object({ silent: option("--silent") })),
+        {
+          args: ["go", "--silent"],
+          programName: "test",
+          contexts: [context],
+        },
+      );
+
+      assert.deepEqual(result, { silent: true });
+    });
+
     it("should parse options with custom program name", () => {
       const parser = object({
         verbose: option("--verbose"),


### PR DESCRIPTION
## Summary

This fixes a regression where `argument()` and `command()` treated annotation-injected initial state as if it were real parser-local progress. The root cause was that both primitives use `undefined` as the "no state yet" sentinel, but top-level annotation injection turns that sentinel into an internal wrapper object. Once that happened, `argument()` thought it had already consumed a value, `command()` fell out of its valid tuple state machine, and top-level suggestion flows changed as well.

The fix makes annotations transparent to these primitives again. *packages/core/src/primitives.ts* now normalizes injected annotation wrappers before inspecting parser-local state, preserves annotations when `command()` rebuilds its tuple state, and forwards child state through a single shared annotation-state contract. I also extracted the shared helper logic into *packages/core/src/annotation-state.ts* and wired *packages/core/src/constructs.ts* into the same helper set so the propagation rules do not drift in future changes.

This PR adds regression coverage for direct `parse()` and `suggest()` calls, static-context runner paths through `runWith()`, `runWithSync()`, `run()`, and `runSync()`, and wrapper compositions that forward primitive state directly. The new tests live in *packages/core/src/primitives.test.ts*, *packages/core/src/facade.test.ts*, and *packages/run/src/run.test.ts*. Because this changes user-visible behavior for annotation users after 0.10.0, *CHANGES.md* is updated as well.

```ts
const annotations = { [Symbol.for("@test/anno")]: true };

parse(argument(string()), ["value"], { annotations });
suggest(argument(choice(["alpha", "beta"] as const)), ["a"], { annotations });
parse(command("go", object({ silent: option("--silent") })), ["go", "--silent"], { annotations });
```

Before this change, these calls could fail with errors like `The argument STRING cannot be used multiple times.` or `Invalid command state.`, and the suggestion call could return an empty array. After this change, they behave the same way they do without annotations.

## Validation

I validated the change with `mise test`.

Fixes https://github.com/dahlia/optique/issues/187