### PR TITLE
Make `runParser()` and `runWith*()` parser-aware for help, version, and completion

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -327,18 +327,13 @@ To be released.
     whitespace-only strings, strings with embedded whitespace, and strings
     with control characters.  [[#401], [#732]]
 
- -  Added meta name collision detection to `runParser()`.  The runner now
-    throws `TypeError` when built-in meta feature names (help, version,
-    completion) collide with user-defined parser names or with each other.
-    Previously, colliding names were silently shadowed by the built-in meta
-    parser, making user-defined commands or options unreachable.
-
-    The check is position-aware: command-form meta features (which only
-    match at `args[0]`) are compared against `Parser.leadingNames`, while
-    option-form meta features (whose lenient scanners match anywhere in
-    `argv`) are compared against all user names at every depth, including
-    literal values from `conditional()` discriminators.  The completion
-    option's `name=value` prefix form is also detected.  [[#227], [#736]]
+ -  Added meta name collision detection to `runParser()`.  The runner
+    rejects collisions among built-in meta features (help, version,
+    completion), including option aliases that shadow completion's
+    `name=value` prefix form.  User-defined parser names are no longer
+    rejected here; runner meta handling is now parser-aware, so ordinary
+    parser data may reuse built-in meta names and aliases when the parser
+    consumes them first.  [[#227], [#736], [#230], [#784]]
 
  -  Added `leadingNames` and `acceptingAnyToken` properties to the `Parser`
     interface.  Each combinator now reports which leading tokens (option

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2164,7 +2164,8 @@ interactive prompt fallback integration via Inquirer.js.  [[#87], [#137]]
  -  Fixed `run()`, `runSync()`, and `runAsync()` to follow the parser-aware
     help, version, and completion semantics from *@optique/core*.  Built-in
     meta requests now yield to ordinary parser data, while genuine meta
-    requests still bypass context loading and process handling as before.
+    requests still stop after phase 1 and bypass phase-two context
+    refinement and process handling as before.
     [[#230], [#784]]
 
  -  Fixed `path()` extension validation for dotfiles (e.g., `.env`,

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -225,7 +225,7 @@ To be released.
     the user parser leaves them unconsumed, so positional values like `help`
     and option values like `--help` can be parsed as ordinary data.  Startup
     validation now also permits user parsers to reuse built-in meta names and
-    aliases.  [[#230]]
+    aliases.  [[#230], [#784]]
 
  -  *Breaking change:* Replaced `SourceContext`'s inferred `mode`
     contract with an explicit required `phase` field whose value must be
@@ -1667,6 +1667,7 @@ To be released.
 [#781]: https://github.com/dahlia/optique/pull/781
 [#782]: https://github.com/dahlia/optique/pull/782
 [#783]: https://github.com/dahlia/optique/pull/783
+[#784]: https://github.com/dahlia/optique/pull/784
 
 ### @optique/config
 
@@ -2164,7 +2165,7 @@ interactive prompt fallback integration via Inquirer.js.  [[#87], [#137]]
     help, version, and completion semantics from *@optique/core*.  Built-in
     meta requests now yield to ordinary parser data, while genuine meta
     requests still bypass context loading and process handling as before.
-    [[#230]]
+    [[#230], [#784]]
 
  -  Fixed `path()` extension validation for dotfiles (e.g., `.env`,
     `.gitignore`) and multi-part extensions (e.g., `.tar.gz`, `.d.ts`).

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -219,6 +219,14 @@ To be released.
     contribution instead of letting stale data override later contexts.
     [[#231], [#782]]
 
+ -  Fixed `runParser()`, `runWith()`, and `runWithSync()` treating built-in
+    help, version, and completion tokens as globally reserved.  These runner
+    features are now parser-aware: command and option forms only trigger when
+    the user parser leaves them unconsumed, so positional values like `help`
+    and option values like `--help` can be parsed as ordinary data.  Startup
+    validation now also permits user parsers to reuse built-in meta names and
+    aliases.  [[#230]]
+
  -  *Breaking change:* Replaced `SourceContext`'s inferred `mode`
     contract with an explicit required `phase` field whose value must be
     `"single-pass"` or `"two-pass"`.  `SourceContextMode`,
@@ -1361,6 +1369,7 @@ To be released.
 [#227]: https://github.com/dahlia/optique/issues/227
 [#228]: https://github.com/dahlia/optique/issues/228
 [#229]: https://github.com/dahlia/optique/issues/229
+[#230]: https://github.com/dahlia/optique/issues/230
 [#231]: https://github.com/dahlia/optique/issues/231
 [#232]: https://github.com/dahlia/optique/issues/232
 [#233]: https://github.com/dahlia/optique/issues/233
@@ -2150,6 +2159,12 @@ interactive prompt fallback integration via Inquirer.js.  [[#87], [#137]]
     wrapping async parsers) at runtime and returning `Promise`s instead of
     throwing.  `runSync()` now validates `parser.$mode` at runtime and throws
     `TypeError` if the parser is not synchronous.  [[#279], [#676]]
+
+ -  Fixed `run()`, `runSync()`, and `runAsync()` to follow the parser-aware
+    help, version, and completion semantics from *@optique/core*.  Built-in
+    meta requests now yield to ordinary parser data, while genuine meta
+    requests still bypass context loading and process handling as before.
+    [[#230]]
 
  -  Fixed `path()` extension validation for dotfiles (e.g., `.env`,
     `.gitignore`) and multi-part extensions (e.g., `.tar.gz`, `.d.ts`).

--- a/docs/concepts/extend.md
+++ b/docs/concepts/extend.md
@@ -1008,17 +1008,22 @@ deferred parts are tracked via `deferredKeys` and selectively hidden as
 `undefined` before phase-two context collection.  No sentinel symbols or
 runtime checks are needed.
 
-### Help and version always available
+### Help, version, and completion remain available
 
-The `runWith()` function ensures that help, version, and completion features
-work immediately without requiring valid configuration files or contexts:
+The `runWith()` family keeps help, version, and completion available
+without requiring valid configuration files or contexts, but it checks
+the user parser first.  These features are treated as runner-level meta
+requests only when the parser leaves the token sequence unconsumed:
 
  -  `--help` displays help even if config files are missing or invalid
  -  `--version` shows version information without loading contexts
  -  Completion scripts generate instantly regardless of environment setup
 
-This means users can always access documentation and basic information,
-even in misconfigured environments.
+If the parser accepts the same tokens as ordinary data, such as a
+positional `help` value or an option value `--help`, the parse result
+wins and normal context collection continues.  Genuine meta requests
+still bypass context loading, so users can access documentation and
+basic information even in misconfigured environments.
 
 ~~~~ typescript
 // Help works even if config file is missing or invalid

--- a/docs/concepts/extend.md
+++ b/docs/concepts/extend.md
@@ -1015,15 +1015,15 @@ without requiring valid configuration files or contexts, but it checks
 the user parser first.  These features are treated as runner-level meta
 requests only when the parser leaves the token sequence unconsumed:
 
- -  `--help` displays help even if config files are missing or invalid
- -  `--version` shows version information without loading contexts
- -  Completion scripts generate instantly regardless of environment setup
+ -  `--help` displays help even if later parse phases would fail
+ -  `--version` shows version information without running phase 2
+ -  Completion scripts still skip phase-two context refinement
 
 If the parser accepts the same tokens as ordinary data, such as a
 positional `help` value or an option value `--help`, the parse result
 wins and normal context collection continues.  Genuine meta requests
-still bypass context loading, so users can access documentation and
-basic information even in misconfigured environments.
+still stop after phase 1, so users can access documentation and basic
+information without needing a successful second parse pass.
 
 ~~~~ typescript
 // Help works even if config file is missing or invalid

--- a/docs/concepts/runners.md
+++ b/docs/concepts/runners.md
@@ -262,6 +262,14 @@ Both approaches automatically handle:
     subcommands
  -  *Usage display*: Shows command syntax when errors occur
 
+Built-in help, version, and completion requests are parser-aware.  The
+runner treats `help`, `version`, `completion`, `--help`, `--version`,
+`--completion`, and any configured aliases as meta requests only when
+the user parser leaves them unconsumed.  If your parser accepts the
+same token sequence as ordinary data, such as a positional `help` value
+or an option value `--help`, the parse result wins and the runner does
+not intercept it.
+
 The `RunOptions` interface provides extensive customization:
 
 ~~~~ typescript twoslash

--- a/docs/integrations/config.md
+++ b/docs/integrations/config.md
@@ -205,8 +205,10 @@ Help, version, and completion
 
 When using `run()` or `runAsync()` with config contexts, help messages,
 version display, and shell completion generation all work seamlessly.
-These features work even when configuration files are missing or invalid,
-ensuring users can always access help:
+Genuine help, version, and completion requests work even when
+configuration files are missing or invalid, ensuring users can still
+access those features unless the user parser already consumes the same
+token sequence as ordinary data:
 
 ~~~~ typescript twoslash
 import { z } from "zod";
@@ -263,8 +265,11 @@ myapp --version
 myapp --completion bash > myapp-completion.sh
 ~~~~
 
-The key benefit is that help, version, and completion work *before* config
-file loading, so they succeed even when the config file is invalid or missing.
+The key benefit is that genuine help, version, and completion requests
+work *before* config file loading, so they succeed even when the config
+file is invalid or missing.  If the parser accepts the same tokens as
+ordinary input, parsing takes precedence and config loading proceeds as
+usual.
 
 
 Nested config values

--- a/docs/integrations/env.md
+++ b/docs/integrations/env.md
@@ -416,9 +416,11 @@ primitive's constraints — but outer combinators layered above
 ### Help, version, and completion
 
 Like config contexts, environment contexts work seamlessly with help,
-version, and completion features.  These are handled before environment
-variable lookup, so `--help` always works even when required environment
-variables are missing:
+version, and completion features.  Genuine help, version, and
+completion requests are handled before environment variable lookup, so
+`--help` still works even when required environment variables are
+missing, unless the user parser already consumes that same token
+sequence as ordinary data:
 
 ~~~~ typescript twoslash
 import { object } from "@optique/core/constructs";

--- a/packages/core/src/constructs.ts
+++ b/packages/core/src/constructs.ts
@@ -154,6 +154,7 @@ function mergeChildExec(
     trace: child.trace ?? parent.trace,
     dependencyRuntime: child.dependencyRuntime ?? parent.dependencyRuntime,
     dependencyRegistry: child.dependencyRegistry ?? parent.dependencyRegistry,
+    commandPath: child.commandPath ?? parent.commandPath,
     preCompletedByParser: child.preCompletedByParser ??
       parent.preCompletedByParser,
     excludedSourceFields: child.excludedSourceFields ??

--- a/packages/core/src/facade.test.ts
+++ b/packages/core/src/facade.test.ts
@@ -11637,6 +11637,160 @@ describe("branch coverage: facade.ts edge cases", () => {
     });
   });
 
+  it("does not reclassify consumed help tokens after sync parse failures", () => {
+    const parsers: readonly Parser<"sync", string, undefined>[] = [
+      {
+        $mode: "sync",
+        $valueType: [] as readonly string[],
+        $stateType: [] as readonly undefined[],
+        priority: 0,
+        usage: [],
+        leadingNames: new Set(["--help"]),
+        acceptingAnyToken: false,
+        initialState: undefined,
+        parse() {
+          return {
+            success: false as const,
+            consumed: 1,
+            error: message`Consumed token failure.`,
+          };
+        },
+        complete() {
+          return {
+            success: false as const,
+            error: message`Should not complete.`,
+          };
+        },
+        *suggest() {},
+        getDocFragments() {
+          return { fragments: [] };
+        },
+      },
+      {
+        $mode: "sync",
+        $valueType: [] as readonly string[],
+        $stateType: [] as readonly undefined[],
+        priority: 0,
+        usage: [],
+        leadingNames: new Set(["--help"]),
+        acceptingAnyToken: false,
+        initialState: undefined,
+        parse(context) {
+          return {
+            success: true as const,
+            next: context,
+            consumed: ["--help"],
+          };
+        },
+        complete() {
+          return {
+            success: false as const,
+            error: message`Should not complete.`,
+          };
+        },
+        *suggest() {},
+        getDocFragments() {
+          return { fragments: [] };
+        },
+      },
+    ];
+
+    for (const parser of parsers) {
+      let stdoutOutput = "";
+      const result = runParser(parser, "test", ["--help"], {
+        help: {
+          option: true,
+          onShow: () => "help",
+        },
+        onError: () => "error",
+        stdout: (text) => {
+          stdoutOutput += text;
+        },
+        stderr: () => {},
+      });
+
+      assert.equal(result, "error");
+      assert.equal(stdoutOutput, "");
+    }
+  });
+
+  it("does not reclassify consumed help tokens after async parse failures", async () => {
+    const parsers: readonly Parser<"async", string, undefined>[] = [
+      {
+        $mode: "async",
+        $valueType: [] as readonly string[],
+        $stateType: [] as readonly undefined[],
+        priority: 0,
+        usage: [],
+        leadingNames: new Set(["--help"]),
+        acceptingAnyToken: false,
+        initialState: undefined,
+        parse() {
+          return Promise.resolve({
+            success: false as const,
+            consumed: 1,
+            error: message`Consumed token failure.`,
+          });
+        },
+        complete() {
+          return Promise.resolve({
+            success: false as const,
+            error: message`Should not complete.`,
+          });
+        },
+        async *suggest() {},
+        getDocFragments() {
+          return { fragments: [] };
+        },
+      },
+      {
+        $mode: "async",
+        $valueType: [] as readonly string[],
+        $stateType: [] as readonly undefined[],
+        priority: 0,
+        usage: [],
+        leadingNames: new Set(["--help"]),
+        acceptingAnyToken: false,
+        initialState: undefined,
+        parse(context) {
+          return Promise.resolve({
+            success: true as const,
+            next: context,
+            consumed: ["--help"],
+          });
+        },
+        complete() {
+          return Promise.resolve({
+            success: false as const,
+            error: message`Should not complete.`,
+          });
+        },
+        async *suggest() {},
+        getDocFragments() {
+          return { fragments: [] };
+        },
+      },
+    ];
+
+    for (const parser of parsers) {
+      let stdoutOutput = "";
+      const result = await runParser(parser, "test", ["--help"], {
+        help: {
+          option: true,
+          onShow: () => "help",
+        },
+        onError: () => "error",
+        stdout: (text) => {
+          stdoutOutput += text;
+        },
+        stderr: () => {},
+      });
+
+      assert.equal(result, "error");
+      assert.equal(stdoutOutput, "");
+    }
+  });
+
   it("needsEarlyExit does not trigger for non-matching completion option args", () => {
     const parser = object({ name: argument(string()) });
     const result = runParser(parser, "test", ["Alice"], {

--- a/packages/core/src/facade.test.ts
+++ b/packages/core/src/facade.test.ts
@@ -5732,7 +5732,7 @@ describe("runWith", () => {
   });
 
   describe("early exit for help/version/completion", () => {
-    it("should not call context.getAnnotations() when --help option is provided", async () => {
+    it("should collect phase 1 annotations when --help option is provided", async () => {
       let annotationsCallCount = 0;
       const trackingContext: SourceContext = {
         id: Symbol.for("@test/tracking"),
@@ -5761,10 +5761,10 @@ describe("runWith", () => {
       });
 
       assert.ok(helpShown);
-      assert.equal(annotationsCallCount, 0);
+      assert.equal(annotationsCallCount, 1);
     });
 
-    it("should not call context.getAnnotations() when --version option is provided", async () => {
+    it("should collect phase 1 annotations when --version option is provided", async () => {
       let annotationsCallCount = 0;
       const trackingContext: SourceContext = {
         id: Symbol.for("@test/tracking"),
@@ -5794,10 +5794,10 @@ describe("runWith", () => {
       });
 
       assert.ok(versionShown);
-      assert.equal(annotationsCallCount, 0);
+      assert.equal(annotationsCallCount, 1);
     });
 
-    it("should not call context.getAnnotations() when help command is provided", async () => {
+    it("should collect phase 1 annotations when help command is provided", async () => {
       let annotationsCallCount = 0;
       const trackingContext: SourceContext = {
         id: Symbol.for("@test/tracking"),
@@ -5826,10 +5826,10 @@ describe("runWith", () => {
       });
 
       assert.ok(helpShown);
-      assert.equal(annotationsCallCount, 0);
+      assert.equal(annotationsCallCount, 1);
     });
 
-    it("should not call context.getAnnotations() when version command is provided", async () => {
+    it("should collect phase 1 annotations when version command is provided", async () => {
       let annotationsCallCount = 0;
       const trackingContext: SourceContext = {
         id: Symbol.for("@test/tracking"),
@@ -5859,10 +5859,10 @@ describe("runWith", () => {
       });
 
       assert.ok(versionShown);
-      assert.equal(annotationsCallCount, 0);
+      assert.equal(annotationsCallCount, 1);
     });
 
-    it("should not call context.getAnnotations() when completion command is provided", async () => {
+    it("should collect phase 1 annotations when completion command is provided", async () => {
       let annotationsCallCount = 0;
       const trackingContext: SourceContext = {
         id: Symbol.for("@test/tracking"),
@@ -5891,10 +5891,10 @@ describe("runWith", () => {
       });
 
       assert.ok(completionShown);
-      assert.equal(annotationsCallCount, 0);
+      assert.equal(annotationsCallCount, 1);
     });
 
-    it("should not call context.getAnnotations() when --completion option is provided", async () => {
+    it("should collect phase 1 annotations when --completion option is provided", async () => {
       let annotationsCallCount = 0;
       const trackingContext: SourceContext = {
         id: Symbol.for("@test/tracking"),
@@ -5923,10 +5923,10 @@ describe("runWith", () => {
       });
 
       assert.ok(completionShown);
-      assert.equal(annotationsCallCount, 0);
+      assert.equal(annotationsCallCount, 1);
     });
 
-    it("should not call context.getAnnotations() when completions (plural) command is provided", async () => {
+    it("should collect phase 1 annotations when completions (plural) command is provided", async () => {
       let annotationsCallCount = 0;
       const trackingContext: SourceContext = {
         id: Symbol.for("@test/tracking"),
@@ -5955,10 +5955,10 @@ describe("runWith", () => {
       });
 
       assert.ok(completionShown);
-      assert.equal(annotationsCallCount, 0);
+      assert.equal(annotationsCallCount, 1);
     });
 
-    it("should not call context.getAnnotations() when --completions (plural) option is provided", async () => {
+    it("should collect phase 1 annotations when --completions (plural) option is provided", async () => {
       let annotationsCallCount = 0;
       const trackingContext: SourceContext = {
         id: Symbol.for("@test/tracking"),
@@ -5987,7 +5987,7 @@ describe("runWith", () => {
       });
 
       assert.ok(completionShown);
-      assert.equal(annotationsCallCount, 0);
+      assert.equal(annotationsCallCount, 1);
     });
 
     it("should continue to context collection when completion option is configured but absent", async () => {
@@ -6014,6 +6014,82 @@ describe("runWith", () => {
 
       assert.deepEqual(result, { name: "alice" });
       assert.equal(annotationsCallCount, 1);
+    });
+
+    it("should let phase 1 annotations keep --help as ordinary parser data", async () => {
+      const key = Symbol.for("@test/phase1-meta-shadow-async");
+      let phase1Calls = 0;
+      let helpShown = false;
+
+      const parser: Parser<
+        "sync",
+        { readonly value: string },
+        string | undefined
+      > = {
+        $mode: "sync",
+        $valueType: [] as readonly { readonly value: string }[],
+        $stateType: [] as readonly (string | undefined)[],
+        priority: 0,
+        usage: [],
+        leadingNames: new Set(),
+        acceptingAnyToken: false,
+        initialState: undefined,
+        parse(context) {
+          const [head, ...rest] = context.buffer;
+          if (
+            head === "--help" &&
+            getAnnotations(context.state)?.[key] === true
+          ) {
+            return {
+              success: true as const,
+              next: { ...context, buffer: rest, state: head },
+              consumed: [head],
+            };
+          }
+          return {
+            success: false as const,
+            error: message`Missing annotated help value.`,
+            consumed: 0,
+          };
+        },
+        complete(state) {
+          return state == null
+            ? {
+              success: false as const,
+              error: message`Missing annotated help value.`,
+            }
+            : { success: true as const, value: { value: state } };
+        },
+        *suggest() {},
+        getDocFragments() {
+          return { fragments: [] };
+        },
+      };
+
+      const context: SourceContext = {
+        id: key,
+        phase: "single-pass",
+        getAnnotations() {
+          phase1Calls++;
+          return { [key]: true };
+        },
+      };
+
+      const result = await runWith(parser, "test", [context], {
+        args: ["--help"],
+        help: {
+          option: true,
+          onShow: () => {
+            helpShown = true;
+            return "help" as const;
+          },
+        },
+        stdout: () => {},
+      });
+
+      assert.deepEqual(result, { value: "--help" });
+      assert.ok(!helpShown, "help should remain ordinary parser data");
+      assert.equal(phase1Calls, 1);
     });
   });
 
@@ -6921,7 +6997,7 @@ describe("runWithSync", () => {
   });
 
   describe("early exit for help/version/completion", () => {
-    it("should not call context.getAnnotations() when --help option is provided", () => {
+    it("should collect phase 1 annotations when --help option is provided", () => {
       let annotationsCallCount = 0;
       const trackingContext: SourceContext = {
         id: Symbol.for("@test/tracking"),
@@ -6950,10 +7026,10 @@ describe("runWithSync", () => {
       });
 
       assert.ok(helpShown);
-      assert.equal(annotationsCallCount, 0);
+      assert.equal(annotationsCallCount, 1);
     });
 
-    it("should not call context.getAnnotations() when --version option is provided", () => {
+    it("should collect phase 1 annotations when --version option is provided", () => {
       let annotationsCallCount = 0;
       const trackingContext: SourceContext = {
         id: Symbol.for("@test/tracking"),
@@ -6983,10 +7059,10 @@ describe("runWithSync", () => {
       });
 
       assert.ok(versionShown);
-      assert.equal(annotationsCallCount, 0);
+      assert.equal(annotationsCallCount, 1);
     });
 
-    it("should not call context.getAnnotations() when completion command is provided", () => {
+    it("should collect phase 1 annotations when completion command is provided", () => {
       let annotationsCallCount = 0;
       const trackingContext: SourceContext = {
         id: Symbol.for("@test/tracking"),
@@ -7015,7 +7091,86 @@ describe("runWithSync", () => {
       });
 
       assert.ok(completionShown);
-      assert.equal(annotationsCallCount, 0);
+      assert.equal(annotationsCallCount, 1);
+    });
+
+    it("should let phase 1 annotations keep --completion=bash as ordinary parser data", () => {
+      const key = Symbol.for("@test/phase1-meta-shadow-sync");
+      let phase1Calls = 0;
+      let completionShown = false;
+
+      const parser: Parser<
+        "sync",
+        { readonly value: string },
+        string | undefined
+      > = {
+        $mode: "sync",
+        $valueType: [] as readonly { readonly value: string }[],
+        $stateType: [] as readonly (string | undefined)[],
+        priority: 0,
+        usage: [],
+        leadingNames: new Set(),
+        acceptingAnyToken: false,
+        initialState: undefined,
+        parse(context) {
+          const [head, ...rest] = context.buffer;
+          if (
+            head === "--completion=bash" &&
+            getAnnotations(context.state)?.[key] === true
+          ) {
+            return {
+              success: true as const,
+              next: { ...context, buffer: rest, state: head },
+              consumed: [head],
+            };
+          }
+          return {
+            success: false as const,
+            error: message`Missing annotated completion value.`,
+            consumed: 0,
+          };
+        },
+        complete(state) {
+          return state == null
+            ? {
+              success: false as const,
+              error: message`Missing annotated completion value.`,
+            }
+            : { success: true as const, value: { value: state } };
+        },
+        *suggest() {},
+        getDocFragments() {
+          return { fragments: [] };
+        },
+      };
+
+      const context: SourceContext = {
+        id: key,
+        phase: "single-pass",
+        getAnnotations() {
+          phase1Calls++;
+          return { [key]: true };
+        },
+      };
+
+      const result = runWithSync(parser, "test", [context], {
+        args: ["--completion=bash"],
+        completion: {
+          option: true,
+          onShow: () => {
+            completionShown = true;
+            return "completion" as const;
+          },
+        },
+        stdout: () => {},
+      });
+
+      assert.deepEqual(result, { value: "--completion=bash" });
+      assert.ok(
+        !completionShown,
+        "completion should remain ordinary parser data",
+      );
+      assert.equal(phase1Calls, 1);
     });
   });
 
@@ -10752,14 +10907,19 @@ describe("branch coverage: facade.ts edge cases", () => {
   });
 
   // Lines 2698/2736/2740/2818: runWithSync two-phase paths
-  it("runWithSync: needsEarlyExit skips context processing", () => {
+  it("runWithSync: needsEarlyExit skips phase two processing", () => {
     const dynKey = Symbol.for("@test/sync-early-exit");
-    let contextCalled = false;
+    let phase1Calls = 0;
+    let phase2Calls = 0;
     const context: SourceContext = {
       id: dynKey,
-      phase: "single-pass",
-      getAnnotations() {
-        contextCalled = true;
+      phase: "two-pass",
+      getAnnotations(parsed?: unknown) {
+        if (parsed === undefined) {
+          phase1Calls++;
+          return { [dynKey]: {} };
+        }
+        phase2Calls++;
         return { [dynKey]: {} };
       },
     };
@@ -10777,7 +10937,8 @@ describe("branch coverage: facade.ts edge cases", () => {
       stdout: () => {},
     });
     assert.ok(helpShown, "help should be shown");
-    assert.ok(!contextCalled, "context should not be called on early exit");
+    assert.equal(phase1Calls, 1, "phase 1 should still run");
+    assert.equal(phase2Calls, 0, "phase 2 should be skipped on early exit");
   });
 
   it("runWithSync: two-phase, first pass fails → handled via runParser", () => {

--- a/packages/core/src/facade.test.ts
+++ b/packages/core/src/facade.test.ts
@@ -12,6 +12,7 @@ import type { SourceContext } from "@optique/core/context";
 import type { DocSection } from "@optique/core/doc";
 import {
   defineInheritedAnnotationParser,
+  type ExecutionContext,
   type Parser,
 } from "@optique/core/parser";
 import {
@@ -49,6 +50,15 @@ import { extractPhase2SeedKey } from "./phase2-seed.ts";
 import { bindEnv, createEnvContext } from "../../env/src/index.ts";
 
 type AssertNever<T extends never> = T;
+
+function getRuntimeExtractPhase2SeedKey(): symbol {
+  const parser = command("probe", constant(null));
+  const key = Object.getOwnPropertySymbols(parser).find((symbol) =>
+    symbol.description === "@optique/core/extractPhase2Seed"
+  );
+  assert.ok(key, "expected command() to expose extractPhase2SeedKey");
+  return key;
+}
 
 describe("runParser", () => {
   describe("basic parsing", () => {
@@ -10784,6 +10794,132 @@ describe("branch coverage: facade.ts edge cases", () => {
       config: "optique.json",
       token: "token:optique.json",
     });
+  });
+
+  it("runWithSync: phase two preserves commandPath during seed extraction", () => {
+    const tokenKey = Symbol.for("@test/dyn-phase-two-command-path-sync");
+    const runtimeExtractPhase2SeedKey = getRuntimeExtractPhase2SeedKey();
+
+    const tokenParser: Parser<"sync", string, undefined> = {
+      $mode: "sync",
+      $valueType: [] as readonly string[],
+      $stateType: [] as readonly undefined[],
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(),
+      acceptingAnyToken: false,
+      initialState: undefined,
+      parse(context) {
+        return {
+          success: true as const,
+          next: context,
+          consumed: [],
+        };
+      },
+      complete(state) {
+        const token = getAnnotations(state)?.[tokenKey];
+        return typeof token === "string"
+          ? { success: true as const, value: token }
+          : { success: false as const, error: message`Missing token.` };
+      },
+      *suggest() {},
+      getDocFragments() {
+        return { fragments: [] };
+      },
+    };
+    defineInheritedAnnotationParser(tokenParser);
+    Object.defineProperty(tokenParser, runtimeExtractPhase2SeedKey, {
+      value(_state: undefined, exec?: ExecutionContext) {
+        return { value: { commandPath: exec?.commandPath ?? [] } };
+      },
+      enumerable: true,
+    });
+
+    const dynamicContext: SourceContext = {
+      id: tokenKey,
+      phase: "two-pass",
+      getAnnotations(
+        parsed: { readonly commandPath: readonly string[] } | undefined,
+      ) {
+        if (parsed == null) return {};
+        return parsed.commandPath[0] === "serve"
+          ? { [tokenKey]: "from-phase-two" }
+          : {};
+      },
+    };
+
+    const parser = command("serve", tokenParser);
+
+    const result = runWithSync(parser, "test", [dynamicContext], {
+      args: ["serve"],
+    });
+
+    assert.equal(result, "from-phase-two");
+  });
+
+  it("runWith: phase two preserves commandPath during seed extraction", async () => {
+    const tokenKey = Symbol.for("@test/dyn-phase-two-command-path-async");
+    const runtimeExtractPhase2SeedKey = getRuntimeExtractPhase2SeedKey();
+
+    const tokenParser: Parser<"async", string, undefined> = {
+      $mode: "async",
+      $valueType: [] as readonly string[],
+      $stateType: [] as readonly undefined[],
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(),
+      acceptingAnyToken: false,
+      initialState: undefined,
+      parse(context) {
+        return Promise.resolve({
+          success: true as const,
+          next: context,
+          consumed: [],
+        });
+      },
+      complete(state) {
+        const token = getAnnotations(state)?.[tokenKey];
+        return Promise.resolve(
+          typeof token === "string"
+            ? { success: true as const, value: token }
+            : { success: false as const, error: message`Missing token.` },
+        );
+      },
+      async *suggest() {},
+      getDocFragments() {
+        return { fragments: [] };
+      },
+    };
+    defineInheritedAnnotationParser(tokenParser);
+    Object.defineProperty(tokenParser, runtimeExtractPhase2SeedKey, {
+      value(_state: undefined, exec?: ExecutionContext) {
+        return Promise.resolve({
+          value: { commandPath: exec?.commandPath ?? [] },
+        });
+      },
+      enumerable: true,
+    });
+
+    const dynamicContext: SourceContext = {
+      id: tokenKey,
+      phase: "two-pass",
+      getAnnotations(
+        parsed: { readonly commandPath: readonly string[] } | undefined,
+      ) {
+        if (parsed == null) return {};
+        return parsed.commandPath[0] === "serve"
+          ? { [tokenKey]: "from-phase-two" }
+          : {};
+      },
+    };
+
+    const parser = command("serve", tokenParser);
+
+    const result = await runWith(parser, "test", [dynamicContext], {
+      args: ["serve"],
+    });
+
+    assert.equal(result, "from-phase-two");
   });
 
   it("runWithSync: phase two unwraps multiple() item states for seeds", () => {

--- a/packages/core/src/facade.test.ts
+++ b/packages/core/src/facade.test.ts
@@ -90,7 +90,7 @@ describe("runParser", () => {
   describe("help functionality", () => {
     it("should show help with --help option when help is enabled", () => {
       const parser = object({
-        name: argument(string()),
+        verbose: option("--verbose"),
       });
 
       let helpShown = false;
@@ -118,7 +118,7 @@ describe("runParser", () => {
     it("should not provide help when help is not configured (default)", () => {
       // Test that help is disabled by default
       const parser = object({
-        name: argument(string()),
+        verbose: option("--verbose"),
       });
 
       assert.throws(() => {
@@ -128,7 +128,7 @@ describe("runParser", () => {
 
     it("should only show help option when help mode is 'option'", () => {
       const parser = object({
-        name: argument(string()),
+        verbose: option("--verbose"),
       });
 
       let helpShown = false;
@@ -180,7 +180,7 @@ describe("runParser", () => {
 
     it("should show examples, author, and bugs for top-level help", () => {
       const parser = object({
-        name: argument(string()),
+        verbose: option("--verbose"),
       });
 
       let helpOutput = "";
@@ -292,7 +292,7 @@ describe("runParser", () => {
   describe("version functionality", () => {
     it("should show version with --version option when version is enabled", () => {
       const parser = object({
-        name: argument(string()),
+        verbose: option("--verbose"),
       });
 
       let versionShown = false;
@@ -317,7 +317,7 @@ describe("runParser", () => {
       assert.equal(versionOutput, "1.0.0");
     });
 
-    it("should show version with version command when version mode is 'command'", () => {
+    it("should let ordinary parser data shadow the version command", () => {
       const parser = object({
         name: argument(string()),
       });
@@ -340,12 +340,12 @@ describe("runParser", () => {
         stderr: () => {},
       });
 
-      assert.equal(result, "version-shown");
-      assert.ok(versionShown);
-      assert.equal(versionOutput, "2.1.0");
+      assert.deepEqual(result, { name: "version" });
+      assert.ok(!versionShown);
+      assert.equal(versionOutput, "");
     });
 
-    it("should support both --version and version command when mode is 'both'", () => {
+    it("should still honor --version while letting parser data shadow the version command", () => {
       const parser = object({
         name: argument(string()),
       });
@@ -383,13 +383,13 @@ describe("runParser", () => {
         stderr: () => {},
       });
 
-      assert.equal(result2, "version-shown");
-      assert.equal(versionOutput, "3.0.0");
+      assert.deepEqual(result2, { name: "version" });
+      assert.equal(versionOutput, "");
     });
 
     it("should not provide version when version is not configured (default)", () => {
       const parser = object({
-        name: argument(string()),
+        verbose: option("--verbose"),
       });
 
       assert.throws(() => {
@@ -399,7 +399,7 @@ describe("runParser", () => {
 
     it("should pass exit code 0 to onShow callback", () => {
       const parser = object({
-        name: argument(string()),
+        verbose: option("--verbose"),
       });
 
       let receivedExitCode: number | undefined;
@@ -421,7 +421,7 @@ describe("runParser", () => {
 
     it("should follow last-option-wins pattern for conflicting options", () => {
       const parser = object({
-        name: argument(string()),
+        verbose: option("--verbose"),
       });
 
       // Test --version --help (help should win - last option)
@@ -487,7 +487,7 @@ describe("runParser", () => {
       assert.equal(versionOutput2, "1.0.0");
     });
 
-    it("should handle version command with help option available", () => {
+    it("should keep version command meta behind ordinary parser data when help is also configured", () => {
       const parser = object({
         name: argument(string()),
       });
@@ -515,12 +515,12 @@ describe("runParser", () => {
         stderr: () => {},
       });
 
-      assert.equal(result, "version-shown");
-      assert.ok(versionShown);
-      assert.equal(versionOutput, "2.0.0");
+      assert.deepEqual(result, { name: "version" });
+      assert.ok(!versionShown);
+      assert.equal(versionOutput, "");
     });
 
-    it("should handle help command with version option available", () => {
+    it("should keep help command meta behind ordinary parser data when version is also configured", () => {
       const parser = object({
         name: argument(string()),
       });
@@ -548,14 +548,14 @@ describe("runParser", () => {
         stderr: () => {},
       });
 
-      assert.equal(result, "help-shown");
-      assert.ok(helpShown);
-      assert.ok(helpOutput.includes("Usage: test"));
+      assert.deepEqual(result, { name: "help" });
+      assert.ok(!helpShown);
+      assert.equal(helpOutput, "");
     });
 
     it("should work with onShow callback without exit code parameter", () => {
       const parser = object({
-        name: argument(string()),
+        verbose: option("--verbose"),
       });
 
       let versionCalled = false;
@@ -1285,39 +1285,27 @@ describe("runParser", () => {
     });
 
     // Meta name collision detection
-    it("should reject user command that collides with help command", () => {
+    it("should allow user command shadowing help command", () => {
       const parser = command("help", object({}));
-      assert.throws(
-        () =>
-          runParser(parser, "test", [], {
-            help: {
-              command: true,
-              onShow: () => "HELP",
-            },
-            stderr: () => {},
-          }),
-        {
-          name: "TypeError",
-          message: /user.*"help".*help command/i,
+      const result = runParser(parser, "test", ["help"], {
+        help: {
+          command: true,
+          onShow: () => "HELP",
         },
-      );
+        stderr: () => {},
+      });
+      assert.deepEqual(result, {});
     });
 
-    it("should reject user option that collides with help option", () => {
+    it("should allow user option shadowing help option", () => {
       const parser = object({ help: flag("--help") });
-      assert.throws(
-        () =>
-          runParser(parser, "test", [], {
-            help: {
-              option: true,
-              onShow: () => "HELP",
-            },
-          }),
-        {
-          name: "TypeError",
-          message: /user.*"--help".*help option/i,
+      const result = runParser(parser, "test", ["--help"], {
+        help: {
+          option: true,
+          onShow: () => "HELP",
         },
-      );
+      });
+      assert.deepEqual(result, { help: true });
     });
 
     it("should allow user command 'help' when help command uses custom name", () => {
@@ -1364,23 +1352,17 @@ describe("runParser", () => {
       );
     });
 
-    it("should reject hidden user option that collides with meta option", () => {
+    it("should allow hidden user option shadowing a meta option", () => {
       const parser = object({
         help: flag("--help", { hidden: true }),
       });
-      assert.throws(
-        () =>
-          runParser(parser, "test", [], {
-            help: {
-              option: true,
-              onShow: () => "HELP",
-            },
-          }),
-        {
-          name: "TypeError",
-          message: /user.*"--help".*help option/i,
+      const result = runParser(parser, "test", ["--help"], {
+        help: {
+          option: true,
+          onShow: () => "HELP",
         },
-      );
+      });
+      assert.deepEqual(result, { help: true });
     });
 
     it("should reject duplicate names within a single meta option", () => {
@@ -1399,38 +1381,27 @@ describe("runParser", () => {
       );
     });
 
-    it("should reject user command that collides with version command", () => {
+    it("should allow user command shadowing version command", () => {
       const parser = command("version", object({}));
-      assert.throws(
-        () =>
-          runParser(parser, "test", [], {
-            version: {
-              command: true,
-              value: "1.0.0",
-            },
-            stderr: () => {},
-          }),
-        {
-          name: "TypeError",
-          message: /user.*"version".*version command/i,
+      const result = runParser(parser, "test", ["version"], {
+        version: {
+          command: true,
+          value: "1.0.0",
         },
-      );
+        stderr: () => {},
+      });
+      assert.deepEqual(result, {});
     });
 
-    it("should reject user command that collides with completion command", () => {
+    it("should allow user command shadowing completion command", () => {
       const parser = command("completion", object({}));
-      assert.throws(
-        () =>
-          runParser(parser, "test", [], {
-            help: { option: true },
-            completion: { command: true },
-            stderr: () => {},
-          }),
-        {
-          name: "TypeError",
-          message: /user.*"completion".*completion command/i,
-        },
-      );
+      const result = runParser(parser, "test", ["completion"], {
+        help: { option: true },
+        completion: { command: true },
+        onError: () => "ERROR",
+        stderr: () => {},
+      });
+      assert.deepEqual(result, {});
     });
 
     // P1: nested subcommands should not trigger false positives
@@ -1493,25 +1464,19 @@ describe("runParser", () => {
     });
 
     // Literal values shadowed by meta option scanners
-    it("should reject conditional discriminator value colliding with meta option", () => {
+    it("should allow conditional discriminator value shadowing a meta option", () => {
       const parser = conditional(
         option("--mode", string()),
         { "--help": object({}) },
       );
-      assert.throws(
-        () =>
-          runParser(parser, "test", [], {
-            help: {
-              option: true,
-              onShow: () => "HELP",
-            },
-            stderr: () => {},
-          }),
-        {
-          name: "TypeError",
-          message: /literal.*"--help".*help option/i,
+      const result = runParser(parser, "test", ["--mode", "--help"], {
+        help: {
+          option: true,
+          onShow: () => "HELP",
         },
-      );
+        stderr: () => {},
+      });
+      assert.deepEqual(result, ["--help", {}]);
     });
 
     it("should not reject conditional(argument()) branch key against meta command", () => {
@@ -1559,22 +1524,16 @@ describe("runParser", () => {
       );
     });
 
-    it("should reject user command('--help') colliding with meta help option", () => {
+    it("should allow user command shadowing a meta help option", () => {
       const parser = command("--help", object({}));
-      assert.throws(
-        () =>
-          runParser(parser, "test", [], {
-            help: {
-              option: true,
-              onShow: () => "HELP",
-            },
-            stderr: () => {},
-          }),
-        {
-          name: "TypeError",
-          message: /user.*"--help".*help option/i,
+      const result = runParser(parser, "test", ["--help"], {
+        help: {
+          option: true,
+          onShow: () => "HELP",
         },
-      );
+        stderr: () => {},
+      });
+      assert.deepEqual(result, {});
     });
 
     // Position-aware scoping: nested options vs meta commands
@@ -1596,10 +1555,7 @@ describe("runParser", () => {
     });
 
     // Position-aware scoping: nested commands vs meta options
-    it("should reject nested command('--help') shadowed by meta help option", () => {
-      // command("tool", command("--help", ...)) + help: { option: true }
-      // The lenient help option scanner intercepts --help ANYWHERE in argv,
-      // so "tool --help" would never reach the nested command.
+    it("should allow nested command shadowing a meta help option", () => {
       const parser = command(
         "tool",
         longestMatch(
@@ -1607,35 +1563,23 @@ describe("runParser", () => {
           command("run", object({})),
         ),
       );
-      assert.throws(
-        () =>
-          runParser(parser, "test", [], {
-            help: {
-              option: true,
-              onShow: () => "HELP",
-            },
-            stderr: () => {},
-          }),
-        {
-          name: "TypeError",
-          message: /user.*"--help".*help option/i,
+      const result = runParser(parser, "test", ["tool", "--help"], {
+        help: {
+          option: true,
+          onShow: () => "HELP",
         },
-      );
+        stderr: () => {},
+      });
+      assert.deepEqual(result, {});
     });
 
-    it("should reject user option colliding with completion prefix form", () => {
+    it("should allow user option shadowing the completion prefix form", () => {
       const parser = object({ bad: flag("--completion=bash") });
-      assert.throws(
-        () =>
-          runParser(parser, "test", [], {
-            completion: { option: true },
-            stderr: () => {},
-          }),
-        {
-          name: "TypeError",
-          message: /user.*"--completion=bash".*completion option/i,
-        },
-      );
+      const result = runParser(parser, "test", ["--completion=bash"], {
+        completion: { option: true },
+        stderr: () => {},
+      });
+      assert.deepEqual(result, { bad: true });
     });
 
     it("should reject completion option aliases that collide via = prefix", () => {
@@ -3511,7 +3455,6 @@ describe("Subcommand help edge cases (Issue #26 comprehensive coverage)", () => 
     it("should generate bash completion script when completion command is used", () => {
       const parser = object({
         verbose: option("--verbose"),
-        name: argument(string()),
       });
 
       let completionOutput = "";
@@ -3540,7 +3483,6 @@ describe("Subcommand help edge cases (Issue #26 comprehensive coverage)", () => 
     it("should generate zsh completion script when completion command is used", () => {
       const parser = object({
         verbose: option("--verbose"),
-        name: argument(string()),
       });
 
       let completionOutput = "";
@@ -3564,7 +3506,6 @@ describe("Subcommand help edge cases (Issue #26 comprehensive coverage)", () => 
       const parser = object({
         verbose: option("--verbose"),
         format: option("--format", string()),
-        name: argument(string()),
       });
 
       let completionOutput = "";
@@ -5868,7 +5809,7 @@ describe("runWith", () => {
       };
 
       const parser = object({
-        name: argument(string()),
+        verbose: option("--verbose"),
       });
 
       let helpShown = false;
@@ -5900,7 +5841,7 @@ describe("runWith", () => {
       };
 
       const parser = object({
-        name: argument(string()),
+        verbose: option("--verbose"),
       });
 
       let versionShown = false;
@@ -5933,7 +5874,7 @@ describe("runWith", () => {
       };
 
       const parser = object({
-        name: argument(string()),
+        verbose: option("--verbose"),
       });
 
       let completionShown = false;
@@ -5965,7 +5906,7 @@ describe("runWith", () => {
       };
 
       const parser = object({
-        name: argument(string()),
+        verbose: option("--verbose"),
       });
 
       let completionShown = false;
@@ -5997,7 +5938,7 @@ describe("runWith", () => {
       };
 
       const parser = object({
-        name: argument(string()),
+        verbose: option("--verbose"),
       });
 
       let completionShown = false;
@@ -6029,7 +5970,7 @@ describe("runWith", () => {
       };
 
       const parser = object({
-        name: argument(string()),
+        verbose: option("--verbose"),
       });
 
       let completionShown = false;
@@ -6405,7 +6346,7 @@ describe("runWith", () => {
       };
 
       const parser = object({
-        name: argument(string()),
+        verbose: option("--verbose"),
       });
 
       await runWith(parser, "test", [context], {
@@ -7057,7 +6998,7 @@ describe("runWithSync", () => {
       };
 
       const parser = object({
-        name: argument(string()),
+        verbose: option("--verbose"),
       });
 
       let completionShown = false;
@@ -7294,7 +7235,7 @@ describe("runWithSync", () => {
       };
 
       const parser = object({
-        name: argument(string()),
+        verbose: option("--verbose"),
       });
 
       runWithSync(parser, "test", [context], {
@@ -8269,7 +8210,7 @@ describe("runWithAsync", () => {
   describe("custom names in CommandSubConfig and OptionSubConfig", () => {
     describe("help command custom names", () => {
       it("should trigger help with a single custom command name", () => {
-        const parser = object({ name: argument(string()) });
+        const parser = object({ verbose: option("--verbose") });
 
         let helpShown = false;
         const result = runParser(parser, "test", ["h"], {
@@ -8288,7 +8229,7 @@ describe("runWithAsync", () => {
       });
 
       it("should not respond to default 'help' when custom name is set", () => {
-        const parser = object({ name: argument(string()) });
+        const parser = object({ verbose: option("--verbose") });
 
         let helpShown = false;
         runParser(parser, "test", ["help"], {
@@ -8311,7 +8252,7 @@ describe("runWithAsync", () => {
       });
 
       it("should show custom command name in usage line", () => {
-        const parser = object({ name: argument(string()) });
+        const parser = object({ verbose: option("--verbose") });
 
         let helpOutput = "";
         runParser(parser, "test", ["h"], {
@@ -8335,7 +8276,7 @@ describe("runWithAsync", () => {
       });
 
       it("should support aliases: first name visible, rest hidden but functional", () => {
-        const parser = object({ name: argument(string()) });
+        const parser = object({ verbose: option("--verbose") });
 
         let helpShown = false;
 
@@ -8370,7 +8311,7 @@ describe("runWithAsync", () => {
       });
 
       it("should show only the first name in help output, not hidden aliases", () => {
-        const parser = object({ name: argument(string()) });
+        const parser = object({ verbose: option("--verbose") });
 
         let helpOutput = "";
         runParser(parser, "test", ["help"], {
@@ -8408,7 +8349,7 @@ describe("runWithAsync", () => {
 
     describe("version command custom names", () => {
       it("should trigger version with a custom command name", () => {
-        const parser = object({ name: argument(string()) });
+        const parser = object({ verbose: option("--verbose") });
 
         let versionShown = false;
         const result = runParser(parser, "test", ["ver"], {
@@ -8428,7 +8369,7 @@ describe("runWithAsync", () => {
       });
 
       it("should not respond to default 'version' when custom name is set", () => {
-        const parser = object({ name: argument(string()) });
+        const parser = object({ verbose: option("--verbose") });
 
         let versionShown = false;
         runParser(parser, "test", ["version"], {
@@ -8452,7 +8393,7 @@ describe("runWithAsync", () => {
       });
 
       it("should support version command aliases", () => {
-        const parser = object({ name: argument(string()) });
+        const parser = object({ verbose: option("--verbose") });
 
         // "version" visible, "ver" hidden alias
         const resultViaDisplay = runParser(parser, "test", ["version"], {
@@ -8708,7 +8649,7 @@ describe("runWithAsync", () => {
   describe("hidden visibility in CommandSubConfig and OptionSubConfig", () => {
     describe("command hidden: true", () => {
       it("should hide help command from usage and doc, but still trigger at runtime", () => {
-        const parser = object({ name: argument(string()) });
+        const parser = object({ verbose: option("--verbose") });
 
         // 'help' command is fully hidden but still functional
         let helpShown = false;
@@ -8741,7 +8682,7 @@ describe("runWithAsync", () => {
       });
 
       it("should hide version command from usage and doc, but still trigger at runtime", () => {
-        const parser = object({ name: argument(string()) });
+        const parser = object({ verbose: option("--verbose") });
 
         let versionShown = false;
         const result = runParser(parser, "test", ["version"], {
@@ -8775,7 +8716,7 @@ describe("runWithAsync", () => {
 
     describe('command hidden: "usage"', () => {
       it("should hide help command from usage line but show in help doc", () => {
-        const parser = object({ name: argument(string()) });
+        const parser = object({ verbose: option("--verbose") });
 
         // Should not appear in error usage line
         let errorOutput = "";
@@ -8814,7 +8755,7 @@ describe("runWithAsync", () => {
       });
 
       it("should hide version command from usage line but show in help doc", () => {
-        const parser = object({ name: argument(string()) });
+        const parser = object({ verbose: option("--verbose") });
 
         let errorOutput = "";
         runParser(parser, "test", ["--invalid"], {
@@ -8838,7 +8779,7 @@ describe("runWithAsync", () => {
 
     describe('command hidden: "help"', () => {
       it("should hide help command from usage/doc but keep runtime trigger", () => {
-        const parser = object({ name: argument(string()) });
+        const parser = object({ verbose: option("--verbose") });
 
         let helpShown = false;
         const result = runParser(parser, "test", ["help"], {
@@ -8893,7 +8834,7 @@ describe("runWithAsync", () => {
       });
 
       it("should hide version command from usage/doc but keep runtime trigger", () => {
-        const parser = object({ name: argument(string()) });
+        const parser = object({ verbose: option("--verbose") });
 
         let versionShown = false;
         const result = runParser(parser, "test", ["version"], {
@@ -9420,7 +9361,7 @@ describe("runWithAsync", () => {
 describe("branch coverage: facade.ts edge cases", () => {
   // Lines 101/149: multi-name help/version commands (i > 0 hidden branch)
   it("multi-name help command uses hidden:true for i>0 names", () => {
-    const parser = object({ name: argument(string()) });
+    const parser = object({ verbose: option("--verbose") });
     let helpOutput = "";
     runParser(parser, "test", ["help"], {
       help: { command: { names: ["help", "h"] }, onShow: () => "shown" },
@@ -9432,7 +9373,7 @@ describe("branch coverage: facade.ts edge cases", () => {
   });
 
   it("multi-name version command uses hidden:true for i>0 names", () => {
-    const parser = object({ name: argument(string()) });
+    const parser = object({ verbose: option("--verbose") });
     let versionOutput = "";
     runParser(parser, "test", ["version"], {
       version: {
@@ -11150,18 +11091,12 @@ describe("branch coverage: facade.ts edge cases", () => {
       acceptingAnyToken: false,
       initialState: { value: null },
       parse(context) {
-        const [head, ...rest] = context.buffer;
-        if (head == null) {
-          return Promise.resolve({
-            success: false as const,
-            error: message`Missing argument.`,
-            consumed: 0,
-          });
-        }
         return Promise.resolve({
-          success: true as const,
-          next: { ...context, buffer: rest, state: { value: head } },
-          consumed: [head],
+          success: false as const,
+          error: context.buffer[0] == null
+            ? message`Missing argument.`
+            : message`Unexpected option or argument: ${context.buffer[0]}.`,
+          consumed: 0,
         });
       },
       complete(state) {
@@ -11518,9 +11453,11 @@ describe("branch coverage: facade.ts edge cases", () => {
       initialState: undefined,
       parse(context) {
         return Promise.resolve({
-          success: true as const,
-          next: { ...context, buffer: [], state: undefined },
-          consumed: [...context.buffer],
+          success: false as const,
+          error: context.buffer[0] == null
+            ? message`Missing argument.`
+            : message`Unexpected option or argument: ${context.buffer[0]}.`,
+          consumed: 0,
         });
       },
       complete() {
@@ -11701,7 +11638,7 @@ describe("branch coverage: facade.ts edge cases", () => {
   });
 
   it("supports hidden aliases for help/version commands", () => {
-    const parser = object({ name: argument(string()) });
+    const parser = object({ verbose: option("--verbose") });
     let stdoutOutput = "";
 
     const helpResult = runParser(parser, "myapp", ["assist"], {
@@ -11728,7 +11665,7 @@ describe("branch coverage: facade.ts edge cases", () => {
   });
 
   it("keeps meta-command aliases fully hidden with partial visibility", () => {
-    const parser = object({ name: argument(string()) });
+    const parser = object({ verbose: option("--verbose") });
 
     let helpOutput = "";
     runParser(parser, "myapp", ["--help"], {
@@ -11787,7 +11724,7 @@ describe("branch coverage: facade.ts edge cases", () => {
   });
 
   it("builds multi-name help/version commands with visible primary names", () => {
-    const parser = object({ name: argument(string()) });
+    const parser = object({ verbose: option("--verbose") });
 
     const helpResult = runParser(parser, "myapp", ["assist"], {
       help: {
@@ -11812,7 +11749,7 @@ describe("branch coverage: facade.ts edge cases", () => {
   });
 
   it("shows meta-command help without top-level examples/author/bugs", () => {
-    const parser = object({ name: argument(string()) });
+    const parser = object({ verbose: option("--verbose") });
     let out = "";
 
     const result = runParser(parser, "myapp", ["help", "completion"], {
@@ -12058,6 +11995,149 @@ describe("branch coverage: facade.ts edge cases", () => {
         }),
       /arg-call rejected/,
     );
+  });
+
+  it("preserves ordinary positional values that match meta commands", () => {
+    const parser = object({ value: argument(string()) });
+
+    assert.deepEqual(
+      runParser(parser, "myapp", ["help"], {
+        help: { command: true, onShow: () => "HELP" },
+        stdout: () => {},
+        stderr: () => {},
+      }),
+      { value: "help" },
+    );
+    assert.deepEqual(
+      runParser(parser, "myapp", ["assist"], {
+        help: {
+          command: { names: ["help", "assist"] },
+          onShow: () => "HELP",
+        },
+        stdout: () => {},
+        stderr: () => {},
+      }),
+      { value: "assist" },
+    );
+    assert.deepEqual(
+      runParser(parser, "myapp", ["version"], {
+        version: {
+          command: true,
+          value: "1.0.0",
+          onShow: () => "VER",
+        },
+        stdout: () => {},
+        stderr: () => {},
+      }),
+      { value: "version" },
+    );
+    assert.deepEqual(
+      runParser(parser, "myapp", ["completion"], {
+        completion: { command: true, onShow: () => "COMP" },
+        onError: () => "ERROR",
+        stdout: () => {},
+        stderr: () => {},
+      }),
+      { value: "completion" },
+    );
+  });
+
+  it("preserves ordinary option values that match meta options and aliases", () => {
+    const parser = object({
+      message: option("--message", string({ metavar: "MESSAGE" })),
+    });
+
+    assert.deepEqual(
+      runParser(parser, "myapp", ["--message", "--help"], {
+        help: { option: true, onShow: () => "HELP" },
+        stdout: () => {},
+        stderr: () => {},
+      }),
+      { message: "--help" },
+    );
+    assert.deepEqual(
+      runParser(parser, "myapp", ["--message", "-h"], {
+        help: {
+          option: { names: ["-h"] },
+          onShow: () => "HELP",
+        },
+        stdout: () => {},
+        stderr: () => {},
+      }),
+      { message: "-h" },
+    );
+    assert.deepEqual(
+      runParser(parser, "myapp", ["--message", "--version"], {
+        version: {
+          option: true,
+          value: "1.0.0",
+          onShow: () => "VER",
+        },
+        stdout: () => {},
+        stderr: () => {},
+      }),
+      { message: "--version" },
+    );
+    assert.deepEqual(
+      runParser(parser, "myapp", ["--message", "-V"], {
+        version: {
+          option: { names: ["-V"] },
+          value: "1.0.0",
+          onShow: () => "VER",
+        },
+        stdout: () => {},
+        stderr: () => {},
+      }),
+      { message: "-V" },
+    );
+    assert.deepEqual(
+      runParser(parser, "myapp", ["--message", "--completion"], {
+        completion: { option: true, onShow: () => "COMP" },
+        onError: () => "ERROR",
+        stdout: () => {},
+        stderr: () => {},
+      }),
+      { message: "--completion" },
+    );
+    assert.deepEqual(
+      runParser(parser, "myapp", ["--message", "--completions"], {
+        completion: {
+          option: { names: ["--completions"] },
+          onShow: () => "COMP",
+        },
+        onError: () => "ERROR",
+        stdout: () => {},
+        stderr: () => {},
+      }),
+      { message: "--completions" },
+    );
+  });
+
+  it("runWithSync does not early-exit when completion-like input is ordinary parser data", () => {
+    let annotationsCallCount = 0;
+    const trackingContext: SourceContext = {
+      id: Symbol.for("@test/issue-230/tracking"),
+      phase: "single-pass",
+      getAnnotations() {
+        annotationsCallCount++;
+        return {};
+      },
+    };
+    const parser = object({ value: argument(string()) });
+
+    const result = runWithSync(parser, "myapp", [trackingContext], {
+      args: ["--completion=bash"],
+      completion: {
+        option: true,
+        onShow: () => "COMP",
+      },
+      onError: () => "ERROR",
+      stdout: () => {},
+      stderr: () => {},
+    });
+
+    assert.deepEqual(result, { value: "--completion=bash" });
+    assert.equal(annotationsCallCount, 1);
   });
 });
 

--- a/packages/core/src/facade.test.ts
+++ b/packages/core/src/facade.test.ts
@@ -3588,6 +3588,72 @@ describe("Subcommand help edge cases (Issue #26 comprehensive coverage)", () => 
       assert.ok(completionOutput.includes("function _myapp"));
     });
 
+    it("should preserve matched subcommand context for separated --completion option", () => {
+      const parser = or(
+        command(
+          "build",
+          object({
+            target: option("--target", string()),
+          }),
+        ),
+        command(
+          "test",
+          object({
+            coverage: option("--coverage"),
+          }),
+        ),
+      );
+
+      let completionOutput = "";
+
+      runParser(parser, "myapp", ["build", "--completion", "bash", "--t"], {
+        completion: {
+          option: true,
+        },
+        stdout: (text) => {
+          completionOutput += text;
+        },
+      });
+
+      const suggestions = completionOutput.split("\n").filter((s) =>
+        s.length > 0
+      );
+      assert.deepEqual(suggestions, ["--target"]);
+    });
+
+    it("should preserve matched subcommand context for equals-form --completion option", () => {
+      const parser = or(
+        command(
+          "build",
+          object({
+            target: option("--target", string()),
+          }),
+        ),
+        command(
+          "test",
+          object({
+            coverage: option("--coverage"),
+          }),
+        ),
+      );
+
+      let completionOutput = "";
+
+      runParser(parser, "myapp", ["build", "--completion=bash", "--t"], {
+        completion: {
+          option: true,
+        },
+        stdout: (text) => {
+          completionOutput += text;
+        },
+      });
+
+      const suggestions = completionOutput.split("\n").filter((s) =>
+        s.length > 0
+      );
+      assert.deepEqual(suggestions, ["--target"]);
+    });
+
     it("should treat --completion in payload as opaque args, not as duplicate meta option", () => {
       const parser = object({
         verbose: option("--verbose"),
@@ -4427,6 +4493,46 @@ describe("Subcommand help edge cases (Issue #26 comprehensive coverage)", () => 
 
       assert.ok(versionShown, "version callback should be called");
       assert.ok(!completionShown, "completion callback should not be called");
+    });
+
+    it("should report an invalid version command before --completion", () => {
+      const parser = object({});
+
+      let completionShown = false;
+      let stderrOutput = "";
+
+      const result = runParser(
+        parser,
+        "myapp",
+        ["version", "foo", "--completion", "bash"],
+        {
+          version: {
+            command: true,
+            option: true,
+            value: "1.0.0",
+          },
+          completion: {
+            option: true,
+            command: true,
+            onShow: () => {
+              completionShown = true;
+              return "completion-shown";
+            },
+          },
+          onError: () => "error-shown",
+          stdout: () => {},
+          stderr: (text) => {
+            stderrOutput += text;
+          },
+        },
+      );
+
+      assert.equal(result, "error-shown");
+      assert.ok(!completionShown, "completion callback should not be called");
+      assert.ok(
+        stderrOutput.includes("Error:"),
+        "invalid version command should be reported as a parse error",
+      );
     });
 
     it("should treat --help after --completion=bash as completion payload", () => {
@@ -12217,6 +12323,14 @@ describe("branch coverage: facade.ts edge cases", () => {
       { message: "--help" },
     );
     assert.deepEqual(
+      runParser(parser, "myapp", ["--message=--help"], {
+        help: { option: true, onShow: () => "HELP" },
+        stdout: () => {},
+        stderr: () => {},
+      }),
+      { message: "--help" },
+    );
+    assert.deepEqual(
       runParser(parser, "myapp", ["--message", "-h"], {
         help: {
           option: { names: ["-h"] },
@@ -12228,7 +12342,30 @@ describe("branch coverage: facade.ts edge cases", () => {
       { message: "-h" },
     );
     assert.deepEqual(
+      runParser(parser, "myapp", ["--message=-h"], {
+        help: {
+          option: { names: ["-h"] },
+          onShow: () => "HELP",
+        },
+        stdout: () => {},
+        stderr: () => {},
+      }),
+      { message: "-h" },
+    );
+    assert.deepEqual(
       runParser(parser, "myapp", ["--message", "--version"], {
+        version: {
+          option: true,
+          value: "1.0.0",
+          onShow: () => "VER",
+        },
+        stdout: () => {},
+        stderr: () => {},
+      }),
+      { message: "--version" },
+    );
+    assert.deepEqual(
+      runParser(parser, "myapp", ["--message=--version"], {
         version: {
           option: true,
           value: "1.0.0",
@@ -12252,6 +12389,18 @@ describe("branch coverage: facade.ts edge cases", () => {
       { message: "-V" },
     );
     assert.deepEqual(
+      runParser(parser, "myapp", ["--message=-V"], {
+        version: {
+          option: { names: ["-V"] },
+          value: "1.0.0",
+          onShow: () => "VER",
+        },
+        stdout: () => {},
+        stderr: () => {},
+      }),
+      { message: "-V" },
+    );
+    assert.deepEqual(
       runParser(parser, "myapp", ["--message", "--completion"], {
         completion: { option: true, onShow: () => "COMP" },
         onError: () => "ERROR",
@@ -12261,7 +12410,28 @@ describe("branch coverage: facade.ts edge cases", () => {
       { message: "--completion" },
     );
     assert.deepEqual(
+      runParser(parser, "myapp", ["--message=--completion"], {
+        completion: { option: true, onShow: () => "COMP" },
+        onError: () => "ERROR",
+        stdout: () => {},
+        stderr: () => {},
+      }),
+      { message: "--completion" },
+    );
+    assert.deepEqual(
       runParser(parser, "myapp", ["--message", "--completions"], {
+        completion: {
+          option: { names: ["--completions"] },
+          onShow: () => "COMP",
+        },
+        onError: () => "ERROR",
+        stdout: () => {},
+        stderr: () => {},
+      }),
+      { message: "--completions" },
+    );
+    assert.deepEqual(
+      runParser(parser, "myapp", ["--message=--completions"], {
         completion: {
           option: { names: ["--completions"] },
           onShow: () => "COMP",

--- a/packages/core/src/facade.test.ts
+++ b/packages/core/src/facade.test.ts
@@ -3561,7 +3561,7 @@ describe("Subcommand help edge cases (Issue #26 comprehensive coverage)", () => 
           option: true,
         },
         stdout: (text) => {
-          completionOutput = text;
+          completionOutput += text;
         },
       });
 
@@ -3581,7 +3581,7 @@ describe("Subcommand help edge cases (Issue #26 comprehensive coverage)", () => 
           option: true,
         },
         stdout: (text) => {
-          completionOutput = text;
+          completionOutput += text;
         },
       });
 
@@ -3713,6 +3713,46 @@ describe("Subcommand help edge cases (Issue #26 comprehensive coverage)", () => 
       // "compdef".  With first-match, --completion=bash is the meta option
       // and "--completion=zsh" is payload, so no zsh script is generated.
       assert.ok(!completionOutput.includes("compdef"));
+    });
+
+    it("should preserve completion payload after -- for separated option form", () => {
+      const parser = or(
+        command("build", object({})),
+        command("beta", object({})),
+      );
+
+      let completionOutput = "";
+
+      runParser(parser, "myapp", ["--completion", "bash", "--", "b"], {
+        completion: {
+          option: true,
+        },
+        stdout: (text) => {
+          completionOutput += text;
+        },
+      });
+
+      assert.deepEqual(completionOutput.split("\n").sort(), ["beta", "build"]);
+    });
+
+    it("should preserve completion payload after -- for equals-form option", () => {
+      const parser = or(
+        command("build", object({})),
+        command("beta", object({})),
+      );
+
+      let completionOutput = "";
+
+      runParser(parser, "myapp", ["--completion=bash", "--", "b"], {
+        completion: {
+          option: true,
+        },
+        stdout: (text) => {
+          completionOutput += text;
+        },
+      });
+
+      assert.deepEqual(completionOutput.split("\n").sort(), ["beta", "build"]);
     });
 
     it("should report missing shell for separated --completion option", () => {

--- a/packages/core/src/facade.test.ts
+++ b/packages/core/src/facade.test.ts
@@ -11231,6 +11231,70 @@ describe("branch coverage: facade.ts edge cases", () => {
     assert.equal(phase2Calls, 0, "phase 2 should be skipped on early exit");
   });
 
+  it("runWithSync: skips the meta probe for single-pass contexts", () => {
+    let parseCalls = 0;
+    const ctxKey = Symbol.for("@test/sync-single-pass-meta-probe");
+    const parser: Parser<"sync", string, string | undefined> = {
+      $mode: "sync",
+      $valueType: [] as readonly string[],
+      $stateType: [] as readonly (string | undefined)[],
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(),
+      acceptingAnyToken: false,
+      initialState: undefined,
+      parse(context) {
+        parseCalls++;
+        const [head, ...rest] = context.buffer;
+        if (head == null) {
+          return {
+            success: false as const,
+            consumed: 0,
+            error: message`Missing value.`,
+          };
+        }
+        return {
+          success: true as const,
+          next: { ...context, buffer: rest, state: head },
+          consumed: [head],
+        };
+      },
+      complete(state) {
+        if (state == null) {
+          return {
+            success: false as const,
+            error: message`Missing value.`,
+          };
+        }
+        return {
+          success: true as const,
+          value: state,
+        };
+      },
+      *suggest() {},
+      getDocFragments() {
+        return { fragments: [] };
+      },
+    };
+    const context: SourceContext = {
+      id: ctxKey,
+      phase: "single-pass",
+      getAnnotations() {
+        return { [ctxKey]: {} };
+      },
+    };
+
+    const result = runWithSync(parser, "test", [context], {
+      args: ["value"],
+      help: { option: true },
+      stdout: () => {},
+      stderr: () => {},
+    });
+
+    assert.equal(result, "value");
+    assert.equal(parseCalls, 1, "single-pass runs should parse only once");
+  });
+
   it("runWithSync: two-phase, first pass fails → handled via runParser", () => {
     const dynKey = Symbol.for("@test/sync-two-phase-fail");
     const context: SourceContext = {
@@ -12006,6 +12070,67 @@ describe("branch coverage: facade.ts edge cases", () => {
       args: ["second"],
     });
     assert.equal(withStaticContext, "second");
+  });
+
+  it("runWith skips the meta probe when meta handling is disabled", async () => {
+    let parseCalls = 0;
+    const ctxKey = Symbol.for("@test/async-two-phase-no-meta-probe");
+    const parser: Parser<"async", string, string | undefined> = {
+      $mode: "async",
+      $valueType: [] as readonly string[],
+      $stateType: [] as readonly (string | undefined)[],
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(),
+      acceptingAnyToken: false,
+      initialState: undefined,
+      parse(context) {
+        parseCalls++;
+        const [head, ...rest] = context.buffer;
+        if (head == null) {
+          return Promise.resolve({
+            success: false as const,
+            consumed: 0,
+            error: message`Missing value.`,
+          });
+        }
+        return Promise.resolve({
+          success: true as const,
+          next: { ...context, buffer: rest, state: head },
+          consumed: [head],
+        });
+      },
+      complete(state) {
+        if (state == null) {
+          return Promise.resolve({
+            success: false as const,
+            error: message`Missing value.`,
+          });
+        }
+        return Promise.resolve({
+          success: true as const,
+          value: state,
+        });
+      },
+      async *suggest() {},
+      getDocFragments() {
+        return { fragments: [] };
+      },
+    };
+    const context: SourceContext = {
+      id: ctxKey,
+      phase: "two-pass",
+      getAnnotations() {
+        return {};
+      },
+    };
+
+    const result = await runWith(parser, "test", [context], {
+      args: ["value"],
+    });
+
+    assert.equal(result, "value");
+    assert.equal(parseCalls, 2, "two-pass runs should not add a meta probe");
   });
 
   it("completion callbacks preserve real callback errors", () => {

--- a/packages/core/src/facade.test.ts
+++ b/packages/core/src/facade.test.ts
@@ -3732,7 +3732,11 @@ describe("Subcommand help edge cases (Issue #26 comprehensive coverage)", () => 
         },
       });
 
-      assert.deepEqual(completionOutput.split("\n").sort(), ["beta", "build"]);
+      const suggestions = completionOutput
+        .split("\n")
+        .filter((line) => line.length > 0)
+        .sort();
+      assert.deepEqual(suggestions, ["beta", "build"]);
     });
 
     it("should preserve completion payload after -- for equals-form option", () => {
@@ -3752,7 +3756,11 @@ describe("Subcommand help edge cases (Issue #26 comprehensive coverage)", () => 
         },
       });
 
-      assert.deepEqual(completionOutput.split("\n").sort(), ["beta", "build"]);
+      const suggestions = completionOutput
+        .split("\n")
+        .filter((line) => line.length > 0)
+        .sort();
+      assert.deepEqual(suggestions, ["beta", "build"]);
     });
 
     it("should report missing shell for separated --completion option", () => {

--- a/packages/core/src/facade.test.ts
+++ b/packages/core/src/facade.test.ts
@@ -12647,6 +12647,42 @@ describe("branch coverage: facade.ts edge cases", () => {
     );
   });
 
+  it("prefers user command docs over colliding meta command docs", () => {
+    const metaDescriptions = new Map<string, string>([
+      ["help", "Command name to show help for."],
+      ["version", "Show version information."],
+      [
+        "completion",
+        "Generate shell completion script or provide completions.",
+      ],
+    ]);
+
+    for (const name of ["help", "version", "completion"] as const) {
+      const output: string[] = [];
+      const parser = command(name, object({}), {
+        description: message`User ${name} command.`,
+      });
+
+      const result = runParser(parser, "myapp", [name, "--help"], {
+        help: { command: true, option: true, onShow: () => "HELP" },
+        version: {
+          command: true,
+          value: "1.0.0",
+          onShow: () => "VERSION",
+        },
+        completion: { command: true, onShow: () => "COMPLETION" },
+        stdout(text) {
+          output.push(text);
+        },
+        stderr: () => {},
+      });
+
+      assert.equal(result, "HELP");
+      assert.ok(output.join("").includes(`User "${name}" command.`));
+      assert.ok(!output.join("").includes(metaDescriptions.get(name)!));
+    }
+  });
+
   it("preserves ordinary option values that match meta options and aliases", () => {
     const parser = object({
       message: option("--message", string({ metavar: "MESSAGE" })),

--- a/packages/core/src/facade.ts
+++ b/packages/core/src/facade.ts
@@ -3220,18 +3220,6 @@ async function runWithBody<
   validateContextIds(contexts);
   validateContextPhases(contexts);
 
-  // Early exit: skip context processing for help/version/completion
-  if (await needsEarlyExitAsync(parser, args, options)) {
-    if (parser.$mode === "async") {
-      return runParser(parser, programName, args, options) as Promise<
-        InferValue<TParser>
-      >;
-    }
-    return Promise.resolve(
-      runParser(parser, programName, args, options) as InferValue<TParser>,
-    );
-  }
-
   // Phase 1: Collect initial annotations
   const ctxOptions = options.contextOptions;
   const {
@@ -3239,25 +3227,49 @@ async function runWithBody<
     needsTwoPhase,
     snapshots: phase1Snapshots,
   } = await collectPhase1Annotations(contexts, ctxOptions);
+  const earlyExitParser = injectAnnotationsIntoParser(
+    parser,
+    phase1Annotations,
+  );
 
-  if (!needsTwoPhase) {
-    // All contexts are single-pass.
-    // Inject annotations into the parser's initial state
-    const augmentedParser = injectAnnotationsIntoParser(
-      parser,
-      phase1Annotations,
-    );
-
+  // Early exit: skip phase-two processing for genuine help/version/
+  // completion requests, but only after phase-1 annotations have been
+  // injected because they may change what the parser accepts as ordinary data.
+  if (await needsEarlyExitAsync(earlyExitParser, args, options)) {
     if (parser.$mode === "async") {
       return runParser(
-        augmentedParser,
+        earlyExitParser,
         programName,
         args,
         options,
       ) as Promise<InferValue<TParser>>;
     }
     return Promise.resolve(
-      runParser(augmentedParser, programName, args, options) as InferValue<
+      runParser(
+        earlyExitParser,
+        programName,
+        args,
+        options,
+      ) as InferValue<TParser>,
+    );
+  }
+  const augmentedParser1 = injectAnnotationsIntoParser(
+    parser,
+    phase1Annotations,
+  );
+
+  if (!needsTwoPhase) {
+    // All contexts are single-pass.
+    if (parser.$mode === "async") {
+      return runParser(
+        augmentedParser1,
+        programName,
+        args,
+        options,
+      ) as Promise<InferValue<TParser>>;
+    }
+    return Promise.resolve(
+      runParser(augmentedParser1, programName, args, options) as InferValue<
         TParser
       >,
     );
@@ -3265,11 +3277,6 @@ async function runWithBody<
 
   // Two-phase parsing for two-pass contexts.
   // First pass: parse with Phase 1 annotations to get initial result
-  const augmentedParser1 = injectAnnotationsIntoParser(
-    parser,
-    phase1Annotations,
-  );
-
   const firstPassSeed = await dispatchByMode(
     parser.$mode,
     () =>
@@ -3284,13 +3291,13 @@ async function runWithBody<
   // This is done outside the try-catch to prevent the catch block from
   // re-invoking runParser when it throws (which caused double error output).
   if (firstPassSeed == null) {
-    const augmentedParser = injectAnnotationsIntoParser(
+    const fallbackParser = injectAnnotationsIntoParser(
       parser,
       phase1Annotations,
     );
     if (parser.$mode === "async") {
       return runParser(
-        augmentedParser,
+        fallbackParser,
         programName,
         args,
         options,
@@ -3299,7 +3306,7 @@ async function runWithBody<
       >;
     }
     return Promise.resolve(
-      runParser(augmentedParser, programName, args, options) as InferValue<
+      runParser(fallbackParser, programName, args, options) as InferValue<
         TParser
       >,
     );
@@ -3472,11 +3479,6 @@ function runWithSyncBody<
   validateContextIds(contexts);
   validateContextPhases(contexts);
 
-  // Early exit: skip context processing for help/version/completion
-  if (needsEarlyExitSync(parser, args, options)) {
-    return runParser(parser, programName, args, options);
-  }
-
   // Phase 1: Collect initial annotations
   const ctxOptions = options.contextOptions;
   const {
@@ -3484,30 +3486,36 @@ function runWithSyncBody<
     needsTwoPhase,
     snapshots: phase1Snapshots,
   } = collectPhase1AnnotationsSync(contexts, ctxOptions);
+  const earlyExitParser = injectAnnotationsIntoParser(
+    parser,
+    phase1Annotations,
+  );
 
-  if (!needsTwoPhase) {
-    // All contexts are single-pass.
-    const augmentedParser = injectAnnotationsIntoParser(
-      parser,
-      phase1Annotations,
-    );
-    return runParser(augmentedParser, programName, args, options);
+  // Early exit: skip phase-two processing for genuine help/version/
+  // completion requests, but only after phase-1 annotations have been
+  // injected because they may change what the parser accepts as ordinary data.
+  if (needsEarlyExitSync(earlyExitParser, args, options)) {
+    return runParser(earlyExitParser, programName, args, options);
   }
-
-  // Two-phase parsing for two-pass contexts.
-  // First pass: parse with Phase 1 annotations
   const augmentedParser1 = injectAnnotationsIntoParser(
     parser,
     phase1Annotations,
   );
 
+  if (!needsTwoPhase) {
+    // All contexts are single-pass.
+    return runParser(augmentedParser1, programName, args, options);
+  }
+
+  // Two-phase parsing for two-pass contexts.
+  // First pass: parse with Phase 1 annotations
   const firstPassSeed = extractPhase2SeedSync(augmentedParser1, args);
   if (firstPassSeed == null) {
-    const augmentedParser = injectAnnotationsIntoParser(
+    const fallbackParser = injectAnnotationsIntoParser(
       parser,
       phase1Annotations,
     );
-    return runParser(augmentedParser, programName, args, options);
+    return runParser(fallbackParser, programName, args, options);
   }
 
   // Phase 2: Collect annotations with parsed result

--- a/packages/core/src/facade.ts
+++ b/packages/core/src/facade.ts
@@ -913,7 +913,11 @@ function createCompletionParser(
  */
 type ParsedResult =
   | { readonly type: "success"; readonly value: unknown }
-  | { readonly type: "help"; readonly commands: readonly string[] }
+  | {
+    readonly type: "help";
+    readonly commands: readonly string[];
+    readonly preferUserCommandDocs?: boolean;
+  }
   | { readonly type: "version" }
   | {
     readonly type: "completion";
@@ -1450,6 +1454,7 @@ function classifyParseFailure(
         failure.remainingArgs,
         winner.index,
       ),
+      preferUserCommandDocs: failure.commandPath.length > 0,
     };
   }
 
@@ -2223,6 +2228,7 @@ export function runParser<
         const requestedCommand = classified.commands[0];
         if (
           requestedCommand != null &&
+          !classified.preferUserCommandDocs &&
           completionCommandNames.includes(requestedCommand) &&
           completionAsCommand &&
           completionParsers.completionCommand
@@ -2231,6 +2237,7 @@ export function runParser<
           helpGeneratorParser = completionParsers.completionCommand;
         } else if (
           requestedCommand != null &&
+          !classified.preferUserCommandDocs &&
           helpCommandNames.includes(requestedCommand) &&
           helpAsCommand &&
           helpParsers.helpCommand
@@ -2239,6 +2246,7 @@ export function runParser<
           helpGeneratorParser = helpParsers.helpCommand;
         } else if (
           requestedCommand != null &&
+          !classified.preferUserCommandDocs &&
           versionCommandNames.includes(requestedCommand) &&
           versionAsCommand &&
           versionParsers.versionCommand

--- a/packages/core/src/facade.ts
+++ b/packages/core/src/facade.ts
@@ -1263,7 +1263,8 @@ interface MetaAction {
 }
 
 function classifyOptionMeta(
-  args: readonly string[],
+  scanArgs: readonly string[],
+  fullArgs: readonly string[],
   helpOptionNames: readonly string[],
   versionOptionNames: readonly string[],
   completionOptionNames: readonly string[],
@@ -1272,8 +1273,8 @@ function classifyOptionMeta(
   readonly completion?: CompletionOptionMatch;
 } {
   let lastHelpVersion: MetaAction | undefined;
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i];
+  for (let i = 0; i < scanArgs.length; i++) {
+    const arg = scanArgs[i];
 
     if (helpOptionNames.includes(arg)) {
       lastHelpVersion = { index: i, kind: "help" };
@@ -1290,18 +1291,19 @@ function classifyOptionMeta(
         completion: {
           index: i,
           shell: arg.slice(equalsMatch.length + 1),
-          args: args.slice(i + 1),
+          args: fullArgs.slice(i + 1),
         },
       };
     }
 
     if (completionOptionNames.includes(arg)) {
+      const shell = scanArgs[i + 1] ?? "";
       return {
         lastHelpVersion,
         completion: {
           index: i,
-          shell: args[i + 1] ?? "",
-          args: i + 1 < args.length ? args.slice(i + 2) : [],
+          shell,
+          args: shell === "" ? [] : fullArgs.slice(i + 2),
         },
       };
     }
@@ -1364,6 +1366,7 @@ function classifyParseFailure(
   })();
   const { lastHelpVersion, completion } = classifyOptionMeta(
     optionArgs,
+    failure.remainingArgs,
     helpOptionNames,
     versionOptionNames,
     completionOptionNames,

--- a/packages/core/src/facade.ts
+++ b/packages/core/src/facade.ts
@@ -250,6 +250,20 @@ function isBufferUnchanged(
   );
 }
 
+function getFailureProgress(
+  args: readonly string[],
+  buffer: readonly string[],
+  consumedInStep: number,
+): {
+  readonly remainingArgs: readonly string[];
+  readonly consumedCount: number;
+} {
+  return {
+    remainingArgs: buffer.slice(consumedInStep),
+    consumedCount: args.length - buffer.length + consumedInStep,
+  };
+}
+
 type ParseAttempt<T> =
   | {
     readonly kind: "success";
@@ -324,11 +338,16 @@ function attemptParseSync<T>(
   do {
     const result = parser.parse(context);
     if (!result.success) {
+      const progress = getFailureProgress(
+        args,
+        context.buffer,
+        result.consumed,
+      );
       return {
         kind: "failure",
         error: result.error,
-        remainingArgs: context.buffer,
-        consumedCount: args.length - context.buffer.length,
+        remainingArgs: progress.remainingArgs,
+        consumedCount: progress.consumedCount,
         optionsTerminated: context.optionsTerminated,
         commandPath: getCommandPath(context.exec),
       };
@@ -336,11 +355,16 @@ function attemptParseSync<T>(
     const previousBuffer = context.buffer;
     context = result.next;
     if (isBufferUnchanged(previousBuffer, context.buffer)) {
+      const progress = getFailureProgress(
+        args,
+        previousBuffer,
+        result.consumed.length,
+      );
       return {
         kind: "failure",
         error: message`Unexpected option or argument: ${context.buffer[0]}.`,
-        remainingArgs: context.buffer,
-        consumedCount: args.length - context.buffer.length,
+        remainingArgs: progress.remainingArgs,
+        consumedCount: progress.consumedCount,
         optionsTerminated: context.optionsTerminated,
         commandPath: getCommandPath(context.exec),
       };
@@ -402,11 +426,16 @@ async function attemptParseAsync<T>(
   do {
     const result = await parser.parse(context);
     if (!result.success) {
+      const progress = getFailureProgress(
+        args,
+        context.buffer,
+        result.consumed,
+      );
       return {
         kind: "failure",
         error: result.error,
-        remainingArgs: context.buffer,
-        consumedCount: args.length - context.buffer.length,
+        remainingArgs: progress.remainingArgs,
+        consumedCount: progress.consumedCount,
         optionsTerminated: context.optionsTerminated,
         commandPath: getCommandPath(context.exec),
       };
@@ -414,11 +443,16 @@ async function attemptParseAsync<T>(
     const previousBuffer = context.buffer;
     context = result.next;
     if (isBufferUnchanged(previousBuffer, context.buffer)) {
+      const progress = getFailureProgress(
+        args,
+        previousBuffer,
+        result.consumed.length,
+      );
       return {
         kind: "failure",
         error: message`Unexpected option or argument: ${context.buffer[0]}.`,
-        remainingArgs: context.buffer,
-        consumedCount: args.length - context.buffer.length,
+        remainingArgs: progress.remainingArgs,
+        consumedCount: progress.consumedCount,
         optionsTerminated: context.optionsTerminated,
         commandPath: getCommandPath(context.exec),
       };

--- a/packages/core/src/facade.ts
+++ b/packages/core/src/facade.ts
@@ -47,9 +47,6 @@ import { createInputTrace } from "./input-trace.ts";
 import { completeOrExtractPhase2Seed } from "./phase2-seed.ts";
 import { argument, command, constant, flag, option } from "./primitives.ts";
 import {
-  extractCommandNames,
-  extractLiteralValues,
-  extractOptionNames,
   formatUsage,
   type HiddenVisibility,
   type OptionName,
@@ -2034,12 +2031,8 @@ export function runParser<
   const completionOptionNames: readonly string[] =
     completionOptionConfig?.names ?? ["--completion"];
 
-  // Validate meta name collisions (meta-vs-user and meta-vs-meta).
-  // The collision scope is position-aware:
-  //   - Meta "command" entries only match at args[0], so they are checked
-  //     against leading user names.
-  //   - Meta "option" entries use lenient scanners that match anywhere in
-  //     argv, so they are checked against all user names at every depth.
+  // Validate only meta/meta collisions. Parser-defined names may now overlap
+  // with meta names; the runner resolves those cases parser-first at runtime.
   const activeMetaEntries: MetaEntry[] = [];
   if (options.help && helpOptionConfig) {
     activeMetaEntries.push(["option", "help option", helpOptionNames]);
@@ -2072,15 +2065,7 @@ export function runParser<
       completionCommandNames,
     ]);
   }
-  validateMetaNameCollisions(
-    {
-      leadingNames: parser.leadingNames,
-      allOptions: extractOptionNames(parser.usage, true),
-      allCommands: extractCommandNames(parser.usage, true),
-      allLiterals: extractLiteralValues(parser.usage),
-    },
-    activeMetaEntries,
-  );
+  validateMetaNameCollisions(activeMetaEntries);
 
   // Get available shells (defaults + user-provided)
   const defaultShells: Record<string, ShellCompletion> = {

--- a/packages/core/src/facade.ts
+++ b/packages/core/src/facade.ts
@@ -2787,6 +2787,16 @@ function classifyEarlyExitFailure<THelp, TError>(
   );
 }
 
+function shouldProbeEarlyExit<THelp, TError>(
+  options: RunWithOptions<THelp, TError>,
+  needsTwoPhase: boolean,
+): boolean {
+  return needsTwoPhase &&
+    (options.help != null ||
+      options.version != null ||
+      options.completion != null);
+}
+
 /**
  * Checks if the arguments contain parser-visible meta requests that can be
  * handled without collecting source-context annotations first.
@@ -3283,31 +3293,34 @@ async function runWithBody<
     needsTwoPhase,
     snapshots: phase1Snapshots,
   } = await collectPhase1Annotations(contexts, ctxOptions);
-  const earlyExitParser = injectAnnotationsIntoParser(
-    parser,
-    phase1Annotations,
-  );
-
-  // Early exit: skip phase-two processing for genuine help/version/
-  // completion requests, but only after phase-1 annotations have been
-  // injected because they may change what the parser accepts as ordinary data.
-  if (await needsEarlyExitAsync(earlyExitParser, args, options)) {
-    if (parser.$mode === "async") {
-      return runParser(
-        earlyExitParser,
-        programName,
-        args,
-        options,
-      ) as Promise<InferValue<TParser>>;
-    }
-    return Promise.resolve(
-      runParser(
-        earlyExitParser,
-        programName,
-        args,
-        options,
-      ) as InferValue<TParser>,
+  if (shouldProbeEarlyExit(options, needsTwoPhase)) {
+    const earlyExitParser = injectAnnotationsIntoParser(
+      parser,
+      phase1Annotations,
     );
+
+    // Early exit: skip phase-two processing for genuine help/version/
+    // completion requests, but only after phase-1 annotations have been
+    // injected because they may change what the parser accepts as ordinary
+    // data.
+    if (await needsEarlyExitAsync(earlyExitParser, args, options)) {
+      if (parser.$mode === "async") {
+        return runParser(
+          earlyExitParser,
+          programName,
+          args,
+          options,
+        ) as Promise<InferValue<TParser>>;
+      }
+      return Promise.resolve(
+        runParser(
+          earlyExitParser,
+          programName,
+          args,
+          options,
+        ) as InferValue<TParser>,
+      );
+    }
   }
   const augmentedParser1 = injectAnnotationsIntoParser(
     parser,
@@ -3542,16 +3555,19 @@ function runWithSyncBody<
     needsTwoPhase,
     snapshots: phase1Snapshots,
   } = collectPhase1AnnotationsSync(contexts, ctxOptions);
-  const earlyExitParser = injectAnnotationsIntoParser(
-    parser,
-    phase1Annotations,
-  );
+  if (shouldProbeEarlyExit(options, needsTwoPhase)) {
+    const earlyExitParser = injectAnnotationsIntoParser(
+      parser,
+      phase1Annotations,
+    );
 
-  // Early exit: skip phase-two processing for genuine help/version/
-  // completion requests, but only after phase-1 annotations have been
-  // injected because they may change what the parser accepts as ordinary data.
-  if (needsEarlyExitSync(earlyExitParser, args, options)) {
-    return runParser(earlyExitParser, programName, args, options);
+    // Early exit: skip phase-two processing for genuine help/version/
+    // completion requests, but only after phase-1 annotations have been
+    // injected because they may change what the parser accepts as ordinary
+    // data.
+    if (needsEarlyExitSync(earlyExitParser, args, options)) {
+      return runParser(earlyExitParser, programName, args, options);
+    }
   }
   const augmentedParser1 = injectAnnotationsIntoParser(
     parser,

--- a/packages/core/src/facade.ts
+++ b/packages/core/src/facade.ts
@@ -499,6 +499,7 @@ function createPhase2SeedExec(
     usage: parser.usage,
     phase: "parse",
     path: [],
+    commandPath: [],
     trace: createInputTrace(),
   };
   const runtime = createDependencyRuntimeContext();
@@ -507,6 +508,7 @@ function createPhase2SeedExec(
     phase: "complete",
     dependencyRuntime: runtime,
     dependencyRegistry: runtime.registry,
+    commandPath: getCommandPath(context.exec),
     trace: context.exec?.trace ?? context.trace ?? exec.trace,
   };
 }
@@ -519,6 +521,7 @@ function createPhase2SeedContext(
     usage: parser.usage,
     phase: "parse",
     path: [],
+    commandPath: [],
     trace: createInputTrace(),
   };
   return createParserContext(

--- a/packages/core/src/facade.ts
+++ b/packages/core/src/facade.ts
@@ -35,11 +35,9 @@ import {
   type InferValue,
   type Mode,
   type ModeValue,
-  parseAsync,
   type Parser,
+  type ParserContext,
   type ParserResult,
-  parseSync,
-  type Result,
   suggest,
   suggestAsync,
 } from "./parser.ts";
@@ -58,7 +56,12 @@ import {
   type Usage,
 } from "./usage.ts";
 import { type DeferredMap, string } from "./valueparser.ts";
-import { type Annotations, injectAnnotations } from "./annotations.ts";
+import {
+  type Annotations,
+  injectAnnotations,
+  isInjectedAnnotationWrapper,
+  unwrapInjectedAnnotationWrapper,
+} from "./annotations.ts";
 import {
   type MetaEntry,
   validateCommandNames,
@@ -248,6 +251,216 @@ function isBufferUnchanged(
     current.length === previous.length &&
     current.every((item, i) => item === previous[i])
   );
+}
+
+type ParseAttempt<T> =
+  | {
+    readonly kind: "success";
+    readonly value: T;
+    readonly deferred?: true;
+    readonly deferredKeys?: DeferredMap;
+  }
+  | {
+    readonly kind: "failure";
+    readonly error: Message;
+    readonly remainingArgs: readonly string[];
+    readonly consumedCount: number;
+    readonly optionsTerminated: boolean;
+    readonly commandPath: readonly string[];
+  };
+
+function createParseExec(
+  parser: Parser<Mode, unknown, unknown>,
+): ExecutionContext {
+  return {
+    usage: parser.usage,
+    phase: "parse",
+    path: [],
+    commandPath: [],
+    trace: createInputTrace(),
+  };
+}
+
+function getCommandPath(exec: ExecutionContext | undefined): readonly string[] {
+  return exec?.commandPath ?? [];
+}
+
+function createCompleteExec(
+  exec: ExecutionContext,
+  context: {
+    readonly exec?: ExecutionContext;
+    readonly trace?: ReturnType<typeof createInputTrace>;
+  },
+): ExecutionContext {
+  const runtime = createDependencyRuntimeContext();
+  return {
+    ...exec,
+    phase: "complete",
+    dependencyRuntime: runtime,
+    dependencyRegistry: runtime.registry,
+    commandPath: getCommandPath(context.exec) ?? exec.commandPath,
+    trace: context.exec?.trace ?? context.trace ?? exec.trace,
+  };
+}
+
+function attemptParseSync<T>(
+  parser: Parser<"sync", T, unknown>,
+  args: readonly string[],
+): ParseAttempt<T>;
+function attemptParseSync(
+  parser: Parser<"sync", unknown, unknown>,
+  args: readonly string[],
+  mode: "parse-only",
+): ParseAttempt<undefined>;
+function attemptParseSync<T>(
+  parser: Parser<"sync", T, unknown>,
+  args: readonly string[],
+  mode: "complete" | "parse-only" = "complete",
+): ParseAttempt<T | undefined> {
+  const shouldUnwrapAnnotatedValue = isInjectedAnnotationWrapper(
+    parser.initialState,
+  );
+  const exec = createParseExec(parser);
+  let context: ParserContext<unknown> = createParserContext(
+    { buffer: args, state: parser.initialState, optionsTerminated: false },
+    exec,
+  );
+
+  do {
+    const result = parser.parse(context);
+    if (!result.success) {
+      return {
+        kind: "failure",
+        error: result.error,
+        remainingArgs: context.buffer,
+        consumedCount: args.length - context.buffer.length,
+        optionsTerminated: context.optionsTerminated,
+        commandPath: getCommandPath(context.exec),
+      };
+    }
+    const previousBuffer = context.buffer;
+    context = result.next;
+    if (isBufferUnchanged(previousBuffer, context.buffer)) {
+      return {
+        kind: "failure",
+        error: message`Unexpected option or argument: ${context.buffer[0]}.`,
+        remainingArgs: context.buffer,
+        consumedCount: args.length - context.buffer.length,
+        optionsTerminated: context.optionsTerminated,
+        commandPath: getCommandPath(context.exec),
+      };
+    }
+  } while (context.buffer.length > 0);
+
+  if (mode === "parse-only") {
+    return {
+      kind: "success",
+      value: undefined,
+    };
+  }
+
+  const endResult = parser.complete(
+    context.state,
+    createCompleteExec(exec, context),
+  );
+  if (!endResult.success) {
+    return {
+      kind: "failure",
+      error: endResult.error,
+      remainingArgs: [],
+      consumedCount: args.length,
+      optionsTerminated: context.optionsTerminated,
+      commandPath: getCommandPath(context.exec),
+    };
+  }
+  return {
+    kind: "success",
+    value: shouldUnwrapAnnotatedValue
+      ? unwrapInjectedAnnotationWrapper(endResult.value)
+      : endResult.value,
+    ...(endResult.deferred ? { deferred: true as const } : {}),
+    ...(endResult.deferredKeys ? { deferredKeys: endResult.deferredKeys } : {}),
+  };
+}
+
+async function attemptParseAsync<T>(
+  parser: Parser<Mode, T, unknown>,
+  args: readonly string[],
+): Promise<ParseAttempt<T>>;
+async function attemptParseAsync(
+  parser: Parser<Mode, unknown, unknown>,
+  args: readonly string[],
+  mode: "parse-only",
+): Promise<ParseAttempt<undefined>>;
+async function attemptParseAsync<T>(
+  parser: Parser<Mode, T, unknown>,
+  args: readonly string[],
+  mode: "complete" | "parse-only" = "complete",
+): Promise<ParseAttempt<T | undefined>> {
+  const shouldUnwrapAnnotatedValue = isInjectedAnnotationWrapper(
+    parser.initialState,
+  );
+  const exec = createParseExec(parser);
+  let context: ParserContext<unknown> = createParserContext(
+    { buffer: args, state: parser.initialState, optionsTerminated: false },
+    exec,
+  );
+
+  do {
+    const result = await parser.parse(context);
+    if (!result.success) {
+      return {
+        kind: "failure",
+        error: result.error,
+        remainingArgs: context.buffer,
+        consumedCount: args.length - context.buffer.length,
+        optionsTerminated: context.optionsTerminated,
+        commandPath: getCommandPath(context.exec),
+      };
+    }
+    const previousBuffer = context.buffer;
+    context = result.next;
+    if (isBufferUnchanged(previousBuffer, context.buffer)) {
+      return {
+        kind: "failure",
+        error: message`Unexpected option or argument: ${context.buffer[0]}.`,
+        remainingArgs: context.buffer,
+        consumedCount: args.length - context.buffer.length,
+        optionsTerminated: context.optionsTerminated,
+        commandPath: getCommandPath(context.exec),
+      };
+    }
+  } while (context.buffer.length > 0);
+
+  if (mode === "parse-only") {
+    return {
+      kind: "success",
+      value: undefined,
+    };
+  }
+
+  const endResult = await parser.complete(
+    context.state,
+    createCompleteExec(exec, context),
+  );
+  if (!endResult.success) {
+    return {
+      kind: "failure",
+      error: endResult.error,
+      remainingArgs: [],
+      consumedCount: args.length,
+      optionsTerminated: context.optionsTerminated,
+      commandPath: getCommandPath(context.exec),
+    };
+  }
+  return {
+    kind: "success",
+    value: shouldUnwrapAnnotatedValue
+      ? unwrapInjectedAnnotationWrapper(endResult.value)
+      : endResult.value,
+    ...(endResult.deferred ? { deferred: true as const } : {}),
+    ...(endResult.deferredKeys ? { deferredKeys: endResult.deferredKeys } : {}),
+  };
 }
 
 function createPhase2SeedExec(
@@ -492,10 +705,6 @@ interface MetaParseResult {
   readonly versionFlag?: boolean;
 }
 
-function isMetaParseResult(value: unknown): value is MetaParseResult {
-  return typeof value === "object" && value != null && metaResultBrand in value;
-}
-
 /**
  * Sub-configuration for a meta command's command form.
  *
@@ -680,6 +889,7 @@ type ParsedResult =
   | { readonly type: "version" }
   | {
     readonly type: "completion";
+    readonly source: "command" | "option";
     readonly shell: string;
     readonly args: readonly string[];
   }
@@ -1049,101 +1259,174 @@ function combineWithHelpVersion(
   return combined;
 }
 
-/**
- * Classifies the parsing result into a discriminated union for cleaner
- * handling.
- */
-function classifyResult(
-  result: Result<unknown>,
+interface CompletionOptionMatch {
+  readonly index: number;
+  readonly shell: string;
+  readonly args: readonly string[];
+}
+
+interface MetaAction {
+  readonly index: number;
+  readonly kind: "help" | "version";
+}
+
+function classifyOptionMeta(
   args: readonly string[],
+  helpOptionNames: readonly string[],
+  versionOptionNames: readonly string[],
+  completionOptionNames: readonly string[],
+): {
+  readonly lastHelpVersion?: MetaAction;
+  readonly completion?: CompletionOptionMatch;
+} {
+  let lastHelpVersion: MetaAction | undefined;
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+
+    if (helpOptionNames.includes(arg)) {
+      lastHelpVersion = { index: i, kind: "help" };
+    } else if (versionOptionNames.includes(arg)) {
+      lastHelpVersion = { index: i, kind: "version" };
+    }
+
+    const equalsMatch = completionOptionNames.find((name) =>
+      arg.startsWith(name + "=")
+    );
+    if (equalsMatch != null) {
+      return {
+        lastHelpVersion,
+        completion: {
+          index: i,
+          shell: arg.slice(equalsMatch.length + 1),
+          args: args.slice(i + 1),
+        },
+      };
+    }
+
+    if (completionOptionNames.includes(arg)) {
+      return {
+        lastHelpVersion,
+        completion: {
+          index: i,
+          shell: args[i + 1] ?? "",
+          args: i + 1 < args.length ? args.slice(i + 2) : [],
+        },
+      };
+    }
+  }
+  return { lastHelpVersion };
+}
+
+function getHelpCommandContext(
+  commandPath: readonly string[],
+  args: readonly string[],
+  helpIndex: number,
+): readonly string[] {
+  const commands = [...commandPath];
+  for (let i = 0; i < helpIndex; i++) {
+    const arg = args[i];
+    if (!arg.startsWith("-")) {
+      commands.push(arg);
+    }
+  }
+  return commands;
+}
+
+function classifyParseFailure(
+  failure: Extract<ParseAttempt<unknown>, { readonly kind: "failure" }>,
   helpOptionNames: readonly string[],
   helpCommandNames: readonly string[],
   versionOptionNames: readonly string[],
   versionCommandNames: readonly string[],
+  completionOptionNames: readonly string[],
   completionCommandNames: readonly string[],
-): ParsedResult {
-  if (!result.success) {
-    return { type: "error", error: result.error };
+): Exclude<ParsedResult, { readonly type: "success" }> {
+  if (failure.remainingArgs.length < 1) {
+    return { type: "error", error: failure.error };
   }
 
-  const value = result.value;
-  if (isMetaParseResult(value)) {
-    const parsedValue = value;
+  const hasConsumedPrefix = failure.consumedCount > 0;
+  const firstArg = failure.remainingArgs[0];
 
-    const hasVersionOption = versionOptionNames.some((n) => args.includes(n));
-    const hasVersionCommand = args.length > 0 &&
-      versionCommandNames.includes(args[0]);
-    const hasCompletionCommand = args.length > 0 &&
-      completionCommandNames.includes(args[0]);
-    const hasHelpOption = hasCompletionCommand
-      // Completion command detected: only check args[1] for help
-      ? helpOptionNames.length > 0 && args.length >= 2 &&
-        helpOptionNames.includes(args[1])
-      : helpOptionNames.some((n) => args.includes(n));
-    const hasHelpCommand = args.length > 0 &&
-      helpCommandNames.includes(args[0]);
-
-    // Standard CLI behavior:
-    // 1. `command --help` should show help for that command
-    // 2. `--help` and `--version` together follow last-option-wins
-    // 3. `--version` alone should show version
-    // 4. `--help` alone should show help
-    // 5. `completion --help` should show help for completion command
-
-    // If we have both version command and help flag, help takes precedence
-    // (show help for version)
-    if (hasVersionCommand && hasHelpOption && parsedValue.helpFlag) {
-      return { type: "help", commands: [args[0]] };
+  if (
+    !hasConsumedPrefix &&
+    completionCommandNames.includes(firstArg)
+  ) {
+    const secondArg = failure.remainingArgs[1];
+    if (helpOptionNames.includes(secondArg)) {
+      return { type: "help", commands: [firstArg] };
     }
-
-    // If we have both completion command and help flag, help takes precedence
-    // (show help for completion)
-    if (hasCompletionCommand && hasHelpOption && parsedValue.helpFlag) {
-      return { type: "help", commands: [args[0]] };
-    }
-
-    // If we have help command or help option, show help
-    if (parsedValue.help && (hasHelpOption || hasHelpCommand)) {
-      let commandContext: readonly string[] = [];
-
-      if (Array.isArray(parsedValue.commands)) {
-        commandContext = parsedValue.commands;
-      } else if (
-        typeof parsedValue.commands === "object" &&
-        parsedValue.commands != null &&
-        "length" in parsedValue.commands
-      ) {
-        commandContext = parsedValue.commands as readonly string[];
-      }
-
-      return { type: "help", commands: commandContext };
-    }
-
-    // If version is present and help is not requested, show version
-    if (
-      (hasVersionOption || hasVersionCommand) &&
-      (parsedValue.version || parsedValue.versionFlag)
-    ) {
-      return { type: "version" };
-    }
-
-    // If completion is present and help is not requested, show completion
-    if (parsedValue.completion && parsedValue.completionData) {
-      return {
-        type: "completion",
-        shell: parsedValue.completionData.shell ?? "",
-        args: parsedValue.completionData.args ?? [],
-      };
-    }
-
-    // Neither help nor version nor completion requested, return actual result
     return {
-      type: "success",
-      value: "result" in parsedValue ? parsedValue.result : value,
+      type: "completion",
+      source: "command",
+      shell: secondArg ?? "",
+      args: failure.remainingArgs.slice(2),
     };
   }
 
-  return { type: "success", value };
+  const optionArgs = failure.optionsTerminated ? [] : (() => {
+    const terminatorIndex = failure.remainingArgs.indexOf("--");
+    return terminatorIndex >= 0
+      ? failure.remainingArgs.slice(0, terminatorIndex)
+      : failure.remainingArgs;
+  })();
+  const { lastHelpVersion, completion } = classifyOptionMeta(
+    optionArgs,
+    helpOptionNames,
+    versionOptionNames,
+    completionOptionNames,
+  );
+
+  let commandAction: MetaAction | undefined;
+  if (!hasConsumedPrefix && helpCommandNames.includes(firstArg)) {
+    commandAction = { index: 0, kind: "help" };
+  } else if (
+    !hasConsumedPrefix &&
+    versionCommandNames.includes(firstArg)
+  ) {
+    const boundaryIndex = completion?.index ?? optionArgs.length;
+    if (boundaryIndex <= 1) {
+      commandAction = { index: 0, kind: "version" };
+    }
+  }
+
+  const winner = lastHelpVersion == null
+    ? commandAction
+    : commandAction == null || lastHelpVersion.index >= commandAction.index
+    ? lastHelpVersion
+    : commandAction;
+
+  if (winner?.kind === "help") {
+    if (winner === commandAction) {
+      return {
+        type: "help",
+        commands: failure.remainingArgs.slice(1),
+      };
+    }
+    return {
+      type: "help",
+      commands: getHelpCommandContext(
+        failure.commandPath,
+        failure.remainingArgs,
+        winner.index,
+      ),
+    };
+  }
+
+  if (winner?.kind === "version") {
+    return { type: "version" };
+  }
+
+  if (completion != null) {
+    return {
+      type: "completion",
+      source: "option",
+      shell: completion.shell,
+      args: completion.args,
+    };
+  }
+
+  return { type: "error", error: failure.error };
 }
 
 /**
@@ -1829,183 +2112,6 @@ export function runParser<
     )
     : { completionCommand: null, completionOption: null };
 
-  // Early return for completion requests (avoids parser conflicts)
-  // Exception: if a help option is present, let the parser handle it
-  if (options.completion) {
-    // Only consider args before the options terminator ("--") when checking
-    // for help options; tokens after "--" are positional data.
-    const helpTerminatorIndex = args.indexOf("--");
-    const helpOptionArgs = helpTerminatorIndex >= 0
-      ? args.slice(0, helpTerminatorIndex)
-      : args;
-
-    const hasHelpOption = helpOptionConfig
-      ? (completionCommandConfig && completionCommandNames.includes(args[0]))
-        // Completion command detected: only check args[1] for help
-        ? args.length >= 2 && helpOptionNames.includes(args[1])
-        // No completion command: check args before "--" only
-        : helpOptionNames.some((n) => helpOptionArgs.includes(n))
-      : false;
-
-    // Handle completion command format: "completion <shell> [args...]"
-    if (
-      completionCommandConfig &&
-      args.length >= 1 &&
-      completionCommandNames.includes(args[0]) &&
-      !hasHelpOption // Let parser handle "completion --help"
-    ) {
-      return handleCompletion<
-        InferMode<TParser>,
-        InferValue<TParser>,
-        InferValue<TParser>
-      >(
-        args.slice(1),
-        programName,
-        parser,
-        completionParsers.completionCommand,
-        stdout,
-        stderr,
-        onCompletionResult,
-        onErrorResult,
-        availableShells,
-        colors,
-        maxWidth,
-        completionCommandNames[0],
-        completionOptionNames[0],
-        false,
-        sectionOrder,
-      ) as ModeValue<InferMode<TParser>, InferValue<TParser>>;
-    }
-
-    // Handle completion option format: "--completion=<shell> [args...]"
-    // The first --completion match is the meta option; everything after it
-    // (including the shell name) is opaque completion payload and must not
-    // be re-interpreted as another meta option.
-    // Exception: if a help or version option/command appears *before* the
-    // completion option, skip the early return and let the combined parser
-    // handle precedence — but only with args truncated at the completion
-    // option position so payload tokens stay opaque.
-    //
-    // This uses a naive token scan (matching raw argv strings against known
-    // meta option names).  The combined parser's lenient help/version parsers
-    // use the same naive approach: they scan the parse buffer for meta flag
-    // names and match regardless of whether a token is actually an option
-    // value.  So this early-return check is consistent with what the combined
-    // parser would do — both treat any token matching a meta flag name as
-    // that meta flag.
-    // Check whether any help/version meta entry (option or command form)
-    // appears in args before a given index.  Command-form entries are only
-    // checked at args[0] since commands are always the first token.
-    const hasMetaEntryBefore = (endIndex: number): boolean => {
-      const argsBefore = args.slice(0, endIndex);
-      if (
-        helpOptionConfig &&
-        helpOptionNames.some((n) => argsBefore.includes(n))
-      ) return true;
-      if (
-        versionOptionConfig &&
-        versionOptionNames.some((n) => argsBefore.includes(n))
-      ) return true;
-      if (endIndex > 0) {
-        if (
-          helpCommandConfig &&
-          helpCommandNames.includes(args[0])
-        ) return true;
-        if (
-          versionCommandConfig &&
-          versionCommandNames.includes(args[0])
-        ) return true;
-      }
-      return false;
-    };
-
-    let completionOptionIndex = -1;
-    if (completionOptionConfig) {
-      // Only scan args before the options terminator; reuse the index
-      // already computed for the hasHelpOption check above.
-      const loopBound = helpTerminatorIndex >= 0
-        ? helpTerminatorIndex
-        : args.length;
-      for (let i = 0; i < loopBound; i++) {
-        const arg = args[i];
-
-        // Check for "--completion=<shell>" format
-        const equalsMatch = completionOptionNames.find((n) =>
-          arg.startsWith(n + "=")
-        );
-        if (equalsMatch) {
-          if (hasMetaEntryBefore(i)) {
-            completionOptionIndex = i;
-            break; // Fall through with truncated args
-          }
-          const shell = arg.slice(equalsMatch.length + 1);
-          const completionArgs = args.slice(i + 1);
-          return handleCompletion<
-            InferMode<TParser>,
-            InferValue<TParser>,
-            InferValue<TParser>
-          >(
-            [shell, ...completionArgs],
-            programName,
-            parser,
-            completionParsers.completionOption,
-            stdout,
-            stderr,
-            onCompletionResult,
-            onErrorResult,
-            availableShells,
-            colors,
-            maxWidth,
-            completionCommandNames[0],
-            completionOptionNames[0],
-            true,
-            sectionOrder,
-          ) as ModeValue<InferMode<TParser>, InferValue<TParser>>;
-        }
-
-        // Check for "--completion <shell>" format (separate arg)
-        const exactMatch = completionOptionNames.includes(arg);
-        if (exactMatch) {
-          if (hasMetaEntryBefore(i)) {
-            completionOptionIndex = i;
-            break; // Fall through with truncated args
-          }
-          const shell = i + 1 < args.length ? args[i + 1] : "";
-          const completionArgs = i + 1 < args.length ? args.slice(i + 2) : [];
-          return handleCompletion<
-            InferMode<TParser>,
-            InferValue<TParser>,
-            InferValue<TParser>
-          >(
-            [shell, ...completionArgs],
-            programName,
-            parser,
-            completionParsers.completionOption,
-            stdout,
-            stderr,
-            onCompletionResult,
-            onErrorResult,
-            availableShells,
-            colors,
-            maxWidth,
-            completionCommandNames[0],
-            completionOptionNames[0],
-            true,
-            sectionOrder,
-          ) as ModeValue<InferMode<TParser>, InferValue<TParser>>;
-        }
-      }
-    }
-
-    // When help/version precedes --completion, truncate args so the combined
-    // parser and classifyResult only see tokens before the completion option.
-    // This keeps completion payload opaque — e.g., --version after
-    // --completion is not re-interpreted as a meta flag.
-    if (completionOptionIndex >= 0) {
-      args = args.slice(0, completionOptionIndex);
-    }
-  }
-
   // Build augmented parser with help, version, and completion functionality
   const augmentedParser = !options.help && !options.version &&
       !options.completion
@@ -2033,18 +2139,8 @@ export function runParser<
   // For async parsers, this may return a Promise when help/error handling
   // requires awaiting getDocPage.
   const handleResult = (
-    result: Result<unknown>,
+    classified: ParsedResult,
   ): InferValue<TParser> | Promise<InferValue<TParser>> => {
-    const classified = classifyResult(
-      result,
-      args,
-      helpOptionConfig ? [...helpOptionNames] : [],
-      helpCommandConfig ? [...helpCommandNames] : [],
-      versionOptionConfig ? [...versionOptionNames] : [],
-      versionCommandConfig ? [...versionCommandNames] : [],
-      completionCommandConfig ? [...completionCommandNames] : [],
-    );
-
     switch (classified.type) {
       case "success":
         return classified.value;
@@ -2054,11 +2150,29 @@ export function runParser<
         return onVersion(0);
 
       case "completion":
-        // This case should never be reached due to early return,
-        // but keep it for type safety
-        throw new RunParserError(
-          "Completion should be handled by early return",
-        );
+        return handleCompletion<
+          InferMode<TParser>,
+          InferValue<TParser>,
+          InferValue<TParser>
+        >(
+          [classified.shell, ...classified.args],
+          programName,
+          parser,
+          classified.source === "command"
+            ? completionParsers.completionCommand
+            : completionParsers.completionOption,
+          stdout,
+          stderr,
+          onCompletionResult,
+          onErrorResult,
+          availableShells,
+          colors,
+          maxWidth,
+          completionCommandNames[0],
+          completionOptionNames[0],
+          classified.source === "option",
+          sectionOrder,
+        ) as InferValue<TParser>;
 
       case "help": {
         // Handle help request - determine which parser to use for help
@@ -2464,19 +2578,41 @@ export function runParser<
   return dispatchByMode(
     parserMode,
     () => {
-      const result = parseSync(
-        augmentedParser as Parser<"sync", unknown, unknown>,
+      const attempted = attemptParseSync(
+        parser as Parser<"sync", unknown, unknown>,
         args,
       );
-      const handled = handleResult(result);
+      const classified: ParsedResult = attempted.kind === "success"
+        ? { type: "success", value: attempted.value }
+        : classifyParseFailure(
+          attempted,
+          helpOptionConfig ? [...helpOptionNames] : [],
+          helpCommandConfig ? [...helpCommandNames] : [],
+          versionOptionConfig ? [...versionOptionNames] : [],
+          versionCommandConfig ? [...versionCommandNames] : [],
+          completionOptionConfig ? [...completionOptionNames] : [],
+          completionCommandConfig ? [...completionCommandNames] : [],
+        );
+      const handled = handleResult(classified);
       if (handled instanceof Promise) {
         throw new RunParserError("Synchronous parser returned async result.");
       }
       return handled;
     },
     async () => {
-      const result = await parseAsync(augmentedParser, args);
-      const handled = handleResult(result);
+      const attempted = await attemptParseAsync(parser, args);
+      const classified: ParsedResult = attempted.kind === "success"
+        ? { type: "success", value: attempted.value }
+        : classifyParseFailure(
+          attempted,
+          helpOptionConfig ? [...helpOptionNames] : [],
+          helpCommandConfig ? [...helpCommandNames] : [],
+          versionOptionConfig ? [...versionOptionNames] : [],
+          versionCommandConfig ? [...versionCommandNames] : [],
+          completionOptionConfig ? [...completionOptionNames] : [],
+          completionCommandConfig ? [...completionCommandNames] : [],
+        );
+      const handled = handleResult(classified);
       return handled instanceof Promise ? await handled : handled;
     },
   ) as ModeValue<InferMode<TParser>, InferValue<TParser>>;
@@ -2566,106 +2702,75 @@ function indentLines(text: string, indent: number): string {
   return text.split("\n").join("\n" + " ".repeat(indent));
 }
 
+function isMetaEarlyExit(classified: ParsedResult): boolean {
+  return classified.type === "help" ||
+    classified.type === "version" ||
+    classified.type === "completion";
+}
+
+function classifyEarlyExitFailure<THelp, TError>(
+  failure: Extract<ParseAttempt<unknown>, { readonly kind: "failure" }>,
+  options: RunWithOptions<THelp, TError>,
+): Exclude<ParsedResult, { readonly type: "success" }> {
+  const norm = <T>(c: true | T | undefined): T | undefined =>
+    c === true ? ({} as T) : c;
+  const helpOptionConfig = norm<OptionSubConfig>(options.help?.option);
+  const helpCommandConfig = norm<CommandSubConfig>(options.help?.command);
+  const versionOptionConfig = norm<OptionSubConfig>(options.version?.option);
+  const versionCommandConfig = norm<CommandSubConfig>(
+    options.version?.command,
+  );
+  const completionOptionConfig = norm<OptionSubConfig>(
+    options.completion?.option,
+  );
+  const completionCommandConfig = norm<CommandSubConfig>(
+    options.completion?.command,
+  );
+
+  return classifyParseFailure(
+    failure,
+    helpOptionConfig ? [...(helpOptionConfig.names ?? ["--help"])] : [],
+    helpCommandConfig ? [...(helpCommandConfig.names ?? ["help"])] : [],
+    versionOptionConfig
+      ? [...(versionOptionConfig.names ?? ["--version"])]
+      : [],
+    versionCommandConfig
+      ? [...(versionCommandConfig.names ?? ["version"])]
+      : [],
+    completionOptionConfig
+      ? [...(completionOptionConfig.names ?? ["--completion"])]
+      : [],
+    completionCommandConfig
+      ? [...(completionCommandConfig.names ?? ["completion"])]
+      : [],
+  );
+}
+
 /**
- * Checks if the arguments contain help, version, or completion requests
- * that should be handled immediately without context processing.
- *
- * This enables early exit optimization: when users request help, version,
- * or completion, we skip annotation collection and context processing
- * entirely, delegating directly to runParser().
- *
- * @param args Command-line arguments to check.
- * @param options Run options containing help/version/completion configuration.
- * @returns `true` if early exit should be performed, `false` otherwise.
+ * Checks if the arguments contain parser-visible meta requests that can be
+ * handled without collecting source-context annotations first.
  */
-function needsEarlyExit<THelp, TError>(
+function needsEarlyExitSync<THelp, TError>(
+  parser: Parser<"sync", unknown, unknown>,
   args: readonly string[],
   options: RunWithOptions<THelp, TError>,
 ): boolean {
-  const norm = <T>(c: true | T | undefined): T | undefined =>
-    c === true ? ({} as T) : c;
+  const attempted = attemptParseSync(parser, args, "parse-only");
+  if (attempted.kind === "success") return false;
+  return isMetaEarlyExit(classifyEarlyExitFailure(attempted, options));
+}
 
-  // Only scan args before the options terminator ("--") for option-form
-  // matches; tokens after "--" are positional data and must not be
-  // interpreted as meta options.
-  const terminatorIndex = args.indexOf("--");
-  const optionArgs = terminatorIndex >= 0
-    ? args.slice(0, terminatorIndex)
-    : args;
-
-  // Check help
-  if (options.help) {
-    const helpOptionConfig = norm<OptionSubConfig>(options.help.option);
-    const helpCommandConfig = norm<CommandSubConfig>(options.help.command);
-    const helpOptionNames: readonly string[] = helpOptionConfig?.names ??
-      ["--help"];
-    const helpCommandNames: readonly string[] = helpCommandConfig?.names ??
-      ["help"];
-
-    if (
-      helpOptionConfig &&
-      helpOptionNames.some((n) => optionArgs.includes(n))
-    ) {
-      return true;
-    }
-    if (helpCommandConfig && helpCommandNames.includes(args[0])) {
-      return true;
-    }
-  }
-
-  // Check version
-  if (options.version) {
-    const versionOptionConfig = norm<OptionSubConfig>(options.version.option);
-    const versionCommandConfig = norm<CommandSubConfig>(
-      options.version.command,
-    );
-    const versionOptionNames: readonly string[] = versionOptionConfig?.names ??
-      ["--version"];
-    const versionCommandNames: readonly string[] =
-      versionCommandConfig?.names ?? ["version"];
-
-    if (
-      versionOptionConfig &&
-      versionOptionNames.some((n) => optionArgs.includes(n))
-    ) {
-      return true;
-    }
-    if (versionCommandConfig && versionCommandNames.includes(args[0])) {
-      return true;
-    }
-  }
-
-  // Check completion
-  if (options.completion) {
-    const completionCommandConfig = norm<CommandSubConfig>(
-      options.completion.command,
-    );
-    const completionOptionConfig = norm<OptionSubConfig>(
-      options.completion.option,
-    );
-    const completionCommandNames: readonly string[] =
-      completionCommandConfig?.names ?? ["completion"];
-    const completionOptionNames: readonly string[] =
-      completionOptionConfig?.names ?? ["--completion"];
-
-    // Command mode
-    if (completionCommandConfig && completionCommandNames.includes(args[0])) {
-      return true;
-    }
-
-    // Option mode
-    if (completionOptionConfig) {
-      for (const arg of optionArgs) {
-        for (const name of completionOptionNames) {
-          if (arg === name || arg.startsWith(name + "=")) {
-            return true;
-          }
-        }
-      }
-    }
-  }
-
-  return false;
+/**
+ * Async variant of {@link needsEarlyExitSync}.
+ */
+async function needsEarlyExitAsync<THelp, TError>(
+  parser: Parser<Mode, unknown, unknown>,
+  args: readonly string[],
+  options: RunWithOptions<THelp, TError>,
+): Promise<boolean> {
+  const attempted = await attemptParseAsync(parser, args, "parse-only");
+  if (attempted.kind === "success") return false;
+  return isMetaEarlyExit(classifyEarlyExitFailure(attempted, options));
 }
 
 /**
@@ -3131,7 +3236,7 @@ async function runWithBody<
   validateContextPhases(contexts);
 
   // Early exit: skip context processing for help/version/completion
-  if (needsEarlyExit(args, options)) {
+  if (await needsEarlyExitAsync(parser, args, options)) {
     if (parser.$mode === "async") {
       return runParser(parser, programName, args, options) as Promise<
         InferValue<TParser>
@@ -3383,7 +3488,7 @@ function runWithSyncBody<
   validateContextPhases(contexts);
 
   // Early exit: skip context processing for help/version/completion
-  if (needsEarlyExit(args, options)) {
+  if (needsEarlyExitSync(parser, args, options)) {
     return runParser(parser, programName, args, options);
   }
 

--- a/packages/core/src/facade.ts
+++ b/packages/core/src/facade.ts
@@ -254,8 +254,6 @@ type ParseAttempt<T> =
   | {
     readonly kind: "success";
     readonly value: T;
-    readonly deferred?: true;
-    readonly deferredKeys?: DeferredMap;
   }
   | {
     readonly kind: "failure";
@@ -375,8 +373,6 @@ function attemptParseSync<T>(
     value: shouldUnwrapAnnotatedValue
       ? unwrapInjectedAnnotationWrapper(endResult.value)
       : endResult.value,
-    ...(endResult.deferred ? { deferred: true as const } : {}),
-    ...(endResult.deferredKeys ? { deferredKeys: endResult.deferredKeys } : {}),
   };
 }
 
@@ -455,8 +451,6 @@ async function attemptParseAsync<T>(
     value: shouldUnwrapAnnotatedValue
       ? unwrapInjectedAnnotationWrapper(endResult.value)
       : endResult.value,
-    ...(endResult.deferred ? { deferred: true as const } : {}),
-    ...(endResult.deferredKeys ? { deferredKeys: endResult.deferredKeys } : {}),
   };
 }
 
@@ -888,6 +882,7 @@ type ParsedResult =
     readonly type: "completion";
     readonly source: "command" | "option";
     readonly shell: string;
+    readonly commandPath?: readonly string[];
     readonly args: readonly string[];
   }
   | { readonly type: "error"; readonly error: Message };
@@ -1374,17 +1369,25 @@ function classifyParseFailure(
     completionOptionNames,
   );
 
+  if (!hasConsumedPrefix && versionCommandNames.includes(firstArg)) {
+    const secondArg = failure.remainingArgs[1];
+    if (helpOptionNames.includes(secondArg)) {
+      return { type: "help", commands: [firstArg] };
+    }
+    const isCompletionImmediatelyAfter = completion?.index === 1;
+    if (
+      secondArg == null ||
+      isCompletionImmediatelyAfter ||
+      (lastHelpVersion?.index === 1 && lastHelpVersion.kind === "version")
+    ) {
+      return { type: "version" };
+    }
+    return { type: "error", error: failure.error };
+  }
+
   let commandAction: MetaAction | undefined;
   if (!hasConsumedPrefix && helpCommandNames.includes(firstArg)) {
     commandAction = { index: 0, kind: "help" };
-  } else if (
-    !hasConsumedPrefix &&
-    versionCommandNames.includes(firstArg)
-  ) {
-    const boundaryIndex = completion?.index ?? optionArgs.length;
-    if (boundaryIndex <= 1) {
-      commandAction = { index: 0, kind: "version" };
-    }
   }
 
   const winner = lastHelpVersion == null
@@ -1419,6 +1422,7 @@ function classifyParseFailure(
       type: "completion",
       source: "option",
       shell: completion.shell,
+      commandPath: failure.commandPath,
       args: completion.args,
     };
   }
@@ -2140,7 +2144,11 @@ export function runParser<
           InferValue<TParser>,
           InferValue<TParser>
         >(
-          [classified.shell, ...classified.args],
+          [
+            classified.shell,
+            ...(classified.commandPath ?? []),
+            ...classified.args,
+          ],
           programName,
           parser,
           classified.source === "command"

--- a/packages/core/src/modifiers.ts
+++ b/packages/core/src/modifiers.ts
@@ -58,6 +58,7 @@ function mergeChildExec(
     trace: child.trace ?? parent.trace,
     dependencyRuntime: child.dependencyRuntime ?? parent.dependencyRuntime,
     dependencyRegistry: child.dependencyRegistry ?? parent.dependencyRegistry,
+    commandPath: child.commandPath ?? parent.commandPath,
     preCompletedByParser: child.preCompletedByParser ??
       parent.preCompletedByParser,
     excludedSourceFields: child.excludedSourceFields ??

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -453,6 +453,17 @@ export interface ExecutionContext {
   readonly path: readonly PropertyKey[];
 
   /**
+   * Matched command names in parse order.
+   *
+   * This is tracked separately from {@link path} because parse-tree paths also
+   * include object fields and other wrapper segments.  Runners use it to
+   * recover subcommand help context from partial parses.
+   *
+   * @internal
+   */
+  readonly commandPath?: readonly string[];
+
+  /**
    * Immutable trace of raw primitive inputs recorded during parsing.
    *
    * Primitives append trace entries keyed by {@link path}, allowing later

--- a/packages/core/src/primitives.ts
+++ b/packages/core/src/primitives.ts
@@ -60,6 +60,7 @@ function mergeChildExec(
     trace: child.trace ?? parent.trace,
     dependencyRuntime: child.dependencyRuntime ?? parent.dependencyRuntime,
     dependencyRegistry: child.dependencyRegistry ?? parent.dependencyRegistry,
+    commandPath: child.commandPath ?? parent.commandPath,
     preCompletedByParser: child.preCompletedByParser ??
       parent.preCompletedByParser,
     excludedSourceFields: child.excludedSourceFields ??
@@ -2444,6 +2445,17 @@ function createCommandState<TState>(
   >;
 }
 
+function appendCommandPath(
+  exec: ExecutionContext | undefined,
+  name: string,
+): ExecutionContext | undefined {
+  if (exec == null) return undefined;
+  return {
+    ...exec,
+    commandPath: [...(exec.commandPath ?? []), name],
+  };
+}
+
 function* suggestCommandSync<T, TState>(
   context: ParserContext<CommandState<TState>>,
   prefix: string,
@@ -2672,6 +2684,11 @@ export function command<M extends Mode, T, TState>(
               context.state,
               ["matched", name] as ["matched", string],
             ),
+            ...(context.exec != null
+              ? {
+                exec: appendCommandPath(context.exec, name),
+              }
+              : {}),
           },
           consumed: context.buffer.slice(0, 1),
         };

--- a/packages/core/src/validate.test.ts
+++ b/packages/core/src/validate.test.ts
@@ -2,7 +2,6 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
   escapeControlChars,
-  type UserParserNames,
   validateCommandNames,
   validateContextIds,
   validateLabel,
@@ -343,28 +342,12 @@ describe("validateCommandNames", () => {
 });
 
 describe("validateMetaNameCollisions", () => {
-  const e: ReadonlySet<string> = new Set<string>();
-  // Helper: build UserParserNames with same sets for leading and all
-  function u(
-    opts: ReadonlySet<string> = e,
-    cmds: ReadonlySet<string> = e,
-    lits: ReadonlySet<string> = e,
-  ): UserParserNames {
-    return {
-      leadingNames: new Set([...opts, ...cmds]),
-      allOptions: opts,
-      allCommands: cmds,
-      allLiterals: lits,
-    };
-  }
-
   it("should pass with no meta features", () => {
-    validateMetaNameCollisions(u(), []);
+    validateMetaNameCollisions([]);
   });
 
   it("should pass with no collisions", () => {
     validateMetaNameCollisions(
-      u(new Set(["--verbose", "-v"]), new Set(["build", "test"])),
       [
         ["option", "help option", ["--help"]],
         ["command", "help command", ["help"]],
@@ -374,7 +357,6 @@ describe("validateMetaNameCollisions", () => {
 
   it("should pass when meta features use custom names avoiding collision", () => {
     validateMetaNameCollisions(
-      u(new Set(["--help"]), new Set(["help"])),
       [
         ["option", "help option", ["--info"]],
         ["command", "help command", ["info"]],
@@ -385,7 +367,7 @@ describe("validateMetaNameCollisions", () => {
   it("should throw on duplicate within a single meta feature", () => {
     assert.throws(
       () =>
-        validateMetaNameCollisions(u(), [
+        validateMetaNameCollisions([
           ["option", "help option", ["--help", "--help"]],
         ]),
       { name: "TypeError", message: /help option.*duplicate.*"--help"/i },
@@ -395,7 +377,7 @@ describe("validateMetaNameCollisions", () => {
   it("should throw on duplicate within a single meta command feature", () => {
     assert.throws(
       () =>
-        validateMetaNameCollisions(u(), [
+        validateMetaNameCollisions([
           ["command", "help command", ["help", "help"]],
         ]),
       { name: "TypeError", message: /help command.*duplicate.*"help"/i },
@@ -405,7 +387,7 @@ describe("validateMetaNameCollisions", () => {
   it("should throw when two meta options share a name", () => {
     assert.throws(
       () =>
-        validateMetaNameCollisions(u(), [
+        validateMetaNameCollisions([
           ["option", "help option", ["--meta"]],
           ["option", "completion option", ["--meta"]],
         ]),
@@ -420,7 +402,7 @@ describe("validateMetaNameCollisions", () => {
   it("should throw when two meta commands share a name", () => {
     assert.throws(
       () =>
-        validateMetaNameCollisions(u(), [
+        validateMetaNameCollisions([
           ["command", "help command", ["meta"]],
           ["command", "version command", ["meta"]],
         ]),
@@ -431,29 +413,8 @@ describe("validateMetaNameCollisions", () => {
     );
   });
 
-  it("should allow user option shadowing a meta option", () => {
-    validateMetaNameCollisions(u(new Set(["--help"])), [
-      ["option", "help option", ["--help"]],
-    ]);
-  });
-
-  it("should allow user command shadowing a meta command", () => {
-    validateMetaNameCollisions(u(e, new Set(["help"])), [
-      ["command", "help command", ["help"]],
-    ]);
-  });
-
   it("should not throw when meta feature is disabled", () => {
-    validateMetaNameCollisions(
-      u(new Set(["--help"]), new Set(["help"])),
-      [],
-    );
-  });
-
-  it("should allow user names shadowing meta aliases", () => {
-    validateMetaNameCollisions(u(e, new Set(["aide"])), [
-      ["command", "help command", ["help", "aide"]],
-    ]);
+    validateMetaNameCollisions([]);
   });
 
   // Meta-vs-meta prefix collision tests
@@ -461,7 +422,7 @@ describe("validateMetaNameCollisions", () => {
     // help.command.names = ["--completion=bash"] + completion.option enabled
     assert.throws(
       () =>
-        validateMetaNameCollisions(u(), [
+        validateMetaNameCollisions([
           ["command", "help command", ["--completion=bash"]],
           ["option", "completion option", ["--completion"], true],
         ]),
@@ -474,7 +435,7 @@ describe("validateMetaNameCollisions", () => {
 
   it("should not prefix-match between meta features without prefixMatch", () => {
     // help and version don't use prefix matching
-    validateMetaNameCollisions(u(), [
+    validateMetaNameCollisions([
       ["option", "help option", ["--help"]],
       ["command", "version command", ["--help=verbose"]],
     ]);
@@ -484,7 +445,7 @@ describe("validateMetaNameCollisions", () => {
     // completion.option.names = ["--completion", "--completion=bash"]
     assert.throws(
       () =>
-        validateMetaNameCollisions(u(), [
+        validateMetaNameCollisions([
           [
             "option",
             "completion option",
@@ -503,7 +464,7 @@ describe("validateMetaNameCollisions", () => {
   it("should throw when meta command name collides with meta option name", () => {
     assert.throws(
       () =>
-        validateMetaNameCollisions(u(), [
+        validateMetaNameCollisions([
           ["option", "help option", ["--help"]],
           ["command", "version command", ["--help"]],
         ]),
@@ -514,184 +475,15 @@ describe("validateMetaNameCollisions", () => {
     );
   });
 
-  it("should allow user command shadowing a meta option", () => {
-    validateMetaNameCollisions(
-      {
-        leadingNames: e,
-        allOptions: e,
-        allCommands: new Set(["--help"]),
-        allLiterals: e,
-      },
-      [["option", "help option", ["--help"]]],
-    );
-  });
-
-  // Position-scoping tests
-  it("should not flag nested option against meta command (position-aware)", () => {
-    validateMetaNameCollisions(
-      {
-        leadingNames: e,
-        allOptions: new Set(["--version"]),
-        allCommands: e,
-        allLiterals: e,
-      },
-      [["command", "version command", ["--version"]]],
-    );
-  });
-
-  it("should not flag nested command against meta command (position-aware)", () => {
-    validateMetaNameCollisions(
-      {
-        leadingNames: e,
-        allOptions: e,
-        allCommands: new Set(["help"]),
-        allLiterals: e,
-      },
-      [["command", "help command", ["help"]]],
-    );
-  });
-
-  it("should allow leading option shadowing a meta command", () => {
-    validateMetaNameCollisions(
-      {
-        leadingNames: new Set(["--version"]),
-        allOptions: new Set(["--version"]),
-        allCommands: e,
-        allLiterals: e,
-      },
-      [["command", "version command", ["--version"]]],
-    );
-  });
-
-  it("should allow nested option shadowing a meta option", () => {
-    validateMetaNameCollisions(
-      {
-        leadingNames: e,
-        allOptions: new Set(["--help"]),
-        allCommands: e,
-        allLiterals: e,
-      },
-      [["option", "help option", ["--help"]]],
-    );
-  });
-
-  it("should allow nested command shadowing a meta option", () => {
-    validateMetaNameCollisions(
-      {
-        leadingNames: e,
-        allOptions: e,
-        allCommands: new Set(["--help"]),
-        allLiterals: e,
-      },
-      [["option", "help option", ["--help"]]],
-    );
-  });
-
-  // Literal value collision tests
-  it("should allow literal value shadowing a meta option", () => {
-    validateMetaNameCollisions(
-      u(e, e, new Set(["--help"])),
-      [["option", "help option", ["--help"]]],
-    );
-  });
-
-  it("should not flag non-leading literal value against meta command", () => {
-    // Meta commands only match at args[0]; non-leading literals are safe.
-    // leadingNames doesn't include literals, so they're invisible to
-    // command-form checks.
-    validateMetaNameCollisions(
-      {
-        leadingNames: e,
-        allOptions: e,
-        allCommands: e,
-        allLiterals: new Set(["help"]),
-      },
-      [["command", "help command", ["help"]]],
-    );
-  });
-
-  it("should allow non-leading literal value shadowing a meta option", () => {
-    validateMetaNameCollisions(
-      {
-        leadingNames: e,
-        allOptions: e,
-        allCommands: e,
-        allLiterals: new Set(["--help"]),
-      },
-      [["option", "help option", ["--help"]]],
-    );
-  });
-
-  // Prefix matching tests (only for entries with prefixMatch: true)
-  it("should allow user option shadowing a prefix-matching meta option", () => {
-    validateMetaNameCollisions(
-      {
-        leadingNames: e,
-        allOptions: new Set(["--completion=bash"]),
-        allCommands: e,
-        allLiterals: e,
-      },
-      [["option", "completion option", ["--completion"], true]],
-    );
-  });
-
-  it("should allow user command shadowing a prefix-matching meta option", () => {
-    validateMetaNameCollisions(
-      {
-        leadingNames: e,
-        allOptions: e,
-        allCommands: new Set(["--completion=bash"]),
-        allLiterals: e,
-      },
-      [["option", "completion option", ["--completion"], true]],
-    );
-  });
-
-  it("should allow literal shadowing a prefix-matching meta option", () => {
-    validateMetaNameCollisions(
-      u(e, e, new Set(["--completion=bash"])),
-      [["option", "completion option", ["--completion"], true]],
-    );
-  });
-
   it("should not prefix-match when prefixMatch is not set", () => {
     // help/version use exact matching; --help=foo is a valid user name
-    validateMetaNameCollisions(
-      u(new Set(["--help=foo"])),
-      [["option", "help option", ["--help"]]],
-    );
+    validateMetaNameCollisions([["option", "help option", ["--help"]]]);
   });
 
   it("should not flag prefix match against meta command entries", () => {
-    validateMetaNameCollisions(
-      u(new Set(["--completion=bash"])),
-      [["command", "completion command", ["--completion"]]],
-    );
-  });
-
-  it("should allow literal shadowing a meta option via prefix form", () => {
-    validateMetaNameCollisions(
-      {
-        leadingNames: e,
-        allOptions: e,
-        allCommands: e,
-        allLiterals: new Set(["--completion=bash"]),
-      },
-      [["option", "completion option", ["--completion"], true]],
-    );
-  });
-
-  it("should not prefix-match literal values when prefixMatch is not set", () => {
-    // help/version use exact matching; --help=verbose is a valid literal
-    validateMetaNameCollisions(
-      {
-        leadingNames: e,
-        allOptions: e,
-        allCommands: e,
-        allLiterals: new Set(["--help=verbose"]),
-      },
-      [["option", "help option", ["--help"]]],
-    );
+    validateMetaNameCollisions([["command", "completion command", [
+      "--completion",
+    ]]]);
   });
 });
 

--- a/packages/core/src/validate.test.ts
+++ b/packages/core/src/validate.test.ts
@@ -480,7 +480,7 @@ describe("validateMetaNameCollisions", () => {
     validateMetaNameCollisions([["option", "help option", ["--help"]]]);
   });
 
-  it("should not flag prefix match against meta command entries", () => {
+  it("should allow exact matching for meta command entries", () => {
     validateMetaNameCollisions([["command", "completion command", [
       "--completion",
     ]]]);

--- a/packages/core/src/validate.test.ts
+++ b/packages/core/src/validate.test.ts
@@ -431,24 +431,16 @@ describe("validateMetaNameCollisions", () => {
     );
   });
 
-  it("should throw when user option collides with meta option", () => {
-    assert.throws(
-      () =>
-        validateMetaNameCollisions(u(new Set(["--help"])), [
-          ["option", "help option", ["--help"]],
-        ]),
-      { name: "TypeError", message: /user.*"--help".*help option/i },
-    );
+  it("should allow user option shadowing a meta option", () => {
+    validateMetaNameCollisions(u(new Set(["--help"])), [
+      ["option", "help option", ["--help"]],
+    ]);
   });
 
-  it("should throw when user command collides with meta command", () => {
-    assert.throws(
-      () =>
-        validateMetaNameCollisions(u(e, new Set(["help"])), [
-          ["command", "help command", ["help"]],
-        ]),
-      { name: "TypeError", message: /user.*"help".*help command/i },
-    );
+  it("should allow user command shadowing a meta command", () => {
+    validateMetaNameCollisions(u(e, new Set(["help"])), [
+      ["command", "help command", ["help"]],
+    ]);
   });
 
   it("should not throw when meta feature is disabled", () => {
@@ -458,14 +450,10 @@ describe("validateMetaNameCollisions", () => {
     );
   });
 
-  it("should detect collision with aliases", () => {
-    assert.throws(
-      () =>
-        validateMetaNameCollisions(u(e, new Set(["aide"])), [
-          ["command", "help command", ["help", "aide"]],
-        ]),
-      { name: "TypeError", message: /user.*"aide".*help command/i },
-    );
+  it("should allow user names shadowing meta aliases", () => {
+    validateMetaNameCollisions(u(e, new Set(["aide"])), [
+      ["command", "help command", ["help", "aide"]],
+    ]);
   });
 
   // Meta-vs-meta prefix collision tests
@@ -526,19 +514,15 @@ describe("validateMetaNameCollisions", () => {
     );
   });
 
-  it("should throw when user command collides with meta option (all depth)", () => {
-    assert.throws(
-      () =>
-        validateMetaNameCollisions(
-          {
-            leadingNames: e,
-            allOptions: e,
-            allCommands: new Set(["--help"]),
-            allLiterals: e,
-          },
-          [["option", "help option", ["--help"]]],
-        ),
-      { name: "TypeError", message: /user.*"--help".*help option/i },
+  it("should allow user command shadowing a meta option", () => {
+    validateMetaNameCollisions(
+      {
+        leadingNames: e,
+        allOptions: e,
+        allCommands: new Set(["--help"]),
+        allLiterals: e,
+      },
+      [["option", "help option", ["--help"]]],
     );
   });
 
@@ -567,67 +551,47 @@ describe("validateMetaNameCollisions", () => {
     );
   });
 
-  it("should flag leading option against meta command (position-aware)", () => {
-    assert.throws(
-      () =>
-        validateMetaNameCollisions(
-          {
-            leadingNames: new Set(["--version"]),
-            allOptions: new Set(["--version"]),
-            allCommands: e,
-            allLiterals: e,
-          },
-          [["command", "version command", ["--version"]]],
-        ),
+  it("should allow leading option shadowing a meta command", () => {
+    validateMetaNameCollisions(
       {
-        name: "TypeError",
-        message: /user.*option.*"--version".*version command/i,
+        leadingNames: new Set(["--version"]),
+        allOptions: new Set(["--version"]),
+        allCommands: e,
+        allLiterals: e,
       },
+      [["command", "version command", ["--version"]]],
     );
   });
 
-  it("should flag nested option against meta option (scans everywhere)", () => {
-    assert.throws(
-      () =>
-        validateMetaNameCollisions(
-          {
-            leadingNames: e,
-            allOptions: new Set(["--help"]),
-            allCommands: e,
-            allLiterals: e,
-          },
-          [["option", "help option", ["--help"]]],
-        ),
-      { name: "TypeError", message: /user.*"--help".*help option/i },
+  it("should allow nested option shadowing a meta option", () => {
+    validateMetaNameCollisions(
+      {
+        leadingNames: e,
+        allOptions: new Set(["--help"]),
+        allCommands: e,
+        allLiterals: e,
+      },
+      [["option", "help option", ["--help"]]],
     );
   });
 
-  it("should flag nested command against meta option (scans everywhere)", () => {
-    assert.throws(
-      () =>
-        validateMetaNameCollisions(
-          {
-            leadingNames: e,
-            allOptions: e,
-            allCommands: new Set(["--help"]),
-            allLiterals: e,
-          },
-          [["option", "help option", ["--help"]]],
-        ),
-      { name: "TypeError", message: /user.*"--help".*help option/i },
+  it("should allow nested command shadowing a meta option", () => {
+    validateMetaNameCollisions(
+      {
+        leadingNames: e,
+        allOptions: e,
+        allCommands: new Set(["--help"]),
+        allLiterals: e,
+      },
+      [["option", "help option", ["--help"]]],
     );
   });
 
   // Literal value collision tests
-  it("should flag literal value colliding with meta option", () => {
-    // conditional(option("--mode", string()), { "--help": object({}) })
-    assert.throws(
-      () =>
-        validateMetaNameCollisions(
-          u(e, e, new Set(["--help"])),
-          [["option", "help option", ["--help"]]],
-        ),
-      { name: "TypeError", message: /literal.*"--help".*help option/i },
+  it("should allow literal value shadowing a meta option", () => {
+    validateMetaNameCollisions(
+      u(e, e, new Set(["--help"])),
+      [["option", "help option", ["--help"]]],
     );
   });
 
@@ -646,76 +610,47 @@ describe("validateMetaNameCollisions", () => {
     );
   });
 
-  it("should flag non-leading literal value colliding with meta option", () => {
-    // Option-form meta entries scan entire argv, so they check allLiterals.
-    assert.throws(
-      () =>
-        validateMetaNameCollisions(
-          {
-            leadingNames: e,
-            allOptions: e,
-            allCommands: e,
-            allLiterals: new Set(["--help"]),
-          },
-          [["option", "help option", ["--help"]]],
-        ),
-      { name: "TypeError", message: /literal.*"--help".*help option/i },
+  it("should allow non-leading literal value shadowing a meta option", () => {
+    validateMetaNameCollisions(
+      {
+        leadingNames: e,
+        allOptions: e,
+        allCommands: e,
+        allLiterals: new Set(["--help"]),
+      },
+      [["option", "help option", ["--help"]]],
     );
   });
 
   // Prefix matching tests (only for entries with prefixMatch: true)
-  it("should flag user option matching prefix when prefixMatch is true", () => {
-    // Put --completion=bash only in allOptions (not leading) to prove
-    // that prefix matching checks the all-depth set.
-    assert.throws(
-      () =>
-        validateMetaNameCollisions(
-          {
-            leadingNames: e,
-            allOptions: new Set(["--completion=bash"]),
-            allCommands: e,
-            allLiterals: e,
-          },
-          [["option", "completion option", ["--completion"], true]],
-        ),
+  it("should allow user option shadowing a prefix-matching meta option", () => {
+    validateMetaNameCollisions(
       {
-        name: "TypeError",
-        message: /user.*"--completion=bash".*completion option/i,
+        leadingNames: e,
+        allOptions: new Set(["--completion=bash"]),
+        allCommands: e,
+        allLiterals: e,
       },
+      [["option", "completion option", ["--completion"], true]],
     );
   });
 
-  it("should flag user command matching prefix when prefixMatch is true", () => {
-    assert.throws(
-      () =>
-        validateMetaNameCollisions(
-          {
-            leadingNames: e,
-            allOptions: e,
-            allCommands: new Set(["--completion=bash"]),
-            allLiterals: e,
-          },
-          [["option", "completion option", ["--completion"], true]],
-        ),
+  it("should allow user command shadowing a prefix-matching meta option", () => {
+    validateMetaNameCollisions(
       {
-        name: "TypeError",
-        message: /user.*"--completion=bash".*completion option/i,
+        leadingNames: e,
+        allOptions: e,
+        allCommands: new Set(["--completion=bash"]),
+        allLiterals: e,
       },
+      [["option", "completion option", ["--completion"], true]],
     );
   });
 
-  it("should flag literal matching prefix when prefixMatch is true", () => {
-    // conditional(option("--mode", string()), { "--completion=bash": ... })
-    assert.throws(
-      () =>
-        validateMetaNameCollisions(
-          u(e, e, new Set(["--completion=bash"])),
-          [["option", "completion option", ["--completion"], true]],
-        ),
-      {
-        name: "TypeError",
-        message: /literal.*"--completion=bash".*completion option/i,
-      },
+  it("should allow literal shadowing a prefix-matching meta option", () => {
+    validateMetaNameCollisions(
+      u(e, e, new Set(["--completion=bash"])),
+      [["option", "completion option", ["--completion"], true]],
     );
   });
 
@@ -734,24 +669,15 @@ describe("validateMetaNameCollisions", () => {
     );
   });
 
-  it("should flag literal matching prefix against meta option", () => {
-    // prefixMatch is only meaningful for option-form meta entries
-    // (facade.ts only sets it for the completion option).
-    assert.throws(
-      () =>
-        validateMetaNameCollisions(
-          {
-            leadingNames: e,
-            allOptions: e,
-            allCommands: e,
-            allLiterals: new Set(["--completion=bash"]),
-          },
-          [["option", "completion option", ["--completion"], true]],
-        ),
+  it("should allow literal shadowing a meta option via prefix form", () => {
+    validateMetaNameCollisions(
       {
-        name: "TypeError",
-        message: /literal.*"--completion=bash".*completion option/i,
+        leadingNames: e,
+        allOptions: e,
+        allCommands: e,
+        allLiterals: new Set(["--completion=bash"]),
       },
+      [["option", "completion option", ["--completion"], true]],
     );
   });
 

--- a/packages/core/src/validate.ts
+++ b/packages/core/src/validate.ts
@@ -151,28 +151,6 @@ export type MetaEntry = readonly [
 ];
 
 /**
- * User parser names extracted at different scopes for collision checking.
- *
- * User-level names are no longer rejected merely for overlapping with
- * built-in meta names.  The runner now resolves those cases at parse time
- * so ordinary parser data can shadow meta handlers when appropriate.
- *
- * @since 1.0.0
- */
-export interface UserParserNames {
-  /** Names (option names, command names) reachable at the first buffer
-   *  position.  A flat set from {@link Parser.leadingNames}. */
-  readonly leadingNames: ReadonlySet<string>;
-  /** All option names at any depth. */
-  readonly allOptions: ReadonlySet<string>;
-  /** All command names at any depth. */
-  readonly allCommands: ReadonlySet<string>;
-  /** All literal values at any depth (e.g., conditional discriminator
-   *  values). */
-  readonly allLiterals: ReadonlySet<string>;
-}
-
-/**
  * Validates that there are no name collisions among active meta features
  * (help, version, completion).
  *
@@ -184,15 +162,11 @@ export interface UserParserNames {
  * because a meta command named `"--help"` and a meta option named
  * `"--help"` both compete for the same token.
  *
- * @param userNames User parser names extracted at different scopes.
- *                  Currently unused, but retained to keep the runtime call
- *                  site stable.
  * @param metaEntries Active meta feature entries annotated with their kind.
  * @throws {TypeError} If any meta/meta collision or duplicate is detected.
  * @since 1.0.0
  */
 export function validateMetaNameCollisions(
-  _userNames: UserParserNames,
   metaEntries: readonly MetaEntry[],
 ): void {
   // 1. Check for duplicates within each meta feature

--- a/packages/core/src/validate.ts
+++ b/packages/core/src/validate.ts
@@ -153,6 +153,10 @@ export type MetaEntry = readonly [
 /**
  * User parser names extracted at different scopes for collision checking.
  *
+ * User-level names are no longer rejected merely for overlapping with
+ * built-in meta names.  The runner now resolves those cases at parse time
+ * so ordinary parser data can shadow meta handlers when appropriate.
+ *
  * @since 1.0.0
  */
 export interface UserParserNames {
@@ -169,28 +173,26 @@ export interface UserParserNames {
 }
 
 /**
- * Validates that there are no name collisions among meta features
- * (help, version, completion) and between meta features and user parsers.
+ * Validates that there are no name collisions among active meta features
+ * (help, version, completion).
  *
- * The collision check is *position-aware*:
- *
- * - Meta **command** entries match at `args[0]` only, so they are checked
- *   against *leading* user names (those reachable before any positional gate).
- * - Meta **option** entries use lenient scanners that match anywhere in
- *   `argv`, so they are checked against *all* user names at every depth,
- *   including literal values from conditional discriminators.
+ * User parser names are accepted even when they overlap with meta names.
+ * Runtime parsing resolves those cases parser-first so ordinary parser data
+ * can shadow built-in meta behavior.
  *
  * Meta-vs-meta collisions are always checked in a unified namespace,
  * because a meta command named `"--help"` and a meta option named
  * `"--help"` both compete for the same token.
  *
  * @param userNames User parser names extracted at different scopes.
+ *                  Currently unused, but retained to keep the runtime call
+ *                  site stable.
  * @param metaEntries Active meta feature entries annotated with their kind.
- * @throws {TypeError} If any collision or duplicate is detected.
+ * @throws {TypeError} If any meta/meta collision or duplicate is detected.
  * @since 1.0.0
  */
 export function validateMetaNameCollisions(
-  userNames: UserParserNames,
+  _userNames: UserParserNames,
   metaEntries: readonly MetaEntry[],
 ): void {
   // 1. Check for duplicates within each meta feature
@@ -237,100 +239,6 @@ export function validateMetaNameCollisions(
             'The prefix form of name "' + name + '" in ' + label +
               ' shadows "' + otherName + '" in ' + otherLabel + ".",
           );
-        }
-      }
-    }
-  }
-
-  // 3. Check for collisions between meta features and user parser.
-  //    The scope depends on the meta feature kind:
-  //    - "command" entries only reach args[0] → check leadingNames +
-  //      allOptions/allCommands for classification
-  //    - "option" entries scan entire argv → check all user names + literals
-  for (const [kind, label, names, prefixMatch] of metaEntries) {
-    for (const name of names) {
-      if (kind === "command") {
-        // Command-form meta entries only match at args[0], so check
-        // the flat leadingNames set.  Classify by cross-referencing
-        // with allOptions/allCommands for accurate error messages.
-        if (userNames.leadingNames.has(name)) {
-          if (userNames.allOptions.has(name)) {
-            throw new TypeError(
-              `User-defined option "${name}" conflicts with the ` +
-                `built-in ${label}.`,
-            );
-          } else if (userNames.allCommands.has(name)) {
-            throw new TypeError(
-              `User-defined command "${name}" conflicts with the ` +
-                `built-in ${label}.`,
-            );
-          } else if (userNames.allLiterals.has(name)) {
-            throw new TypeError(
-              `Literal value "${name}" conflicts with the ` +
-                `built-in ${label}.`,
-            );
-          } else {
-            throw new TypeError(
-              `User-defined name "${name}" conflicts with the ` +
-                `built-in ${label}.`,
-            );
-          }
-        }
-      } else {
-        // Option-form meta entries scan entire argv, so check all
-        // user names at every depth.
-        if (userNames.allOptions.has(name)) {
-          throw new TypeError(
-            `User-defined option "${name}" conflicts with the ` +
-              `built-in ${label}.`,
-          );
-        }
-        if (userNames.allCommands.has(name)) {
-          throw new TypeError(
-            `User-defined command "${name}" conflicts with the ` +
-              `built-in ${label}.`,
-          );
-        }
-        if (userNames.allLiterals.has(name)) {
-          throw new TypeError(
-            `Literal value "${name}" conflicts with the ` +
-              `built-in ${label}.`,
-          );
-        }
-      }
-      if (prefixMatch) {
-        const prefix = name + "=";
-        const checkSets = kind === "command" ? [userNames.leadingNames] : [
-          userNames.allOptions,
-          userNames.allCommands,
-          userNames.allLiterals,
-        ];
-        for (const nameSet of checkSets) {
-          for (const userName of nameSet) {
-            if (!userName.startsWith(prefix)) continue;
-            // Classify the name for the error message
-            if (userNames.allOptions.has(userName)) {
-              throw new TypeError(
-                `User-defined option "${userName}" conflicts with the ` +
-                  `built-in ${label} (prefix "${prefix}").`,
-              );
-            } else if (userNames.allCommands.has(userName)) {
-              throw new TypeError(
-                `User-defined command "${userName}" conflicts with the ` +
-                  `built-in ${label} (prefix "${prefix}").`,
-              );
-            } else if (userNames.allLiterals.has(userName)) {
-              throw new TypeError(
-                `Literal value "${userName}" conflicts with the ` +
-                  `built-in ${label} (prefix "${prefix}").`,
-              );
-            } else {
-              throw new TypeError(
-                `User-defined name "${userName}" conflicts with the ` +
-                  `built-in ${label} (prefix "${prefix}").`,
-              );
-            }
-          }
         }
       }
     }

--- a/packages/run/README.md
+++ b/packages/run/README.md
@@ -23,6 +23,12 @@ Use *@optique/core* instead when:
  -  Working in environments without `process` (browsers, web workers)
  -  Building reusable parser components
 
+Built-in help, version, and completion are parser-aware.  Optique only
+intercepts `help`, `version`, `completion`, `--help`, `--version`,
+`--completion`, and configured aliases when the user parser leaves them
+unconsumed.  If your parser uses the same token sequence as ordinary
+data, the parse result wins.
+
 
 Installation
 ------------

--- a/packages/run/src/run.test.ts
+++ b/packages/run/src/run.test.ts
@@ -1559,10 +1559,10 @@ describe("runAsync", () => {
       assert.ok(typeof helpOutput === "string");
     });
 
-    it("preserves positional values that match built-in help commands", () => {
+    it("preserves positional values that match built-in help commands", async () => {
       const parser = object({ value: argument(string()) });
       let exited = false;
-      const result = run(parser, {
+      const result = await runAsync(parser, {
         args: ["help"],
         programName: "myapp",
         help: "command",

--- a/packages/run/src/run.test.ts
+++ b/packages/run/src/run.test.ts
@@ -536,7 +536,7 @@ describe("run", () => {
 
     it("should handle version as object with custom mode", () => {
       const parser = object({
-        name: argument(string()),
+        verbose: option("--verbose"),
       });
 
       let output = "";
@@ -1558,6 +1558,18 @@ describe("runAsync", () => {
 
       assert.ok(typeof helpOutput === "string");
     });
+
+    it("preserves positional values that match built-in help commands", () => {
+      const parser = object({ value: argument(string()) });
+      const result = run(parser, {
+        args: ["help"],
+        programName: "myapp",
+        help: "command",
+        stdout: () => {},
+        stderr: () => {},
+      });
+      assert.deepEqual(result, { value: "help" });
+    });
   });
 });
 
@@ -2174,6 +2186,18 @@ describe("run with contexts", () => {
 });
 
 describe("runSync with contexts", () => {
+  it("preserves parser options that shadow the built-in help option", () => {
+    const parser = object({ help: option("--help") });
+    const result = runSync(parser, {
+      args: ["--help"],
+      programName: "myapp",
+      help: "option",
+      stdout: () => {},
+      stderr: () => {},
+    });
+    assert.deepEqual(result, { help: true });
+  });
+
   it("preserves context-backed parsing for help/version names after --", () => {
     assert.deepEqual(runIssue267SyncWith("--help", "help"), {
       file: "--help",

--- a/packages/run/src/run.test.ts
+++ b/packages/run/src/run.test.ts
@@ -1561,14 +1561,20 @@ describe("runAsync", () => {
 
     it("preserves positional values that match built-in help commands", () => {
       const parser = object({ value: argument(string()) });
+      let exited = false;
       const result = run(parser, {
         args: ["help"],
         programName: "myapp",
         help: "command",
         stdout: () => {},
         stderr: () => {},
+        onExit: (code) => {
+          exited = true;
+          throw new Error(`UNEXPECTED_EXIT:${code}`);
+        },
       });
       assert.deepEqual(result, { value: "help" });
+      assert.equal(exited, false);
     });
   });
 });
@@ -2188,14 +2194,20 @@ describe("run with contexts", () => {
 describe("runSync with contexts", () => {
   it("preserves parser options that shadow the built-in help option", () => {
     const parser = object({ help: option("--help") });
+    let exited = false;
     const result = runSync(parser, {
       args: ["--help"],
       programName: "myapp",
       help: "option",
       stdout: () => {},
       stderr: () => {},
+      onExit: (code) => {
+        exited = true;
+        throw new Error(`UNEXPECTED_EXIT:${code}`);
+      },
     });
     assert.deepEqual(result, { help: true });
+    assert.equal(exited, false);
   });
 
   it("preserves context-backed parsing for help/version names after --", () => {

--- a/packages/run/src/run.test.ts
+++ b/packages/run/src/run.test.ts
@@ -2272,7 +2272,7 @@ describe("runSync with contexts", () => {
     assert.ok(disposed);
   });
 
-  it("should handle help with contexts in runSync", () => {
+  it("should collect phase 1 annotations for help in runSync", () => {
     const key = Symbol.for("@test/runsync-help");
     let annotationsCallCount = 0;
     const context: SourceContext = {
@@ -2310,8 +2310,8 @@ describe("runSync with contexts", () => {
     }
 
     assert.ok(helpShown);
-    // Contexts should not be called for early exits
-    assert.equal(annotationsCallCount, 0);
+    // Genuine meta requests still stop after phase 1.
+    assert.equal(annotationsCallCount, 1);
   });
 
   it("should support Program input with contexts", () => {

--- a/packages/run/src/run.test.ts
+++ b/packages/run/src/run.test.ts
@@ -1574,7 +1574,7 @@ describe("runAsync", () => {
         },
       });
       assert.deepEqual(result, { value: "help" });
-      assert.equal(exited, false);
+      assert.ok(!exited);
     });
   });
 });
@@ -2207,7 +2207,7 @@ describe("runSync with contexts", () => {
       },
     });
     assert.deepEqual(result, { help: true });
-    assert.equal(exited, false);
+    assert.ok(!exited);
   });
 
   it("preserves context-backed parsing for help/version names after --", () => {


### PR DESCRIPTION
Closes https://github.com/dahlia/optique/issues/230.

This PR fixes runner-level help, version, and completion detection so it follows parser boundaries instead of scanning raw `argv` and stealing tokens that are ordinary parser values. The main change is in *packages/core/src/facade.ts*, where `runParser()`, `runWith()`, and `runWithSync()` now parse with the user parser first and classify only genuinely unconsumed tokens as meta requests.

This changes visible behavior in the cases reported in the issue. Inputs such as `["--message", "--help"]`, `["help"]`, and `["--completion=bash"]` now stay aligned with ordinary parser semantics when those tokens are valid data for the user parser, while real meta requests such as top-level `--help`, `serve --help`, `--version`, and completion requests still behave as before.

```ts
const parser = object({
  message: option("--message", string({ metavar: "MESSAGE" })),
});

runParser(parser, "myapp", ["--message", "--help"], {
  help: { option: true },
});
// => { message: "--help" }
```

```ts
const parser = object({
  value: argument(string({ metavar: "VALUE" })),
});

runParser(parser, "myapp", ["help"], {
  help: { command: true },
});
// => { value: "help" }
```

To keep subcommand help and completion accurate after parser-first classification, this PR threads matched command names through the execution context in *packages/core/src/parser.ts*, *packages/core/src/primitives.ts*, *packages/core/src/constructs.ts*, and *packages/core/src/modifiers.ts*. I also removed the old startup validation rule that rejected user parsers for reusing built-in meta names and aliases, because that rule no longer matches the intended runtime semantics. A follow-up cleanup trims the obsolete validation plumbing in *packages/core/src/validate.ts* and its focused tests.

I updated *docs/concepts/runners.md*, *docs/concepts/extend.md*, *docs/integrations/config.md*, *docs/integrations/env.md*, *packages/run/README.md*, and *CHANGES.md* to document the new parser-aware runner semantics and the user-visible behavior change after 0.10.0.

Regression coverage was added in *packages/core/src/facade.test.ts*, *packages/core/src/validate.test.ts*, and *packages/run/src/run.test.ts*. I also reran the full project test matrix with `mise test` and rebuilt the docs with `pnpm -C docs build`.