### PR TITLE
Make `SourceContext.phase` explicit in `runWith()` and `runWithSync()`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -219,6 +219,16 @@ To be released.
     contribution instead of letting stale data override later contexts.
     [[#231], [#782]]
 
+ -  Replaced `SourceContext`'s inferred `mode` contract with an explicit
+    required `phase` field whose value must be `"single-pass"` or
+    `"two-pass"`.  `SourceContextMode`, `SourceContext.mode`, and
+    `isStaticContext()` have been removed.  `runWith()`, `runWithSync()`, and
+    higher-level runners now decide whether to perform phase 2 solely from
+    `context.phase`, which fixes contexts that emit non-empty phase-1
+    annotations and still need phase-2 refinement.  `createEnvContext()`
+    now declares `phase: "single-pass"` and `createConfigContext()`
+    declares `phase: "two-pass"`.  [[#243], [#783]]
+
  -  Fixed `or()` crashing with an internal `TypeError` when parsing started
     from an annotation-injected initial state.  Exclusive branch selection now
     treats annotations as transparent parser context, so annotated calls through
@@ -368,7 +378,7 @@ To be released.
  -  Replaced the `DeferredPromptValue` sentinel with type-appropriate
     placeholder values during two-phase parsing.  `prompt()` now uses
     `Parser.placeholder` instead of a branded sentinel when deferring,
-    so `map()` transforms always receive valid values and dynamic contexts
+    so `map()` transforms always receive valid values and two-pass contexts
     observe structurally valid objects.  Note that `map()` intentionally
     does not propagate `deferredKeys`, so mapped structured outputs may
     still carry placeholder values for deferred fields.  This removes the
@@ -1358,6 +1368,7 @@ To be released.
 [#240]: https://github.com/dahlia/optique/issues/240
 [#241]: https://github.com/dahlia/optique/issues/241
 [#242]: https://github.com/dahlia/optique/issues/242
+[#243]: https://github.com/dahlia/optique/issues/243
 [#245]: https://github.com/dahlia/optique/issues/245
 [#246]: https://github.com/dahlia/optique/issues/246
 [#247]: https://github.com/dahlia/optique/issues/247
@@ -1644,6 +1655,7 @@ To be released.
 [#780]: https://github.com/dahlia/optique/pull/780
 [#781]: https://github.com/dahlia/optique/pull/781
 [#782]: https://github.com/dahlia/optique/pull/782
+[#783]: https://github.com/dahlia/optique/pull/783
 
 ### @optique/config
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -219,15 +219,17 @@ To be released.
     contribution instead of letting stale data override later contexts.
     [[#231], [#782]]
 
- -  Replaced `SourceContext`'s inferred `mode` contract with an explicit
-    required `phase` field whose value must be `"single-pass"` or
-    `"two-pass"`.  `SourceContextMode`, `SourceContext.mode`, and
-    `isStaticContext()` have been removed.  `runWith()`, `runWithSync()`, and
-    higher-level runners now decide whether to perform phase 2 solely from
-    `context.phase`, which fixes contexts that emit non-empty phase-1
-    annotations and still need phase-2 refinement.  `createEnvContext()`
-    now declares `phase: "single-pass"` and `createConfigContext()`
-    declares `phase: "two-pass"`.  [[#243], [#783]]
+ -  *Breaking change:* Replaced `SourceContext`'s inferred `mode`
+    contract with an explicit required `phase` field whose value must be
+    `"single-pass"` or `"two-pass"`.  `SourceContextMode`,
+    `SourceContext.mode`, and `isStaticContext()` have been removed.
+    `runWith()`, `runWithSync()`, and higher-level runners now decide
+    whether to perform phase 2 solely from `context.phase`, which fixes
+    contexts that emit non-empty phase-1 annotations and still need
+    phase-2 refinement.  `createEnvContext()` now declares
+    `phase: "single-pass"` and `createConfigContext()` declares
+    `phase: "two-pass"`.  Consumers must migrate custom contexts to this
+    new API contract.  [[#243], [#783]]
 
  -  Fixed `or()` crashing with an internal `TypeError` when parsing started
     from an annotation-injected initial state.  Exclusive branch selection now

--- a/docs/concepts/extend.md
+++ b/docs/concepts/extend.md
@@ -892,7 +892,7 @@ const configContext: SourceContext = {
   id: Symbol.for("@myapp/config"),
   phase: "two-pass",
   async getAnnotations(parsed?: unknown) {
-    if (!parsed) return {}; // Return empty on first pass
+    if (parsed === undefined) return {}; // Return empty on first pass
     
     const result = parsed as { config?: string };
     if (!result.config) return {};
@@ -1121,7 +1121,7 @@ export function createConfigContext(): SourceContext {
     id: configKey,
     phase: "two-pass",
     async getAnnotations(parsed?: unknown): Promise<Annotations> {
-      if (!parsed) return {}; // First pass - no config yet
+      if (parsed === undefined) return {}; // First pass - no config yet
       
       const result = parsed as { config?: string };
       if (!result.config) return {}; // No config file specified
@@ -1183,7 +1183,7 @@ export function createConfigContext(): ConfigContext {
     id: configKey,
     phase: "two-pass",
     async getAnnotations(parsed?: unknown): Promise<Annotations> {
-      if (!parsed) return {};
+      if (parsed === undefined) return {};
       
       // Use the injected getConfigPath function
       const configPath = context.getConfigPath?.(parsed);

--- a/docs/concepts/extend.md
+++ b/docs/concepts/extend.md
@@ -715,10 +715,10 @@ API reference
 
 ### Types from `@optique/core/context`
 
-`SourceContextMode`
-:   Type alias for `"static" | "dynamic"`. Indicates whether a context is
-    static (can provide data without any parsed results) or dynamic (needs
-    parsed results from a first pass to do its work).
+`SourceContextPhase`
+:   Type alias for `"single-pass" | "two-pass"`. Indicates whether a context
+    contributes only its phase-1 annotations or is recollected after a usable
+    first parse pass to refine them.
 
 `SourceContext<TRequiredOptions = void>`
 :   Interface for data sources that provide annotations. The `TRequiredOptions`
@@ -728,9 +728,8 @@ API reference
     Members:
 
      -  `id: symbol` — Unique identifier for the context
-     -  `mode?: SourceContextMode` — Optional hint declaring whether this
-        context is `"static"` or `"dynamic"`. When set, `isStaticContext()`
-        uses this field directly instead of probing `getAnnotations()`.
+     -  `phase: SourceContextPhase` — Required policy declaring whether this
+        context is `"single-pass"` or `"two-pass"`
      -  `getAnnotations(parsed?, options?): Promise<Annotations> | Annotations`
         — Returns annotations to inject into parsing
      -  `getInternalAnnotations?(parsed, annotations): Annotations | undefined`
@@ -778,18 +777,11 @@ API reference
     const myData = annotations?.[myKey];
     ~~~~
 
-`isStaticContext(context: SourceContext): boolean`
-:   Checks whether a context is static (returns non-empty annotations without
-    needing parsed results). When the context has a `mode` field set,
-    `isStaticContext()` uses it directly (`"static"` → `true`,
-    `"dynamic"` → `false`). When `mode` is absent, the function probes
-    `getAnnotations()` with no arguments to determine the answer.
-
 ### Functions from `@optique/core/facade`
 
 `runWith(parser, programName, contexts, options): Promise<T>`
 :   Runs a parser with multiple source contexts. Automatically handles
-    static and dynamic contexts with two-phase parsing when needed.
+    single-pass and two-pass contexts with two-phase parsing when needed.
 
     The `options` parameter accepts a `contextOptions` property for any options
     required by the contexts.  For example, if a context specifies
@@ -847,7 +839,7 @@ import type { SourceContext } from "@optique/core/context";
 
 const envContext: SourceContext = {
   id: Symbol.for("@myapp/env"),
-  mode: "static",
+  phase: "single-pass",
   getAnnotations() {
     return {
       [Symbol.for("@myapp/env")]: {
@@ -860,21 +852,22 @@ const envContext: SourceContext = {
 ~~~~
 
 The `id` symbol identifies this context for debugging and priority resolution.
-The optional `mode` field declares whether the context is `"static"` or
-`"dynamic"`, which lets `isStaticContext()` determine static-ness without
-probing `getAnnotations()`. The `runWith*()` runners also use it when
-deciding whether a second parse pass may be required, instead of inferring
-dynamic-ness from an empty first-pass result or `Promise`.
+The required `phase` field declares whether the context is `"single-pass"` or
+`"two-pass"`. This removes the old inference ambiguity between “this context
+already has some phase-1 data” and “this context still needs phase-2
+refinement.”
 The `getAnnotations()` method returns an object mapping annotation keys to
 their values. Parsers can then access these values using `getAnnotations()`.
 
-### Static vs dynamic contexts
+### Single-pass vs two-pass contexts
 
-Contexts can be either *static* or *dynamic*:
+Contexts can be either *single-pass* or *two-pass*:
 
- -  *Static contexts* return data immediately (e.g., environment variables)
- -  *Dynamic contexts* need parsing results first (e.g., config files whose
-    path is determined by a CLI option)
+ -  *Single-pass contexts* contribute their final annotations before parsing
+    starts (e.g., environment variables)
+ -  *Two-pass contexts* may contribute phase-1 annotations and then refine
+    them after a usable first parse pass (e.g., config files whose path is
+    determined by a CLI option)
 
 The difference lies in whether `getAnnotations()` needs the parsed result to
 do its work:
@@ -882,10 +875,10 @@ do its work:
 ~~~~ typescript
 import type { SourceContext } from "@optique/core/context";
 
-// Static context: data is always available
+// Single-pass context: data is always available
 const envContext: SourceContext = {
   id: Symbol.for("@myapp/env"),
-  mode: "static",
+  phase: "single-pass",
   getAnnotations() {
     // Returns immediately - no need for parsing results
     return {
@@ -894,10 +887,10 @@ const envContext: SourceContext = {
   }
 };
 
-// Dynamic context: needs parsed result to load config
+// Two-pass context: needs parsed result to load config
 const configContext: SourceContext = {
   id: Symbol.for("@myapp/config"),
-  mode: "dynamic",
+  phase: "two-pass",
   async getAnnotations(parsed?: unknown) {
     if (!parsed) return {}; // Return empty on first pass
     
@@ -913,10 +906,12 @@ const configContext: SourceContext = {
 };
 ~~~~
 
-The static `envContext` reads environment variables directly and doesn't need
-any parsed values. The dynamic `configContext`, however, needs to know the
-config file path from the parsed `--config` option before it can load the file.
-When `parsed` is `undefined` (first pass), it returns an empty object.
+The single-pass `envContext` reads environment variables directly and doesn't
+need any parsed values. The two-pass `configContext`, however, needs to know
+the config file path from the parsed `--config` option before it can load the
+file. When `parsed` is `undefined` (phase 1), it can return empty data or a
+provisional snapshot; phase 2 still runs because the context explicitly opted
+into `"two-pass"`.
 
 
 Using `runWith()`
@@ -941,6 +936,7 @@ import type { SourceContext } from "@optique/core/context";
 
 const envContext: SourceContext = {
   id: Symbol.for("@myapp/env"),
+  phase: "single-pass",
   getAnnotations() {
     return {
       [Symbol.for("@myapp/env")]: {
@@ -984,23 +980,25 @@ const result = await runWith(
 
 ### Two-phase parsing
 
-When dynamic contexts are present, `runWith()` automatically performs two-phase
-parsing:
+When two-pass contexts are present, `runWith()` automatically performs
+two-phase parsing:
 
-1.  *Phase 1*: Parse with static context data to get initial result
-2.  *Phase 2*: Call `getAnnotations(parsed)` on all contexts with the parsed
-    result, then parse again with the merged phase-2 annotations
+1.  *Phase 1*: Parse with phase-1 annotations from all contexts
+2.  *Phase 2*: Call `getAnnotations(parsed)` on two-pass contexts with the
+    parsed result, then parse again with the merged final annotations
 
-For each context, the phase-2 return value replaces that context's phase-1
-annotation set for the final parse.  This means returning an empty object
-from `getAnnotations(parsed)` clears any annotations the same context
-contributed during phase 1.
+For each two-pass context, the phase-2 return value replaces that context's
+phase-1 annotation set for the final parse.  This means returning an empty
+object from `getAnnotations(parsed)` clears any annotations the same context
+contributed during phase 1. Single-pass contexts keep their phase-1 snapshot.
 
 This ensures that:
 
- -  Static contexts (like environment variables) are available immediately
- -  Dynamic contexts (like config files) can extract information from the
-    first parse pass
+ -  Single-pass contexts (like environment variables) are available
+    immediately
+ -  Two-pass contexts (like config files) can extract information from the
+    first parse pass without being misclassified when phase 1 already returns
+    non-empty annotations
 
 During phase 1, parsers whose values are not yet resolved (e.g., deferred
 interactive prompts) use the `ValueParser.placeholder` property to produce a
@@ -1081,7 +1079,7 @@ interface EnvData {
 export function createEnvContext(prefix: string = ""): SourceContext {
   return {
     id: envKey,
-    mode: "static",
+    phase: "single-pass",
     getAnnotations(): Annotations {
       const data: EnvData = {
         HOST: process.env[`${prefix}HOST`],
@@ -1098,12 +1096,12 @@ const envContext = createEnvContext("MYAPP_");
 ~~~~
 
 When called with `"MYAPP_"`, the context reads `MYAPP_HOST`, `MYAPP_PORT`, and
-`MYAPP_DEBUG` from the environment. This is a static context since it doesn't
-need any parsed values.
+`MYAPP_DEBUG` from the environment. This is a single-pass context since it
+doesn't need any parsed values.
 
 ### Creating a config file context
 
-A config file context is dynamic because it needs to know the file path from
+A config file context is two-pass because it needs to know the file path from
 parsed arguments. The `getAnnotations()` method receives the parsed result and
 uses it to load the configuration:
 
@@ -1121,7 +1119,7 @@ interface ConfigData {
 export function createConfigContext(): SourceContext {
   return {
     id: configKey,
-    mode: "dynamic",
+    phase: "two-pass",
     async getAnnotations(parsed?: unknown): Promise<Annotations> {
       if (!parsed) return {}; // First pass - no config yet
       
@@ -1183,7 +1181,7 @@ interface ConfigContext extends SourceContext<ConfigContextOptions> {
 export function createConfigContext(): ConfigContext {
   const context: ConfigContext = {
     id: configKey,
-    mode: "dynamic",
+    phase: "two-pass",
     async getAnnotations(parsed?: unknown): Promise<Annotations> {
       if (!parsed) return {};
       
@@ -1244,11 +1242,10 @@ guide for a complete implementation.
 
  -  *Use unique symbols*: Always use `Symbol.for()` with a namespaced string
     matching your package name
- -  *Declare `mode` explicitly*: Set `mode: "static"` or `mode: "dynamic"` on
-    every context so `isStaticContext()` can determine static-ness without
-    probing `getAnnotations()`, and so `runWith*()` does not have to infer
-    dynamic-ness from an empty first-pass result or `Promise`, avoiding
-    unnecessary two-phase parsing and duplicate `getAnnotations()` calls
+ -  *Declare `phase` explicitly*: Set `phase: "single-pass"` or
+    `phase: "two-pass"` on every context. This makes refinement intent
+    explicit and prevents the runner from guessing based on the shape of the
+    phase-1 annotations
  -  *Handle missing data gracefully*: Return empty objects instead of throwing
     errors
  -  *Keep contexts focused*: Each context should handle one data source
@@ -1293,11 +1290,11 @@ Annotation injection creates a shallow copy of the initial state. This has
 minimal performance impact, but be aware that it happens on every call to
 `parse()`, `suggest()`, or `getDocPage()` when annotations are provided.
 
-For `runWith()` with dynamic contexts, two parse passes are performed. This
+For `runWith()` with two-pass contexts, two parse passes are performed. This
 is necessary for the two-phase approach but doubles the parsing overhead.
 For performance-critical applications:
 
- -  Use only static contexts when possible (single pass)
+ -  Use only single-pass contexts when possible (single pass)
  -  Cache parsed results rather than re-parsing multiple times
  -  Consider using `runWithSync()` for sync-only contexts to avoid Promise
     overhead

--- a/docs/concepts/runners.md
+++ b/docs/concepts/runners.md
@@ -1248,12 +1248,12 @@ const result = await runAsync(parser, {
 
 When `contexts` is provided, the runner delegates to `runWith()` (or
 `runWithSync()` for sync parsers) from `@optique/core/facade`, which handles
-static and dynamic contexts automatically and performs two-phase parsing only
-when needed.  In two-phase runs, each context's phase-two annotations replace
-that same context's phase-one contribution for the final parse, so returning
-an empty object from `getAnnotations(parsed)` clears that context's earlier
-annotations.  Context-specific options like `getConfigPath` are passed through
-to the contexts via the `contextOptions` property.
+single-pass and two-pass contexts automatically and performs two-phase parsing
+only when needed.  In two-phase runs, each two-pass context's phase-two
+annotations replace that same context's phase-one contribution for the final
+parse, so returning an empty object from `getAnnotations(parsed)` clears that
+context's earlier annotations.  Context-specific options like `getConfigPath`
+are passed through to the contexts via the `contextOptions` property.
 
 For more details on config file integration, see the
 [config file integration guide](../integrations/config.md).

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -1360,8 +1360,8 @@ an interactive fallback *after* checking CLI arguments, environment variables,
 and config files.
 
 A practical approach is to preload config annotations once and expose them via
-a static context. This keeps the fallback order predictable while still using
-`bindEnv()` and `bindConfig()` together:
+a single-pass context. This keeps the fallback order predictable while still
+using `bindEnv()` and `bindConfig()` together:
 
 ~~~~ typescript twoslash
 import { z } from "zod";
@@ -1403,7 +1403,7 @@ const configAnnotations = await configContext.getAnnotations(
 
 const staticConfigContext = {
   id: configContext.id,
-  mode: "static" as const,
+  phase: "single-pass" as const,
   getAnnotations() {
     return configAnnotations;
   },

--- a/examples/patterns/custom-source-context.ts
+++ b/examples/patterns/custom-source-context.ts
@@ -52,7 +52,7 @@ function createConfigContext(): ConfigContext {
     id: configKey,
     phase: "two-pass",
     async getAnnotations(parsed?: unknown): Promise<Annotations> {
-      if (!parsed) return {}; // First pass - no config yet
+      if (parsed === undefined) return {}; // First pass - no config yet
 
       // Use the injected getConfigPath function
       const configPath = context.getConfigPath?.(parsed);

--- a/examples/patterns/custom-source-context.ts
+++ b/examples/patterns/custom-source-context.ts
@@ -50,6 +50,7 @@ interface ConfigContext extends SourceContext<ConfigContextOptions> {
 function createConfigContext(): ConfigContext {
   const context: ConfigContext = {
     id: configKey,
+    phase: "two-pass",
     async getAnnotations(parsed?: unknown): Promise<Annotations> {
       if (!parsed) return {}; // First pass - no config yet
 

--- a/examples/patterns/interactive-env-config-composition.ts
+++ b/examples/patterns/interactive-env-config-composition.ts
@@ -46,7 +46,7 @@ const configContext = createConfigContext({ schema: configSchema });
 
 const args = Deno.args;
 
-// Preload config annotations once and expose them through a static context so
+// Preload config annotations once and expose them through a single-pass context so
 // prompt() remains the final fallback after CLI/env/config values.
 const configAnnotations = await configContext.getAnnotations(
   { config: getConfigPathFromArgs(args) },
@@ -55,7 +55,7 @@ const configAnnotations = await configContext.getAnnotations(
 
 const staticConfigContext = {
   id: configContext.id,
-  mode: "static" as const,
+  phase: "single-pass" as const,
   getAnnotations() {
     return configAnnotations;
   },

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -1319,7 +1319,7 @@ describe("bindConfig parity with bindEnv", () => {
       { context: envCtx, key: "PORT", parser: integer() },
     );
 
-    // Provide env annotations (as a static context, getAnnotations() is called
+    // Provide env annotations (as a single-pass context, getAnnotations() is called
     // manually here to simulate what runWith() does).
     const envAnnotations = envCtx.getAnnotations();
     if (envAnnotations instanceof Promise) {

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -430,7 +430,7 @@ export function createConfigContext<T, TConfigMeta = ConfigMeta>(
   const context: ConfigContext<T, TConfigMeta> = {
     id: contextId,
     schema: rawSchema,
-    mode: "dynamic",
+    phase: "two-pass",
     getInternalAnnotations(parsed: unknown, annotations: Annotations) {
       if (parsed === undefined) {
         return { [contextId]: phase1ConfigAnnotationMarker };

--- a/packages/config/src/run.test.ts
+++ b/packages/config/src/run.test.ts
@@ -130,7 +130,7 @@ describe("run with config context", { concurrency: false }, () => {
     const metadataByParsed = new WeakMap<object, string>();
     const identityContext: SourceContext = {
       id: Symbol.for("@test/config-loader-identity"),
-      mode: "dynamic",
+      phase: "two-pass",
       getAnnotations(parsed?: unknown) {
         if (parsed != null && typeof parsed === "object") {
           metadataByParsed.set(parsed as object, "seen");

--- a/packages/core/src/annotations.ts
+++ b/packages/core/src/annotations.ts
@@ -19,7 +19,7 @@ export const annotationKey: unique symbol = Symbol.for(
 
 /**
  * Internal marker attached during the first pass of `runWith()` so wrappers
- * with side effects can defer work until dynamic contexts have resolved.
+ * with side effects can defer work until two-pass contexts have resolved.
  *
  * @internal
  */

--- a/packages/core/src/context.test.ts
+++ b/packages/core/src/context.test.ts
@@ -95,7 +95,7 @@ describe("SourceContext", () => {
         id: configKey,
         phase: "two-pass",
         getAnnotations(parsed?: unknown) {
-          if (!parsed) return {};
+          if (parsed === undefined) return {};
           return { [configKey]: { host: "config-host" } };
         },
       };

--- a/packages/core/src/context.test.ts
+++ b/packages/core/src/context.test.ts
@@ -33,7 +33,7 @@ describe("SourceContext", () => {
         id: configKey,
         phase: "two-pass",
         getAnnotations(parsed?: unknown) {
-          if (!parsed) {
+          if (parsed === undefined) {
             return { [configKey]: { phase1: true } };
           }
           const result = parsed as { config?: string };

--- a/packages/core/src/context.test.ts
+++ b/packages/core/src/context.test.ts
@@ -1,15 +1,15 @@
 import type { Annotations } from "@optique/core/annotations";
-import { isStaticContext, type SourceContext } from "@optique/core/context";
+import type { SourceContext } from "@optique/core/context";
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import * as fc from "fast-check";
 
 describe("SourceContext", () => {
   describe("interface implementation", () => {
-    it("should allow creating a static context", () => {
+    it("should allow creating a single-pass context", () => {
       const envKey = Symbol.for("@test/env");
       const context: SourceContext = {
         id: envKey,
+        phase: "single-pass",
         getAnnotations() {
           return {
             [envKey]: { HOST: "localhost", PORT: "3000" },
@@ -18,6 +18,7 @@ describe("SourceContext", () => {
       };
 
       assert.equal(context.id, envKey);
+      assert.equal(context.phase, "single-pass");
       const annotations = context.getAnnotations();
       assert.ok(!(annotations instanceof Promise));
       assert.deepEqual(annotations[envKey], {
@@ -26,15 +27,17 @@ describe("SourceContext", () => {
       });
     });
 
-    it("should allow creating a dynamic context", async () => {
+    it("should allow creating a two-pass context", async () => {
       const configKey = Symbol.for("@test/config");
       const context: SourceContext = {
         id: configKey,
+        phase: "two-pass",
         getAnnotations(parsed?: unknown) {
-          if (!parsed) return {};
+          if (!parsed) {
+            return { [configKey]: { phase1: true } };
+          }
           const result = parsed as { config?: string };
           if (!result.config) return {};
-          // Simulate async config loading
           return Promise.resolve({
             [configKey]: { host: "example.com", port: 8080 },
           });
@@ -42,13 +45,12 @@ describe("SourceContext", () => {
       };
 
       assert.equal(context.id, configKey);
+      assert.equal(context.phase, "two-pass");
 
-      // First call without parsed result should return empty
       const firstPass = context.getAnnotations();
       assert.ok(!(firstPass instanceof Promise));
-      assert.deepEqual(firstPass, {});
+      assert.deepEqual(firstPass[configKey], { phase1: true });
 
-      // Second call with parsed result should return config data
       const secondPass = await context.getAnnotations({
         config: "config.json",
       });
@@ -62,8 +64,8 @@ describe("SourceContext", () => {
       const asyncKey = Symbol.for("@test/async");
       const context: SourceContext = {
         id: asyncKey,
+        phase: "single-pass",
         async getAnnotations() {
-          // Simulate async operation
           await new Promise((resolve) => setTimeout(resolve, 1));
           return {
             [asyncKey]: { data: "async-value" },
@@ -76,121 +78,6 @@ describe("SourceContext", () => {
     });
   });
 
-  describe("isStaticContext", () => {
-    it("should return true for static contexts that return non-empty annotations", () => {
-      const staticKey = Symbol.for("@test/static");
-      const context: SourceContext = {
-        id: staticKey,
-        getAnnotations() {
-          return {
-            [staticKey]: { value: "static" },
-          };
-        },
-      };
-
-      assert.ok(isStaticContext(context));
-    });
-
-    it("should return false for dynamic contexts that return empty annotations", () => {
-      const dynamicKey = Symbol.for("@test/dynamic");
-      const context: SourceContext = {
-        id: dynamicKey,
-        getAnnotations(parsed?: unknown) {
-          if (!parsed) return {};
-          return {
-            [dynamicKey]: { value: "dynamic" },
-          };
-        },
-      };
-
-      assert.ok(!isStaticContext(context));
-    });
-
-    it("should return false for contexts that return promises", () => {
-      const asyncKey = Symbol.for("@test/async");
-      const context: SourceContext = {
-        id: asyncKey,
-        getAnnotations() {
-          return Promise.resolve({
-            [asyncKey]: { value: "async" },
-          });
-        },
-      };
-
-      assert.ok(!isStaticContext(context));
-    });
-
-    it("should return false for contexts that return empty object synchronously", () => {
-      const emptyKey = Symbol.for("@test/empty");
-      const context: SourceContext = {
-        id: emptyKey,
-        getAnnotations() {
-          return {};
-        },
-      };
-
-      assert.ok(!isStaticContext(context));
-    });
-
-    it("should only check symbol-keyed annotations (ignore string keys)", () => {
-      // isStaticContext checks Object.getOwnPropertySymbols().length,
-      // so annotations with only string keys should return false
-      const stringKeyContext: SourceContext = {
-        id: Symbol.for("@test/string-keys"),
-        getAnnotations() {
-          return { someStringKey: "value" } as Annotations;
-        },
-      };
-
-      assert.ok(!isStaticContext(stringKeyContext));
-    });
-
-    it('does not call getAnnotations() when mode field is "static"', () => {
-      // isStaticContext() should not call getAnnotations() as a side effect
-      // when the context declares its own mode field.  This matters for
-      // contexts like EnvContext whose getAnnotations() mutates global state.
-      let getAnnotationsCalled = false;
-      const contextId = Symbol("@test/side-effect-check");
-
-      const context: SourceContext = {
-        id: contextId,
-        mode: "static",
-        getAnnotations() {
-          getAnnotationsCalled = true;
-          return { [contextId]: { value: "x" } };
-        },
-      };
-
-      const result = isStaticContext(context);
-      assert.ok(result, 'Expected mode: "static" to report as static');
-      assert.ok(
-        !getAnnotationsCalled,
-        "isStaticContext() must not call getAnnotations() when mode field is set",
-      );
-    });
-
-    it('returns false without calling getAnnotations() for mode: "dynamic"', () => {
-      let getAnnotationsCalled = false;
-      const contextId = Symbol("@test/side-effect-false");
-
-      const context: SourceContext = {
-        id: contextId,
-        mode: "dynamic",
-        getAnnotations() {
-          getAnnotationsCalled = true;
-          return { [contextId]: { value: "x" } };
-        },
-      };
-
-      const result = isStaticContext(context);
-      assert.ok(!result, 'Expected mode: "dynamic" to report as dynamic');
-      assert.ok(
-        !getAnnotationsCalled,
-        "isStaticContext() must not call getAnnotations() when mode field is set",
-      );
-    });
-  });
-
   describe("context composition patterns", () => {
     it("should allow multiple contexts with different keys", () => {
       const envKey = Symbol.for("@test/env");
@@ -198,6 +85,7 @@ describe("SourceContext", () => {
 
       const envContext: SourceContext = {
         id: envKey,
+        phase: "single-pass",
         getAnnotations() {
           return { [envKey]: { HOST: "localhost" } };
         },
@@ -205,13 +93,13 @@ describe("SourceContext", () => {
 
       const configContext: SourceContext = {
         id: configKey,
+        phase: "two-pass",
         getAnnotations(parsed?: unknown) {
           if (!parsed) return {};
           return { [configKey]: { host: "config-host" } };
         },
       };
 
-      // Both contexts can coexist
       const envAnnotations = envContext.getAnnotations();
       const configAnnotations = configContext.getAnnotations({
         config: "test.json",
@@ -228,6 +116,7 @@ describe("SourceContext", () => {
 
       const context1: SourceContext = {
         id: Symbol.for("@test/context1"),
+        phase: "single-pass",
         getAnnotations() {
           return { [sharedKey]: { source: "context1", priority: 1 } };
         },
@@ -235,6 +124,7 @@ describe("SourceContext", () => {
 
       const context2: SourceContext = {
         id: Symbol.for("@test/context2"),
+        phase: "single-pass",
         getAnnotations() {
           return { [sharedKey]: { source: "context2", priority: 2 } };
         },
@@ -243,8 +133,6 @@ describe("SourceContext", () => {
       const annotations1 = context1.getAnnotations() as Annotations;
       const annotations2 = context2.getAnnotations() as Annotations;
 
-      // Different contexts can provide data for the same annotation key
-      // Priority handling is done by runWith()
       assert.deepEqual(annotations1[sharedKey], {
         source: "context1",
         priority: 1,
@@ -262,6 +150,7 @@ describe("SourceContext", () => {
       const internalKey = Symbol("@test/internal-extra");
       const context: SourceContext = {
         id: key,
+        phase: "single-pass",
         getAnnotations() {
           return { [key]: { value: "primary" } };
         },
@@ -280,6 +169,7 @@ describe("SourceContext", () => {
       const key = Symbol("@test/no-internal");
       const context: SourceContext = {
         id: key,
+        phase: "single-pass",
         getAnnotations() {
           return { [key]: { value: "only" } };
         },
@@ -295,6 +185,7 @@ describe("SourceContext", () => {
       const marker = Symbol("undefined-marker");
       const context: SourceContext = {
         id: key,
+        phase: "two-pass",
         getAnnotations() {
           return {};
         },
@@ -314,93 +205,13 @@ describe("SourceContext", () => {
       const key = Symbol("@test/no-finalize");
       const context: SourceContext = {
         id: key,
+        phase: "single-pass",
         getAnnotations() {
           return {};
         },
       };
 
       assert.equal(context.finalizeParsed, undefined);
-    });
-  });
-
-  describe("property-based tests", () => {
-    const propertyParameters = { numRuns: 150 } as const;
-
-    it("mode should determine static-ness without calling getAnnotations", () => {
-      fc.assert(
-        fc.property(
-          fc.constantFrom<"static" | "dynamic">("static", "dynamic"),
-          fc.boolean(),
-          (mode: "static" | "dynamic", asyncResult: boolean) => {
-            let calls = 0;
-            const marker = Symbol("@test/mode-controlled");
-            const context: SourceContext = {
-              id: marker,
-              mode,
-              getAnnotations() {
-                calls++;
-                if (asyncResult) {
-                  return Promise.resolve({ [marker]: true });
-                }
-                return { [marker]: true };
-              },
-            };
-
-            assert.equal(isStaticContext(context), mode === "static");
-            assert.equal(calls, 0);
-          },
-        ),
-        propertyParameters,
-      );
-    });
-
-    it("fallback static detection should depend on sync symbol annotations", () => {
-      fc.assert(
-        fc.property(
-          fc.boolean(),
-          fc.integer({ min: 0, max: 3 }),
-          fc.integer({ min: 0, max: 3 }),
-          (
-            asyncResult: boolean,
-            symbolKeyCount: number,
-            stringKeyCount: number,
-          ) => {
-            let calls = 0;
-            const symbolEntries = Array.from(
-              { length: symbolKeyCount },
-              (_unused, i) => [Symbol(`@test/symbol-${i}`), i] as const,
-            );
-            const stringEntries = Array.from(
-              { length: stringKeyCount },
-              (_unused, i) => [`k${i}`, i] as const,
-            );
-
-            const syncAnnotations: Annotations = {};
-            for (const [key, value] of symbolEntries) {
-              syncAnnotations[key] = value;
-            }
-            for (const [key, value] of stringEntries) {
-              (syncAnnotations as unknown as Record<string, unknown>)[key] =
-                value;
-            }
-
-            const context: SourceContext = {
-              id: Symbol("@test/fallback"),
-              getAnnotations() {
-                calls++;
-                return asyncResult
-                  ? Promise.resolve(syncAnnotations)
-                  : syncAnnotations;
-              },
-            };
-
-            const result = isStaticContext(context);
-            assert.equal(calls, 1);
-            assert.equal(result, !asyncResult && symbolKeyCount > 0);
-          },
-        ),
-        propertyParameters,
-      );
     });
   });
 });

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -3,8 +3,8 @@
  *
  * This module provides the SourceContext interface that allows packages to
  * provide data sources (environment variables, config files, etc.) in a
- * standard way with clear priority ordering and automatic static/dynamic
- * optimization.
+ * standard way with clear priority ordering and explicit single-pass /
+ * two-pass execution.
  *
  * @module
  * @since 0.10.0
@@ -15,16 +15,15 @@ import type { Annotations } from "./annotations.ts";
 export type { Annotations } from "./annotations.ts";
 
 /**
- * Declares whether a {@link SourceContext} provides its annotations
- * immediately (`"static"`) or only after a prior parse pass (`"dynamic"`).
+ * Declares whether a {@link SourceContext} participates only in the initial
+ * annotation collection (`"single-pass"`) or is recollected after a usable
+ * first parse pass (`"two-pass"`).
  *
- * Used as the type of the optional `mode` field on {@link SourceContext}.
- * When set, {@link isStaticContext} reads this value directly instead of
- * calling `getAnnotations()`, preventing any side effects.
+ * Used as the type of the required `phase` field on {@link SourceContext}.
  *
  * @since 1.0.0
  */
-export type SourceContextMode = "static" | "dynamic";
+export type SourceContextPhase = "single-pass" | "two-pass";
 
 /**
  * Brand symbol for ParserValuePlaceholder type.
@@ -65,12 +64,14 @@ export type ParserValuePlaceholder = {
 /**
  * A source context that can provide data to parsers via annotations.
  *
- * Source contexts are used to inject external data (like environment variables
- * or config files) into the parsing process. They can be either:
+ * Source contexts are used to inject external data (like environment
+ * variables or config files) into the parsing process. They can be either:
  *
- * - *Static*: Data is immediately available (e.g., environment variables)
- * - *Dynamic*: Data depends on parsing results (e.g., config files whose path
- *   is determined by a CLI option)
+ * - *Single-pass*: The runner collects annotations once before parsing
+ *   (e.g., environment variables)
+ * - *Two-pass*: The runner collects annotations before parsing and then
+ *   recollects them after a usable first parse pass (e.g., config files whose
+ *   path is determined by a CLI option)
  *
  * Contexts may optionally implement `Disposable` or `AsyncDisposable` for
  * cleanup.  When present, `runWith()` and `runWithSync()` call the dispose
@@ -83,9 +84,10 @@ export type ParserValuePlaceholder = {
  *
  * @example
  * ```typescript
- * // Static context example (environment variables) - no extra options needed
+ * // Single-pass context example (environment variables)
  * const envContext: SourceContext = {
  *   id: Symbol.for("@myapp/env"),
+ *   phase: "single-pass",
  *   getAnnotations() {
  *     return {
  *       [Symbol.for("@myapp/env")]: {
@@ -96,7 +98,7 @@ export type ParserValuePlaceholder = {
  *   }
  * };
  *
- * // Dynamic context that requires options from runWith()
+ * // Two-pass context that requires options from runWith()
  * interface ConfigContext extends SourceContext<{
  *   getConfigPath: (parsed: ParserValuePlaceholder) => string | undefined;
  * }> {
@@ -124,41 +126,38 @@ export interface SourceContext<TRequiredOptions = void> {
   readonly $requiredOptions?: TRequiredOptions;
 
   /**
-   * Optional declaration of whether this context is static or dynamic.
+   * Declares whether this context is collected once or recollected after a
+   * usable first parse pass.
    *
-   * When present, {@link isStaticContext} reads this field directly instead
-   * of calling {@link getAnnotations}, avoiding any side effects that
-   * `getAnnotations` might have (such as mutating a global registry).
-   *
-   * If omitted, {@link isStaticContext} falls back to calling
-   * `getAnnotations()` with no arguments to determine static-ness.
+   * `single-pass` contexts contribute only their phase-1 annotations to the
+   * final parse. `two-pass` contexts are called again with the first-pass
+   * parsed value (or a best-effort seed extracted from parser state) and that
+   * second return value becomes the context's final annotation snapshot.
    *
    * @since 1.0.0
    */
-  readonly mode?: SourceContextMode;
+  readonly phase: SourceContextPhase;
 
   /**
    * Get annotations to inject into parsing.
    *
-   * This method is called twice during `runWith()` execution:
+   * This method is called during phase 1 for every context and during phase 2
+   * only for `two-pass` contexts:
    *
-   * 1. *First call*: `parsed` is `undefined`. Static contexts should return
-   *    their annotations, while dynamic contexts should return an empty object.
-   * 2. *Second call*: `parsed` contains the first pass result, or a
-   *    best-effort partial value extracted from parser state when the first
-   *    pass reached a usable intermediate state but still did not complete
-   *    successfully. Dynamic contexts can use this to load external data
-   *    (e.g., reading a config file whose path was determined in the first
-   *    pass). Deferred or otherwise unresolved fields may be `undefined`.
-   *    This second return value is treated as the context's final annotation
+   * 1. *Phase 1*: `parsed` is `undefined`.
+   * 2. *Phase 2*: `parsed` contains the first pass result, or a best-effort
+   *    partial value extracted from parser state when the first pass reached a
+   *    usable intermediate state but still did not complete successfully.
+   *    Deferred or otherwise unresolved fields may be `undefined`. This
+   *    second return value is treated as the context's final annotation
    *    snapshot for the second parse pass, replacing that context's phase-one
    *    contribution. If the runner cannot extract a usable value at all, this
    *    second call is skipped and the original parse failure is reported
    *    instead.
    *
    * @param parsed Optional parsed result from a previous parse pass.
-   *               Static contexts can ignore this parameter.
-   *               Dynamic contexts use this to extract necessary data.
+   *               `single-pass` contexts can ignore this parameter.
+   *               `two-pass` contexts use this to extract or refine data.
    * @param options Optional context-required options provided by the caller
    *               of `runWith()`. These are the options declared via the
    *               `TRequiredOptions` type parameter.
@@ -220,31 +219,4 @@ export interface SourceContext<TRequiredOptions = void> {
    * Promise.
    */
   [Symbol.asyncDispose]?(): void | PromiseLike<void>;
-}
-
-/**
- * Checks whether a context is static (returns annotations without needing
- * parsed results).
- *
- * A context is considered static if it declares `mode: "static"` or if
- * `getAnnotations()` called without arguments returns a non-empty
- * annotations object synchronously.
- *
- * @param context The source context to check.
- * @returns `true` if the context is static, `false` otherwise.
- * @since 0.10.0
- */
-export function isStaticContext(context: SourceContext<unknown>): boolean {
-  // If the context explicitly declares its static-ness, use that directly
-  // to avoid calling getAnnotations() and triggering any side effects it
-  // might have (e.g. mutating a global registry as EnvContext does).
-  if (context.mode !== undefined) {
-    return context.mode === "static";
-  }
-
-  const result = context.getAnnotations();
-  if (result instanceof Promise) {
-    return false;
-  }
-  return Object.getOwnPropertySymbols(result).length > 0;
 }

--- a/packages/core/src/facade.test.ts
+++ b/packages/core/src/facade.test.ts
@@ -5255,6 +5255,7 @@ describe("runWith", () => {
       const envKey = Symbol.for("@test/env-primitive-async");
       const envContext: SourceContext = {
         id: envKey,
+        phase: "single-pass",
         getAnnotations() {
           return { [envKey]: { HOST: "localhost" } };
         },
@@ -5278,10 +5279,11 @@ describe("runWith", () => {
       assert.deepEqual(result, { name: "Alice" });
     });
 
-    it("should parse with a static context", async () => {
+    it("should parse with a single-pass context", async () => {
       const envKey = Symbol.for("@test/env");
       const envContext: SourceContext = {
         id: envKey,
+        phase: "single-pass",
         getAnnotations() {
           return { [envKey]: { HOST: "localhost" } };
         },
@@ -5299,10 +5301,11 @@ describe("runWith", () => {
       assert.deepEqual(result, { host: "default" });
     });
 
-    it("should call static context once in async runWith", async () => {
+    it("should call a single-pass context once in async runWith", async () => {
       let callCount = 0;
       const staticContext: SourceContext = {
         id: Symbol.for("@test/static-once"),
+        phase: "single-pass",
         getAnnotations() {
           callCount++;
           return {
@@ -5323,11 +5326,11 @@ describe("runWith", () => {
       assert.equal(callCount, 1);
     });
 
-    it('should not force two-phase parsing for mode: "static" with empty annotations', async () => {
+    it('should not force two-phase parsing for phase: "single-pass" with empty annotations', async () => {
       let callCount = 0;
       const staticContext: SourceContext = {
         id: Symbol.for("@test/static-empty-once"),
-        mode: "static",
+        phase: "single-pass",
         getAnnotations() {
           callCount++;
           return {};
@@ -5346,11 +5349,11 @@ describe("runWith", () => {
       assert.equal(callCount, 1);
     });
 
-    it('should not force two-phase parsing for async mode: "static" contexts', async () => {
+    it('should not force two-phase parsing for async phase: "single-pass" contexts', async () => {
       let callCount = 0;
       const staticContext: SourceContext = {
         id: Symbol.for("@test/static-empty-async-once"),
-        mode: "static",
+        phase: "single-pass",
         getAnnotations() {
           callCount++;
           return Promise.resolve({});
@@ -5369,12 +5372,13 @@ describe("runWith", () => {
       assert.equal(callCount, 1);
     });
 
-    it("should parse with multiple static contexts", async () => {
+    it("should parse with multiple single-pass contexts", async () => {
       const envKey = Symbol.for("@test/env");
       const configKey = Symbol.for("@test/config");
 
       const envContext: SourceContext = {
         id: envKey,
+        phase: "single-pass",
         getAnnotations() {
           return { [envKey]: { HOST: "env-host" } };
         },
@@ -5382,6 +5386,7 @@ describe("runWith", () => {
 
       const configContext: SourceContext = {
         id: configKey,
+        phase: "single-pass",
         getAnnotations() {
           return { [configKey]: { host: "config-host" } };
         },
@@ -5408,6 +5413,7 @@ describe("runWith", () => {
 
       const context1: SourceContext = {
         id: Symbol.for("@test/context1"),
+        phase: "single-pass",
         getAnnotations() {
           return { [sharedKey]: { value: "from-context1" } };
         },
@@ -5415,6 +5421,7 @@ describe("runWith", () => {
 
       const context2: SourceContext = {
         id: Symbol.for("@test/context2"),
+        phase: "single-pass",
         getAnnotations() {
           return { [sharedKey]: { value: "from-context2" } };
         },
@@ -5474,6 +5481,7 @@ describe("runWith", () => {
 
       const earlyContext: SourceContext = {
         id: Symbol.for("@test/phase-merge-early"),
+        phase: "single-pass",
         getAnnotations() {
           return { [sharedKey]: "phase1-early" };
         },
@@ -5481,7 +5489,7 @@ describe("runWith", () => {
 
       const lateDynamicContext: SourceContext = {
         id: Symbol.for("@test/phase-merge-late"),
-        mode: "dynamic",
+        phase: "two-pass",
         getAnnotations(parsed?: unknown) {
           if (parsed == null) {
             return {};
@@ -5535,7 +5543,7 @@ describe("runWith", () => {
 
       const clearingContext: SourceContext = {
         id: Symbol.for("@test/phase-clear-early"),
-        mode: "dynamic",
+        phase: "two-pass",
         getAnnotations(parsed?: unknown) {
           if (parsed == null) {
             return { [sharedKey]: "phase1-early" };
@@ -5546,7 +5554,7 @@ describe("runWith", () => {
 
       const fallbackContext: SourceContext = {
         id: Symbol.for("@test/phase-clear-late"),
-        mode: "dynamic",
+        phase: "two-pass",
         getAnnotations(parsed?: unknown) {
           if (parsed == null) {
             return {};
@@ -5566,12 +5574,13 @@ describe("runWith", () => {
     });
   });
 
-  describe("dynamic contexts", () => {
-    it("should handle dynamic context with two-phase parsing", async () => {
+  describe("two-pass contexts", () => {
+    it("should handle a two-pass context with two-phase parsing", async () => {
       const configKey = Symbol.for("@test/config");
 
       const dynamicContext: SourceContext = {
         id: configKey,
+        phase: "two-pass",
         getAnnotations(parsed?: unknown) {
           if (!parsed) return {};
           const result = parsed as { config?: string };
@@ -5601,7 +5610,7 @@ describe("runWith", () => {
 
       const firstContext: SourceContext = {
         id: Symbol.for("@test/phase-two-identity-first"),
-        mode: "dynamic",
+        phase: "two-pass",
         getAnnotations(parsed?: unknown) {
           if (parsed != null && typeof parsed === "object") {
             seenParsed.set(parsed as object, true);
@@ -5612,7 +5621,7 @@ describe("runWith", () => {
 
       const secondContext: SourceContext = {
         id: Symbol.for("@test/phase-two-identity-second"),
-        mode: "dynamic",
+        phase: "two-pass",
         getAnnotations(parsed?: unknown) {
           reusedIdentity = parsed != null &&
             typeof parsed === "object" &&
@@ -5636,12 +5645,13 @@ describe("runWith", () => {
       assert.deepEqual(result, { name: "default" });
     });
 
-    it("should handle mixed static and dynamic contexts", async () => {
+    it("should handle mixed single-pass and two-pass contexts", async () => {
       const envKey = Symbol.for("@test/env");
       const configKey = Symbol.for("@test/config");
 
       const staticContext: SourceContext = {
         id: envKey,
+        phase: "single-pass",
         getAnnotations() {
           return { [envKey]: { HOST: "env-host" } };
         },
@@ -5649,6 +5659,7 @@ describe("runWith", () => {
 
       const dynamicContext: SourceContext = {
         id: configKey,
+        phase: "two-pass",
         getAnnotations(parsed?: unknown) {
           if (!parsed) return {};
           return { [configKey]: { host: "config-host" } };
@@ -5674,6 +5685,7 @@ describe("runWith", () => {
 
       const asyncContext: SourceContext = {
         id: asyncKey,
+        phase: "single-pass",
         async getAnnotations() {
           await new Promise((resolve) => setTimeout(resolve, 1));
           return { [asyncKey]: { value: "async-value" } };
@@ -5777,6 +5789,7 @@ describe("runWith", () => {
       let annotationsCallCount = 0;
       const trackingContext: SourceContext = {
         id: Symbol.for("@test/tracking"),
+        phase: "single-pass",
         getAnnotations() {
           annotationsCallCount++;
           return {};
@@ -5808,6 +5821,7 @@ describe("runWith", () => {
       let annotationsCallCount = 0;
       const trackingContext: SourceContext = {
         id: Symbol.for("@test/tracking"),
+        phase: "single-pass",
         getAnnotations() {
           annotationsCallCount++;
           return {};
@@ -5840,6 +5854,7 @@ describe("runWith", () => {
       let annotationsCallCount = 0;
       const trackingContext: SourceContext = {
         id: Symbol.for("@test/tracking"),
+        phase: "single-pass",
         getAnnotations() {
           annotationsCallCount++;
           return {};
@@ -5871,6 +5886,7 @@ describe("runWith", () => {
       let annotationsCallCount = 0;
       const trackingContext: SourceContext = {
         id: Symbol.for("@test/tracking"),
+        phase: "single-pass",
         getAnnotations() {
           annotationsCallCount++;
           return {};
@@ -5903,6 +5919,7 @@ describe("runWith", () => {
       let annotationsCallCount = 0;
       const trackingContext: SourceContext = {
         id: Symbol.for("@test/tracking"),
+        phase: "single-pass",
         getAnnotations() {
           annotationsCallCount++;
           return {};
@@ -5934,6 +5951,7 @@ describe("runWith", () => {
       let annotationsCallCount = 0;
       const trackingContext: SourceContext = {
         id: Symbol.for("@test/tracking"),
+        phase: "single-pass",
         getAnnotations() {
           annotationsCallCount++;
           return {};
@@ -5965,6 +5983,7 @@ describe("runWith", () => {
       let annotationsCallCount = 0;
       const trackingContext: SourceContext = {
         id: Symbol.for("@test/tracking"),
+        phase: "single-pass",
         getAnnotations() {
           annotationsCallCount++;
           return {};
@@ -5996,6 +6015,7 @@ describe("runWith", () => {
       let annotationsCallCount = 0;
       const trackingContext: SourceContext = {
         id: Symbol.for("@test/tracking"),
+        phase: "single-pass",
         getAnnotations() {
           annotationsCallCount++;
           return {};
@@ -6023,10 +6043,11 @@ describe("runWith", () => {
       assert.equal(annotationsCallCount, 0);
     });
 
-    it("should continue to context phase when completion option is configured but absent", async () => {
+    it("should continue to context collection when completion option is configured but absent", async () => {
       let annotationsCallCount = 0;
       const trackingContext: SourceContext = {
         id: Symbol.for("@test/tracking-present-but-absent-completion"),
+        phase: "single-pass",
         getAnnotations() {
           annotationsCallCount++;
           return {};
@@ -6045,12 +6066,12 @@ describe("runWith", () => {
       });
 
       assert.deepEqual(result, { name: "alice" });
-      assert.equal(annotationsCallCount, 2);
+      assert.equal(annotationsCallCount, 1);
     });
   });
 
   describe("error handling", () => {
-    it("should display error only once with dynamic context and empty args", async () => {
+    it("should display error only once with a two-pass context and empty args", async () => {
       const cmd1 = command("foo", object({ cmd: constant("foo") }));
       const cmd2 = command("bar", object({ cmd: constant("bar") }));
       const parser = merge(
@@ -6060,6 +6081,7 @@ describe("runWith", () => {
 
       const dynamicContext: SourceContext = {
         id: Symbol("dynamic"),
+        phase: "two-pass",
         getAnnotations(_parsed?: unknown) {
           return Promise.resolve({});
         },
@@ -6103,6 +6125,7 @@ describe("runWith", () => {
       let disposed = false;
       const context: SourceContext = {
         id: Symbol.for("@test/disposable"),
+        phase: "single-pass",
         getAnnotations() {
           return {
             [Symbol.for("@test/disposable")]: { value: true },
@@ -6125,6 +6148,7 @@ describe("runWith", () => {
       let disposed = false;
       const context: SourceContext = {
         id: Symbol.for("@test/disposable-error"),
+        phase: "single-pass",
         getAnnotations() {
           return {
             [Symbol.for("@test/disposable-error")]: { value: true },
@@ -6156,6 +6180,7 @@ describe("runWith", () => {
       const disposed: string[] = [];
       const context: SourceContext = {
         id: Symbol.for("@test/async-disposable"),
+        phase: "single-pass",
         getAnnotations() {
           return {
             [Symbol.for("@test/async-disposable")]: { value: true },
@@ -6182,6 +6207,7 @@ describe("runWith", () => {
 
       const context1: SourceContext = {
         id: Symbol.for("@test/dispose1"),
+        phase: "single-pass",
         getAnnotations() {
           return {
             [Symbol.for("@test/dispose1")]: { value: 1 },
@@ -6194,6 +6220,7 @@ describe("runWith", () => {
 
       const context2: SourceContext = {
         id: Symbol.for("@test/dispose2"),
+        phase: "single-pass",
         getAnnotations() {
           return {
             [Symbol.for("@test/dispose2")]: { value: 2 },
@@ -6217,6 +6244,7 @@ describe("runWith", () => {
 
       const context1: SourceContext = {
         id: Symbol.for("@test/dispose-error-1"),
+        phase: "single-pass",
         getAnnotations() {
           return {
             [Symbol.for("@test/dispose-error-1")]: { value: 1 },
@@ -6230,6 +6258,7 @@ describe("runWith", () => {
 
       const context2: SourceContext = {
         id: Symbol.for("@test/dispose-error-2"),
+        phase: "single-pass",
         getAnnotations() {
           return {
             [Symbol.for("@test/dispose-error-2")]: { value: 2 },
@@ -6254,6 +6283,7 @@ describe("runWith", () => {
     it("should handle context without dispose methods", async () => {
       const context: SourceContext = {
         id: Symbol.for("@test/no-dispose"),
+        phase: "single-pass",
         getAnnotations() {
           return {
             [Symbol.for("@test/no-dispose")]: { value: true },
@@ -6274,6 +6304,7 @@ describe("runWith", () => {
       let disposed = 0;
       const context: SourceContext = {
         id: Symbol.for("@test/dispose-help"),
+        phase: "single-pass",
         getAnnotations() {
           return {};
         },
@@ -6301,6 +6332,7 @@ describe("runWith", () => {
       let disposed = 0;
       const context: SourceContext = {
         id: Symbol.for("@test/dispose-version"),
+        phase: "single-pass",
         getAnnotations() {
           return {};
         },
@@ -6329,6 +6361,7 @@ describe("runWith", () => {
       let disposed = 0;
       const context: SourceContext = {
         id: Symbol.for("@test/async-dispose-help"),
+        phase: "single-pass",
         getAnnotations() {
           return {};
         },
@@ -6356,6 +6389,7 @@ describe("runWith", () => {
       let disposed = 0;
       const context: SourceContext = {
         id: Symbol.for("@test/dispose-completion"),
+        phase: "single-pass",
         getAnnotations() {
           return {};
         },
@@ -6383,6 +6417,7 @@ describe("runWith", () => {
       let disposed = false;
       const context: SourceContext = {
         id: Symbol.for("@test/dispose-shadow"),
+        phase: "single-pass",
         getAnnotations() {
           return {};
         },
@@ -6427,6 +6462,7 @@ describe("runWith", () => {
 
       const context1: SourceContext = {
         id: Symbol.for("@test/dispose-shadow-multi-1"),
+        phase: "single-pass",
         getAnnotations() {
           return {};
         },
@@ -6438,6 +6474,7 @@ describe("runWith", () => {
 
       const context2: SourceContext = {
         id: Symbol.for("@test/dispose-shadow-multi-2"),
+        phase: "single-pass",
         getAnnotations() {
           return {};
         },
@@ -6478,6 +6515,7 @@ describe("runWith", () => {
       let disposed = false;
       const context: SourceContext = {
         id: Symbol.for("@test/dispose-no-shadow"),
+        phase: "single-pass",
         getAnnotations() {
           return {};
         },
@@ -6514,6 +6552,7 @@ describe("runWith", () => {
       // extra fields.  The context reads options from the untyped second arg.
       const context: SourceContext = {
         id: passthroughKey,
+        phase: "two-pass",
         getAnnotations(_parsed?: unknown, options?: unknown) {
           receivedOptions = options;
           if (!_parsed) return {};
@@ -6544,6 +6583,7 @@ describe("runWith", () => {
 
       const context: SourceContext = {
         id: dynamicKey,
+        phase: "two-pass",
         getAnnotations(parsed?: unknown, options?: unknown) {
           receivedOptionsPerCall.push(options);
           if (!parsed) return {};
@@ -6573,6 +6613,7 @@ describe("runWith", () => {
 
       const context: SourceContext<{ args: string[] }> = {
         id: key,
+        phase: "two-pass",
         getAnnotations(_parsed?: unknown, options?: unknown) {
           receivedOptions = options;
           return {};
@@ -6602,6 +6643,7 @@ describe("runWith", () => {
 
       const context: SourceContext<{ help: string; programName: string }> = {
         id: key,
+        phase: "two-pass",
         getAnnotations(_parsed?: unknown, options?: unknown) {
           receivedOptions = options;
           return {};
@@ -6630,6 +6672,7 @@ describe("runWith", () => {
 
       const context: SourceContext<Record<never, never>> = {
         id: key,
+        phase: "single-pass",
         getAnnotations() {
           return {};
         },
@@ -6653,6 +6696,7 @@ describe("runWith", () => {
 
       const context: SourceContext<{ profile?: string }> = {
         id: key,
+        phase: "two-pass",
         getAnnotations(_parsed?: unknown, options?: unknown) {
           receivedOptions = options;
           return {};
@@ -6689,10 +6733,12 @@ describe("runWith", () => {
       const shared = Symbol.for("@test/dup-runWith");
       const ctx1: SourceContext = {
         id: shared,
+        phase: "single-pass",
         getAnnotations: () => ({ [shared]: "one" }),
       };
       const ctx2: SourceContext = {
         id: shared,
+        phase: "single-pass",
         getAnnotations: () => ({ [shared]: "two" }),
       };
 
@@ -6712,6 +6758,7 @@ describe("runWithSync", () => {
     const envKey = Symbol.for("@test/env-primitive");
     const envContext: SourceContext = {
       id: envKey,
+      phase: "single-pass",
       getAnnotations() {
         return { [envKey]: { HOST: "localhost" } };
       },
@@ -6724,11 +6771,11 @@ describe("runWithSync", () => {
     assert.equal(result, "ok");
   });
 
-  it("should keep argument parsing transparent for static contexts", () => {
+  it("should keep argument parsing transparent for single-pass contexts", () => {
     const annotation = Symbol.for("@test/issue-187/runwithsync-argument");
     const context: SourceContext = {
       id: annotation,
-      mode: "static",
+      phase: "single-pass",
       getAnnotations() {
         return { [annotation]: true };
       },
@@ -6741,11 +6788,11 @@ describe("runWithSync", () => {
     assert.equal(result, "value");
   });
 
-  it("should keep command parsing transparent for static contexts", () => {
+  it("should keep command parsing transparent for single-pass contexts", () => {
     const annotation = Symbol.for("@test/issue-187/runwithsync-command");
     const context: SourceContext = {
       id: annotation,
-      mode: "static",
+      phase: "single-pass",
       getAnnotations() {
         return { [annotation]: true };
       },
@@ -6765,6 +6812,7 @@ describe("runWithSync", () => {
     const envKey = Symbol.for("@test/env-array");
     const envContext: SourceContext = {
       id: envKey,
+      phase: "single-pass",
       getAnnotations() {
         return { [envKey]: { value: true } };
       },
@@ -6778,10 +6826,11 @@ describe("runWithSync", () => {
     assert.deepEqual(result, ["alpha"]);
   });
 
-  it("should parse with static contexts synchronously", () => {
+  it("should parse with single-pass contexts synchronously", () => {
     const envKey = Symbol.for("@test/env");
     const envContext: SourceContext = {
       id: envKey,
+      phase: "single-pass",
       getAnnotations() {
         return { [envKey]: { HOST: "localhost" } };
       },
@@ -6798,10 +6847,11 @@ describe("runWithSync", () => {
     assert.deepEqual(result, { host: "default" });
   });
 
-  it("should call static context once in runWithSync", () => {
+  it("should call a single-pass context once in runWithSync", () => {
     let callCount = 0;
     const staticContext: SourceContext = {
       id: Symbol.for("@test/static-once-sync"),
+      phase: "single-pass",
       getAnnotations() {
         callCount++;
         return {
@@ -6822,11 +6872,11 @@ describe("runWithSync", () => {
     assert.equal(callCount, 1);
   });
 
-  it('should not force two-phase parsing in runWithSync for mode: "static" with empty annotations', () => {
+  it('should not force two-phase parsing in runWithSync for phase: "single-pass" with empty annotations', () => {
     let callCount = 0;
     const staticContext: SourceContext = {
       id: Symbol.for("@test/static-empty-once-sync"),
-      mode: "static",
+      phase: "single-pass",
       getAnnotations() {
         callCount++;
         return {};
@@ -6849,6 +6899,7 @@ describe("runWithSync", () => {
     const asyncKey = Symbol.for("@test/async");
     const asyncContext: SourceContext = {
       id: asyncKey,
+      phase: "single-pass",
       getAnnotations() {
         return Promise.resolve({ [asyncKey]: { value: "async" } });
       },
@@ -6870,6 +6921,7 @@ describe("runWithSync", () => {
     const mixedKey = Symbol.for("@test/mixed-async");
     const mixedContext: SourceContext = {
       id: mixedKey,
+      phase: "two-pass",
       getAnnotations(parsed?: unknown) {
         if (!parsed) return {}; // sync (empty → dynamic)
         return Promise.resolve({ [mixedKey]: { value: "loaded" } });
@@ -6926,6 +6978,7 @@ describe("runWithSync", () => {
       let annotationsCallCount = 0;
       const trackingContext: SourceContext = {
         id: Symbol.for("@test/tracking"),
+        phase: "single-pass",
         getAnnotations() {
           annotationsCallCount++;
           return {};
@@ -6957,6 +7010,7 @@ describe("runWithSync", () => {
       let annotationsCallCount = 0;
       const trackingContext: SourceContext = {
         id: Symbol.for("@test/tracking"),
+        phase: "single-pass",
         getAnnotations() {
           annotationsCallCount++;
           return {};
@@ -6989,6 +7043,7 @@ describe("runWithSync", () => {
       let annotationsCallCount = 0;
       const trackingContext: SourceContext = {
         id: Symbol.for("@test/tracking"),
+        phase: "single-pass",
         getAnnotations() {
           annotationsCallCount++;
           return {};
@@ -7022,6 +7077,7 @@ describe("runWithSync", () => {
       let disposed = false;
       const context: SourceContext = {
         id: Symbol.for("@test/sync-disposable"),
+        phase: "single-pass",
         getAnnotations() {
           return {
             [Symbol.for("@test/sync-disposable")]: { value: true },
@@ -7044,6 +7100,7 @@ describe("runWithSync", () => {
       let disposed = false;
       const context: SourceContext = {
         id: Symbol.for("@test/sync-disposable-error"),
+        phase: "single-pass",
         getAnnotations() {
           return {
             [Symbol.for("@test/sync-disposable-error")]: { value: true },
@@ -7075,6 +7132,7 @@ describe("runWithSync", () => {
       const disposed: string[] = [];
       const context: SourceContext = {
         id: Symbol.for("@test/sync-no-async-dispose"),
+        phase: "single-pass",
         getAnnotations() {
           return {
             [Symbol.for("@test/sync-no-async-dispose")]: { value: true },
@@ -7100,6 +7158,7 @@ describe("runWithSync", () => {
       const disposed: string[] = [];
       const context: SourceContext = {
         id: Symbol.for("@test/sync-async-dispose-only"),
+        phase: "single-pass",
         getAnnotations() {
           return {
             [Symbol.for("@test/sync-async-dispose-only")]: { value: true },
@@ -7123,6 +7182,7 @@ describe("runWithSync", () => {
 
       const context1: SourceContext = {
         id: Symbol.for("@test/sync-dispose-error-1"),
+        phase: "single-pass",
         getAnnotations() {
           return {
             [Symbol.for("@test/sync-dispose-error-1")]: { value: 1 },
@@ -7136,6 +7196,7 @@ describe("runWithSync", () => {
 
       const context2: SourceContext = {
         id: Symbol.for("@test/sync-dispose-error-2"),
+        phase: "single-pass",
         getAnnotations() {
           return {
             [Symbol.for("@test/sync-dispose-error-2")]: { value: 2 },
@@ -7160,6 +7221,7 @@ describe("runWithSync", () => {
       let disposed = 0;
       const context: SourceContext = {
         id: Symbol.for("@test/sync-dispose-help"),
+        phase: "single-pass",
         getAnnotations() {
           return {};
         },
@@ -7187,6 +7249,7 @@ describe("runWithSync", () => {
       let disposed = 0;
       const context: SourceContext = {
         id: Symbol.for("@test/sync-dispose-version"),
+        phase: "single-pass",
         getAnnotations() {
           return {};
         },
@@ -7215,6 +7278,7 @@ describe("runWithSync", () => {
       let disposed = 0;
       const context: SourceContext = {
         id: Symbol.for("@test/sync-dispose-completion"),
+        phase: "single-pass",
         getAnnotations() {
           return {};
         },
@@ -7242,6 +7306,7 @@ describe("runWithSync", () => {
       let disposed = false;
       const context: SourceContext = {
         id: Symbol.for("@test/sync-dispose-shadow"),
+        phase: "single-pass",
         getAnnotations() {
           return {};
         },
@@ -7286,6 +7351,7 @@ describe("runWithSync", () => {
 
       const context1: SourceContext = {
         id: Symbol.for("@test/sync-dispose-shadow-multi-1"),
+        phase: "single-pass",
         getAnnotations() {
           return {};
         },
@@ -7297,6 +7363,7 @@ describe("runWithSync", () => {
 
       const context2: SourceContext = {
         id: Symbol.for("@test/sync-dispose-shadow-multi-2"),
+        phase: "single-pass",
         getAnnotations() {
           return {};
         },
@@ -7337,6 +7404,7 @@ describe("runWithSync", () => {
       let disposed = false;
       const context: SourceContext = {
         id: Symbol.for("@test/sync-dispose-no-shadow"),
+        phase: "single-pass",
         getAnnotations() {
           return {};
         },
@@ -7407,6 +7475,7 @@ describe("runWithSync", () => {
 
       const earlyContext: SourceContext = {
         id: Symbol.for("@test/phase-merge-sync-early"),
+        phase: "single-pass",
         getAnnotations() {
           return { [sharedKey]: "phase1-early" };
         },
@@ -7414,7 +7483,7 @@ describe("runWithSync", () => {
 
       const lateDynamicContext: SourceContext = {
         id: Symbol.for("@test/phase-merge-sync-late"),
-        mode: "dynamic",
+        phase: "two-pass",
         getAnnotations(parsed?: unknown) {
           if (parsed == null) {
             return {};
@@ -7468,7 +7537,7 @@ describe("runWithSync", () => {
 
       const clearingContext: SourceContext = {
         id: Symbol.for("@test/phase-clear-sync-early"),
-        mode: "dynamic",
+        phase: "two-pass",
         getAnnotations(parsed?: unknown) {
           if (parsed == null) {
             return { [sharedKey]: "phase1-early" };
@@ -7479,7 +7548,7 @@ describe("runWithSync", () => {
 
       const fallbackContext: SourceContext = {
         id: Symbol.for("@test/phase-clear-sync-late"),
-        mode: "dynamic",
+        phase: "two-pass",
         getAnnotations(parsed?: unknown) {
           if (parsed == null) {
             return {};
@@ -7506,6 +7575,7 @@ describe("runWithSync", () => {
 
       const context: SourceContext = {
         id: syncKey,
+        phase: "two-pass",
         getAnnotations(_parsed?: unknown, options?: unknown) {
           receivedOptions = options;
           if (!_parsed) return {};
@@ -7536,6 +7606,7 @@ describe("runWithSync", () => {
 
       const context: SourceContext<{ help: string; programName: string }> = {
         id: key,
+        phase: "two-pass",
         getAnnotations(_parsed?: unknown, options?: unknown) {
           receivedOptions = options;
           return {};
@@ -7565,10 +7636,12 @@ describe("runWithSync", () => {
       const shared = Symbol.for("@test/dup-runWithSync");
       const ctx1: SourceContext = {
         id: shared,
+        phase: "single-pass",
         getAnnotations: () => ({ [shared]: "one" }),
       };
       const ctx2: SourceContext = {
         id: shared,
+        phase: "single-pass",
         getAnnotations: () => ({ [shared]: "two" }),
       };
 
@@ -7588,6 +7661,7 @@ describe("runWithAsync", () => {
     const asyncKey = Symbol.for("@test/async");
     const asyncContext: SourceContext = {
       id: asyncKey,
+      phase: "single-pass",
       async getAnnotations() {
         await new Promise((resolve) => setTimeout(resolve, 1));
         return { [asyncKey]: { value: "async-value" } };
@@ -7623,6 +7697,7 @@ describe("runWithAsync", () => {
 
     const context1: SourceContext = {
       id: key1,
+      phase: "single-pass",
       async getAnnotations() {
         await new Promise((resolve) => setTimeout(resolve, 1));
         return { [key1]: { value: "value1" } };
@@ -7631,6 +7706,7 @@ describe("runWithAsync", () => {
 
     const context2: SourceContext = {
       id: key2,
+      phase: "single-pass",
       async getAnnotations() {
         await new Promise((resolve) => setTimeout(resolve, 1));
         return { [key2]: { value: "value2" } };
@@ -9315,10 +9391,12 @@ describe("runWithAsync", () => {
       const shared = Symbol.for("@test/dup-runWithAsync");
       const ctx1: SourceContext = {
         id: shared,
+        phase: "single-pass",
         getAnnotations: () => ({ [shared]: "one" }),
       };
       const ctx2: SourceContext = {
         id: shared,
+        phase: "single-pass",
         getAnnotations: () => ({ [shared]: "two" }),
       };
 
@@ -9617,13 +9695,14 @@ describe("branch coverage: facade.ts edge cases", () => {
     assert.deepEqual(result, { name: "Alice" });
   });
 
-  it("runWith: dynamic context (hasDynamic) triggers two-phase, first pass succeeds", async () => {
+  it("runWith: two-pass context triggers phase 2 after a successful first pass", async () => {
     const dynKey = Symbol.for("@test/dyn-two-phase");
     let phase2Called = false;
     const dynamicContext: SourceContext = {
       id: dynKey,
+      phase: "two-pass",
       getAnnotations(parsed?: unknown) {
-        if (!parsed) return {}; // dynamic: no symbols → hasDynamic = true
+        if (!parsed) return {};
         phase2Called = true;
         return { [dynKey]: {} };
       },
@@ -9633,6 +9712,58 @@ describe("branch coverage: facade.ts edge cases", () => {
       args: ["hello"],
     });
     assert.deepEqual(result, { x: "hello" });
+    assert.ok(phase2Called, "phase 2 context should be called");
+  });
+
+  it("runWith: two-pass context refines non-empty phase-1 annotations", async () => {
+    const key = Symbol.for("@test/two-pass-refine-non-empty-async");
+    let phase2Called = false;
+
+    const parser: Parser<"sync", unknown, undefined> = {
+      $valueType: [] as unknown[],
+      $stateType: [] as undefined[],
+      $mode: "sync",
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(),
+      acceptingAnyToken: false,
+      initialState: undefined,
+      parse(context) {
+        return {
+          success: true as const,
+          next: context,
+          consumed: [],
+        };
+      },
+      complete(state) {
+        return {
+          success: true as const,
+          value: getAnnotations(state)?.[key] ?? null,
+        };
+      },
+      *suggest() {},
+      getDocFragments() {
+        return { fragments: [] };
+      },
+    };
+
+    const context: SourceContext = {
+      id: key,
+      phase: "two-pass",
+      getAnnotations(parsed?: unknown) {
+        if (parsed === undefined) {
+          return { [key]: { phase1: true } };
+        }
+        phase2Called = true;
+        return { [key]: { phase2: true } };
+      },
+    };
+
+    const result = await runWith(parser, "test", [context], {
+      args: [],
+    });
+
+    assert.deepEqual(result, { phase2: true });
     assert.ok(phase2Called, "phase 2 context should be called");
   });
 
@@ -9676,7 +9807,7 @@ describe("branch coverage: facade.ts edge cases", () => {
       ) => string | undefined;
     }> = {
       id: tokenKey,
-      mode: "dynamic",
+      phase: "two-pass",
       getAnnotations(
         parsed: { readonly config: string } | undefined,
         options?: {
@@ -9752,7 +9883,7 @@ describe("branch coverage: facade.ts edge cases", () => {
       ) => string | undefined;
     }> = {
       id: tokenKey,
-      mode: "dynamic",
+      phase: "two-pass",
       getAnnotations(
         parsed: { readonly config: string } | undefined,
         options?: {
@@ -9833,7 +9964,7 @@ describe("branch coverage: facade.ts edge cases", () => {
       ) => string | undefined;
     }> = {
       id: tokenKey,
-      mode: "dynamic",
+      phase: "two-pass",
       getAnnotations(
         parsed: { readonly config: string } | undefined,
         options?: {
@@ -9959,7 +10090,7 @@ describe("branch coverage: facade.ts edge cases", () => {
         ) => string | undefined;
       }> = {
         id: tokenKey,
-        mode: "dynamic",
+        phase: "two-pass",
         getAnnotations(
           parsed: { readonly config: string } | undefined,
           options?: {
@@ -10085,7 +10216,7 @@ describe("branch coverage: facade.ts edge cases", () => {
       ) => string | undefined;
     }> = {
       id: tokenKey,
-      mode: "dynamic",
+      phase: "two-pass",
       getAnnotations(
         parsed: { readonly config: string } | undefined,
         options?: {
@@ -10162,7 +10293,7 @@ describe("branch coverage: facade.ts edge cases", () => {
 
     const dynamicContext: SourceContext = {
       id: tokenKey,
-      mode: "dynamic",
+      phase: "two-pass",
       getAnnotations(parsed) {
         if (parsed == null) return {};
         phase2Called = true;
@@ -10227,7 +10358,7 @@ describe("branch coverage: facade.ts edge cases", () => {
 
     const dynamicContext: SourceContext = {
       id: tokenKey,
-      mode: "dynamic",
+      phase: "two-pass",
       getAnnotations(parsed) {
         if (parsed == null) return {};
         phase2Called = true;
@@ -10284,7 +10415,7 @@ describe("branch coverage: facade.ts edge cases", () => {
       ) => string | undefined;
     }> = {
       id: tokenKey,
-      mode: "dynamic",
+      phase: "two-pass",
       getAnnotations(
         parsed: { readonly config: string } | undefined,
         options?: {
@@ -10359,7 +10490,7 @@ describe("branch coverage: facade.ts edge cases", () => {
       ) => string | undefined;
     }> = {
       id: tokenKey,
-      mode: "dynamic",
+      phase: "two-pass",
       getAnnotations(
         parsed: { readonly config: string } | undefined,
         options?: {
@@ -10400,7 +10531,7 @@ describe("branch coverage: facade.ts edge cases", () => {
 
     const markerContext: SourceContext = {
       id: markerKey,
-      mode: "static",
+      phase: "single-pass",
       getAnnotations() {
         return { [markerKey]: true };
       },
@@ -10481,7 +10612,7 @@ describe("branch coverage: facade.ts edge cases", () => {
       ) => string | undefined;
     }> = {
       id: tokenKey,
-      mode: "dynamic",
+      phase: "two-pass",
       getAnnotations(
         parsed: { readonly configs: readonly string[] } | undefined,
         options?: {
@@ -10523,6 +10654,7 @@ describe("branch coverage: facade.ts edge cases", () => {
     const dynKey = Symbol.for("@test/dyn-firstfail");
     const dynamicContext: SourceContext = {
       id: dynKey,
+      phase: "two-pass",
       getAnnotations(parsed?: unknown) {
         if (!parsed) return {};
         return { [dynKey]: {} };
@@ -10545,6 +10677,7 @@ describe("branch coverage: facade.ts edge cases", () => {
     const dynKey = Symbol.for("@test/dyn-async-parser2");
     const dynamicContext: SourceContext = {
       id: dynKey,
+      phase: "two-pass",
       getAnnotations(parsed?: unknown) {
         if (!parsed) return {}; // dynamic (no symbols → hasDynamic = true)
         return { [dynKey]: {} };
@@ -10603,6 +10736,7 @@ describe("branch coverage: facade.ts edge cases", () => {
     const dynKey = Symbol.for("@test/dyn-async-fail2");
     const dynamicContext: SourceContext = {
       id: dynKey,
+      phase: "two-pass",
       getAnnotations(parsed?: unknown) {
         if (!parsed) return {}; // dynamic
         return { [dynKey]: {} };
@@ -10671,6 +10805,7 @@ describe("branch coverage: facade.ts edge cases", () => {
     let contextCalled = false;
     const context: SourceContext = {
       id: dynKey,
+      phase: "single-pass",
       getAnnotations() {
         contextCalled = true;
         return { [dynKey]: {} };
@@ -10697,6 +10832,7 @@ describe("branch coverage: facade.ts edge cases", () => {
     const dynKey = Symbol.for("@test/sync-two-phase-fail");
     const context: SourceContext = {
       id: dynKey,
+      phase: "two-pass",
       getAnnotations(parsed?: unknown) {
         if (!parsed) return {}; // dynamic
         return { [dynKey]: {} };
@@ -10721,6 +10857,7 @@ describe("branch coverage: facade.ts edge cases", () => {
     let staleParserReused = false;
     const context: SourceContext = {
       id: dynKey,
+      phase: "two-pass",
       getAnnotations(parsed?: unknown) {
         if (!parsed) return {};
         return { [dynKey]: {} };
@@ -10769,6 +10906,7 @@ describe("branch coverage: facade.ts edge cases", () => {
     const dynKey = Symbol.for("@test/sync-two-phase-throw");
     const context: SourceContext = {
       id: dynKey,
+      phase: "two-pass",
       getAnnotations(parsed?: unknown) {
         if (!parsed) return {}; // dynamic
         return { [dynKey]: {} };
@@ -10785,6 +10923,148 @@ describe("branch coverage: facade.ts edge cases", () => {
       args: ["hi"],
     });
     assert.deepEqual(result, { x: "hi" });
+  });
+
+  it("runWithSync: two-pass context refines non-empty phase-1 annotations", () => {
+    const key = Symbol.for("@test/two-pass-refine-non-empty-sync");
+    let phase2Called = false;
+
+    const parser: Parser<"sync", unknown, undefined> = {
+      $valueType: [] as unknown[],
+      $stateType: [] as undefined[],
+      $mode: "sync",
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(),
+      acceptingAnyToken: false,
+      initialState: undefined,
+      parse(context) {
+        return {
+          success: true as const,
+          next: context,
+          consumed: [],
+        };
+      },
+      complete(state) {
+        return {
+          success: true as const,
+          value: getAnnotations(state)?.[key] ?? null,
+        };
+      },
+      *suggest() {},
+      getDocFragments() {
+        return { fragments: [] };
+      },
+    };
+
+    const context: SourceContext = {
+      id: key,
+      phase: "two-pass",
+      getAnnotations(parsed?: unknown) {
+        if (parsed === undefined) {
+          return { [key]: { phase1: true } };
+        }
+        phase2Called = true;
+        return { [key]: { phase2: true } };
+      },
+    };
+
+    const result = runWithSync(parser, "test", [context], {
+      args: [],
+    });
+
+    assert.deepEqual(result, { phase2: true });
+    assert.ok(phase2Called, "phase 2 context should be called");
+  });
+
+  it("runWithSync: should reject contexts without explicit phase", () => {
+    const key = Symbol.for("@test/missing-phase-sync");
+    const parser = object({
+      name: withDefault(option("--name", string()), "x"),
+    });
+    const context = {
+      id: key,
+      getAnnotations() {
+        return {};
+      },
+    } as unknown as SourceContext;
+
+    assert.throws(
+      () => runWithSync(parser, "test", [context], { args: [] }),
+      {
+        name: "TypeError",
+        message: `Context ${String(key)} must declare phase as ` +
+          '"single-pass" or "two-pass".',
+      },
+    );
+  });
+
+  it("runWithSync: should reject contexts with invalid phase", () => {
+    const key = Symbol.for("@test/invalid-phase-sync");
+    const parser = object({
+      name: withDefault(option("--name", string()), "x"),
+    });
+    const context = {
+      id: key,
+      phase: "invalid",
+      getAnnotations() {
+        return {};
+      },
+    } as unknown as SourceContext;
+
+    assert.throws(
+      () => runWithSync(parser, "test", [context], { args: [] }),
+      {
+        name: "TypeError",
+        message: `Context ${String(key)} must declare phase as ` +
+          '"single-pass" or "two-pass".',
+      },
+    );
+  });
+
+  it("runWith: should reject contexts without explicit phase", async () => {
+    const key = Symbol.for("@test/missing-phase-async");
+    const parser = object({
+      name: withDefault(option("--name", string()), "x"),
+    });
+    const context = {
+      id: key,
+      getAnnotations() {
+        return {};
+      },
+    } as unknown as SourceContext;
+
+    await assert.rejects(
+      () => runWith(parser, "test", [context], { args: [] }),
+      {
+        name: "TypeError",
+        message: `Context ${String(key)} must declare phase as ` +
+          '"single-pass" or "two-pass".',
+      },
+    );
+  });
+
+  it("runWith: should reject contexts with invalid phase", async () => {
+    const key = Symbol.for("@test/invalid-phase-async");
+    const parser = object({
+      name: withDefault(option("--name", string()), "x"),
+    });
+    const context = {
+      id: key,
+      phase: "invalid",
+      getAnnotations() {
+        return {};
+      },
+    } as unknown as SourceContext;
+
+    await assert.rejects(
+      () => runWith(parser, "test", [context], { args: [] }),
+      {
+        name: "TypeError",
+        message: `Context ${String(key)} must declare phase as ` +
+          '"single-pass" or "two-pass".',
+      },
+    );
   });
 
   it("runWithAsync wraps runWith and returns Promise", async () => {
@@ -10904,6 +11184,7 @@ describe("branch coverage: facade.ts edge cases", () => {
   it("runWith handles first-pass throw in two-phase flow", async () => {
     const dynamicContext: SourceContext = {
       id: Symbol.for("@test/dyn-throw-in-first-pass"),
+      phase: "two-pass",
       getAnnotations(parsed?: unknown) {
         if (!parsed) return {};
         return { [Symbol.for("@test/dyn-throw-in-first-pass")]: {} };
@@ -10949,6 +11230,7 @@ describe("branch coverage: facade.ts edge cases", () => {
   it("runWithSync handles first-pass throw in two-phase flow", () => {
     const dynamicContext: SourceContext = {
       id: Symbol.for("@test/sync-dyn-throw-in-first-pass"),
+      phase: "two-pass",
       getAnnotations(parsed?: unknown) {
         if (!parsed) return {};
         return { [Symbol.for("@test/sync-dyn-throw-in-first-pass")]: {} };
@@ -11107,7 +11389,7 @@ describe("branch coverage: facade.ts edge cases", () => {
     assert.deepEqual(result, { name: "Alice" });
   });
 
-  it("runWith uses async fast-path without contexts and with static contexts", async () => {
+  it("runWith uses async fast-path without contexts and with single-pass contexts", async () => {
     const asyncParser: Parser<"async", string, { value: string | null }> = {
       $mode: "async",
       $valueType: [] as readonly string[],
@@ -11157,6 +11439,7 @@ describe("branch coverage: facade.ts edge cases", () => {
 
     const staticContext: SourceContext = {
       id: Symbol.for("@test/facade-static-fastpath"),
+      phase: "single-pass",
       getAnnotations() {
         return { [Symbol.for("@test/facade-static-fastpath")]: {} };
       },
@@ -11803,6 +12086,7 @@ describe("runWithSync async parser rejection", () => {
     const parser = object({ name: argument(asyncVp) });
     const ctx: SourceContext = {
       id: Symbol.for("@test/async-reject"),
+      phase: "single-pass",
       getAnnotations() {
         return {};
       },

--- a/packages/core/src/facade.test.ts
+++ b/packages/core/src/facade.test.ts
@@ -9718,10 +9718,14 @@ describe("branch coverage: facade.ts edge cases", () => {
   it("runWith: two-pass context refines non-empty phase-1 annotations", async () => {
     const key = Symbol.for("@test/two-pass-refine-non-empty-async");
     let phase2Called = false;
+    type AnnotationValue = { readonly phase1?: true; readonly phase2?: true };
+    const isAnnotationValue = (
+      value: unknown,
+    ): value is AnnotationValue => value != null && typeof value === "object";
 
-    const parser: Parser<"sync", unknown, undefined> = {
-      $valueType: [] as unknown[],
-      $stateType: [] as undefined[],
+    const parser: Parser<"sync", AnnotationValue | null, undefined> = {
+      $valueType: [] as readonly (AnnotationValue | null)[],
+      $stateType: [] as readonly undefined[],
       $mode: "sync",
       priority: 0,
       usage: [],
@@ -9736,9 +9740,10 @@ describe("branch coverage: facade.ts edge cases", () => {
         };
       },
       complete(state) {
+        const value = getAnnotations(state)?.[key];
         return {
           success: true as const,
-          value: getAnnotations(state)?.[key] ?? null,
+          value: isAnnotationValue(value) ? value : null,
         };
       },
       *suggest() {},
@@ -10928,10 +10933,14 @@ describe("branch coverage: facade.ts edge cases", () => {
   it("runWithSync: two-pass context refines non-empty phase-1 annotations", () => {
     const key = Symbol.for("@test/two-pass-refine-non-empty-sync");
     let phase2Called = false;
+    type AnnotationValue = { readonly phase1?: true; readonly phase2?: true };
+    const isAnnotationValue = (
+      value: unknown,
+    ): value is AnnotationValue => value != null && typeof value === "object";
 
-    const parser: Parser<"sync", unknown, undefined> = {
-      $valueType: [] as unknown[],
-      $stateType: [] as undefined[],
+    const parser: Parser<"sync", AnnotationValue | null, undefined> = {
+      $valueType: [] as readonly (AnnotationValue | null)[],
+      $stateType: [] as readonly undefined[],
       $mode: "sync",
       priority: 0,
       usage: [],
@@ -10946,9 +10955,10 @@ describe("branch coverage: facade.ts edge cases", () => {
         };
       },
       complete(state) {
+        const value = getAnnotations(state)?.[key];
         return {
           success: true as const,
-          value: getAnnotations(state)?.[key] ?? null,
+          value: isAnnotationValue(value) ? value : null,
         };
       },
       *suggest() {},
@@ -10987,10 +10997,10 @@ describe("branch coverage: facade.ts edge cases", () => {
       getAnnotations() {
         return {};
       },
-    } as unknown as SourceContext;
+    };
 
     assert.throws(
-      () => runWithSync(parser, "test", [context], { args: [] }),
+      () => runWithSync(parser, "test", [context as never], { args: [] }),
       {
         name: "TypeError",
         message: `Context ${String(key)} must declare phase as ` +
@@ -11010,10 +11020,10 @@ describe("branch coverage: facade.ts edge cases", () => {
       getAnnotations() {
         return {};
       },
-    } as unknown as SourceContext;
+    };
 
     assert.throws(
-      () => runWithSync(parser, "test", [context], { args: [] }),
+      () => runWithSync(parser, "test", [context as never], { args: [] }),
       {
         name: "TypeError",
         message: `Context ${String(key)} must declare phase as ` +
@@ -11032,10 +11042,10 @@ describe("branch coverage: facade.ts edge cases", () => {
       getAnnotations() {
         return {};
       },
-    } as unknown as SourceContext;
+    };
 
     await assert.rejects(
-      () => runWith(parser, "test", [context], { args: [] }),
+      () => runWith(parser, "test", [context as never], { args: [] }),
       {
         name: "TypeError",
         message: `Context ${String(key)} must declare phase as ` +
@@ -11055,10 +11065,10 @@ describe("branch coverage: facade.ts edge cases", () => {
       getAnnotations() {
         return {};
       },
-    } as unknown as SourceContext;
+    };
 
     await assert.rejects(
-      () => runWith(parser, "test", [context], { args: [] }),
+      () => runWith(parser, "test", [context as never], { args: [] }),
       {
         name: "TypeError",
         message: `Context ${String(key)} must declare phase as ` +

--- a/packages/core/src/facade.test.ts
+++ b/packages/core/src/facade.test.ts
@@ -6592,7 +6592,7 @@ describe("runWith", () => {
         phase: "two-pass",
         getAnnotations(parsed?: unknown, options?: unknown) {
           receivedOptionsPerCall.push(options);
-          if (!parsed) return {};
+          if (parsed === undefined) return {};
           return { [dynamicKey]: { value: "loaded" } };
         },
       };
@@ -6929,7 +6929,7 @@ describe("runWithSync", () => {
       id: mixedKey,
       phase: "two-pass",
       getAnnotations(parsed?: unknown) {
-        if (!parsed) return {}; // sync (empty → dynamic)
+        if (parsed === undefined) return {}; // sync (empty → dynamic)
         return Promise.resolve({ [mixedKey]: { value: "loaded" } });
       },
     };
@@ -9708,7 +9708,7 @@ describe("branch coverage: facade.ts edge cases", () => {
       id: dynKey,
       phase: "two-pass",
       getAnnotations(parsed?: unknown) {
-        if (!parsed) return {};
+        if (parsed === undefined) return {};
         phase2Called = true;
         return { [dynKey]: {} };
       },
@@ -10667,7 +10667,7 @@ describe("branch coverage: facade.ts edge cases", () => {
       id: dynKey,
       phase: "two-pass",
       getAnnotations(parsed?: unknown) {
-        if (!parsed) return {};
+        if (parsed === undefined) return {};
         return { [dynKey]: {} };
       },
     };
@@ -10690,7 +10690,7 @@ describe("branch coverage: facade.ts edge cases", () => {
       id: dynKey,
       phase: "two-pass",
       getAnnotations(parsed?: unknown) {
-        if (!parsed) return {}; // dynamic (no symbols → hasDynamic = true)
+        if (parsed === undefined) return {}; // dynamic (no symbols → hasDynamic = true)
         return { [dynKey]: {} };
       },
     };
@@ -10749,7 +10749,7 @@ describe("branch coverage: facade.ts edge cases", () => {
       id: dynKey,
       phase: "two-pass",
       getAnnotations(parsed?: unknown) {
-        if (!parsed) return {}; // dynamic
+        if (parsed === undefined) return {}; // dynamic
         return { [dynKey]: {} };
       },
     };
@@ -10845,7 +10845,7 @@ describe("branch coverage: facade.ts edge cases", () => {
       id: dynKey,
       phase: "two-pass",
       getAnnotations(parsed?: unknown) {
-        if (!parsed) return {}; // dynamic
+        if (parsed === undefined) return {}; // dynamic
         return { [dynKey]: {} };
       },
     };
@@ -10870,7 +10870,7 @@ describe("branch coverage: facade.ts edge cases", () => {
       id: dynKey,
       phase: "two-pass",
       getAnnotations(parsed?: unknown) {
-        if (!parsed) return {};
+        if (parsed === undefined) return {};
         return { [dynKey]: {} };
       },
     };
@@ -10919,7 +10919,7 @@ describe("branch coverage: facade.ts edge cases", () => {
       id: dynKey,
       phase: "two-pass",
       getAnnotations(parsed?: unknown) {
-        if (!parsed) return {}; // dynamic
+        if (parsed === undefined) return {}; // dynamic
         return { [dynKey]: {} };
       },
     };
@@ -11202,7 +11202,7 @@ describe("branch coverage: facade.ts edge cases", () => {
       id: Symbol.for("@test/dyn-throw-in-first-pass"),
       phase: "two-pass",
       getAnnotations(parsed?: unknown) {
-        if (!parsed) return {};
+        if (parsed === undefined) return {};
         return { [Symbol.for("@test/dyn-throw-in-first-pass")]: {} };
       },
     };
@@ -11248,7 +11248,7 @@ describe("branch coverage: facade.ts edge cases", () => {
       id: Symbol.for("@test/sync-dyn-throw-in-first-pass"),
       phase: "two-pass",
       getAnnotations(parsed?: unknown) {
-        if (!parsed) return {};
+        if (parsed === undefined) return {};
         return { [Symbol.for("@test/sync-dyn-throw-in-first-pass")]: {} };
       },
     };

--- a/packages/core/src/facade.test.ts
+++ b/packages/core/src/facade.test.ts
@@ -5577,12 +5577,14 @@ describe("runWith", () => {
   describe("two-pass contexts", () => {
     it("should handle a two-pass context with two-phase parsing", async () => {
       const configKey = Symbol.for("@test/config");
+      let phase2Called = false;
 
       const dynamicContext: SourceContext = {
         id: configKey,
         phase: "two-pass",
         getAnnotations(parsed?: unknown) {
-          if (!parsed) return {};
+          if (parsed === undefined) return {};
+          phase2Called = true;
           const result = parsed as { config?: string };
           if (!result.config) return {};
           // Simulate loaded config
@@ -5602,6 +5604,7 @@ describe("runWith", () => {
       // Parser should complete successfully
       assert.equal(result.config, "test.json");
       assert.equal(result.host, "default");
+      assert.ok(phase2Called, "phase 2 context should be called");
     });
 
     it("preserves plain parsed object identity when no scrub is needed", async () => {
@@ -5648,6 +5651,7 @@ describe("runWith", () => {
     it("should handle mixed single-pass and two-pass contexts", async () => {
       const envKey = Symbol.for("@test/env");
       const configKey = Symbol.for("@test/config");
+      let phase2Called = false;
 
       const staticContext: SourceContext = {
         id: envKey,
@@ -5661,7 +5665,8 @@ describe("runWith", () => {
         id: configKey,
         phase: "two-pass",
         getAnnotations(parsed?: unknown) {
-          if (!parsed) return {};
+          if (parsed === undefined) return {};
+          phase2Called = true;
           return { [configKey]: { host: "config-host" } };
         },
       };
@@ -5678,6 +5683,7 @@ describe("runWith", () => {
       );
 
       assert.deepEqual(result, { host: "default" });
+      assert.ok(phase2Called, "phase 2 context should be called");
     });
 
     it("should handle async context", async () => {

--- a/packages/core/src/facade.ts
+++ b/packages/core/src/facade.ts
@@ -2691,57 +2691,81 @@ function mergeAnnotations(
   return result;
 }
 
+type CollectedPhase1Annotations = {
+  readonly annotations: Annotations;
+  readonly needsTwoPhase: boolean;
+  readonly snapshots: readonly Annotations[];
+};
+
+function validateContextPhases(
+  contexts: readonly SourceContext<unknown>[],
+): void {
+  for (const context of contexts) {
+    const phase = (context as { readonly phase?: unknown }).phase;
+    if (phase !== "single-pass" && phase !== "two-pass") {
+      throw new TypeError(
+        `Context ${String(context.id)} must declare phase as ` +
+          '"single-pass" or "two-pass".',
+      );
+    }
+  }
+}
+
 /**
  * Collects phase 1 annotations from all contexts and determines whether
  * two-phase parsing is needed.
  *
  * @param contexts Source contexts to collect annotations from.
  * @param options Optional context-required options to pass to each context.
- * @returns Promise with merged annotations and dynamic-context hint.
+ * @returns Promise with merged annotations, per-context snapshots, and a
+ * two-phase hint.
  */
 async function collectPhase1Annotations(
   contexts: readonly SourceContext<unknown>[],
   options?: unknown,
-): Promise<
-  {
-    readonly annotations: Annotations;
-    readonly hasDynamic: boolean;
-  }
-> {
+): Promise<CollectedPhase1Annotations> {
   const annotationsList: Annotations[] = [];
-  let hasDynamic = false;
+  const snapshots: Annotations[] = [];
+  let needsTwoPhase = false;
 
   for (const context of contexts) {
     const result = context.getAnnotations(undefined, options);
-    hasDynamic ||= needsTwoPhaseContext(context, result);
     const annotations = result instanceof Promise ? await result : result;
     const internalAnnotations = context.getInternalAnnotations?.(
       undefined,
       annotations,
     );
-    annotationsList.push(
-      internalAnnotations == null
-        ? annotations
-        : mergeAnnotations([annotations, internalAnnotations]),
-    );
+    const snapshot = internalAnnotations == null
+      ? annotations
+      : mergeAnnotations([annotations, internalAnnotations]);
+    annotationsList.push(snapshot);
+    snapshots.push(snapshot);
+    needsTwoPhase ||= context.phase === "two-pass";
   }
 
   return {
     annotations: mergeAnnotations(annotationsList),
-    hasDynamic,
+    needsTwoPhase,
+    snapshots,
   };
 }
 
 /**
- * Collects annotations from all contexts.
+ * Collects final annotations from all contexts.
+ *
+ * `single-pass` contexts reuse their phase-1 snapshot. `two-pass` contexts
+ * are recollected with the parsed value and replace their own phase-1
+ * snapshot in the final merge.
  *
  * @param contexts Source contexts to collect annotations from.
+ * @param phase1Snapshots Per-context snapshots collected during phase 1.
  * @param parsed Optional parsed result from a previous parse pass.
  * @param options Optional context-required options to pass to each context.
  * @returns Promise that resolves to merged annotations.
  */
-async function collectAnnotations(
+async function collectFinalAnnotations(
   contexts: readonly SourceContext<unknown>[],
+  phase1Snapshots: readonly Annotations[],
   parsed?: unknown,
   options?: unknown,
   deferred?: true,
@@ -2754,7 +2778,13 @@ async function collectAnnotations(
     deferredKeys,
   );
 
-  for (const context of contexts) {
+  for (let index = 0; index < contexts.length; index++) {
+    const context = contexts[index];
+    if (context.phase === "single-pass") {
+      annotationsList.push(phase1Snapshots[index]);
+      continue;
+    }
+
     const mergedAnnotations = await withPreparedParsedForContext(
       context,
       preparedParsed,
@@ -2784,18 +2814,16 @@ async function collectAnnotations(
  *
  * @param contexts Source contexts to collect annotations from.
  * @param options Optional context-required options to pass to each context.
- * @returns Merged annotations with dynamic-context hint.
+ * @returns Merged annotations, per-context snapshots, and a two-phase hint.
  * @throws Error if any context returns a Promise.
  */
 function collectPhase1AnnotationsSync(
   contexts: readonly SourceContext<unknown>[],
   options?: unknown,
-): {
-  readonly annotations: Annotations;
-  readonly hasDynamic: boolean;
-} {
+): CollectedPhase1Annotations {
   const annotationsList: Annotations[] = [];
-  let hasDynamic = false;
+  const snapshots: Annotations[] = [];
+  let needsTwoPhase = false;
 
   for (const context of contexts) {
     const result = context.getAnnotations(undefined, options);
@@ -2805,57 +2833,42 @@ function collectPhase1AnnotationsSync(
           "Use runWith() or runWithAsync() for async contexts.",
       );
     }
-    hasDynamic ||= needsTwoPhaseContext(context, result);
     const internalAnnotations = context.getInternalAnnotations?.(
       undefined,
       result,
     );
-    annotationsList.push(
-      internalAnnotations == null
-        ? result
-        : mergeAnnotations([result, internalAnnotations]),
-    );
+    const snapshot = internalAnnotations == null
+      ? result
+      : mergeAnnotations([result, internalAnnotations]);
+    annotationsList.push(snapshot);
+    snapshots.push(snapshot);
+    needsTwoPhase ||= context.phase === "two-pass";
   }
 
   return {
     annotations: mergeAnnotations(annotationsList),
-    hasDynamic,
+    needsTwoPhase,
+    snapshots,
   };
 }
 
 /**
- * Determines whether a context requires a second parse pass.
+ * Collects final annotations from all contexts synchronously.
  *
- * Explicit `mode` declarations take precedence over legacy heuristics so
- * static contexts are not forced into two-phase parsing when they return
- * empty annotations or a Promise.
- */
-function needsTwoPhaseContext(
-  context: SourceContext<unknown>,
-  result: Promise<Annotations> | Annotations,
-): boolean {
-  if (context.mode !== undefined) {
-    return context.mode === "dynamic";
-  }
-
-  if (result instanceof Promise) {
-    return true;
-  }
-
-  return Object.getOwnPropertySymbols(result).length === 0;
-}
-
-/**
- * Collects annotations from all contexts synchronously.
+ * `single-pass` contexts reuse their phase-1 snapshot. `two-pass` contexts
+ * are recollected with the parsed value and replace their own phase-1
+ * snapshot in the final merge.
  *
  * @param contexts Source contexts to collect annotations from.
+ * @param phase1Snapshots Per-context snapshots collected during phase 1.
  * @param parsed Optional parsed result from a previous parse pass.
  * @param options Optional context-required options to pass to each context.
  * @returns Merged annotations.
  * @throws Error if any context returns a Promise.
  */
-function collectAnnotationsSync(
+function collectFinalAnnotationsSync(
   contexts: readonly SourceContext<unknown>[],
+  phase1Snapshots: readonly Annotations[],
   parsed?: unknown,
   options?: unknown,
   deferred?: true,
@@ -2868,7 +2881,13 @@ function collectAnnotationsSync(
     deferredKeys,
   );
 
-  for (const context of contexts) {
+  for (let index = 0; index < contexts.length; index++) {
+    const context = contexts[index];
+    if (context.phase === "single-pass") {
+      annotationsList.push(phase1Snapshots[index]);
+      continue;
+    }
+
     const mergedAnnotations = withPreparedParsedForContext(
       context,
       preparedParsed,
@@ -3105,6 +3124,7 @@ async function runWithBody<
   options: RunWithOptions<THelp, TError>,
 ): Promise<InferValue<TParser>> {
   validateContextIds(contexts);
+  validateContextPhases(contexts);
 
   // Early exit: skip context processing for help/version/completion
   if (needsEarlyExit(args, options)) {
@@ -3122,11 +3142,12 @@ async function runWithBody<
   const ctxOptions = options.contextOptions;
   const {
     annotations: phase1Annotations,
-    hasDynamic: needsTwoPhase,
+    needsTwoPhase,
+    snapshots: phase1Snapshots,
   } = await collectPhase1Annotations(contexts, ctxOptions);
 
   if (!needsTwoPhase) {
-    // All static contexts - single pass is sufficient
+    // All contexts are single-pass.
     // Inject annotations into the parser's initial state
     const augmentedParser = injectAnnotationsIntoParser(
       parser,
@@ -3148,7 +3169,7 @@ async function runWithBody<
     );
   }
 
-  // Two-phase parsing for dynamic contexts
+  // Two-phase parsing for two-pass contexts.
   // First pass: parse with Phase 1 annotations to get initial result
   const augmentedParser1 = injectAnnotationsIntoParser(
     parser,
@@ -3191,8 +3212,9 @@ async function runWithBody<
   }
 
   // Phase 2: Collect annotations with parsed result
-  const { annotations: finalAnnotations } = await collectAnnotations(
+  const { annotations: finalAnnotations } = await collectFinalAnnotations(
     contexts,
+    phase1Snapshots,
     firstPassSeed.value,
     ctxOptions,
     firstPassSeed.deferred,
@@ -3220,28 +3242,28 @@ async function runWithBody<
 /**
  * Runs a parser with multiple source contexts.
  *
- * This function automatically handles static and dynamic contexts with proper
- * priority. Earlier contexts in the array override later ones.
+ * This function automatically handles single-pass and two-pass contexts with
+ * proper priority. Earlier contexts in the array override later ones.
  *
  * The function uses a smart two-phase approach:
  *
- * 1. *Phase 1*: Collect annotations from all contexts (static contexts return
- *    their data, dynamic contexts may return empty).
+ * 1. *Phase 1*: Collect annotations from all contexts.
  * 2. *First parse*: Parse with Phase 1 annotations. If that pass finishes
  *    successfully, its value becomes the phase-two input. If the parser
  *    reaches a usable intermediate state but still does not complete
  *    successfully, the runner extracts a best-effort seed from that state
  *    instead.
- * 3. *Phase 2*: Call `getAnnotations(parsed)` on all contexts with the first
- *    pass value. Deferred or otherwise unresolved fields in `parsed` may be
- *    `undefined`. Each context's phase-two return value replaces its own
- *    phase-one contribution for the final parse, so returning `{}` clears any
- *    annotations that context provided during phase 1.
+ * 3. *Phase 2*: Call `getAnnotations(parsed)` on all two-pass contexts with
+ *    the first pass value. Deferred or otherwise unresolved fields in
+ *    `parsed` may be `undefined`. Each two-pass context's phase-two return
+ *    value replaces its own phase-one contribution for the final parse, so
+ *    returning `{}` clears any annotations that context provided during
+ *    phase 1. Single-pass contexts reuse their phase-one snapshot.
  * 4. *Second parse*: Parse again with the merged phase-two annotations.
  *
- * If all contexts are static (no dynamic contexts), the second parse is
- * skipped for optimization. Phase 2 is also skipped when the first pass does
- * not yield any usable seed at all.
+ * If all contexts are single-pass, the second parse is skipped for
+ * optimization. Phase 2 is also skipped when the first pass does not yield
+ * any usable seed at all.
  *
  * @template TParser The parser type.
  * @template THelp Return type when help is shown.
@@ -3253,6 +3275,8 @@ async function runWithBody<
  * @returns Promise that resolves to the parsed result.
  * @throws {TypeError} If two or more contexts share the same
  * {@link SourceContext.id}.
+ * @throws {TypeError} If any context omits `phase` or declares an invalid
+ * phase value.
  * @throws {SuppressedError} If the runner throws and a context's disposal
  * also throws.  The original error is available via `.suppressed` and the
  * disposal error via `.error`.
@@ -3265,6 +3289,7 @@ async function runWithBody<
  *
  * const envContext: SourceContext = {
  *   id: Symbol.for("@myapp/env"),
+ *   phase: "single-pass",
  *   getAnnotations() {
  *     return { [Symbol.for("@myapp/env")]: process.env };
  *   }
@@ -3351,6 +3376,7 @@ function runWithSyncBody<
   options: RunWithOptions<THelp, TError>,
 ): InferValue<TParser> {
   validateContextIds(contexts);
+  validateContextPhases(contexts);
 
   // Early exit: skip context processing for help/version/completion
   if (needsEarlyExit(args, options)) {
@@ -3361,11 +3387,12 @@ function runWithSyncBody<
   const ctxOptions = options.contextOptions;
   const {
     annotations: phase1Annotations,
-    hasDynamic: needsTwoPhase,
+    needsTwoPhase,
+    snapshots: phase1Snapshots,
   } = collectPhase1AnnotationsSync(contexts, ctxOptions);
 
   if (!needsTwoPhase) {
-    // All static contexts - single pass is sufficient
+    // All contexts are single-pass.
     const augmentedParser = injectAnnotationsIntoParser(
       parser,
       phase1Annotations,
@@ -3373,7 +3400,7 @@ function runWithSyncBody<
     return runParser(augmentedParser, programName, args, options);
   }
 
-  // Two-phase parsing for dynamic contexts
+  // Two-phase parsing for two-pass contexts.
   // First pass: parse with Phase 1 annotations
   const augmentedParser1 = injectAnnotationsIntoParser(
     parser,
@@ -3390,8 +3417,9 @@ function runWithSyncBody<
   }
 
   // Phase 2: Collect annotations with parsed result
-  const { annotations: finalAnnotations } = collectAnnotationsSync(
+  const { annotations: finalAnnotations } = collectFinalAnnotationsSync(
     contexts,
+    phase1Snapshots,
     firstPassSeed.value,
     ctxOptions,
     firstPassSeed.deferred,
@@ -3412,10 +3440,10 @@ function runWithSyncBody<
  *
  * This is the sync-only variant of {@link runWith}. All contexts must return
  * annotations synchronously (not Promises). It uses the same two-phase
- * best-effort seed extraction as {@link runWith} when dynamic contexts are
- * present. In two-phase runs, each context's phase-two return value replaces
- * that context's phase-one contribution for the final parse, so returning `{}`
- * clears any annotations that context provided during phase 1.
+ * best-effort seed extraction as {@link runWith} when two-pass contexts are
+ * present. In two-phase runs, each two-pass context's phase-two return value
+ * replaces that context's phase-one contribution for the final parse, so
+ * returning `{}` clears any annotations that context provided during phase 1.
  *
  * @template TParser The sync parser type.
  * @template THelp Return type when help is shown.
@@ -3429,6 +3457,8 @@ function runWithSyncBody<
  * {@link runWith} or {@link runWithAsync} for async parsers.
  * @throws {TypeError} If two or more contexts share the same
  * {@link SourceContext.id}.
+ * @throws {TypeError} If any context omits `phase` or declares an invalid
+ * phase value.
  * @throws {Error} If any context returns a Promise or if a context's
  * `[Symbol.asyncDispose]` returns a Promise.
  * @throws {SuppressedError} If the runner throws and a context's disposal

--- a/packages/core/src/facade.ts
+++ b/packages/core/src/facade.ts
@@ -2725,8 +2725,7 @@ async function collectPhase1Annotations(
   options?: unknown,
 ): Promise<CollectedPhase1Annotations> {
   const annotationsList: Annotations[] = [];
-  const snapshots: Annotations[] = [];
-  let needsTwoPhase = false;
+  let snapshots: Annotations[] | undefined;
 
   for (const context of contexts) {
     const result = context.getAnnotations(undefined, options);
@@ -2739,14 +2738,17 @@ async function collectPhase1Annotations(
       ? annotations
       : mergeAnnotations([annotations, internalAnnotations]);
     annotationsList.push(snapshot);
-    snapshots.push(snapshot);
-    needsTwoPhase ||= context.phase === "two-pass";
+    if (snapshots != null) {
+      snapshots.push(snapshot);
+    } else if (context.phase === "two-pass") {
+      snapshots = [...annotationsList];
+    }
   }
 
   return {
     annotations: mergeAnnotations(annotationsList),
-    needsTwoPhase,
-    snapshots,
+    needsTwoPhase: snapshots != null,
+    snapshots: snapshots ?? [],
   };
 }
 
@@ -2822,8 +2824,7 @@ function collectPhase1AnnotationsSync(
   options?: unknown,
 ): CollectedPhase1Annotations {
   const annotationsList: Annotations[] = [];
-  const snapshots: Annotations[] = [];
-  let needsTwoPhase = false;
+  let snapshots: Annotations[] | undefined;
 
   for (const context of contexts) {
     const result = context.getAnnotations(undefined, options);
@@ -2841,14 +2842,17 @@ function collectPhase1AnnotationsSync(
       ? result
       : mergeAnnotations([result, internalAnnotations]);
     annotationsList.push(snapshot);
-    snapshots.push(snapshot);
-    needsTwoPhase ||= context.phase === "two-pass";
+    if (snapshots != null) {
+      snapshots.push(snapshot);
+    } else if (context.phase === "two-pass") {
+      snapshots = [...annotationsList];
+    }
   }
 
   return {
     annotations: mergeAnnotations(annotationsList),
-    needsTwoPhase,
-    snapshots,
+    needsTwoPhase: snapshots != null,
+    snapshots: snapshots ?? [],
   };
 }
 

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -266,7 +266,7 @@ export interface Parser<
    * A type-appropriate default value used as a stand-in during deferred
    * prompt resolution.  When present, combinators like `prompt()` use this
    * value instead of an internal sentinel during two-phase parsing, so that
-   * `map()` transforms and dynamic contexts always receive a valid value
+   * `map()` transforms and two-pass contexts always receive a valid value
    * of type {@link TValue}.
    *
    * This property is set automatically by `option()` and `argument()` from

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -113,7 +113,7 @@ export interface ValueParser<M extends Mode = "sync", T = unknown> {
    * A type-appropriate default value used as a stand-in during deferred
    * prompt resolution.  When an interactive prompt is deferred during
    * two-phase parsing, this value is used instead of an internal sentinel
-   * so that `map()` transforms and dynamic contexts always receive a valid
+   * so that `map()` transforms and two-pass contexts always receive a valid
    * value of type {@link T}.
    *
    * The placeholder does not need to be meaningful; it only needs to be

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -173,7 +173,7 @@ export function createEnvContext(options: EnvContextOptions = {}): EnvContext {
     id: contextId,
     prefix,
     source,
-    mode: "static",
+    phase: "single-pass",
 
     getAnnotations(): Annotations {
       const sourceData: EnvSourceData = { prefix, source };

--- a/packages/inquirer/src/index.test.ts
+++ b/packages/inquirer/src/index.test.ts
@@ -1516,7 +1516,7 @@ describe("prompt()", () => {
       let phase2Parsed: { readonly config: string } | undefined;
       const dynamicContext: SourceContext = {
         id: Symbol.for("@test/prompt-phase-two"),
-        mode: "dynamic",
+        phase: "two-pass",
         getAnnotations(parsed?: unknown) {
           if (parsed === undefined) {
             return {};
@@ -1555,7 +1555,7 @@ describe("prompt()", () => {
         let phase2Parsed: { readonly apiKey?: string | undefined } | undefined;
         const dynamicContext: SourceContext = {
           id: Symbol.for("@test/config-prompt-phase-two"),
-          mode: "dynamic",
+          phase: "two-pass",
           getAnnotations(parsed?: unknown) {
             if (parsed === undefined) {
               return {};
@@ -1609,7 +1609,7 @@ describe("prompt()", () => {
         let sawUndefined = false;
         const dynamicContext: SourceContext = {
           id: Symbol.for("@test/top-level-config-prompt-phase-two"),
-          mode: "dynamic",
+          phase: "two-pass",
           getAnnotations(parsed?: unknown) {
             sawUndefined = parsed === undefined;
             return {};
@@ -1661,7 +1661,7 @@ describe("prompt()", () => {
         let phase2Parsed: ConfigInput | undefined;
         const dynamicContext: SourceContext = {
           id: Symbol.for("@test/non-plain-phase-two"),
-          mode: "dynamic",
+          phase: "two-pass",
           getAnnotations(parsed?: unknown) {
             if (parsed !== undefined) {
               phase2Parsed = parsed as ConfigInput;
@@ -1735,7 +1735,7 @@ describe("prompt()", () => {
         let phase2Masked: string | undefined;
         const dynamicContext: SourceContext = {
           id: Symbol.for("@test/private-field-phase-two"),
-          mode: "dynamic",
+          phase: "two-pass",
           getAnnotations(parsed?: unknown) {
             if (parsed !== undefined) {
               phase2SawSecretHolder = parsed instanceof SecretHolder;
@@ -1801,7 +1801,7 @@ describe("prompt()", () => {
       let phase2Values: readonly unknown[] | undefined;
       const dynamicContext: SourceContext = {
         id: Symbol.for("@test/set-phase-two"),
-        mode: "dynamic",
+        phase: "two-pass",
         getAnnotations(parsed?: unknown) {
           if (parsed instanceof Set) {
             phase2Values = [...parsed];
@@ -1862,7 +1862,7 @@ describe("prompt()", () => {
         let phase2ApiKey: string | undefined;
         const dynamicContext: SourceContext = {
           id: Symbol.for("@test/set-own-prop-phase-two"),
-          mode: "dynamic",
+          phase: "two-pass",
           getAnnotations(parsed?: unknown) {
             if (parsed instanceof BoxSet) {
               phase2WasBoxSet = true;
@@ -1922,7 +1922,7 @@ describe("prompt()", () => {
       let phase2Set: BoxSet | undefined;
       const dynamicContext: SourceContext = {
         id: Symbol.for("@test/nested-clean-collection-phase-two"),
-        mode: "dynamic",
+        phase: "two-pass",
         getAnnotations(parsed?: unknown) {
           if (parsed != null && typeof parsed === "object") {
             phase2Set = (parsed as { readonly clean: BoxSet }).clean;
@@ -1991,7 +1991,7 @@ describe("prompt()", () => {
       let phase2Value: string | undefined;
       const dynamicContext: SourceContext = {
         id: Symbol.for("@test/nested-clean-non-plain-phase-two"),
-        mode: "dynamic",
+        phase: "two-pass",
         getAnnotations(parsed?: unknown) {
           if (parsed != null && typeof parsed === "object") {
             phase2Box = (parsed as { readonly clean: CleanBox }).clean;
@@ -2053,7 +2053,7 @@ describe("prompt()", () => {
         let phase2ApiKey: string | undefined;
         const dynamicContext: SourceContext = {
           id: Symbol.for("@test/nested-non-plain-phase-two"),
-          mode: "dynamic",
+          phase: "two-pass",
           getAnnotations(parsed?: unknown) {
             if (parsed != null && typeof parsed === "object") {
               phase2ApiKey = (
@@ -2180,7 +2180,7 @@ describe("prompt()", () => {
         const metadataByParsed = new WeakMap<object, string>();
         const identityContext: SourceContext = {
           id: Symbol.for("@test/scrubbed-phase-two-identity"),
-          mode: "dynamic",
+          phase: "two-pass",
           getAnnotations(parsed?: unknown) {
             if (parsed != null && typeof parsed === "object") {
               metadataByParsed.set(parsed as object, "seen");
@@ -2332,7 +2332,7 @@ describe("prompt()", () => {
         let phase2Token: string | undefined;
         const dynamicContext: SourceContext = {
           id: Symbol.for("@test/mapped-placeholder-phase-two"),
-          mode: "dynamic",
+          phase: "two-pass",
           getAnnotations(parsed?: unknown) {
             if (parsed != null && typeof parsed === "object") {
               phase2Token = (parsed as { readonly token: string }).token;
@@ -2374,7 +2374,7 @@ describe("prompt()", () => {
         );
 
         // map() drops deferredKeys because the transform is opaque.
-        // The placeholder "" leaks through to the dynamic context.
+        // The placeholder "" leaks through to the two-pass context.
         // This is an intentional trade-off: forwarding stale inner
         // keys would risk stripping the wrong output fields.
         assert.equal(phase2Token, "");
@@ -2392,7 +2392,7 @@ describe("prompt()", () => {
         let phase2Parsed: unknown = "not-called";
         const dynamicContext: SourceContext = {
           id: Symbol.for("@test/mapped-throw-phase-two"),
-          mode: "dynamic",
+          phase: "two-pass",
           getAnnotations(parsed?: unknown) {
             phase2Parsed = parsed;
             return {};
@@ -2460,7 +2460,7 @@ describe("prompt()", () => {
       const phaseOneValues: unknown[] = [];
       const spyContext: SourceContext = {
         id: Symbol("spy"),
-        mode: "dynamic",
+        phase: "two-pass",
         getAnnotations(parsed?: unknown) {
           if (parsed !== undefined) {
             phaseOneValues.push(parsed);

--- a/packages/run/src/run.test.ts
+++ b/packages/run/src/run.test.ts
@@ -120,6 +120,7 @@ function createIssue183RunFixture() {
   );
   const context: SourceContext = {
     id: issue183ContextKey,
+    phase: "single-pass",
     getAnnotations() {
       return { [issue183ContextKey]: true };
     },
@@ -164,11 +165,11 @@ describe("run", () => {
       assert.deepEqual(result, { tag: "a", silent: true });
     });
 
-    it("should parse arguments with annotated static contexts in runSync()", () => {
+    it("should parse arguments with annotated single-pass contexts in runSync()", () => {
       const annotation = Symbol.for("@test/issue-187/run-runSync");
       const context: SourceContext = {
         id: annotation,
-        mode: "static",
+        phase: "single-pass",
         getAnnotations() {
           return { [annotation]: true };
         },
@@ -183,11 +184,11 @@ describe("run", () => {
       assert.equal(result, "value");
     });
 
-    it("should parse commands with annotated static contexts in run()", async () => {
+    it("should parse commands with annotated single-pass contexts in run()", async () => {
       const annotation = Symbol.for("@test/issue-187/run-run");
       const context: SourceContext = {
         id: annotation,
-        mode: "static",
+        phase: "single-pass",
         getAnnotations() {
           return { [annotation]: true };
         },
@@ -1587,6 +1588,7 @@ describe("run with contexts", () => {
     const envKey = Symbol.for("@test/env-run");
     const context: SourceContext = {
       id: envKey,
+      phase: "single-pass",
       getAnnotations() {
         return { [envKey]: { HOST: "localhost" } };
       },
@@ -1653,6 +1655,7 @@ describe("run with contexts", () => {
 
     const context: SourceContext = {
       id: key,
+      phase: "two-pass",
       getAnnotations(_parsed?: unknown, options?: unknown) {
         receivedOptions = options;
         if (!_parsed) return {};
@@ -1685,6 +1688,7 @@ describe("run with contexts", () => {
 
     const context: SourceContext<{ help: string }> = {
       id: key,
+      phase: "two-pass",
       getAnnotations(_parsed?: unknown, options?: unknown) {
         receivedOptions = options;
         return {};
@@ -1717,6 +1721,7 @@ describe("run with contexts", () => {
 
     const context: SourceContext<{ programName: string }> = {
       id: key,
+      phase: "two-pass",
       getAnnotations(_parsed?: unknown, options?: unknown) {
         receivedOptions = options;
         return {};
@@ -1747,6 +1752,7 @@ describe("run with contexts", () => {
 
     const context: SourceContext = {
       id: key,
+      phase: "single-pass",
       getAnnotations() {
         return { [key]: { value: true } };
       },
@@ -1802,13 +1808,14 @@ describe("run with contexts", () => {
     assert.deepEqual(result, { name: "Alice" });
   });
 
-  it("should widen parser run() for dynamic context arrays", async () => {
+  it("should widen parser run() for context arrays", async () => {
     const key = Symbol.for("@test/parser-run-dynamic-contexts");
     const parser = object({
       name: withDefault(option("--name", string()), "default"),
     });
     const context: SourceContext = {
       id: key,
+      phase: "single-pass",
       getAnnotations() {
         return { [key]: { value: true } };
       },
@@ -1836,7 +1843,7 @@ describe("run with contexts", () => {
     assert.ok(filledResult instanceof Promise);
     assert.deepEqual(await filledResult, { name: "default" });
 
-    // @ts-expect-error - dynamic context arrays may still resolve async.
+    // @ts-expect-error - context arrays may still resolve async.
     const syncResult: { name: string } = run(parser, {
       args: [],
       contexts: filledContexts,
@@ -1847,6 +1854,7 @@ describe("run with contexts", () => {
   it("should reject Program run() with contexts when options are missing", () => {
     const context: ProgramPathContext = {
       id: Symbol.for("@test/program-run-missing-options"),
+      phase: "single-pass",
       getAnnotations() {
         return {};
       },
@@ -1894,6 +1902,7 @@ describe("run with contexts", () => {
     const key = Symbol.for("@test/program-run-runoptions-contexts");
     const context: SourceContext = {
       id: key,
+      phase: "single-pass",
       getAnnotations() {
         return { [key]: { value: true } };
       },
@@ -1940,10 +1949,11 @@ describe("run with contexts", () => {
     void _wrap;
   });
 
-  it("should widen Program run() for dynamic context arrays", async () => {
+  it("should widen Program run() for context arrays", async () => {
     let resolvedPath: string | undefined;
     const context: ProgramPathContext = {
       id: Symbol.for("@test/program-run-dynamic-context-array"),
+      phase: "two-pass",
       getAnnotations(parsed, options) {
         if (parsed && options) {
           resolvedPath = (
@@ -2002,7 +2012,7 @@ describe("run with contexts", () => {
     });
     assert.equal(resolvedPath, "optique.json");
 
-    // @ts-expect-error - dynamic context arrays may resolve asynchronously.
+    // @ts-expect-error - context arrays may resolve asynchronously.
     const syncResult: { config: string; host: string } = run(program, {
       args: [],
       contexts: filledContexts,
@@ -2057,6 +2067,7 @@ describe("run with contexts", () => {
     let resolvedPath: string | undefined;
     const context: ProgramPathContext = {
       id: Symbol.for("@test/program-run-context"),
+      phase: "two-pass",
       getAnnotations(parsed, options) {
         if (parsed && options) {
           resolvedPath = (
@@ -2108,6 +2119,7 @@ describe("run with contexts", () => {
     let resolvedPath: string | undefined;
     const context: ProgramPathContext = {
       id: Symbol.for("@test/program-run-dynamic-contexts"),
+      phase: "two-pass",
       getAnnotations(parsed, options) {
         if (parsed && options) {
           resolvedPath = (
@@ -2188,6 +2200,7 @@ describe("runSync with contexts", () => {
     const envKey = Symbol.for("@test/env-runsync");
     const context: SourceContext = {
       id: envKey,
+      phase: "single-pass",
       getAnnotations() {
         return { [envKey]: { HOST: "localhost" } };
       },
@@ -2213,6 +2226,7 @@ describe("runSync with contexts", () => {
 
     const context: SourceContext = {
       id: key,
+      phase: "single-pass",
       getAnnotations() {
         return { [key]: { value: true } };
       },
@@ -2239,6 +2253,7 @@ describe("runSync with contexts", () => {
     let annotationsCallCount = 0;
     const context: SourceContext = {
       id: key,
+      phase: "single-pass",
       getAnnotations() {
         annotationsCallCount++;
         return {};
@@ -2279,6 +2294,7 @@ describe("runSync with contexts", () => {
     const contextKey = Symbol.for("@test/runsync-program-context");
     const context: SourceContext = {
       id: contextKey,
+      phase: "single-pass",
       getAnnotations() {
         return { [contextKey]: { value: true } };
       },
@@ -2310,6 +2326,7 @@ describe("runSync with contexts", () => {
   it("should reject Program runSync() with contexts when options are missing", () => {
     const context: ProgramPathContext = {
       id: Symbol.for("@test/program-runsync-missing-options"),
+      phase: "single-pass",
       getAnnotations() {
         return {};
       },
@@ -2414,6 +2431,7 @@ describe("runSync with contexts", () => {
     let resolvedPath: string | undefined;
     const context: ProgramPathContext = {
       id: Symbol.for("@test/program-runsync-context"),
+      phase: "two-pass",
       getAnnotations(parsed, options) {
         if (parsed && options) {
           resolvedPath = (
@@ -2559,6 +2577,7 @@ describe("runAsync with contexts", () => {
     const envKey = Symbol.for("@test/env-runasync");
     const context: SourceContext = {
       id: envKey,
+      phase: "single-pass",
       getAnnotations() {
         return { [envKey]: { HOST: "localhost" } };
       },
@@ -2583,6 +2602,7 @@ describe("runAsync with contexts", () => {
 
     const context: SourceContext = {
       id: key,
+      phase: "single-pass",
       getAnnotations() {
         return { [key]: { value: true } };
       },
@@ -2608,6 +2628,7 @@ describe("runAsync with contexts", () => {
     const key = Symbol.for("@test/runasync-extra-options");
     const context: SourceContext = {
       id: key,
+      phase: "single-pass",
       getAnnotations() {
         return { [key]: { value: true } };
       },
@@ -2633,6 +2654,7 @@ describe("runAsync with contexts", () => {
     let resolvedPath: string | undefined;
     const context: ProgramPathContext = {
       id: Symbol.for("@test/program-runasync-context"),
+      phase: "two-pass",
       getAnnotations(parsed, options) {
         if (parsed && options) {
           resolvedPath = (


### PR DESCRIPTION
This PR fixes https://github.com/dahlia/optique/issues/243 by replacing the inferred `mode` behavior in *packages/core/src/context.ts* and *packages/core/src/facade.ts* with an explicit `phase` contract on every `SourceContext`.

Before this change, `runWith()` and `runWithSync()` could skip phase 2 when a mode-less context returned non-empty symbol annotations during phase 1. That made some contexts look static even when they still needed the parsed result to refine their annotations, so the final parse could keep stale phase-1 data.

The new contract requires `phase: "single-pass" | "two-pass"` and removes `SourceContextMode`, `SourceContext.mode`, and `isStaticContext()`. The runners now collect phase-1 annotations from all contexts, cache each context's phase-1 snapshot, and re-run only contexts that explicitly opt into `two-pass`. This also makes clearing semantics predictable, because returning `{}` in phase 2 now clears only that context's own provisional contribution.

The built-in contexts in *packages/env/src/index.ts* and *packages/config/src/index.ts* were migrated to the new API, and the regression coverage in *packages/core/src/facade.test.ts* now verifies that a two-pass context can return non-empty phase-1 annotations and still refine them in phase 2. I also updated the public docs in *docs/concepts/extend.md*, *docs/concepts/runners.md*, *docs/cookbook.md*, and *CHANGES.md* to describe the new single-pass and two-pass terminology for Optique 1.0.0.

For custom contexts, the migration looks like this:

```ts
// Before
const context: SourceContext = {
  id: myKey,
  mode: "dynamic",
  getAnnotations(parsed) {
    // ...
  },
};

// After
const context: SourceContext = {
  id: myKey,
  phase: "two-pass",
  getAnnotations(parsed) {
    // ...
  },
};
```

Closes https://github.com/dahlia/optique/issues/243

Testing: `mise check`, `mise test`, `pnpm -C docs build`