### PR TITLE
Make `runWith()` and `runWithSync()` treat phase 2 as the final annotation snapshot

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -210,6 +210,15 @@ To be released.
     that phase-two value may be `undefined`.  Phase two is still skipped
     when no usable first-pass seed exists.  [[#180], [#780]]
 
+ -  Fixed `runWith()`, `runWithSync()`, and the higher-level `run()` helpers
+    preserving a context's phase-1 annotations into the final parse when that
+    same context returned an empty annotation object in phase 2.  In two-phase
+    runs, each context's phase-2 annotation set is now treated as that
+    context's final snapshot for the second parse pass.  Returning `{}` from
+    `getAnnotations(parsed)` now clears that context's earlier phase-1
+    contribution instead of letting stale data override later contexts.
+    [[#231]]
+
  -  Fixed `or()` crashing with an internal `TypeError` when parsing started
     from an annotation-injected initial state.  Exclusive branch selection now
     treats annotations as transparent parser context, so annotated calls through
@@ -1340,6 +1349,7 @@ To be released.
 [#227]: https://github.com/dahlia/optique/issues/227
 [#228]: https://github.com/dahlia/optique/issues/228
 [#229]: https://github.com/dahlia/optique/issues/229
+[#231]: https://github.com/dahlia/optique/issues/231
 [#232]: https://github.com/dahlia/optique/issues/232
 [#233]: https://github.com/dahlia/optique/issues/233
 [#235]: https://github.com/dahlia/optique/issues/235

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -217,7 +217,7 @@ To be released.
     context's final snapshot for the second parse pass.  Returning `{}` from
     `getAnnotations(parsed)` now clears that context's earlier phase-1
     contribution instead of letting stale data override later contexts.
-    [[#231]]
+    [[#231], [#782]]
 
  -  Fixed `or()` crashing with an internal `TypeError` when parsing started
     from an annotation-injected initial state.  Exclusive branch selection now
@@ -1643,6 +1643,7 @@ To be released.
 [#779]: https://github.com/dahlia/optique/pull/779
 [#780]: https://github.com/dahlia/optique/pull/780
 [#781]: https://github.com/dahlia/optique/pull/781
+[#782]: https://github.com/dahlia/optique/pull/782
 
 ### @optique/config
 

--- a/docs/concepts/extend.md
+++ b/docs/concepts/extend.md
@@ -989,7 +989,12 @@ parsing:
 
 1.  *Phase 1*: Parse with static context data to get initial result
 2.  *Phase 2*: Call `getAnnotations(parsed)` on all contexts with the parsed
-    result, then parse again with merged annotations
+    result, then parse again with the merged phase-2 annotations
+
+For each context, the phase-2 return value replaces that context's phase-1
+annotation set for the final parse.  This means returning an empty object
+from `getAnnotations(parsed)` clears any annotations the same context
+contributed during phase 1.
 
 This ensures that:
 

--- a/docs/concepts/runners.md
+++ b/docs/concepts/runners.md
@@ -1249,7 +1249,10 @@ const result = await runAsync(parser, {
 When `contexts` is provided, the runner delegates to `runWith()` (or
 `runWithSync()` for sync parsers) from `@optique/core/facade`, which handles
 static and dynamic contexts automatically and performs two-phase parsing only
-when needed.  Context-specific options like `getConfigPath` are passed through
+when needed.  In two-phase runs, each context's phase-two annotations replace
+that same context's phase-one contribution for the final parse, so returning
+an empty object from `getAnnotations(parsed)` clears that context's earlier
+annotations.  Context-specific options like `getConfigPath` are passed through
 to the contexts via the `contextOptions` property.
 
 For more details on config file integration, see the

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -150,8 +150,11 @@ export interface SourceContext<TRequiredOptions = void> {
    *    successfully. Dynamic contexts can use this to load external data
    *    (e.g., reading a config file whose path was determined in the first
    *    pass). Deferred or otherwise unresolved fields may be `undefined`.
-   *    If the runner cannot extract a usable value at all, this second call
-   *    is skipped and the original parse failure is reported instead.
+   *    This second return value is treated as the context's final annotation
+   *    snapshot for the second parse pass, replacing that context's phase-one
+   *    contribution. If the runner cannot extract a usable value at all, this
+   *    second call is skipped and the original parse failure is reported
+   *    instead.
    *
    * @param parsed Optional parsed result from a previous parse pass.
    *               Static contexts can ignore this parameter.
@@ -159,8 +162,10 @@ export interface SourceContext<TRequiredOptions = void> {
    * @param options Optional context-required options provided by the caller
    *               of `runWith()`. These are the options declared via the
    *               `TRequiredOptions` type parameter.
-   * @returns Annotations to merge into the parsing session. Can be a Promise
-   *          for async operations (e.g., loading config files).
+   * @returns Annotations to merge into the parsing session. During phase 2,
+   *          returning `{}` clears any annotations this context contributed
+   *          during phase 1. Can be a Promise for async operations (e.g.,
+   *          loading config files).
    */
   getAnnotations(
     parsed?: unknown,

--- a/packages/core/src/facade.test.ts
+++ b/packages/core/src/facade.test.ts
@@ -5499,6 +5499,71 @@ describe("runWith", () => {
 
       assert.equal(result, "phase1-early");
     });
+
+    it("lets phase 2 clear a context's phase 1 annotations", async () => {
+      const sharedKey = Symbol.for("@test/phase-clear-priority");
+
+      const parser: Parser<"sync", string | undefined, undefined> = {
+        $mode: "sync",
+        $valueType: [] as readonly (string | undefined)[],
+        $stateType: [] as readonly undefined[],
+        priority: 1,
+        usage: [],
+        leadingNames: new Set(),
+        acceptingAnyToken: false,
+        initialState: undefined,
+        parse(context) {
+          return {
+            success: true as const,
+            next: context,
+            consumed: [],
+          };
+        },
+        complete(state) {
+          return {
+            success: true as const,
+            value: getAnnotations(state)?.[sharedKey] as string | undefined,
+          };
+        },
+        suggest() {
+          return [];
+        },
+        getDocFragments() {
+          return { fragments: [] };
+        },
+      };
+
+      const clearingContext: SourceContext = {
+        id: Symbol.for("@test/phase-clear-early"),
+        mode: "dynamic",
+        getAnnotations(parsed?: unknown) {
+          if (parsed == null) {
+            return { [sharedKey]: "phase1-early" };
+          }
+          return {};
+        },
+      };
+
+      const fallbackContext: SourceContext = {
+        id: Symbol.for("@test/phase-clear-late"),
+        mode: "dynamic",
+        getAnnotations(parsed?: unknown) {
+          if (parsed == null) {
+            return {};
+          }
+          return { [sharedKey]: "phase2-late" };
+        },
+      };
+
+      const result = await runWith(
+        parser,
+        "test",
+        [clearingContext, fallbackContext],
+        { args: [] },
+      );
+
+      assert.equal(result, "phase2-late");
+    });
   });
 
   describe("dynamic contexts", () => {
@@ -7366,6 +7431,71 @@ describe("runWithSync", () => {
       );
 
       assert.equal(result, "phase1-early");
+    });
+
+    it("lets phase 2 clear a context's phase 1 annotations", () => {
+      const sharedKey = Symbol.for("@test/phase-clear-priority-sync");
+
+      const parser: Parser<"sync", string | undefined, undefined> = {
+        $mode: "sync",
+        $valueType: [] as readonly (string | undefined)[],
+        $stateType: [] as readonly undefined[],
+        priority: 1,
+        usage: [],
+        leadingNames: new Set(),
+        acceptingAnyToken: false,
+        initialState: undefined,
+        parse(context) {
+          return {
+            success: true as const,
+            next: context,
+            consumed: [],
+          };
+        },
+        complete(state) {
+          return {
+            success: true as const,
+            value: getAnnotations(state)?.[sharedKey] as string | undefined,
+          };
+        },
+        suggest() {
+          return [];
+        },
+        getDocFragments() {
+          return { fragments: [] };
+        },
+      };
+
+      const clearingContext: SourceContext = {
+        id: Symbol.for("@test/phase-clear-sync-early"),
+        mode: "dynamic",
+        getAnnotations(parsed?: unknown) {
+          if (parsed == null) {
+            return { [sharedKey]: "phase1-early" };
+          }
+          return {};
+        },
+      };
+
+      const fallbackContext: SourceContext = {
+        id: Symbol.for("@test/phase-clear-sync-late"),
+        mode: "dynamic",
+        getAnnotations(parsed?: unknown) {
+          if (parsed == null) {
+            return {};
+          }
+          return { [sharedKey]: "phase2-late" };
+        },
+      };
+
+      const result = runWithSync(
+        parser,
+        "test",
+        [clearingContext, fallbackContext],
+        { args: [] },
+      );
+
+      assert.equal(result, "phase2-late");
     });
   });
 

--- a/packages/core/src/facade.ts
+++ b/packages/core/src/facade.ts
@@ -2705,7 +2705,6 @@ async function collectPhase1Annotations(
 ): Promise<
   {
     readonly annotations: Annotations;
-    readonly annotationsList: readonly Annotations[];
     readonly hasDynamic: boolean;
   }
 > {
@@ -2729,7 +2728,6 @@ async function collectPhase1Annotations(
 
   return {
     annotations: mergeAnnotations(annotationsList),
-    annotationsList,
     hasDynamic,
   };
 }
@@ -2748,10 +2746,7 @@ async function collectAnnotations(
   options?: unknown,
   deferred?: true,
   deferredKeys?: DeferredMap,
-): Promise<{
-  readonly annotations: Annotations;
-  readonly annotationsList: readonly Annotations[];
-}> {
+): Promise<{ readonly annotations: Annotations }> {
   const annotationsList: Annotations[] = [];
   const preparedParsed = prepareParsedForContexts(
     parsed,
@@ -2780,7 +2775,6 @@ async function collectAnnotations(
 
   return {
     annotations: mergeAnnotations(annotationsList),
-    annotationsList,
   };
 }
 
@@ -2798,7 +2792,6 @@ function collectPhase1AnnotationsSync(
   options?: unknown,
 ): {
   readonly annotations: Annotations;
-  readonly annotationsList: readonly Annotations[];
   readonly hasDynamic: boolean;
 } {
   const annotationsList: Annotations[] = [];
@@ -2826,7 +2819,6 @@ function collectPhase1AnnotationsSync(
 
   return {
     annotations: mergeAnnotations(annotationsList),
-    annotationsList,
     hasDynamic,
   };
 }
@@ -2868,10 +2860,7 @@ function collectAnnotationsSync(
   options?: unknown,
   deferred?: true,
   deferredKeys?: DeferredMap,
-): {
-  readonly annotations: Annotations;
-  readonly annotationsList: readonly Annotations[];
-} {
+): { readonly annotations: Annotations } {
   const annotationsList: Annotations[] = [];
   const preparedParsed = prepareParsedForContexts(
     parsed,
@@ -2905,28 +2894,7 @@ function collectAnnotationsSync(
 
   return {
     annotations: mergeAnnotations(annotationsList),
-    annotationsList,
   };
-}
-
-function mergeTwoPhaseAnnotations(
-  phase1AnnotationsList: readonly Annotations[],
-  phase2AnnotationsList: readonly Annotations[],
-): Annotations {
-  const mergedPerContext: Annotations[] = [];
-  const length = Math.max(
-    phase1AnnotationsList.length,
-    phase2AnnotationsList.length,
-  );
-  for (let i = 0; i < length; i++) {
-    mergedPerContext.push(
-      mergeAnnotations([
-        phase2AnnotationsList[i] ?? {},
-        phase1AnnotationsList[i] ?? {},
-      ]),
-    );
-  }
-  return mergeAnnotations(mergedPerContext);
 }
 
 /**
@@ -3154,7 +3122,6 @@ async function runWithBody<
   const ctxOptions = options.contextOptions;
   const {
     annotations: phase1Annotations,
-    annotationsList: phase1AnnotationsList,
     hasDynamic: needsTwoPhase,
   } = await collectPhase1Annotations(contexts, ctxOptions);
 
@@ -3224,7 +3191,7 @@ async function runWithBody<
   }
 
   // Phase 2: Collect annotations with parsed result
-  const { annotationsList: phase2AnnotationsList } = await collectAnnotations(
+  const { annotations: finalAnnotations } = await collectAnnotations(
     contexts,
     firstPassSeed.value,
     ctxOptions,
@@ -3232,11 +3199,7 @@ async function runWithBody<
     firstPassSeed.deferredKeys,
   );
 
-  // Final parse with merged annotations
-  const finalAnnotations = mergeTwoPhaseAnnotations(
-    phase1AnnotationsList,
-    phase2AnnotationsList,
-  );
+  // Final parse with phase-two annotations as the final per-context snapshot.
   const augmentedParser2 = injectAnnotationsIntoParser(
     parser,
     finalAnnotations,
@@ -3271,8 +3234,10 @@ async function runWithBody<
  *    instead.
  * 3. *Phase 2*: Call `getAnnotations(parsed)` on all contexts with the first
  *    pass value. Deferred or otherwise unresolved fields in `parsed` may be
- *    `undefined`.
- * 4. *Second parse*: Parse again with merged annotations from both phases.
+ *    `undefined`. Each context's phase-two return value replaces its own
+ *    phase-one contribution for the final parse, so returning `{}` clears any
+ *    annotations that context provided during phase 1.
+ * 4. *Second parse*: Parse again with the merged phase-two annotations.
  *
  * If all contexts are static (no dynamic contexts), the second parse is
  * skipped for optimization. Phase 2 is also skipped when the first pass does
@@ -3396,7 +3361,6 @@ function runWithSyncBody<
   const ctxOptions = options.contextOptions;
   const {
     annotations: phase1Annotations,
-    annotationsList: phase1AnnotationsList,
     hasDynamic: needsTwoPhase,
   } = collectPhase1AnnotationsSync(contexts, ctxOptions);
 
@@ -3426,7 +3390,7 @@ function runWithSyncBody<
   }
 
   // Phase 2: Collect annotations with parsed result
-  const { annotationsList: phase2AnnotationsList } = collectAnnotationsSync(
+  const { annotations: finalAnnotations } = collectAnnotationsSync(
     contexts,
     firstPassSeed.value,
     ctxOptions,
@@ -3434,11 +3398,7 @@ function runWithSyncBody<
     firstPassSeed.deferredKeys,
   );
 
-  // Final parse with merged annotations
-  const finalAnnotations = mergeTwoPhaseAnnotations(
-    phase1AnnotationsList,
-    phase2AnnotationsList,
-  );
+  // Final parse with phase-two annotations as the final per-context snapshot.
   const augmentedParser2 = injectAnnotationsIntoParser(
     parser,
     finalAnnotations,
@@ -3453,7 +3413,9 @@ function runWithSyncBody<
  * This is the sync-only variant of {@link runWith}. All contexts must return
  * annotations synchronously (not Promises). It uses the same two-phase
  * best-effort seed extraction as {@link runWith} when dynamic contexts are
- * present.
+ * present. In two-phase runs, each context's phase-two return value replaces
+ * that context's phase-one contribution for the final parse, so returning `{}`
+ * clears any annotations that context provided during phase 1.
  *
  * @template TParser The sync parser type.
  * @template THelp Return type when help is shown.


### PR DESCRIPTION
Fixes https://github.com/dahlia/optique/issues/231

This fixes a bug in two-phase source-context parsing where `runWith()`, `runWithSync()`, and the higher-level `run()` helpers could preserve a context's phase-1 annotations into the final parse even after the same context returned an empty annotation object in phase 2.

The root cause was in *packages/core/src/facade.ts*. The final parse reconstructed per-context annotations by merging phase-1 and phase-2 results together, so phase 2 behaved like a partial patch instead of the final refinement step. In practice, stale phase-1 data could continue to win in the second parse pass, and an earlier context that intentionally cleared its own annotations could still block later contexts from taking effect.

This change makes the contract explicit and enforces it in the implementation. For each context, the phase-2 return value is now treated as that context's final annotation snapshot for the second parse. If `getAnnotations(parsed)` returns `{}`, that now clears the same context's phase-1 contribution instead of keeping old values alive.

For example, a dynamic context like this should be able to contribute a value in phase 1 and then remove it in phase 2:

```typescript
const ctx: SourceContext = {
  id: Symbol.for("@example/context"),
  mode: "dynamic",
  getAnnotations(parsed) {
    if (parsed == null) {
      return { [myKey]: "phase1" };
    }
    return {};
  },
};
```

Before this change, the final parse could still observe `"phase1"`. After this change, the final parse sees that the context has cleared its annotation, so later contexts can provide the effective value again.

I added regression coverage in *packages/core/src/facade.test.ts* for both async and sync runners, updated the public contract in *packages/core/src/context.ts*, documented the two-phase behavior in *docs/concepts/extend.md* and *docs/concepts/runners.md*, and recorded the user-visible behavior change in *CHANGES.md*.

I verified the change with `mise test` and `cd docs && pnpm build`.