### PR TITLE
Stop leaked env/config fallback state from affecting later parses

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1671,7 +1671,7 @@ To be released.
     later plain parses unless the returned annotations are passed
     explicitly or the parser is run through a context-aware runner.
     This also fixes stale config values surviving later empty or
-    failing probes.  [[#234]]
+    failing probes.  [[#234], [#785]]
 
  -  Fixed `bindConfig()` not re-validating fallback values (values loaded
     from the config file and configured defaults) against the inner CLI
@@ -1826,6 +1826,7 @@ To be released.
 [#655]: https://github.com/dahlia/optique/pull/655
 [#680]: https://github.com/dahlia/optique/pull/680
 [#770]: https://github.com/dahlia/optique/pull/770
+[#785]: https://github.com/dahlia/optique/pull/785
 
 ### @optique/env
 
@@ -1836,7 +1837,7 @@ environment variable integration via source contexts.  [[#86], [#135]]
     Calling `envContext.getAnnotations()` manually no longer affects
     later plain parses unless the returned annotations are passed
     explicitly or the parser is run through a context-aware runner.
-    [[#234]]
+    [[#234], [#785]]
 
  -  Fixed `bindEnv()` not re-validating fallback values (environment
     variable values parsed by a looser env-level `parser` and configured
@@ -1959,7 +1960,7 @@ interactive prompt fallback integration via Inquirer.js.  [[#87], [#137]]
     prompts based on stale source state from earlier manual
     `getAnnotations()` calls. Prompts are skipped only when the current
     parse carries explicit annotations or runner-provided contexts.
-    [[#234]]
+    [[#234], [#785]]
 
  -  Added `prompt()` for wrapping any parser with an interactive prompt that
     fires when no CLI value is provided.  Supports ten prompt types:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1666,6 +1666,13 @@ To be released.
 
 ### @optique/config
 
+ -  Removed the hidden process-global fallback from `bindConfig()`.
+    Calling `configContext.getAnnotations()` manually no longer affects
+    later plain parses unless the returned annotations are passed
+    explicitly or the parser is run through a context-aware runner.
+    This also fixes stale config values surviving later empty or
+    failing probes.  [[#234]]
+
  -  Fixed `bindConfig()` not re-validating fallback values (values loaded
     from the config file and configured defaults) against the inner CLI
     parser's constraints.  Previously, constraints like
@@ -1803,6 +1810,7 @@ To be released.
 [#162]: https://github.com/dahlia/optique/pull/162
 [#164]: https://github.com/dahlia/optique/pull/164
 [#179]: https://github.com/dahlia/optique/issues/179
+[#234]: https://github.com/dahlia/optique/issues/234
 [#236]: https://github.com/dahlia/optique/issues/236
 [#259]: https://github.com/dahlia/optique/issues/259
 [#391]: https://github.com/dahlia/optique/issues/391
@@ -1823,6 +1831,12 @@ To be released.
 
 The *@optique/env* package was introduced in this release, providing
 environment variable integration via source contexts.  [[#86], [#135]]
+
+ -  Removed the hidden process-global fallback from `bindEnv()`.
+    Calling `envContext.getAnnotations()` manually no longer affects
+    later plain parses unless the returned annotations are passed
+    explicitly or the parser is run through a context-aware runner.
+    [[#234]]
 
  -  Fixed `bindEnv()` not re-validating fallback values (environment
     variable values parsed by a looser env-level `parser` and configured
@@ -1940,6 +1954,12 @@ environment variable integration via source contexts.  [[#86], [#135]]
 
 The *@optique/inquirer* package was introduced in this release, providing
 interactive prompt fallback integration via Inquirer.js.  [[#87], [#137]]
+
+ -  `prompt(bindEnv(...))` and `prompt(bindConfig(...))` no longer skip
+    prompts based on stale source state from earlier manual
+    `getAnnotations()` calls. Prompts are skipped only when the current
+    parse carries explicit annotations or runner-provided contexts.
+    [[#234]]
 
  -  Added `prompt()` for wrapping any parser with an interactive prompt that
     fires when no CLI value is provided.  Supports ten prompt types:

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -1443,6 +1443,12 @@ const result = await runAsync(parser, {
 });
 ~~~~
 
+When you preload annotations manually like this, you still need to thread
+them back into parsing explicitly, either by wrapping them in a static
+context as shown here or by passing them directly to low-level APIs such
+as `parse()` or `parseAsync()`. The `getAnnotations()` call itself does
+not change later parses.
+
 This preserves the priority chain:
 
 CLI argument > environment variable > config file > interactive prompt

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -1446,8 +1446,8 @@ const result = await runAsync(parser, {
 When you preload annotations manually like this, you still need to thread
 them back into parsing explicitly, either by wrapping them in a static
 context as shown here or by passing them directly to low-level APIs such
-as `parse()` or `parseAsync()`. The `getAnnotations()` call itself does
-not change later parses.
+as `parse()`, `parseAsync()`, or `parser.complete()`. The
+`getAnnotations()` call itself does not change later parses.
 
 This preserves the priority chain:
 

--- a/docs/integrations/config.md
+++ b/docs/integrations/config.md
@@ -867,6 +867,12 @@ Parameters
 Returns
 :   `ConfigContext<T, TConfigMeta>` implementing `SourceContext` interface
 
+> [!IMPORTANT]
+> If you call `configContext.getAnnotations()` manually, pass the returned
+> object to low-level APIs such as `parse()`, `parseAsync()`, `suggest()`,
+> or `getDocPage()`. Calling `getAnnotations()` alone does not affect later
+> parses.
+
 ### `bindConfig(parser, options)`
 
 Binds a parser to configuration values with fallback priority.

--- a/docs/integrations/config.md
+++ b/docs/integrations/config.md
@@ -869,9 +869,9 @@ Returns
 
 > [!IMPORTANT]
 > If you call `configContext.getAnnotations()` manually, pass the returned
-> object to low-level APIs such as `parse()`, `parseAsync()`, `suggest()`,
-> or `getDocPage()`. Calling `getAnnotations()` alone does not affect later
-> parses.
+> object to low-level APIs such as `parse()`, `parseAsync()`,
+> `parser.complete()`, `suggest()`, or `getDocPage()`. Calling
+> `getAnnotations()` alone does not affect later parses.
 
 ### `bindConfig(parser, options)`
 

--- a/docs/integrations/env.md
+++ b/docs/integrations/env.md
@@ -467,9 +467,9 @@ Returns
 
 > [!IMPORTANT]
 > If you call `envContext.getAnnotations()` manually, pass the returned
-> object to low-level APIs such as `parse()`, `parseAsync()`, `suggest()`,
-> or `getDocPage()`. Calling `getAnnotations()` alone does not affect later
-> parses.
+> object to low-level APIs such as `parse()`, `parseAsync()`,
+> `parser.complete()`, `suggest()`, or `getDocPage()`. Calling
+> `getAnnotations()` alone does not affect later parses.
 
 ### `bindEnv(parser, options)`
 

--- a/docs/integrations/env.md
+++ b/docs/integrations/env.md
@@ -465,6 +465,12 @@ Parameters
 Returns
 :   `EnvContext` implementing `SourceContext` and `Disposable`.
 
+> [!IMPORTANT]
+> If you call `envContext.getAnnotations()` manually, pass the returned
+> object to low-level APIs such as `parse()`, `parseAsync()`, `suggest()`,
+> or `getDocPage()`. Calling `getAnnotations()` alone does not affect later
+> parses.
+
 ### `bindEnv(parser, options)`
 
 Binds a parser to environment variables with fallback priority

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -25,14 +25,7 @@ import {
   collectExplicitSourceValues,
   createDependencyRuntimeContext,
 } from "../../core/src/dependency-runtime.ts";
-import {
-  bindConfig,
-  createConfigContext,
-  getActiveConfig,
-  getActiveConfigMeta,
-  setActiveConfig,
-  setActiveConfigMeta,
-} from "./index.ts";
+import { bindConfig, createConfigContext } from "./index.ts";
 import type { ConfigLoadResult, ConfigMeta } from "./index.ts";
 
 type IsExact<T, U> = (<V>() => V extends T ? 1 : 2) extends
@@ -892,7 +885,7 @@ describe("bindConfig", () => {
     assert.equal(defaultResult.value, 3000);
   });
 
-  test("keeps multiple ConfigContext instances isolated in the active registry", async () => {
+  test("keeps multiple ConfigContext instances isolated in merged annotations", async () => {
     const leftContext = createConfigContext({
       schema: z.object({ host: z.string() }),
     });
@@ -909,15 +902,19 @@ describe("bindConfig", () => {
     });
 
     try {
-      await leftContext.getAnnotations(true, {
+      const leftAnnotations = await leftContext.getAnnotations(true, {
         load: () => ({ config: { host: "left.example.com" } }),
       });
-      await rightContext.getAnnotations(true, {
+      const rightAnnotations = await rightContext.getAnnotations(true, {
         load: () => ({ config: { host: "right.example.com" } }),
       });
+      const annotations: Annotations = {
+        ...rightAnnotations,
+        ...leftAnnotations,
+      };
 
-      const leftResult = parse(leftParser, []);
-      const rightResult = parse(rightParser, []);
+      const leftResult = parse(leftParser, [], { annotations });
+      const rightResult = parse(rightParser, [], { annotations });
 
       assert.ok(leftResult.success);
       assert.ok(rightResult.success);
@@ -1718,37 +1715,121 @@ describe("load() return value validation", () => {
     );
   });
 
-  test("no-config load clears stale active registry from prior load", () => {
+  test("later phase-one probes do not leak prior config into plain parse", () => {
     const context = createNameContext();
-    // First call loads real config, populating the active registry
-    context.getAnnotations(
+    const parser = bindConfig(option("--name", string()), {
+      context,
+      key: "name",
+    });
+
+    const annotations = context.getAnnotations(
       {},
-      { load: () => ({ config: { name: "STALE" }, meta: undefined }) },
+      { load: () => ({ config: { name: "configured" }, meta: undefined }) },
     );
-    // Verify the registry is populated
-    assert.deepStrictEqual(getActiveConfig(context.id), { name: "STALE" });
-    // Second call returns no-config; registry must be cleared
-    context.getAnnotations(
+    if (annotations instanceof Promise) {
+      throw new TypeError("Expected synchronous annotations.");
+    }
+    assert.deepEqual(
+      parse(parser, [], { annotations }),
+      { success: true, value: "configured" },
+    );
+
+    assert.deepEqual(
+      context.getAnnotations(
+        undefined,
+        { load: () => ({ config: { name: "later" }, meta: undefined }) },
+      ),
       {},
-      { load: () => undefined },
     );
-    assert.equal(getActiveConfig(context.id), undefined);
+
+    const result = parse(parser, []);
+    assert.ok(!result.success);
+    if (result.success) return;
+    assert.equal(
+      formatMessage(result.error),
+      "Missing required configuration value.",
+    );
   });
 
-  test("no-config getConfigPath clears stale active registry", () => {
+  test(
+    "validation failures in later probes do not leak prior config into plain parse",
+    () => {
+      const context = createNameContext();
+      const parser = bindConfig(option("--name", string()), {
+        context,
+        key: "name",
+      });
+
+      const annotations = context.getAnnotations(
+        {},
+        { load: () => ({ config: { name: "configured" }, meta: undefined }) },
+      );
+      if (annotations instanceof Promise) {
+        throw new TypeError("Expected synchronous annotations.");
+      }
+      assert.deepEqual(
+        parse(parser, [], { annotations }),
+        { success: true, value: "configured" },
+      );
+
+      assert.throws(
+        () =>
+          context.getAnnotations(
+            {},
+            {
+              load: () => ({
+                config: { name: 123 },
+                meta: undefined,
+              }),
+            },
+          ),
+        { message: /Config validation failed/ },
+      );
+
+      const result = parse(parser, []);
+      assert.ok(!result.success);
+      if (result.success) return;
+      assert.equal(
+        formatMessage(result.error),
+        "Missing required configuration value.",
+      );
+    },
+  );
+
+  test("no-config phase-two probes do not leak prior config into plain parse", () => {
     const context = createNameContext();
-    // Populate the active registry directly
-    context.getAnnotations(
+    const parser = bindConfig(option("--name", string()), {
+      context,
+      key: "name",
+    });
+
+    const annotations = context.getAnnotations(
       {},
-      { load: () => ({ config: { name: "STALE" }, meta: undefined }) },
+      { load: () => ({ config: { name: "configured" }, meta: undefined }) },
     );
-    assert.deepStrictEqual(getActiveConfig(context.id), { name: "STALE" });
-    // getConfigPath returning undefined must also clear the registry
-    context.getAnnotations(
+    if (annotations instanceof Promise) {
+      throw new TypeError("Expected synchronous annotations.");
+    }
+    assert.deepEqual(
+      parse(parser, [], { annotations }),
+      { success: true, value: "configured" },
+    );
+
+    assert.deepEqual(
+      context.getAnnotations(
+        undefined,
+        { getConfigPath: () => undefined },
+      ),
       {},
-      { getConfigPath: () => undefined },
     );
-    assert.equal(getActiveConfig(context.id), undefined);
+
+    const result = parse(parser, []);
+    assert.ok(!result.success);
+    if (result.success) return;
+    assert.equal(
+      formatMessage(result.error),
+      "Missing required configuration value.",
+    );
   });
 
   test("rejects array return value from load()", () => {
@@ -2331,26 +2412,27 @@ describe("createConfigContext error paths", () => {
     );
   });
 
-  test("Symbol.dispose clears active config registry", () => {
+  test("Symbol.dispose does not invalidate returned annotations", () => {
     const schema = z.object({ host: z.string() });
     const context = createConfigContext({ schema });
-
-    // Simulate what happens during context-aware parsing
-    setActiveConfig(context.id, { host: "test-host" });
-    setActiveConfigMeta(context.id, {
-      configDir: "/test",
-      configPath: "/test/config.json",
+    const parser = bindConfig(option("--host", string()), {
+      context,
+      key: "host",
     });
 
-    // Verify it's set
-    assert.ok(getActiveConfig(context.id) !== undefined);
-    assert.ok(getActiveConfigMeta(context.id) !== undefined);
-
-    // Dispose should clear both registries
+    const annotations = context.getAnnotations(
+      {},
+      { load: () => ({ config: { host: "test-host" }, meta: undefined }) },
+    );
+    if (annotations instanceof Promise) {
+      throw new TypeError("Expected synchronous annotations.");
+    }
     context[Symbol.dispose]!();
 
-    assert.equal(getActiveConfig(context.id), undefined);
-    assert.equal(getActiveConfigMeta(context.id), undefined);
+    assert.deepEqual(
+      parse(parser, [], { annotations }),
+      { success: true, value: "test-host" },
+    );
   });
 
   test("load function receives parsed value and returns config", async () => {

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -1817,7 +1817,7 @@ describe("load() return value validation", () => {
 
     assert.deepEqual(
       context.getAnnotations(
-        undefined,
+        {},
         { getConfigPath: () => undefined },
       ),
       {},

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -319,8 +319,8 @@ function validateWithSchema<T>(
  * *@optique/run* to provide configuration file support.
  * When calling `context.getAnnotations()` manually, pass the returned
  * annotations to low-level APIs such as `parse()`, `parseAsync()`,
- * `suggest()`, or `getDocPage()`. Calling `getAnnotations()` by itself does
- * not affect later parses.
+ * `complete()`, `suggest()`, or `getDocPage()`. Calling `getAnnotations()`
+ * by itself does not affect later parses.
  *
  * @template T The output type of the config schema.
  * @template TConfigMeta The metadata type for config sources.

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -319,8 +319,8 @@ function validateWithSchema<T>(
  * *@optique/run* to provide configuration file support.
  * When calling `context.getAnnotations()` manually, pass the returned
  * annotations to low-level APIs such as `parse()`, `parseAsync()`,
- * `complete()`, `suggest()`, or `getDocPage()`. Calling `getAnnotations()`
- * by itself does not affect later parses.
+ * `parser.complete()`, `suggest()`, or `getDocPage()`. Calling
+ * `getAnnotations()` by itself does not affect later parses.
  *
  * @template T The output type of the config schema.
  * @template TConfigMeta The metadata type for config sources.

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -392,8 +392,10 @@ export function createConfigContext<T, TConfigMeta = ConfigMeta>(
       parsed?: unknown,
       runtimeOptions?: unknown,
     ): Promise<Annotations> | Annotations {
-      // Phase 1 (no parsed result): mark the context as unresolved so
-      // prompt(bindConfig(...)) can defer interactive fallback.
+      // Phase 1 (no parsed result): return no public annotations here.
+      // Runners add the phase-1 unresolved marker through
+      // getInternalAnnotations() so prompt(bindConfig(...)) can defer
+      // interactive fallback without exposing that marker as user data.
       if (parsed === undefined) {
         return {};
       }

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -59,19 +59,6 @@ export interface ConfigMeta {
   readonly configPath: string;
 }
 
-/**
- * Internal registry for active config data during config context execution.
- * This is a workaround for the limitation that object() doesn't propagate
- * annotations to child field parsers.
- * @internal
- */
-const activeConfigRegistry: Map<symbol, unknown> = new Map();
-
-/**
- * Internal registry for active config metadata during config context execution.
- * @internal
- */
-const activeConfigMetaRegistry: Map<symbol, unknown> = new Map();
 const phase1ConfigAnnotationMarker = Symbol(
   "@optique/config/phase1Annotation",
 );
@@ -80,54 +67,6 @@ function isPhase2UndefinedParsedValue(value: unknown): boolean {
   return value != null &&
     typeof value === "object" &&
     phase2UndefinedParsedValueKey in value;
-}
-
-/**
- * Sets active config data for a context.
- * @internal
- */
-export function setActiveConfig<T>(contextId: symbol, data: T): void {
-  activeConfigRegistry.set(contextId, data);
-}
-
-/**
- * Gets active config data for a context.
- * @internal
- */
-export function getActiveConfig<T>(contextId: symbol): T | undefined {
-  return activeConfigRegistry.get(contextId) as T | undefined;
-}
-
-/**
- * Clears active config data for a context.
- * @internal
- */
-export function clearActiveConfig(contextId: symbol): void {
-  activeConfigRegistry.delete(contextId);
-}
-
-/**
- * Sets active config metadata for a context.
- * @internal
- */
-export function setActiveConfigMeta<T>(contextId: symbol, meta: T): void {
-  activeConfigMetaRegistry.set(contextId, meta);
-}
-
-/**
- * Gets active config metadata for a context.
- * @internal
- */
-export function getActiveConfigMeta<T>(contextId: symbol): T | undefined {
-  return activeConfigMetaRegistry.get(contextId) as T | undefined;
-}
-
-/**
- * Clears active config metadata for a context.
- * @internal
- */
-export function clearActiveConfigMeta(contextId: symbol): void {
-  activeConfigMetaRegistry.delete(contextId);
 }
 
 /**
@@ -378,6 +317,10 @@ function validateWithSchema<T>(
  * The config context implements the `SourceContext` interface and can be used
  * with `runWith()` from *@optique/core* or `run()`/`runAsync()` from
  * *@optique/run* to provide configuration file support.
+ * When calling `context.getAnnotations()` manually, pass the returned
+ * annotations to low-level APIs such as `parse()`, `parseAsync()`,
+ * `suggest()`, or `getDocPage()`. Calling `getAnnotations()` by itself does
+ * not affect later parses.
  *
  * @template T The output type of the config schema.
  * @template TConfigMeta The metadata type for config sources.
@@ -488,11 +431,7 @@ export function createConfigContext<T, TConfigMeta = ConfigMeta>(
         : parsed;
       const parsedPlaceholder = parsedValue as ParserValuePlaceholder;
 
-      const emptyAnnotations = (): Annotations => {
-        clearActiveConfig(contextId);
-        clearActiveConfigMeta(contextId);
-        return {};
-      };
+      const emptyAnnotations = (): Annotations => ({});
 
       const buildAnnotations = (
         configData: T | undefined,
@@ -502,15 +441,12 @@ export function createConfigContext<T, TConfigMeta = ConfigMeta>(
           return emptyAnnotations();
         }
 
-        // Set active config in registry for nested parsers inside object()
-        setActiveConfig(contextId, configData);
         // Use the per-instance contextId as the annotation key so that
         // multiple ConfigContext instances can coexist without overwriting
         // each other during mergeAnnotations().  Data and metadata are
         // stored together under a single key.
         // See: https://github.com/dahlia/optique/issues/136
         if (configMeta !== undefined) {
-          setActiveConfigMeta(contextId, configMeta);
           return {
             [contextId]: { data: configData, meta: configMeta },
           };
@@ -620,8 +556,7 @@ export function createConfigContext<T, TConfigMeta = ConfigMeta>(
     },
 
     [Symbol.dispose]() {
-      clearActiveConfig(contextId);
-      clearActiveConfigMeta(contextId);
+      // No-op. Config annotations are detached parse-time snapshots.
     },
   };
 
@@ -970,9 +905,7 @@ export function bindConfig<
 
 /**
  * Helper function to get value from config or default.
- * Checks both annotations (for top-level parsers) and the active config
- * registry (for parsers nested inside object() when used with context-aware
- * runners).
+ * Reads only from explicit annotations carried by the current parse state.
  *
  * When `innerParser.validateValue` is available, the returned fallback
  * value is routed through it so that the inner CLI parser's constraints
@@ -1001,7 +934,6 @@ function getConfigOrDefault<
   mode: M,
   innerParser?: Parser<M, TValue, unknown>,
 ): ModeValue<M, Result<TValue>> {
-  // First, try to get config from annotations (works for top-level parsers).
   // Read from the per-instance context id so that the correct config data is
   // selected even when annotations from multiple config contexts are merged.
   // See: https://github.com/dahlia/optique/issues/136
@@ -1010,15 +942,8 @@ function getConfigOrDefault<
   const annotationValue = annotations?.[contextId] as
     | { readonly data: T; readonly meta?: TConfigMeta | undefined }
     | undefined;
-  let configData = annotationValue?.data;
-  let configMeta = annotationValue?.meta;
-
-  // If not found in annotations, check the active config registry
-  // (this handles the case when used inside object() with context-aware runners)
-  if (configData === undefined || configData === null) {
-    configData = getActiveConfig<T>(contextId);
-    configMeta = getActiveConfigMeta<TConfigMeta>(contextId);
-  }
+  const configData = annotationValue?.data;
+  const configMeta = annotationValue?.meta;
 
   let configValue: TValue | undefined;
 
@@ -1092,10 +1017,9 @@ function validateFallbackValue<M extends "sync" | "async", TValue>(
 /**
  * Resolves a config-backed dependency source with fallback priority.
  *
- * This first checks annotations or the active config registry via
- * {@link getConfigOrDefault}. If no config-backed value is available, it falls
- * back to `options.default` and finally delegates to the wrapped parser's
- * source extractor.
+ * This first checks annotations via {@link getConfigOrDefault}. If no
+ * config-backed value is available, it falls back to `options.default` and
+ * finally delegates to the wrapped parser's source extractor.
  *
  * When `innerParser` exposes `validateValue`, the returned fallback is
  * routed through it so that the inner CLI parser's constraints are
@@ -1144,7 +1068,7 @@ function getConfigSourceValue<
   const annotationValue = annotations?.[contextId] as
     | { readonly data: T; readonly meta?: TConfigMeta | undefined }
     | undefined;
-  const configData = annotationValue?.data ?? getActiveConfig<T>(contextId);
+  const configData = annotationValue?.data;
 
   // Runs a successful fallback value through the inner parser's
   // validateValue() hook when available.  May return a Promise if the

--- a/packages/config/src/run.test.ts
+++ b/packages/config/src/run.test.ts
@@ -6,16 +6,12 @@ import { join, relative, resolve } from "node:path";
 import { z } from "zod";
 import { object } from "@optique/core/constructs";
 import type { SourceContext } from "@optique/core/context";
+import { parse } from "@optique/core/parser";
 import { fail, flag, option } from "@optique/core/primitives";
 import { integer, string } from "@optique/core/valueparser";
 import { withDefault } from "@optique/core/modifiers";
 import { runWith, runWithSync } from "@optique/core/facade";
-import {
-  bindConfig,
-  createConfigContext,
-  getActiveConfig,
-  getActiveConfigMeta,
-} from "./index.ts";
+import { bindConfig, createConfigContext } from "./index.ts";
 import type { ConfigMeta } from "./index.ts";
 
 const TEST_DIR = join(import.meta.dirname ?? ".", "test-configs");
@@ -1135,7 +1131,7 @@ describe("run with config context", { concurrency: false }, () => {
     assert.deepEqual(result, { enabled: true, dependent: "foo" });
   });
 
-  test("dispose clears active config registry after runWith", async () => {
+  test("runWith does not leak config state into later plain parses", async () => {
     await mkdir(TEST_DIR, { recursive: true });
     const configPath = join(TEST_DIR, "test-config-dispose.json");
     await writeFile(
@@ -1146,6 +1142,10 @@ describe("run with config context", { concurrency: false }, () => {
     try {
       const schema = z.object({ host: z.string() });
       const context = createConfigContext({ schema });
+      const detachedParser = bindConfig(option("--host", string()), {
+        context,
+        key: "host",
+      });
 
       const parser = object({
         config: withDefault(option("--config", string()), configPath),
@@ -1163,9 +1163,8 @@ describe("run with config context", { concurrency: false }, () => {
         args: [],
       });
 
-      // After runWith completes, dispose should have cleared the registries
-      assert.equal(getActiveConfig(context.id), undefined);
-      assert.equal(getActiveConfigMeta(context.id), undefined);
+      const detachedResult = parse(detachedParser, []);
+      assert.ok(!detachedResult.success);
     } finally {
       await rm(configPath, { force: true });
     }

--- a/packages/env/src/index.test.ts
+++ b/packages/env/src/index.test.ts
@@ -30,12 +30,7 @@ import {
   collectExplicitSourceValues,
   createDependencyRuntimeContext,
 } from "../../core/src/dependency-runtime.ts";
-import {
-  bindEnv,
-  bool,
-  createEnvContext,
-  getActiveEnvSource,
-} from "./index.ts";
+import { bindEnv, bool, createEnvContext } from "./index.ts";
 
 const sourcePath = fileURLToPath(new URL("./index.ts", import.meta.url));
 
@@ -1365,10 +1360,12 @@ describe("bindEnv()", () => {
       parser: string(),
     });
 
-    // Register env source
-    context.getAnnotations();
+    const annotations = context.getAnnotations();
+    if (annotations instanceof Promise) {
+      throw new TypeError("Expected synchronous annotations.");
+    }
 
-    const result = parse(parser, []);
+    const result = parse(parser, [], { annotations });
     assert.ok(result.success);
     assert.equal(result.value, "from-env");
   });
@@ -1624,12 +1621,10 @@ describe("bindEnv()", () => {
         parser: choice(["dev", "prod"] as const),
       },
     );
-    const state = injectAnnotations(
-      injectAnnotations(parser.initialState, envAnnotations),
-      {
-        [configContext.id]: { data: { mode: "dev" as const } },
-      },
-    );
+    const state = injectAnnotations(parser.initialState, {
+      ...envAnnotations,
+      [configContext.id]: { data: { mode: "dev" as const } },
+    });
     const nodes = parser.getSuggestRuntimeNodes?.(state, ["mode"]);
     assert.ok(nodes != null);
     if (nodes == null) return;
@@ -1675,13 +1670,18 @@ describe("bindEnv()", () => {
       parser: asyncInt,
     });
 
-    // Register the active env source (normally done by the runner).
-    context.getAnnotations();
+    const annotations = context.getAnnotations();
+    if (annotations instanceof Promise) {
+      throw new TypeError("Expected synchronous annotations.");
+    }
 
     const completeResult = parser.complete(
-      { hasCliValue: false } as unknown as Parameters<
-        typeof parser.complete
-      >[0],
+      injectAnnotations(
+        { hasCliValue: false } as unknown as Parameters<
+          typeof parser.complete
+        >[0],
+        annotations,
+      ),
     );
     assert.ok(
       completeResult instanceof Promise,
@@ -2048,15 +2048,9 @@ describe("bindEnv()", () => {
     }
   });
 
-  it("propagates source errors from the active registry lookup", () => {
-    const sourceError = new Error("Environment access failed.");
+  it("ignores prior context.getAnnotations() calls during plain parse", () => {
     const context = createEnvContext({
-      source: (key) => {
-        if (key === "APP_PORT") {
-          throw sourceError;
-        }
-        return undefined;
-      },
+      source: (key) => ({ APP_PORT: "8080" })[key],
       prefix: "APP_",
     });
     const parser = bindEnv(option("--port", integer()), {
@@ -2066,13 +2060,19 @@ describe("bindEnv()", () => {
       default: 3000,
     });
 
-    context.getAnnotations();
+    const annotations = context.getAnnotations();
+    if (annotations instanceof Promise) {
+      throw new TypeError("Expected synchronous annotations.");
+    }
+
+    assert.deepEqual(
+      parse(parser, [], { annotations }),
+      { success: true, value: 8080 },
+    );
 
     try {
-      assert.throws(
-        () => parse(parser, []),
-        (error) => error === sourceError,
-      );
+      const result = parse(parser, []);
+      assert.deepEqual(result, { success: true, value: 3000 });
     } finally {
       context[Symbol.dispose]?.();
     }
@@ -2130,22 +2130,28 @@ describe("bindEnv()", () => {
 });
 
 describe("createEnvContext defaults", () => {
-  it("removes the active registry entry on dispose", () => {
+  it("dispose does not invalidate returned annotations", () => {
     const context = createEnvContext({
       source: (key) => ({ APP_PORT: "8080" })[key],
       prefix: "APP_",
     });
+    const parser = bindEnv(option("--port", integer()), {
+      context,
+      key: "PORT",
+      parser: integer(),
+    });
 
-    assert.equal(getActiveEnvSource(context.id), undefined);
     const annotations = context.getAnnotations();
     if (annotations instanceof Promise) {
       throw new TypeError("Expected synchronous annotations.");
     }
-    assert.equal(getActiveEnvSource(context.id)?.prefix, "APP_");
 
     context[Symbol.dispose]?.();
 
-    assert.equal(getActiveEnvSource(context.id), undefined);
+    assert.deepEqual(
+      parse(parser, [], { annotations }),
+      { success: true, value: 8080 },
+    );
   });
 
   it("uses Deno.env.get by default when available", () => {

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -84,40 +84,6 @@ export interface EnvContextOptions {
   readonly source?: EnvSource;
 }
 
-const activeEnvSourceRegistry: Map<symbol, EnvSourceData> = new Map();
-
-/**
- * Sets active environment source data for a context.
- *
- * @internal
- */
-export function setActiveEnvSource(
-  contextId: symbol,
-  sourceData: EnvSourceData,
-): void {
-  activeEnvSourceRegistry.set(contextId, sourceData);
-}
-
-/**
- * Gets active environment source data for a context.
- *
- * @internal
- */
-export function getActiveEnvSource(
-  contextId: symbol,
-): EnvSourceData | undefined {
-  return activeEnvSourceRegistry.get(contextId);
-}
-
-/**
- * Clears active environment source data for a context.
- *
- * @internal
- */
-export function clearActiveEnvSource(contextId: symbol): void {
-  activeEnvSourceRegistry.delete(contextId);
-}
-
 function defaultEnvSource(key: string): string | undefined {
   const denoGlobal = (globalThis as {
     readonly Deno?: { readonly env?: { readonly get?: EnvSource } };
@@ -133,6 +99,11 @@ function defaultEnvSource(key: string): string | undefined {
 
 /**
  * Creates an environment context for use with Optique runners.
+ *
+ * When calling `context.getAnnotations()` manually, pass the returned
+ * annotations to low-level APIs such as `parse()`, `parseAsync()`,
+ * `suggest()`, or `getDocPage()`. Calling `getAnnotations()` by itself does
+ * not affect later parses.
  *
  * @param options Environment context options.
  * @returns A context that provides environment source annotations.
@@ -177,7 +148,6 @@ export function createEnvContext(options: EnvContextOptions = {}): EnvContext {
 
     getAnnotations(): Annotations {
       const sourceData: EnvSourceData = { prefix, source };
-      setActiveEnvSource(contextId, sourceData);
       // Use the per-instance contextId as the annotation key so that
       // multiple EnvContext instances can coexist without overwriting each
       // other during mergeAnnotations().  See:
@@ -186,7 +156,7 @@ export function createEnvContext(options: EnvContextOptions = {}): EnvContext {
     },
 
     [Symbol.dispose]() {
-      clearActiveEnvSource(contextId);
+      // No-op. Env annotations are detached parse-time snapshots.
     },
   };
 }
@@ -571,9 +541,9 @@ function getEnvOrDefault<M extends Mode, TValue>(
   // Read from the per-instance context id so that the correct source is
   // selected even when annotations from multiple env contexts are merged.
   // See: https://github.com/dahlia/optique/issues/136
-  const sourceData =
-    (annotations?.[options.context.id] as EnvSourceData | undefined) ??
-      getActiveEnvSource(options.context.id);
+  const sourceData = annotations?.[options.context.id] as
+    | EnvSourceData
+    | undefined;
 
   const fullKey = `${
     sourceData?.prefix ?? options.context.prefix
@@ -679,10 +649,9 @@ function getEnvOrDefault<M extends Mode, TValue>(
 /**
  * Resolves an env-backed dependency source with env and default fallbacks.
  *
- * This first checks annotations or the active env registry for the bound
- * variable. If no env-backed value is available, it falls back to
- * `options.default` and finally delegates to the wrapped parser's source
- * extractor.
+ * This first checks annotations for the bound variable. If no env-backed value
+ * is available, it falls back to `options.default` and finally delegates to
+ * the wrapped parser's source extractor.
  *
  * When `innerParser` exposes a `validateValue` hook, env-sourced values
  * and the configured default are re-validated against the inner parser's
@@ -721,9 +690,9 @@ function getEnvSourceValue<M extends Mode, TValue>(
   | Promise<ValueParserResult<unknown> | undefined>
   | undefined {
   const annotations = getAnnotations(state);
-  const sourceData =
-    (annotations?.[options.context.id] as EnvSourceData | undefined) ??
-      getActiveEnvSource(options.context.id);
+  const sourceData = annotations?.[options.context.id] as
+    | EnvSourceData
+    | undefined;
 
   const fullKey = `${
     sourceData?.prefix ?? options.context.prefix

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -102,8 +102,8 @@ function defaultEnvSource(key: string): string | undefined {
  *
  * When calling `context.getAnnotations()` manually, pass the returned
  * annotations to low-level APIs such as `parse()`, `parseAsync()`,
- * `suggest()`, or `getDocPage()`. Calling `getAnnotations()` by itself does
- * not affect later parses.
+ * `complete()`, `suggest()`, or `getDocPage()`. Calling `getAnnotations()`
+ * by itself does not affect later parses.
  *
  * @param options Environment context options.
  * @returns A context that provides environment source annotations.

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -102,8 +102,8 @@ function defaultEnvSource(key: string): string | undefined {
  *
  * When calling `context.getAnnotations()` manually, pass the returned
  * annotations to low-level APIs such as `parse()`, `parseAsync()`,
- * `complete()`, `suggest()`, or `getDocPage()`. Calling `getAnnotations()`
- * by itself does not affect later parses.
+ * `parser.complete()`, `suggest()`, or `getDocPage()`. Calling
+ * `getAnnotations()` by itself does not affect later parses.
  *
  * @param options Environment context options.
  * @returns A context that provides environment source annotations.

--- a/packages/inquirer/src/index.test.ts
+++ b/packages/inquirer/src/index.test.ts
@@ -834,36 +834,39 @@ describe("prompt()", () => {
       assert.equal(result.value.port, 8080);
     });
 
-    it("prompts when prompt(bindEnv(...)) is parsed without annotations", async () => {
-      const context = createEnvContext({
-        source: (key) => ({ APP_NAME: "env-name" })[key],
-        prefix: "APP_",
-      });
-      context.getAnnotations();
-      let promptCalls = 0;
-      const parser = object({
-        name: prompt(
-          bindEnv(option("--name", string()), {
-            context,
-            key: "NAME",
-            parser: string(),
-          }),
-          {
-            type: "input",
-            message: "Enter name:",
-            prompter: () => {
-              promptCalls += 1;
-              return Promise.resolve("prompted-name");
+    it(
+      "prompts when prompt(bindEnv(...)) is parsed after getAnnotations() without passing annotations",
+      async () => {
+        const context = createEnvContext({
+          source: (key) => ({ APP_NAME: "env-name" })[key],
+          prefix: "APP_",
+        });
+        context.getAnnotations();
+        let promptCalls = 0;
+        const parser = object({
+          name: prompt(
+            bindEnv(option("--name", string()), {
+              context,
+              key: "NAME",
+              parser: string(),
+            }),
+            {
+              type: "input",
+              message: "Enter name:",
+              prompter: () => {
+                promptCalls += 1;
+                return Promise.resolve("prompted-name");
+              },
             },
-          },
-        ),
-      });
+          ),
+        });
 
-      const result = await parseAsync(parser, []);
-      assert.ok(result.success);
-      assert.equal(result.value.name, "prompted-name");
-      assert.equal(promptCalls, 1);
-    });
+        const result = await parseAsync(parser, []);
+        assert.ok(result.success);
+        assert.equal(result.value.name, "prompted-name");
+        assert.equal(promptCalls, 1);
+      },
+    );
 
     it("skips prompt for prompt(optional(bindEnv(...))) inside object()", async () => {
       // Regression: optional wraps the inner bindEnv state in an array
@@ -1324,42 +1327,45 @@ describe("prompt()", () => {
       assert.equal(promptCalls, 0);
     });
 
-    it("prompts when prompt(bindConfig(...)) is parsed without annotations", async () => {
-      const context = createConfigContext({
-        schema: createPromptConfigSchema(),
-      });
-      await context.getAnnotations(
-        { any: true },
-        {
-          load: () => ({
-            config: { apiKey: "config-secret" },
-            meta: undefined,
-          }),
-        },
-      );
-      let promptCalls = 0;
-      const parser = object({
-        apiKey: prompt(
-          bindConfig(option("--api-key", string()), {
-            context,
-            key: "apiKey",
-          }),
+    it(
+      "prompts when prompt(bindConfig(...)) is parsed after getAnnotations() without passing annotations",
+      async () => {
+        const context = createConfigContext({
+          schema: createPromptConfigSchema(),
+        });
+        await context.getAnnotations(
+          { any: true },
           {
-            type: "password",
-            message: "API key:",
-            prompter: () => {
-              promptCalls += 1;
-              return Promise.resolve("prompt-secret");
-            },
+            load: () => ({
+              config: { apiKey: "config-secret" },
+              meta: undefined,
+            }),
           },
-        ),
-      });
+        );
+        let promptCalls = 0;
+        const parser = object({
+          apiKey: prompt(
+            bindConfig(option("--api-key", string()), {
+              context,
+              key: "apiKey",
+            }),
+            {
+              type: "password",
+              message: "API key:",
+              prompter: () => {
+                promptCalls += 1;
+                return Promise.resolve("prompt-secret");
+              },
+            },
+          ),
+        });
 
-      const result = await parseAsync(parser, []);
-      assert.ok(result.success);
-      assert.equal(result.value.apiKey, "prompt-secret");
-      assert.equal(promptCalls, 1);
-    });
+        const result = await parseAsync(parser, []);
+        assert.ok(result.success);
+        assert.equal(result.value.apiKey, "prompt-secret");
+        assert.equal(promptCalls, 1);
+      },
+    );
 
     it("prompts when bindEnv() has no value and env var is absent", async () => {
       // prompt(bindEnv(...)) must fall back to the interactive prompt when

--- a/packages/inquirer/src/index.test.ts
+++ b/packages/inquirer/src/index.test.ts
@@ -834,17 +834,13 @@ describe("prompt()", () => {
       assert.equal(result.value.port, 8080);
     });
 
-    it("skips prompt for prompt(bindEnv(...)) inside object() via active env source", async () => {
-      // Regression: bindEnv can resolve via getActiveEnvSource() even
-      // when annotations are not threaded through parseAsync().  The
-      // sentinel path must not short-circuit to executePrompt() and
-      // should still delegate to the inner parser's complete().
+    it("prompts when prompt(bindEnv(...)) is parsed without annotations", async () => {
       const context = createEnvContext({
         source: (key) => ({ APP_NAME: "env-name" })[key],
         prefix: "APP_",
       });
-      // getAnnotations() registers the active env source globally.
       context.getAnnotations();
+      let promptCalls = 0;
       const parser = object({
         name: prompt(
           bindEnv(option("--name", string()), {
@@ -855,17 +851,18 @@ describe("prompt()", () => {
           {
             type: "input",
             message: "Enter name:",
-            prompter: () =>
-              Promise.reject(new Error("Prompt should not be called")),
+            prompter: () => {
+              promptCalls += 1;
+              return Promise.resolve("prompted-name");
+            },
           },
         ),
       });
 
-      // Note: annotations NOT passed to parseAsync — bindEnv resolves
-      // via the global active env source registry instead.
       const result = await parseAsync(parser, []);
       assert.ok(result.success);
-      assert.equal(result.value.name, "env-name");
+      assert.equal(result.value.name, "prompted-name");
+      assert.equal(promptCalls, 1);
     });
 
     it("skips prompt for prompt(optional(bindEnv(...))) inside object()", async () => {
@@ -1325,6 +1322,43 @@ describe("prompt()", () => {
 
       assert.equal(result, "config-secret");
       assert.equal(promptCalls, 0);
+    });
+
+    it("prompts when prompt(bindConfig(...)) is parsed without annotations", async () => {
+      const context = createConfigContext({
+        schema: createPromptConfigSchema(),
+      });
+      await context.getAnnotations(
+        { any: true },
+        {
+          load: () => ({
+            config: { apiKey: "config-secret" },
+            meta: undefined,
+          }),
+        },
+      );
+      let promptCalls = 0;
+      const parser = object({
+        apiKey: prompt(
+          bindConfig(option("--api-key", string()), {
+            context,
+            key: "apiKey",
+          }),
+          {
+            type: "password",
+            message: "API key:",
+            prompter: () => {
+              promptCalls += 1;
+              return Promise.resolve("prompt-secret");
+            },
+          },
+        ),
+      });
+
+      const result = await parseAsync(parser, []);
+      assert.ok(result.success);
+      assert.equal(result.value.apiKey, "prompt-secret");
+      assert.equal(promptCalls, 1);
     });
 
     it("prompts when bindEnv() has no value and env var is absent", async () => {
@@ -4877,7 +4911,7 @@ describe("prompt() with dependency sources", () => {
     );
     const parseResult = await modeParser.parse({
       buffer: [],
-      state: modeParser.initialState,
+      state: injectAnnotations(modeParser.initialState, annotations),
       optionsTerminated: false,
       usage: modeParser.usage,
     });

--- a/packages/inquirer/src/index.test.ts
+++ b/packages/inquirer/src/index.test.ts
@@ -841,7 +841,14 @@ describe("prompt()", () => {
           source: (key) => ({ APP_NAME: "env-name" })[key],
           prefix: "APP_",
         });
-        context.getAnnotations();
+        const annotations = context.getAnnotations();
+        if (annotations instanceof Promise) {
+          throw new TypeError("Expected synchronous annotations.");
+        }
+        assert.ok(
+          Object.getOwnPropertySymbols(annotations).length > 0,
+          "Expected getAnnotations() to capture env-backed annotations.",
+        );
         let promptCalls = 0;
         const parser = object({
           name: prompt(
@@ -1333,7 +1340,7 @@ describe("prompt()", () => {
         const context = createConfigContext({
           schema: createPromptConfigSchema(),
         });
-        await context.getAnnotations(
+        const annotations = await context.getAnnotations(
           { any: true },
           {
             load: () => ({
@@ -1341,6 +1348,10 @@ describe("prompt()", () => {
               meta: undefined,
             }),
           },
+        );
+        assert.ok(
+          Object.getOwnPropertySymbols(annotations).length > 0,
+          "Expected getAnnotations() to capture config-backed annotations.",
         );
         let promptCalls = 0;
         const parser = object({


### PR DESCRIPTION
## Summary

This PR removes the hidden process-global fallback path behind `bindConfig()` and `bindEnv()`. Manual calls to `getAnnotations()` are now purely observational: they return an annotation snapshot, but they do not silently influence unrelated later `parse()` or `parseAsync()` calls. Source-backed values now flow only through explicit `annotations` or through context-aware runners such as `runWith()`, `run()`, and `runAsync()`.

This fixes the stale-lifetime bug reported in #234. Previously, a successful config or env probe could leave behind hidden source state that later low-level parses would still read, even after a later empty probe or validation failure. In practice that could surface as stale config values being reused, or prompts being skipped because old env/config state was still visible.

## What changed

In *packages/config/src/index.ts*, I removed the active config registry and changed `bindConfig()` to resolve fallback values only from annotations carried by the current parse state. In *packages/env/src/index.ts*, I made the same change for `bindEnv()`. As a result, calling `configContext.getAnnotations()` or `envContext.getAnnotations()` no longer "arms" future parses on its own.

The prompt path was adjusted through regression coverage in *packages/inquirer/src/index.test.ts*. `prompt(bindEnv(...))` and `prompt(bindConfig(...))` now skip prompting only when the current parse actually carries explicit annotations or is running under a context-aware runner. They no longer skip prompts because of stale source state from an earlier manual context call.

The new contract is documented in *docs/integrations/config.md*, *docs/integrations/env.md*, and *docs/cookbook.md*, and the release notes were updated in *CHANGES.md*.

## Behavioral change

This is a deliberate breaking change for low-level manual context usage, which is acceptable for the upcoming 1.0.0 release. If a caller manually collects annotations, they now need to pass those annotations back into the parse explicitly.

```typescript
const annotations = await configContext.getAnnotations(parsed, options);
const result = parse(parser, [], { annotations });
```

Calling `getAnnotations()` alone no longer changes the behavior of later `parse()`, `parseAsync()`, `suggest()`, or `getDocPage()` calls.

## Tests

I added regression coverage in *packages/config/src/index.test.ts* for stale config lifetime after later empty probes, later phase-one probes, and later validation failures. I also updated *packages/env/src/index.test.ts* to assert that prior manual `getAnnotations()` calls do not affect unrelated plain parses, while explicit annotation-driven flows continue to work. Prompt regressions were covered in *packages/inquirer/src/index.test.ts*.

I verified the change with the affected package test suites under Deno, Node, and Bun, and with documentation and package builds.

Fixes #234.