### PR TITLE
Protect annotations from parser mutation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,16 @@ To be released.
 
 ### @optique/core
 
+ -  Fixed annotation isolation across the public parser entrypoints and
+    runner-driven context injection. `parse()`, `parseSync()`, `parseAsync()`,
+    `suggest()`, `suggestSync()`, `suggestAsync()`, `getDocPage()`,
+    `getDocPageSync()`, `getDocPageAsync()`, `runWith()`, and `runWithSync()`
+    now expose annotations through protected read-only views instead of
+    leaking caller- or context-owned objects by reference. Custom parsers can
+    still read live annotation data, but ordinary mutation attempts against
+    supported container types now fail fast with `TypeError` and no longer
+    mutate the original annotation payload. [[#491], [#787]]
+
  -  Replaced the sentinel-based two-pass `SourceContext` contract with an
     explicit `SourceContextRequest` object. `getAnnotations()` and
     `getInternalAnnotations()` now receive `phase: "phase1"` / `"phase2"`
@@ -1491,6 +1501,7 @@ To be released.
 [#485]: https://github.com/dahlia/optique/issues/485
 [#488]: https://github.com/dahlia/optique/issues/488
 [#490]: https://github.com/dahlia/optique/pull/490
+[#491]: https://github.com/dahlia/optique/issues/491
 [#492]: https://github.com/dahlia/optique/issues/492
 [#493]: https://github.com/dahlia/optique/issues/493
 [#494]: https://github.com/dahlia/optique/issues/494
@@ -1681,6 +1692,7 @@ To be released.
 [#783]: https://github.com/dahlia/optique/pull/783
 [#784]: https://github.com/dahlia/optique/pull/784
 [#786]: https://github.com/dahlia/optique/pull/786
+[#787]: https://github.com/dahlia/optique/pull/787
 
 ### @optique/config
 

--- a/docs/concepts/extend.md
+++ b/docs/concepts/extend.md
@@ -133,6 +133,8 @@ function myCustomComplete(state: unknown) {
 The function returns `undefined` if no annotations were provided, so always
 use optional chaining (`?.`) when accessing annotation data. Since annotations
 are typed as `unknown`, you need to cast them to your expected type.
+The returned record is a read-only view owned by the current parse run, not
+the caller's original annotations object.
 
 
 Creating custom parsers with annotations
@@ -702,16 +704,23 @@ API reference
 ### Types and symbols from `@optique/core/annotations`
 
 `annotationKey`
-:   Unique symbol for storing annotations in parser state. Use this symbol to
-    access the raw annotations object from state if needed.
+:   Unique symbol for storing annotations in parser state. Values injected by
+    Optique are exposed through protected read-only views rather than
+    caller-owned mutable objects.
 
 `Annotations`
 :   Type alias for `Record<symbol, unknown>`. Represents the annotation data
     structure where each key is a symbol and each value can be any type.
 
+`ReadonlyAnnotations`
+:   Read-only annotation view returned by `getAnnotations()`. Supported
+    nested container values are also exposed through protected read-only
+    views.
+
 `ParseOptions`
 :   Interface containing options for parse functions. Currently has one field:
-    `annotations?: Annotations`.
+    `annotations?: Annotations`. Optique treats these annotations as
+    immutable input.
 
 ### Types from `@optique/core/context`
 
@@ -770,9 +779,10 @@ API reference
 
 ### Functions from `@optique/core/annotations`
 
-`getAnnotations(state: unknown): Annotations | undefined`
+`getAnnotations(state: unknown): ReadonlyAnnotations | undefined`
 :   Extracts annotations from parser state. Returns `undefined` if the state
     does not contain annotations or if the state is not an object.
+    Returned annotations are protected read-only views.
 
     ~~~~ typescript twoslash
     import { getAnnotations } from "@optique/core/annotations";
@@ -1322,19 +1332,26 @@ advanced parsers. For high-level usage, use the SourceContext system with
 ### State immutability
 
 Annotations are injected into the initial state and should be treated as
-read-only. Do not modify annotation data during parsing:
+read-only. Optique now exposes supported annotation values through protected
+read-only views, so ordinary mutation attempts fail fast with `TypeError`
+instead of mutating the caller's original object:
 
 ~~~~ typescript
 // Good: read-only access
 const annotations = getAnnotations(state);
 const value = annotations?.[myKey];
 
-// Bad: modifying annotations (undefined behavior)
+// Bad: modifying annotations
 const annotations = getAnnotations(state);
 if (annotations) {
-  annotations[myKey] = newValue; // Don't do this
+  Reflect.set(annotations, myKey, newValue); // Throws TypeError
 }
 ~~~~
+
+Opaque live objects and functions are still passed by reference. If you store
+an API client, callback, or other non-plain object in annotations, Optique
+does not virtualize its internal behavior; any intentional side effects
+through that object's own methods remain your responsibility.
 
 ### Performance considerations
 

--- a/docs/concepts/extend.md
+++ b/docs/concepts/extend.md
@@ -719,8 +719,8 @@ API reference
 
 `ParseOptions`
 :   Interface containing options for parse functions. Currently has one field:
-    `annotations?: Annotations`. Optique treats these annotations as
-    immutable input.
+    `annotations?: Annotations | ReadonlyAnnotations`. Optique treats these
+    annotations as immutable input.
 
 ### Types from `@optique/core/context`
 

--- a/docs/integrations/logtape.md
+++ b/docs/integrations/logtape.md
@@ -50,7 +50,7 @@ The fastest way to add logging configuration to your CLI is using the
 ~~~~ typescript twoslash
 import { loggingOptions, createLoggingConfig } from "@optique/logtape";
 import { object } from "@optique/core/constructs";
-import { parse } from "@optique/core/parser";
+import { parseSync } from "@optique/core/parser";
 import { configure } from "@logtape/logtape";
 
 const parser = object({
@@ -58,7 +58,7 @@ const parser = object({
 });
 
 const args = ["-vv", "--log-output=-"];
-const result = parse(parser, args);
+const result = parseSync(parser, args);
 if (result.success) {
   const config = await createLoggingConfig(result.value.logging);
   await configure(config);
@@ -83,7 +83,7 @@ import { logLevel } from "@optique/logtape";
 import { option } from "@optique/core/primitives";
 import { withDefault } from "@optique/core/modifiers";
 import { object, merge } from "@optique/core/constructs";
-import { parse } from "@optique/core/parser";
+import { parseSync } from "@optique/core/parser";
 import type { LogLevel } from "@logtape/logtape";
 
 const parser = object({
@@ -94,7 +94,7 @@ const parser = object({
 });
 
 // Accepts: "trace", "debug", "info", "warning", "error", "fatal"
-const result = parse(parser, ["--log-level=debug"]);
+const result = parseSync(parser, ["--log-level=debug"]);
 ~~~~
 
 ### Features
@@ -124,26 +124,26 @@ controlling log verbosity. Each additional `-v` flag increases the verbosity
 ~~~~ typescript twoslash
 import { verbosity } from "@optique/logtape";
 import { object } from "@optique/core/constructs";
-import { parse } from "@optique/core/parser";
+import { parseSync } from "@optique/core/parser";
 
 const parser = object({
   logLevel: verbosity(),
 });
 
 // No flags → "warning"
-parse(parser, []);
+parseSync(parser, []);
 
 // -v → "info"
-parse(parser, ["-v"]);
+parseSync(parser, ["-v"]);
 
 // -vv → "debug"
-parse(parser, ["-v", "-v"]);
+parseSync(parser, ["-v", "-v"]);
 
 // -vvv → "trace"
-parse(parser, ["-v", "-v", "-v"]);
+parseSync(parser, ["-v", "-v", "-v"]);
 
 // Additional flags beyond -vvv stay at "trace"
-parse(parser, ["-v", "-v", "-v", "-v"]);
+parseSync(parser, ["-v", "-v", "-v", "-v"]);
 ~~~~
 
 ### Level mapping
@@ -190,17 +190,17 @@ control.
 ~~~~ typescript twoslash
 import { debug } from "@optique/logtape";
 import { object } from "@optique/core/constructs";
-import { parse } from "@optique/core/parser";
+import { parseSync } from "@optique/core/parser";
 
 const parser = object({
   logLevel: debug(),
 });
 
 // No flag → "info"
-const normal = parse(parser, []);
+const normal = parseSync(parser, []);
 
 // --debug or -d → "debug"
-const debugging = parse(parser, ["--debug"]);
+const debugging = parseSync(parser, ["--debug"]);
 ~~~~
 
 ### Options
@@ -226,22 +226,22 @@ conventions, it accepts `-` for console output or a file path for file output.
 ~~~~ typescript twoslash
 import { logOutput } from "@optique/logtape";
 import { object } from "@optique/core/constructs";
-import { parse } from "@optique/core/parser";
+import { parseSync } from "@optique/core/parser";
 
 const parser = object({
   output: logOutput(),
 });
 
 // Console output
-const console = parse(parser, ["--log-output=-"]);
+const console = parseSync(parser, ["--log-output=-"]);
 // → { type: "console" }
 
 // File output
-const file = parse(parser, ["--log-output=/var/log/app.log"]);
+const file = parseSync(parser, ["--log-output=/var/log/app.log"]);
 // → { type: "file", path: "/var/log/app.log" }
 
 // Optional: undefined when not specified
-const none = parse(parser, []);
+const none = parseSync(parser, []);
 // → undefined
 ~~~~
 
@@ -271,14 +271,14 @@ methods.
 ~~~~ typescript twoslash
 import { loggingOptions } from "@optique/logtape";
 import { object } from "@optique/core/constructs";
-import { parse } from "@optique/core/parser";
+import { parseSync } from "@optique/core/parser";
 
 const parser = object({
   logging: loggingOptions({ level: "option" }),
 });
 
 // --log-level=debug --log-output=/var/log/app.log
-const result = parse(parser, ["--log-level=debug", "--log-output=-"]);
+const result = parseSync(parser, ["--log-level=debug", "--log-output=-"]);
 ~~~~
 
 Configuration options for `level: "option"`:
@@ -294,14 +294,14 @@ Configuration options for `level: "option"`:
 ~~~~ typescript twoslash
 import { loggingOptions } from "@optique/logtape";
 import { object } from "@optique/core/constructs";
-import { parse } from "@optique/core/parser";
+import { parseSync } from "@optique/core/parser";
 
 const parser = object({
   logging: loggingOptions({ level: "verbosity" }),
 });
 
 // -vv --log-output=-
-const result = parse(parser, ["-v", "-v", "--log-output=-"]);
+const result = parseSync(parser, ["-v", "-v", "--log-output=-"]);
 ~~~~
 
 Configuration options for `level: "verbosity"`:
@@ -317,14 +317,14 @@ Configuration options for `level: "verbosity"`:
 ~~~~ typescript twoslash
 import { loggingOptions } from "@optique/logtape";
 import { object } from "@optique/core/constructs";
-import { parse } from "@optique/core/parser";
+import { parseSync } from "@optique/core/parser";
 
 const parser = object({
   logging: loggingOptions({ level: "debug" }),
 });
 
 // --debug
-const result = parse(parser, ["--debug"]);
+const result = parseSync(parser, ["--debug"]);
 ~~~~
 
 Configuration options for `level: "debug"`:
@@ -356,14 +356,14 @@ LogTape configuration object that can be passed directly to `configure()`.
 ~~~~ typescript twoslash
 import { loggingOptions, createLoggingConfig } from "@optique/logtape";
 import { object } from "@optique/core/constructs";
-import { parse } from "@optique/core/parser";
+import { parseSync } from "@optique/core/parser";
 import { configure } from "@logtape/logtape";
 
 const parser = object({
   logging: loggingOptions({ level: "verbosity" }),
 });
 
-const result = parse(parser, ["-vv"]);
+const result = parseSync(parser, ["-vv"]);
 if (result.success) {
   const config = await createLoggingConfig(result.value.logging);
   await configure(config);
@@ -377,12 +377,12 @@ Customize how console output is handled:
 ~~~~ typescript twoslash
 import { loggingOptions, createLoggingConfig } from "@optique/logtape";
 import { object } from "@optique/core/constructs";
-import { parse } from "@optique/core/parser";
+import { parseSync } from "@optique/core/parser";
 
 const parser = object({
   logging: loggingOptions({ level: "option" }),
 });
-const result = parse(parser, ["--log-level=debug"]);
+const result = parseSync(parser, ["--log-level=debug"]);
 if (!result.success) throw new Error();
 // ---cut-before---
 // Write all logs to stderr
@@ -404,13 +404,13 @@ Extend the generated configuration with custom loggers, filters, or sinks:
 ~~~~ typescript twoslash
 import { loggingOptions, createLoggingConfig } from "@optique/logtape";
 import { object } from "@optique/core/constructs";
-import { parse } from "@optique/core/parser";
+import { parseSync } from "@optique/core/parser";
 import { configure } from "@logtape/logtape";
 
 const parser = object({
   logging: loggingOptions({ level: "option" }),
 });
-const result = parse(parser, ["--log-level=debug"]);
+const result = parseSync(parser, ["--log-level=debug"]);
 if (!result.success) throw new Error();
 // ---cut-before---
 const config = await createLoggingConfig(result.value.logging, {}, {
@@ -502,7 +502,7 @@ import { object } from "@optique/core/constructs";
 import { option } from "@optique/core/primitives";
 import { string, integer } from "@optique/core/valueparser";
 import { withDefault } from "@optique/core/modifiers";
-import { parse } from "@optique/core/parser";
+import { parseSync } from "@optique/core/parser";
 import { configure, getLogger } from "@logtape/logtape";
 
 const parser = object({
@@ -514,7 +514,7 @@ const parser = object({
   logging: loggingOptions({ level: "verbosity" }),
 });
 
-const result = parse(parser, ["--host", "0.0.0.0", "-vv"]);
+const result = parseSync(parser, ["--host", "0.0.0.0", "-vv"]);
 
 if (result.success) {
   // Configure LogTape

--- a/mise.toml
+++ b/mise.toml
@@ -42,7 +42,12 @@ run = "deno task test:bun"
 
 [tasks.test]
 description = "Run the test suite across all environments"
-depends = ["check", "test:*"]
+run = '''
+mise run check
+mise run test:deno
+mise run test:node
+mise run test:bun
+'''
 
 [tasks.build]
 description = "Build all packages for npm publishing"

--- a/mise.toml
+++ b/mise.toml
@@ -45,8 +45,9 @@ description = "Run the test suite across all environments"
 run = '''
 mise run check
 mise run test:deno
-mise run test:node
-mise run test:bun
+mise run build
+deno task test:node
+deno task test:bun
 '''
 
 [tasks.build]

--- a/packages/core/src/annotation-state.ts
+++ b/packages/core/src/annotation-state.ts
@@ -4,6 +4,7 @@ import {
   getAnnotations,
   inheritAnnotations,
   injectAnnotations,
+  type ReadonlyAnnotations,
   unwrapInjectedAnnotationWrapper,
 } from "./annotations.ts";
 import {
@@ -48,7 +49,7 @@ export function unwrapAnnotationView<T>(value: T): T {
  */
 export function withAnnotationView<T extends object>(
   state: T,
-  annotations: Annotations,
+  annotations: Annotations | ReadonlyAnnotations,
 ): T {
   const target = unwrapAnnotationView(state) as T;
   const view = new Proxy(target, {

--- a/packages/core/src/annotations.test.ts
+++ b/packages/core/src/annotations.test.ts
@@ -200,6 +200,47 @@ describe("getAnnotations", () => {
       assert.equal(rawRegExp.lastIndex, 0);
     });
 
+    it("should preserve RegExp metadata on protected views", () => {
+      const marker = Symbol.for("@test/issue-491/regexp-metadata");
+      const extraKey = Symbol.for("@test/issue-491/regexp-extra");
+
+      class TaggedRegExp extends RegExp {
+        readonly label = "tagged";
+
+        matches(input: string): boolean {
+          return this.test(input);
+        }
+      }
+
+      const rawRegExp = new TaggedRegExp("ab+", "gi") as TaggedRegExp & {
+        [extraKey]: { value: number };
+      };
+      rawRegExp.lastIndex = 2;
+      rawRegExp[extraKey] = { value: 1 };
+
+      const state = injectAnnotations(undefined, { [marker]: rawRegExp });
+      const annotations = getAnnotations(state);
+      assert.ok(annotations !== undefined);
+
+      const protectedRegExp = annotations[marker] as TaggedRegExp & {
+        [extraKey]: { value: number };
+      };
+
+      assert.ok(protectedRegExp instanceof TaggedRegExp);
+      assert.equal(protectedRegExp.label, "tagged");
+      assert.equal(protectedRegExp.lastIndex, 2);
+      assert.ok(protectedRegExp.matches("zzabbb"));
+      assert.notEqual(protectedRegExp[extraKey], rawRegExp[extraKey]);
+      assert.equal(protectedRegExp[extraKey].value, 1);
+      assert.throws(
+        () => {
+          protectedRegExp[extraKey].value = 2;
+        },
+        { name: "TypeError" },
+      );
+      assert.equal(rawRegExp[extraKey].value, 1);
+    });
+
     it("should not reuse protected views across separate injectAnnotations() calls", () => {
       const marker = Symbol.for("@test/issue-491/per-run-cache");
       const sharedAnnotations = { [marker]: /ab+/g };
@@ -358,15 +399,24 @@ describe("injectAnnotations", () => {
 
   it("should preserve RegExp state shape", () => {
     const marker = Symbol.for("@test/inject-regexp");
-    const source = /ab+/gi;
+    class TaggedRegExp extends RegExp {
+      readonly label = "tagged";
+    }
+    const extraKey = Symbol.for("@test/inject-regexp-extra");
+    const source = new TaggedRegExp("ab+", "gi") as TaggedRegExp & {
+      [extraKey]: { value: number };
+    };
+    source[extraKey] = { value: 1 };
     source.lastIndex = 3;
     const result = injectAnnotations(source, { [marker]: "ok" });
 
-    assert.ok(result instanceof RegExp);
+    assert.ok(result instanceof TaggedRegExp);
     assert.notEqual(result, source);
     assert.equal(result.source, "ab+");
     assert.equal(result.flags, "gi");
     assert.equal(result.lastIndex, 3);
+    assert.equal(result.label, "tagged");
+    assert.equal(result[extraKey], source[extraKey]);
     assert.equal(getAnnotations(result)?.[marker], "ok");
   });
 
@@ -541,15 +591,24 @@ describe("inheritAnnotations", () => {
   it("should preserve RegExp state shape", () => {
     const marker = Symbol.for("@test/inherit-regexp");
     const source = { [annotationKey]: { [marker]: "ok" } };
-    const target = /ab+/gi;
+    class TaggedRegExp extends RegExp {
+      readonly label = "tagged";
+    }
+    const extraKey = Symbol.for("@test/inherit-regexp-extra");
+    const target = new TaggedRegExp("ab+", "gi") as TaggedRegExp & {
+      [extraKey]: { value: number };
+    };
+    target[extraKey] = { value: 1 };
     target.lastIndex = 4;
     const result = inheritAnnotations(source, target);
 
-    assert.ok(result instanceof RegExp);
+    assert.ok(result instanceof TaggedRegExp);
     assert.notEqual(result, target);
     assert.equal(result.source, "ab+");
     assert.equal(result.flags, "gi");
     assert.equal(result.lastIndex, 4);
+    assert.equal(result.label, "tagged");
+    assert.equal(result[extraKey], target[extraKey]);
     assert.equal(getAnnotations(result)?.[marker], "ok");
   });
 

--- a/packages/core/src/annotations.test.ts
+++ b/packages/core/src/annotations.test.ts
@@ -765,18 +765,29 @@ describe("getAnnotations", () => {
 
 describe("injectAnnotations", () => {
   it("should preserve wrapper markers when reinjecting injected wrappers", () => {
-    const first = injectAnnotations(undefined, { [Symbol.for("@test/a")]: 1 });
+    const firstKey = Symbol.for("@test/a");
+    const secondKey = Symbol.for("@test/b");
+    const first = injectAnnotations(undefined, { [firstKey]: 1 });
     assert.ok(isInjectedAnnotationWrapper(first));
 
-    const second = injectAnnotations(first, { [Symbol.for("@test/b")]: 2 });
-    assert.equal(second, first);
+    const second = injectAnnotations(first, { [secondKey]: 2 });
+    assert.notEqual(second, first);
     assert.ok(isInjectedAnnotationWrapper(second));
 
-    const wrapper = second as unknown as Record<PropertyKey, unknown>;
-    assert.ok(Object.hasOwn(wrapper, annotationStateValueKey));
-    assert.ok(Object.hasOwn(wrapper, annotationWrapperKey));
-    assert.equal(wrapper[annotationWrapperKey], true);
-    assert.equal(wrapper[annotationStateValueKey], undefined);
+    const firstWrapper = first as unknown as Record<PropertyKey, unknown>;
+    const secondWrapper = second as unknown as Record<PropertyKey, unknown>;
+
+    assert.ok(Object.hasOwn(firstWrapper, annotationStateValueKey));
+    assert.ok(Object.hasOwn(firstWrapper, annotationWrapperKey));
+    assert.equal(firstWrapper[annotationWrapperKey], true);
+    assert.equal(firstWrapper[annotationStateValueKey], undefined);
+    assert.equal(getAnnotations(first)?.[firstKey], 1);
+
+    assert.ok(Object.hasOwn(secondWrapper, annotationStateValueKey));
+    assert.ok(Object.hasOwn(secondWrapper, annotationWrapperKey));
+    assert.equal(secondWrapper[annotationWrapperKey], true);
+    assert.equal(secondWrapper[annotationStateValueKey], undefined);
+    assert.equal(getAnnotations(second)?.[secondKey], 2);
   });
 
   it("should preserve Date state shape", () => {
@@ -787,6 +798,25 @@ describe("injectAnnotations", () => {
     assert.ok(result instanceof Date);
     assert.notEqual(result, source);
     assert.equal(result.toISOString(), "2026-03-08T00:00:00.000Z");
+    assert.equal(getAnnotations(result)?.[marker], "ok");
+  });
+
+  it("should preserve Date subclass methods with private fields", () => {
+    const marker = Symbol.for("@test/inject-date-private-field");
+
+    class TaggedDate extends Date {
+      readonly #label = "tagged";
+
+      label(): string {
+        return this.#label;
+      }
+    }
+
+    const source = new TaggedDate("2026-03-08T00:00:00.000Z");
+    const result = injectAnnotations(source, { [marker]: "ok" });
+
+    assert.ok(result instanceof TaggedDate);
+    assert.equal(result.label(), "tagged");
     assert.equal(getAnnotations(result)?.[marker], "ok");
   });
 
@@ -801,6 +831,26 @@ describe("injectAnnotations", () => {
     assert.equal(getAnnotations(result)?.[marker], "ok");
   });
 
+  it("should preserve Map subclass methods with private fields", () => {
+    const marker = Symbol.for("@test/inject-map-private-field");
+
+    class TaggedMap<K, V> extends Map<K, V> {
+      readonly #label = "tagged";
+
+      label(): string {
+        return this.#label;
+      }
+    }
+
+    const source = new TaggedMap<string, number>([["a", 1]]);
+    const result = injectAnnotations(source, { [marker]: "ok" });
+
+    assert.ok(result instanceof TaggedMap);
+    assert.equal(result.label(), "tagged");
+    assert.equal(result.get("a"), 1);
+    assert.equal(getAnnotations(result)?.[marker], "ok");
+  });
+
   it("should preserve Set state shape", () => {
     const marker = Symbol.for("@test/inject-set");
     const source = new Set(["a", "b"]);
@@ -808,6 +858,26 @@ describe("injectAnnotations", () => {
 
     assert.ok(result instanceof Set);
     assert.notEqual(result, source);
+    assert.deepEqual([...result], ["a", "b"]);
+    assert.equal(getAnnotations(result)?.[marker], "ok");
+  });
+
+  it("should preserve Set subclass methods with private fields", () => {
+    const marker = Symbol.for("@test/inject-set-private-field");
+
+    class TaggedSet<T> extends Set<T> {
+      readonly #label = "tagged";
+
+      label(): string {
+        return this.#label;
+      }
+    }
+
+    const source = new TaggedSet(["a", "b"]);
+    const result = injectAnnotations(source, { [marker]: "ok" });
+
+    assert.ok(result instanceof TaggedSet);
+    assert.equal(result.label(), "tagged");
     assert.deepEqual([...result], ["a", "b"]);
     assert.equal(getAnnotations(result)?.[marker], "ok");
   });
@@ -998,6 +1068,26 @@ describe("inheritAnnotations", () => {
     assert.equal(getAnnotations(result)?.[marker], "ok");
   });
 
+  it("should preserve Date subclass methods with private fields", () => {
+    const marker = Symbol.for("@test/inherit-date-private-field");
+    const source = { [annotationKey]: { [marker]: "ok" } };
+
+    class TaggedDate extends Date {
+      readonly #label = "tagged";
+
+      label(): string {
+        return this.#label;
+      }
+    }
+
+    const target = new TaggedDate("2026-03-08T00:00:00.000Z");
+    const result = inheritAnnotations(source, target);
+
+    assert.ok(result instanceof TaggedDate);
+    assert.equal(result.label(), "tagged");
+    assert.equal(getAnnotations(result)?.[marker], "ok");
+  });
+
   it("should preserve Map state shape", () => {
     const marker = Symbol.for("@test/inherit-map");
     const source = { [annotationKey]: { [marker]: "ok" } };
@@ -1010,6 +1100,27 @@ describe("inheritAnnotations", () => {
     assert.equal(getAnnotations(result)?.[marker], "ok");
   });
 
+  it("should preserve Map subclass methods with private fields", () => {
+    const marker = Symbol.for("@test/inherit-map-private-field");
+    const source = { [annotationKey]: { [marker]: "ok" } };
+
+    class TaggedMap<K, V> extends Map<K, V> {
+      readonly #label = "tagged";
+
+      label(): string {
+        return this.#label;
+      }
+    }
+
+    const target = new TaggedMap<string, number>([["a", 1]]);
+    const result = inheritAnnotations(source, target);
+
+    assert.ok(result instanceof TaggedMap);
+    assert.equal(result.label(), "tagged");
+    assert.equal(result.get("a"), 1);
+    assert.equal(getAnnotations(result)?.[marker], "ok");
+  });
+
   it("should preserve Set state shape", () => {
     const marker = Symbol.for("@test/inherit-set");
     const source = { [annotationKey]: { [marker]: "ok" } };
@@ -1018,6 +1129,27 @@ describe("inheritAnnotations", () => {
 
     assert.ok(result instanceof Set);
     assert.notEqual(result, target);
+    assert.deepEqual([...result], ["a", "b"]);
+    assert.equal(getAnnotations(result)?.[marker], "ok");
+  });
+
+  it("should preserve Set subclass methods with private fields", () => {
+    const marker = Symbol.for("@test/inherit-set-private-field");
+    const source = { [annotationKey]: { [marker]: "ok" } };
+
+    class TaggedSet<T> extends Set<T> {
+      readonly #label = "tagged";
+
+      label(): string {
+        return this.#label;
+      }
+    }
+
+    const target = new TaggedSet(["a", "b"]);
+    const result = inheritAnnotations(source, target);
+
+    assert.ok(result instanceof TaggedSet);
+    assert.equal(result.label(), "tagged");
     assert.deepEqual([...result], ["a", "b"]);
     assert.equal(getAnnotations(result)?.[marker], "ok");
   });

--- a/packages/core/src/annotations.test.ts
+++ b/packages/core/src/annotations.test.ts
@@ -441,6 +441,35 @@ describe("getAnnotations", () => {
       assert.equal(map.get(iteratedKey), "ok");
     });
 
+    it("should preserve Map key identity for directly injected protected inputs", () => {
+      const keyMarker = Symbol.for("@test/issue-491/map-protected-key-direct");
+      const mapMarker = Symbol.for(
+        "@test/issue-491/map-protected-key-direct-wrapper",
+      );
+      const seedState = injectAnnotations(undefined, {
+        [keyMarker]: { value: 1 },
+      });
+      const protectedAnnotations = getAnnotations(seedState);
+
+      assert.ok(protectedAnnotations !== undefined);
+
+      const directAnnotations = {
+        [mapMarker]: new Map([[protectedAnnotations[keyMarker], "ok"]]),
+      };
+
+      const state = injectAnnotations(undefined, directAnnotations);
+      const annotations = getAnnotations(state);
+
+      assert.ok(annotations !== undefined);
+
+      const map = annotations[mapMarker] as Map<object, string>;
+      const iteratedKey = [...map.keys()][0];
+
+      assert.ok(iteratedKey !== undefined);
+      assert.ok(map.has(iteratedKey));
+      assert.equal(map.get(iteratedKey), "ok");
+    });
+
     it("should preserve Set membership for fresh-run protected inputs", () => {
       const valueMarker = Symbol.for("@test/issue-491/set-protected-value");
       const setMarker = Symbol.for(
@@ -467,6 +496,91 @@ describe("getAnnotations", () => {
 
       assert.ok(iteratedValue !== undefined);
       assert.ok(set.has(iteratedValue));
+    });
+
+    it("should preserve Set membership for directly injected protected inputs", () => {
+      const valueMarker = Symbol.for(
+        "@test/issue-491/set-protected-value-direct",
+      );
+      const setMarker = Symbol.for(
+        "@test/issue-491/set-protected-value-direct-wrapper",
+      );
+      const seedState = injectAnnotations(undefined, {
+        [valueMarker]: { value: 1 },
+      });
+      const protectedAnnotations = getAnnotations(seedState);
+
+      assert.ok(protectedAnnotations !== undefined);
+
+      const directAnnotations = {
+        [setMarker]: new Set([protectedAnnotations[valueMarker]]),
+      };
+
+      const state = injectAnnotations(undefined, directAnnotations);
+      const annotations = getAnnotations(state);
+
+      assert.ok(annotations !== undefined);
+
+      const set = annotations[setMarker] as Set<object>;
+      const iteratedValue = [...set.values()][0];
+
+      assert.ok(iteratedValue !== undefined);
+      assert.ok(set.has(iteratedValue));
+    });
+
+    it("should not expose mutable clone-backed built-ins through valueOf", () => {
+      const marker = Symbol.for("@test/issue-491/value-of");
+      const map = new Map<string, { value: number }>([["k", { value: 1 }]]);
+      const set = new Set([{ value: 1 }]);
+      const regex = /ab+/g;
+      const url = new URL("https://example.com/a?x=1");
+      const params = new URLSearchParams("x=1");
+
+      const state = injectAnnotations(undefined, {
+        [marker]: { map, set, regex, url, params },
+      });
+      const annotations = getAnnotations(state);
+
+      assert.ok(annotations !== undefined);
+
+      const value = annotations[marker] as {
+        map: Map<string, { value: number }>;
+        set: Set<{ value: number }>;
+        regex: RegExp;
+        url: URL;
+        params: URLSearchParams;
+      };
+
+      assert.equal(value.map.valueOf(), value.map);
+      assert.equal(value.set.valueOf(), value.set);
+      assert.equal(value.regex.valueOf(), value.regex);
+      assert.equal(value.url.valueOf(), value.url);
+      assert.equal(value.params.valueOf(), value.params);
+
+      assert.throws(() =>
+        (value.map.valueOf() as typeof value.map).set("x", {
+          value: 2,
+        }), {
+        name: "TypeError",
+      });
+      assert.throws(() =>
+        (value.set.valueOf() as typeof value.set).add({
+          value: 2,
+        }), {
+        name: "TypeError",
+      });
+      assert.throws(() => Reflect.set(value.regex.valueOf(), "lastIndex", 3), {
+        name: "TypeError",
+      });
+      assert.throws(() => Reflect.set(value.url.valueOf(), "pathname", "/b"), {
+        name: "TypeError",
+      });
+      assert.throws(
+        () => (value.params.valueOf() as typeof value.params).set("x", "2"),
+        {
+          name: "TypeError",
+        },
+      );
     });
 
     it("should throw when mutating URL-like annotations", () => {

--- a/packages/core/src/annotations.test.ts
+++ b/packages/core/src/annotations.test.ts
@@ -359,12 +359,14 @@ describe("injectAnnotations", () => {
   it("should preserve RegExp state shape", () => {
     const marker = Symbol.for("@test/inject-regexp");
     const source = /ab+/gi;
+    source.lastIndex = 3;
     const result = injectAnnotations(source, { [marker]: "ok" });
 
     assert.ok(result instanceof RegExp);
     assert.notEqual(result, source);
     assert.equal(result.source, "ab+");
     assert.equal(result.flags, "gi");
+    assert.equal(result.lastIndex, 3);
     assert.equal(getAnnotations(result)?.[marker], "ok");
   });
 
@@ -540,12 +542,14 @@ describe("inheritAnnotations", () => {
     const marker = Symbol.for("@test/inherit-regexp");
     const source = { [annotationKey]: { [marker]: "ok" } };
     const target = /ab+/gi;
+    target.lastIndex = 4;
     const result = inheritAnnotations(source, target);
 
     assert.ok(result instanceof RegExp);
     assert.notEqual(result, target);
     assert.equal(result.source, "ab+");
     assert.equal(result.flags, "gi");
+    assert.equal(result.lastIndex, 4);
     assert.equal(getAnnotations(result)?.[marker], "ok");
   });
 

--- a/packages/core/src/annotations.test.ts
+++ b/packages/core/src/annotations.test.ts
@@ -414,6 +414,54 @@ describe("getAnnotations", () => {
       }
     });
 
+    it("should preserve built-in subclass methods with private fields", () => {
+      const marker = Symbol.for("@test/issue-491/map-subclass-private-field");
+
+      class TaggedMap<K, V> extends Map<K, V> {
+        readonly #label = "tagged";
+
+        label(): string {
+          return this.#label;
+        }
+      }
+
+      const rawMap = new TaggedMap<string, string>([["a", "b"]]);
+      const state = injectAnnotations(undefined, { [marker]: rawMap });
+      const annotations = getAnnotations(state);
+
+      assert.ok(annotations !== undefined);
+
+      const received = annotations[marker] as TaggedMap<string, string>;
+
+      assert.ok(received instanceof TaggedMap);
+      assert.equal(received.get("a"), "b");
+      assert.equal(received.label(), "tagged");
+    });
+
+    it("should preserve URL subclass methods with private fields", () => {
+      const marker = Symbol.for("@test/issue-491/url-subclass-private-field");
+
+      class TaggedUrl extends URL {
+        readonly #label = "tagged";
+
+        label(): string {
+          return this.#label;
+        }
+      }
+
+      const rawUrl = new TaggedUrl("https://example.com/hello?name=world");
+      const state = injectAnnotations(undefined, { [marker]: rawUrl });
+      const annotations = getAnnotations(state);
+
+      assert.ok(annotations !== undefined);
+
+      const received = annotations[marker] as TaggedUrl;
+
+      assert.ok(received instanceof TaggedUrl);
+      assert.equal(received.href, "https://example.com/hello?name=world");
+      assert.equal(received.label(), "tagged");
+    });
+
     it("should preserve Map key identity for fresh-run protected inputs", () => {
       const keyMarker = Symbol.for("@test/issue-491/map-protected-key");
       const mapMarker = Symbol.for("@test/issue-491/map-protected-key-wrapper");

--- a/packages/core/src/annotations.test.ts
+++ b/packages/core/src/annotations.test.ts
@@ -8,8 +8,8 @@ import {
   getAnnotations,
   inheritAnnotations,
   injectAnnotations,
+  injectFreshRunAnnotations,
   isInjectedAnnotationWrapper,
-  normalizeRunAnnotationInput,
   unwrapInjectedAnnotationWrapper,
 } from "./annotations.ts";
 
@@ -272,13 +272,13 @@ describe("getAnnotations", () => {
 
       assert.ok(protectedAnnotations !== undefined);
 
-      const firstState = injectAnnotations(
+      const firstState = injectFreshRunAnnotations(
         undefined,
-        normalizeRunAnnotationInput(protectedAnnotations),
+        protectedAnnotations,
       );
-      const secondState = injectAnnotations(
+      const secondState = injectFreshRunAnnotations(
         undefined,
-        normalizeRunAnnotationInput(protectedAnnotations),
+        protectedAnnotations,
       );
       const firstAnnotations = getAnnotations(firstState);
       const secondAnnotations = getAnnotations(secondState);
@@ -294,6 +294,124 @@ describe("getAnnotations", () => {
       assert.ok(firstRegExp.test("ab ab"));
       assert.equal(firstRegExp.lastIndex, 2);
       assert.equal(secondRegExp.lastIndex, 0);
+    });
+
+    it("should normalize nested protected annotation values for a fresh run", () => {
+      const innerMarker = Symbol.for("@test/issue-491/nested-protected-input");
+      const outerMarker = Symbol.for(
+        "@test/issue-491/nested-protected-input-wrapper",
+      );
+      const seedState = injectAnnotations(undefined, { [innerMarker]: /ab+/g });
+      const protectedAnnotations = getAnnotations(seedState);
+
+      assert.ok(protectedAnnotations !== undefined);
+
+      const rebuiltAnnotations = {
+        [outerMarker]: {
+          regex: protectedAnnotations[innerMarker],
+        },
+      };
+
+      const firstState = injectFreshRunAnnotations(
+        undefined,
+        rebuiltAnnotations,
+      );
+      const secondState = injectFreshRunAnnotations(
+        undefined,
+        rebuiltAnnotations,
+      );
+      const firstAnnotations = getAnnotations(firstState);
+      const secondAnnotations = getAnnotations(secondState);
+
+      assert.ok(firstAnnotations !== undefined);
+      assert.ok(secondAnnotations !== undefined);
+
+      const firstRegExp = (
+        firstAnnotations[outerMarker] as { regex: RegExp }
+      ).regex;
+      const secondRegExp = (
+        secondAnnotations[outerMarker] as { regex: RegExp }
+      ).regex;
+
+      assert.notEqual(firstRegExp, secondRegExp);
+      assert.ok(firstRegExp.test("ab ab"));
+      assert.equal(firstRegExp.lastIndex, 2);
+      assert.equal(secondRegExp.lastIndex, 0);
+    });
+
+    it("should preserve array subclass prototypes on protected views", () => {
+      const marker = Symbol.for("@test/issue-491/array-subclass");
+
+      class TaggedArray<T> extends Array<T> {
+        first(): T | undefined {
+          return this[0];
+        }
+      }
+
+      const rawArray = TaggedArray.from([{ value: 1 }]) as TaggedArray<
+        { value: number }
+      >;
+      const state = injectAnnotations(undefined, { [marker]: rawArray });
+      const annotations = getAnnotations(state);
+
+      assert.ok(annotations !== undefined);
+
+      const received = annotations[marker] as TaggedArray<{ value: number }>;
+
+      assert.ok(received instanceof TaggedArray);
+      assert.equal(received.first()?.value, 1);
+      assert.throws(
+        () => {
+          const first = received.first();
+          assert.ok(first !== undefined);
+          first.value = 2;
+        },
+        { name: "TypeError" },
+      );
+      assert.equal(rawArray.first()?.value, 1);
+    });
+
+    it("should protect custom properties on built-in annotation views", () => {
+      const marker = Symbol.for("@test/issue-491/builtin-custom-property");
+
+      const cases = [
+        new Map<string, string>(),
+        new Set(["a"]),
+        new Date("2026-03-08T00:00:00.000Z"),
+        new URL("https://example.com/a?x=1"),
+        new URLSearchParams("x=1"),
+      ] as const;
+
+      for (const rawValue of cases) {
+        const withCustomProperty = rawValue as (typeof rawValue) & {
+          extra: { value: number };
+        };
+        withCustomProperty.extra = { value: 1 };
+
+        const state = injectAnnotations(undefined, {
+          [marker]: withCustomProperty,
+        });
+        const annotations = getAnnotations(state);
+
+        assert.ok(annotations !== undefined);
+
+        const received = annotations[marker] as (typeof rawValue) & {
+          extra: { value: number };
+        };
+        const descriptor = Object.getOwnPropertyDescriptor(received, "extra");
+
+        assert.notEqual(received.extra, withCustomProperty.extra);
+        assert.equal(received.extra.value, 1);
+        assert.ok(descriptor != null && "value" in descriptor);
+        assert.notEqual(descriptor.value, withCustomProperty.extra);
+        assert.throws(
+          () => {
+            received.extra.value = 2;
+          },
+          { name: "TypeError" },
+        );
+        assert.equal(withCustomProperty.extra.value, 1);
+      }
     });
 
     it("should throw when mutating URL-like annotations", () => {

--- a/packages/core/src/annotations.test.ts
+++ b/packages/core/src/annotations.test.ts
@@ -458,6 +458,22 @@ describe("getAnnotations", () => {
       assert.equal(received.toString(), "[object Map]");
     });
 
+    it("should keep clone-backed URL method identity stable", () => {
+      const marker = Symbol.for("@test/issue-491/url-method-identity");
+      const state = injectAnnotations(undefined, {
+        [marker]: new URL("https://example.com/a?x=1"),
+      });
+      const annotations = getAnnotations(state);
+
+      assert.ok(annotations !== undefined);
+
+      const received = annotations[marker] as URL;
+
+      assert.equal(received.toString, received.toString);
+      assert.equal(received.constructor, URL);
+      assert.equal(received.toString(), "https://example.com/a?x=1");
+    });
+
     it("should preserve built-in subclass methods with private fields", () => {
       const marker = Symbol.for("@test/issue-491/map-subclass-private-field");
 

--- a/packages/core/src/annotations.test.ts
+++ b/packages/core/src/annotations.test.ts
@@ -470,6 +470,7 @@ describe("getAnnotations", () => {
       const received = annotations[marker] as URL;
 
       assert.equal(received.toString, received.toString);
+      assert.equal(received.valueOf, received.valueOf);
       assert.equal(received.constructor, URL);
       assert.equal(received.toString(), "https://example.com/a?x=1");
     });

--- a/packages/core/src/annotations.test.ts
+++ b/packages/core/src/annotations.test.ts
@@ -371,6 +371,34 @@ describe("getAnnotations", () => {
       assert.equal(rawArray.first()?.value, 1);
     });
 
+    it("should preserve array subclass methods with private fields", () => {
+      const marker = Symbol.for(
+        "@test/issue-491/array-subclass-private-field",
+      );
+
+      class TaggedArray<T> extends Array<T> {
+        readonly #label = "tagged";
+
+        label(): string {
+          return this.#label;
+        }
+      }
+
+      const rawArray = TaggedArray.from([{ value: 1 }]) as TaggedArray<
+        { value: number }
+      >;
+      const state = injectAnnotations(undefined, { [marker]: rawArray });
+      const annotations = getAnnotations(state);
+
+      assert.ok(annotations !== undefined);
+
+      const received = annotations[marker] as TaggedArray<{ value: number }>;
+
+      assert.ok(received instanceof TaggedArray);
+      assert.equal(received.label(), "tagged");
+      assert.equal(received[0]?.value, 1);
+    });
+
     it("should protect custom properties on built-in annotation views", () => {
       const marker = Symbol.for("@test/issue-491/builtin-custom-property");
 

--- a/packages/core/src/annotations.test.ts
+++ b/packages/core/src/annotations.test.ts
@@ -203,6 +203,50 @@ describe("getAnnotations", () => {
       assert.equal(rawUrl.pathname, "/a");
       assert.equal(rawUrl.searchParams.get("x"), "1");
     });
+
+    it("should keep frozen annotation inputs readable without proxy invariant violations", () => {
+      const marker = Symbol.for("@test/issue-491/frozen");
+      const rawValue = { value: 1 };
+      const rawAnnotations = Object.freeze({ [marker]: rawValue });
+      const state = injectAnnotations(undefined, rawAnnotations);
+
+      const annotations = getAnnotations(state);
+      assert.ok(annotations !== undefined);
+      assert.doesNotThrow(() => Object.getOwnPropertySymbols(annotations));
+      const protectedValue = annotations[marker] as { value: number };
+      assert.equal(protectedValue.value, 1);
+      assert.throws(
+        () => Reflect.set(protectedValue, "value", 2),
+        { name: "TypeError" },
+      );
+      assert.equal(rawValue.value, 1);
+    });
+
+    it("should keep URLSearchParams callbacks on the protected view", () => {
+      const marker = Symbol.for("@test/issue-491/url-search-params");
+      const raw = new URLSearchParams("alpha=1&beta=2");
+      const state = injectAnnotations(undefined, { [marker]: raw });
+
+      const annotations = getAnnotations(state);
+      assert.ok(annotations !== undefined);
+      const params = annotations[marker] as URLSearchParams;
+      let owner: URLSearchParams | undefined;
+
+      params.forEach((_value, _key, searchParams) => {
+        owner = searchParams;
+      });
+
+      assert.equal(owner, params);
+      assert.deepEqual([...params.entries()], [
+        ["alpha", "1"],
+        ["beta", "2"],
+      ]);
+      assert.throws(
+        () => owner?.set("alpha", "3"),
+        { name: "TypeError" },
+      );
+      assert.equal(raw.get("alpha"), "1");
+    });
   });
 });
 

--- a/packages/core/src/annotations.test.ts
+++ b/packages/core/src/annotations.test.ts
@@ -9,6 +9,7 @@ import {
   inheritAnnotations,
   injectAnnotations,
   isInjectedAnnotationWrapper,
+  normalizeRunAnnotationInput,
   unwrapInjectedAnnotationWrapper,
 } from "./annotations.ts";
 
@@ -262,6 +263,37 @@ describe("getAnnotations", () => {
       assert.equal(firstRegExp.lastIndex, 2);
       assert.equal(secondRegExp.lastIndex, 0);
       assert.equal((sharedAnnotations[marker] as RegExp).lastIndex, 0);
+    });
+
+    it("should normalize protected annotation inputs for a fresh run", () => {
+      const marker = Symbol.for("@test/issue-491/protected-input-rerun");
+      const seedState = injectAnnotations(undefined, { [marker]: /ab+/g });
+      const protectedAnnotations = getAnnotations(seedState);
+
+      assert.ok(protectedAnnotations !== undefined);
+
+      const firstState = injectAnnotations(
+        undefined,
+        normalizeRunAnnotationInput(protectedAnnotations),
+      );
+      const secondState = injectAnnotations(
+        undefined,
+        normalizeRunAnnotationInput(protectedAnnotations),
+      );
+      const firstAnnotations = getAnnotations(firstState);
+      const secondAnnotations = getAnnotations(secondState);
+
+      assert.ok(firstAnnotations !== undefined);
+      assert.ok(secondAnnotations !== undefined);
+
+      const firstRegExp = firstAnnotations[marker] as RegExp;
+      const secondRegExp = secondAnnotations[marker] as RegExp;
+
+      assert.notEqual(firstAnnotations, secondAnnotations);
+      assert.notEqual(firstRegExp, secondRegExp);
+      assert.ok(firstRegExp.test("ab ab"));
+      assert.equal(firstRegExp.lastIndex, 2);
+      assert.equal(secondRegExp.lastIndex, 0);
     });
 
     it("should throw when mutating URL-like annotations", () => {

--- a/packages/core/src/annotations.test.ts
+++ b/packages/core/src/annotations.test.ts
@@ -3,7 +3,6 @@ import { describe, it } from "node:test";
 import * as fc from "fast-check";
 import {
   annotationKey,
-  type Annotations,
   annotationStateValueKey,
   annotationWrapperKey,
   getAnnotations,
@@ -73,7 +72,8 @@ describe("getAnnotations", () => {
             if (
               annotationValue != null && typeof annotationValue === "object"
             ) {
-              assert.equal(result, annotationValue as Annotations);
+              assert.ok(result !== undefined);
+              assert.equal(typeof result, "object");
             } else {
               assert.equal(result, undefined);
             }
@@ -81,6 +81,127 @@ describe("getAnnotations", () => {
         ),
         propertyParameters,
       );
+    });
+  });
+
+  describe("protected views (issue #491)", () => {
+    it("should return a stable protected view instead of the caller object", () => {
+      const marker = Symbol.for("@test/issue-491/stable-view");
+      const rawAnnotations = { [marker]: { value: 1 } };
+      const state = injectAnnotations(undefined, rawAnnotations);
+
+      const first = getAnnotations(state);
+      const second = getAnnotations(state);
+
+      assert.ok(first !== undefined);
+      assert.ok(second !== undefined);
+      assert.equal(first, second);
+      assert.notEqual(first, rawAnnotations);
+      assert.equal(first[marker], second[marker]);
+      assert.notEqual(first[marker], rawAnnotations[marker]);
+    });
+
+    it("should throw when mutating nested plain objects", () => {
+      const marker = Symbol.for("@test/issue-491/nested-object");
+      const rawValue = { value: 1 };
+      const state = injectAnnotations(undefined, { [marker]: rawValue });
+
+      const annotations = getAnnotations(state);
+      assert.ok(annotations !== undefined);
+      const nested = annotations[marker] as Record<PropertyKey, unknown>;
+
+      assert.throws(
+        () => Reflect.set(nested, "value", 2),
+        { name: "TypeError" },
+      );
+      assert.equal(rawValue.value, 1);
+    });
+
+    it("should throw when mutating Map annotations", () => {
+      const marker = Symbol.for("@test/issue-491/map");
+      const rawEntry = { value: 1 };
+      const rawMap = new Map<string, { value: number }>([["a", rawEntry]]);
+      const state = injectAnnotations(undefined, { [marker]: rawMap });
+
+      const annotations = getAnnotations(state);
+      assert.ok(annotations !== undefined);
+      const received = annotations[marker] as Map<string, { value: number }>;
+
+      assert.throws(
+        () => received.set("b", { value: 2 }),
+        { name: "TypeError" },
+      );
+      assert.throws(
+        () => Reflect.set(received.get("a") as object, "value", 2),
+        { name: "TypeError" },
+      );
+      assert.equal(rawMap.size, 1);
+      assert.equal(rawEntry.value, 1);
+    });
+
+    it("should throw when mutating Set annotations", () => {
+      const marker = Symbol.for("@test/issue-491/set");
+      const rawSet = new Set(["a"]);
+      const state = injectAnnotations(undefined, { [marker]: rawSet });
+
+      const annotations = getAnnotations(state);
+      assert.ok(annotations !== undefined);
+      const received = annotations[marker] as Set<string>;
+
+      assert.throws(
+        () => received.add("b"),
+        { name: "TypeError" },
+      );
+      assert.deepEqual([...rawSet], ["a"]);
+    });
+
+    it("should throw when mutating Date and RegExp annotations", () => {
+      const dateMarker = Symbol.for("@test/issue-491/date");
+      const regexMarker = Symbol.for("@test/issue-491/regexp");
+      const rawDate = new Date("2026-03-08T00:00:00.000Z");
+      const rawRegExp = /ab+/g;
+      const state = injectAnnotations(undefined, {
+        [dateMarker]: rawDate,
+        [regexMarker]: rawRegExp,
+      });
+
+      const annotations = getAnnotations(state);
+      assert.ok(annotations !== undefined);
+
+      const receivedDate = annotations[dateMarker] as Date;
+      const receivedRegExp = annotations[regexMarker] as RegExp;
+
+      assert.throws(
+        () => receivedDate.setUTCFullYear(2030),
+        { name: "TypeError" },
+      );
+      assert.throws(
+        () => Reflect.set(receivedRegExp, "lastIndex", 3),
+        { name: "TypeError" },
+      );
+      assert.equal(rawDate.toISOString(), "2026-03-08T00:00:00.000Z");
+      assert.equal(rawRegExp.lastIndex, 0);
+    });
+
+    it("should throw when mutating URL-like annotations", () => {
+      const marker = Symbol.for("@test/issue-491/url");
+      const rawUrl = new URL("https://example.com/a?x=1");
+      const state = injectAnnotations(undefined, { [marker]: rawUrl });
+
+      const annotations = getAnnotations(state);
+      assert.ok(annotations !== undefined);
+      const received = annotations[marker] as URL;
+
+      assert.throws(
+        () => Reflect.set(received, "pathname", "/b"),
+        { name: "TypeError" },
+      );
+      assert.throws(
+        () => received.searchParams.set("x", "2"),
+        { name: "TypeError" },
+      );
+      assert.equal(rawUrl.pathname, "/a");
+      assert.equal(rawUrl.searchParams.get("x"), "1");
     });
   });
 });

--- a/packages/core/src/annotations.test.ts
+++ b/packages/core/src/annotations.test.ts
@@ -442,6 +442,33 @@ describe("getAnnotations", () => {
       }
     });
 
+    it("should keep frozen function properties readable on clone-backed views", () => {
+      const marker = Symbol.for("@test/issue-491/frozen-function");
+      const source = new Map<string, string>();
+      const fn = function thisIsReadonly(): string {
+        return "ok";
+      };
+
+      Object.defineProperty(source, "extraFn", {
+        value: fn,
+        enumerable: true,
+        configurable: false,
+        writable: false,
+      });
+
+      const state = injectAnnotations(undefined, { [marker]: source });
+      const annotations = getAnnotations(state);
+
+      assert.ok(annotations !== undefined);
+
+      const received = annotations[marker] as Map<string, string> & {
+        extraFn: () => string;
+      };
+
+      assert.equal(received.extraFn, fn);
+      assert.equal(received.extraFn(), "ok");
+    });
+
     it("should keep clone-backed built-in method identity stable", () => {
       const marker = Symbol.for("@test/issue-491/clone-method-identity");
       const state = injectAnnotations(undefined, {

--- a/packages/core/src/annotations.test.ts
+++ b/packages/core/src/annotations.test.ts
@@ -183,6 +183,23 @@ describe("getAnnotations", () => {
       assert.equal(rawRegExp.lastIndex, 0);
     });
 
+    it("should not leak RegExp lastIndex mutations back to the caller object", () => {
+      const marker = Symbol.for("@test/issue-491/regexp-last-index");
+      const rawRegExp = /ab+/g;
+      const state = injectAnnotations(undefined, { [marker]: rawRegExp });
+
+      const annotations = getAnnotations(state);
+      assert.ok(annotations !== undefined);
+      const protectedRegExp = annotations[marker] as RegExp;
+
+      assert.equal(protectedRegExp.test("ab ab"), true);
+      assert.equal(protectedRegExp.lastIndex, 2);
+      assert.equal(rawRegExp.lastIndex, 0);
+
+      assert.equal(protectedRegExp.exec("ab ab")?.[0], "ab");
+      assert.equal(rawRegExp.lastIndex, 0);
+    });
+
     it("should throw when mutating URL-like annotations", () => {
       const marker = Symbol.for("@test/issue-491/url");
       const rawUrl = new URL("https://example.com/a?x=1");

--- a/packages/core/src/annotations.test.ts
+++ b/packages/core/src/annotations.test.ts
@@ -442,6 +442,22 @@ describe("getAnnotations", () => {
       }
     });
 
+    it("should keep clone-backed built-in method identity stable", () => {
+      const marker = Symbol.for("@test/issue-491/clone-method-identity");
+      const state = injectAnnotations(undefined, {
+        [marker]: new Map<string, number>([["a", 1]]),
+      });
+      const annotations = getAnnotations(state);
+
+      assert.ok(annotations !== undefined);
+
+      const received = annotations[marker] as Map<string, number>;
+
+      assert.equal(received.toString, received.toString);
+      assert.equal(received.constructor, Map);
+      assert.equal(received.toString(), "[object Map]");
+    });
+
     it("should preserve built-in subclass methods with private fields", () => {
       const marker = Symbol.for("@test/issue-491/map-subclass-private-field");
 
@@ -475,6 +491,53 @@ describe("getAnnotations", () => {
         { name: "TypeError" },
       );
       assert.equal(rawMap.has("c"), false);
+    });
+
+    it("should fall back when Map subclass cloning drops entries", () => {
+      const marker = Symbol.for("@test/issue-491/map-subclass-clone-parity");
+
+      class SparseMap<K, V> extends Map<K, V> {
+        constructor(_entries?: Iterable<readonly [K, V]>) {
+          super();
+        }
+      }
+
+      const rawMap = new SparseMap<string, number>();
+      rawMap.set("a", 1);
+
+      const state = injectAnnotations(undefined, { [marker]: rawMap });
+      const annotations = getAnnotations(state);
+
+      assert.ok(annotations !== undefined);
+
+      const received = annotations[marker] as Map<string, number>;
+
+      assert.ok(!(received instanceof SparseMap));
+      assert.equal(received.get("a"), 1);
+      assert.equal(received.size, 1);
+    });
+
+    it("should fall back when Date subclass cloning changes time", () => {
+      const marker = Symbol.for("@test/issue-491/date-subclass-clone-parity");
+
+      class FrozenDate extends Date {
+        constructor(_time?: string | number | Date) {
+          super(0);
+        }
+      }
+
+      const rawDate = new FrozenDate();
+      rawDate.setTime(123456789);
+
+      const state = injectAnnotations(undefined, { [marker]: rawDate });
+      const annotations = getAnnotations(state);
+
+      assert.ok(annotations !== undefined);
+
+      const received = annotations[marker] as Date;
+
+      assert.ok(!(received instanceof FrozenDate));
+      assert.equal(received.getTime(), 123456789);
     });
 
     it("should preserve URL subclass methods with private fields", () => {

--- a/packages/core/src/annotations.test.ts
+++ b/packages/core/src/annotations.test.ts
@@ -414,6 +414,61 @@ describe("getAnnotations", () => {
       }
     });
 
+    it("should preserve Map key identity for fresh-run protected inputs", () => {
+      const keyMarker = Symbol.for("@test/issue-491/map-protected-key");
+      const mapMarker = Symbol.for("@test/issue-491/map-protected-key-wrapper");
+      const seedState = injectAnnotations(undefined, {
+        [keyMarker]: { value: 1 },
+      });
+      const protectedAnnotations = getAnnotations(seedState);
+
+      assert.ok(protectedAnnotations !== undefined);
+
+      const rebuiltAnnotations = {
+        [mapMarker]: new Map([[protectedAnnotations[keyMarker], "ok"]]),
+      };
+
+      const state = injectFreshRunAnnotations(undefined, rebuiltAnnotations);
+      const annotations = getAnnotations(state);
+
+      assert.ok(annotations !== undefined);
+
+      const map = annotations[mapMarker] as Map<object, string>;
+      const iteratedKey = [...map.keys()][0];
+
+      assert.ok(iteratedKey !== undefined);
+      assert.ok(map.has(iteratedKey));
+      assert.equal(map.get(iteratedKey), "ok");
+    });
+
+    it("should preserve Set membership for fresh-run protected inputs", () => {
+      const valueMarker = Symbol.for("@test/issue-491/set-protected-value");
+      const setMarker = Symbol.for(
+        "@test/issue-491/set-protected-value-wrapper",
+      );
+      const seedState = injectAnnotations(undefined, {
+        [valueMarker]: { value: 1 },
+      });
+      const protectedAnnotations = getAnnotations(seedState);
+
+      assert.ok(protectedAnnotations !== undefined);
+
+      const rebuiltAnnotations = {
+        [setMarker]: new Set([protectedAnnotations[valueMarker]]),
+      };
+
+      const state = injectFreshRunAnnotations(undefined, rebuiltAnnotations);
+      const annotations = getAnnotations(state);
+
+      assert.ok(annotations !== undefined);
+
+      const set = annotations[setMarker] as Set<object>;
+      const iteratedValue = [...set.values()][0];
+
+      assert.ok(iteratedValue !== undefined);
+      assert.ok(set.has(iteratedValue));
+    });
+
     it("should throw when mutating URL-like annotations", () => {
       const marker = Symbol.for("@test/issue-491/url");
       const rawUrl = new URL("https://example.com/a?x=1");

--- a/packages/core/src/annotations.test.ts
+++ b/packages/core/src/annotations.test.ts
@@ -423,6 +423,10 @@ describe("getAnnotations", () => {
         label(): string {
           return this.#label;
         }
+
+        bump(key: K, value: V): void {
+          this.set(key, value);
+        }
       }
 
       const rawMap = new TaggedMap<string, string>([["a", "b"]]);
@@ -436,6 +440,13 @@ describe("getAnnotations", () => {
       assert.ok(received instanceof TaggedMap);
       assert.equal(received.get("a"), "b");
       assert.equal(received.label(), "tagged");
+      assert.throws(
+        () => {
+          received.bump("c", "d");
+        },
+        { name: "TypeError" },
+      );
+      assert.equal(rawMap.has("c"), false);
     });
 
     it("should preserve URL subclass methods with private fields", () => {
@@ -446,6 +457,10 @@ describe("getAnnotations", () => {
 
         label(): string {
           return this.#label;
+        }
+
+        retag(value: string): void {
+          this.searchParams.set("name", value);
         }
       }
 
@@ -460,6 +475,39 @@ describe("getAnnotations", () => {
       assert.ok(received instanceof TaggedUrl);
       assert.equal(received.href, "https://example.com/hello?name=world");
       assert.equal(received.label(), "tagged");
+      assert.throws(
+        () => {
+          received.retag("reader");
+        },
+        { name: "TypeError" },
+      );
+      assert.equal(rawUrl.searchParams.get("name"), "world");
+    });
+
+    it("should preserve RegExp subclass methods with private fields", () => {
+      const marker = Symbol.for(
+        "@test/issue-491/regexp-subclass-private-field",
+      );
+
+      class TaggedRegExp extends RegExp {
+        readonly #label = "tagged";
+
+        label(): string {
+          return this.#label;
+        }
+      }
+
+      const raw = new TaggedRegExp("hello", "g");
+      const state = injectAnnotations(undefined, { [marker]: raw });
+      const annotations = getAnnotations(state);
+
+      assert.ok(annotations !== undefined);
+
+      const received = annotations[marker] as TaggedRegExp;
+
+      assert.ok(received instanceof TaggedRegExp);
+      assert.equal(received.label(), "tagged");
+      assert.equal(received.test("hello world"), true);
     });
 
     it("should preserve Map key identity for fresh-run protected inputs", () => {
@@ -787,6 +835,25 @@ describe("injectAnnotations", () => {
     assert.equal(getAnnotations(result)?.[marker], "ok");
   });
 
+  it("should preserve RegExp subclass methods with private fields", () => {
+    const marker = Symbol.for("@test/inject-regexp-private-field");
+
+    class TaggedRegExp extends RegExp {
+      readonly #label = "tagged";
+
+      label(): string {
+        return this.#label;
+      }
+    }
+
+    const source = new TaggedRegExp("ab+", "gi");
+    const result = injectAnnotations(source, { [marker]: "ok" });
+
+    assert.ok(result instanceof TaggedRegExp);
+    assert.equal(result.label(), "tagged");
+    assert.equal(getAnnotations(result)?.[marker], "ok");
+  });
+
   it("should clone non-plain object states without mutation", () => {
     const marker = Symbol.for("@test/inject-nonplain");
     class CustomState {
@@ -976,6 +1043,26 @@ describe("inheritAnnotations", () => {
     assert.equal(result.lastIndex, 4);
     assert.equal(result.label, "tagged");
     assert.equal(result[extraKey], target[extraKey]);
+    assert.equal(getAnnotations(result)?.[marker], "ok");
+  });
+
+  it("should preserve RegExp subclass methods with private fields", () => {
+    const marker = Symbol.for("@test/inherit-regexp-private-field");
+    const source = { [annotationKey]: { [marker]: "ok" } };
+
+    class TaggedRegExp extends RegExp {
+      readonly #label = "tagged";
+
+      label(): string {
+        return this.#label;
+      }
+    }
+
+    const target = new TaggedRegExp("ab+", "gi");
+    const result = inheritAnnotations(source, target);
+
+    assert.ok(result instanceof TaggedRegExp);
+    assert.equal(result.label(), "tagged");
     assert.equal(getAnnotations(result)?.[marker], "ok");
   });
 

--- a/packages/core/src/annotations.test.ts
+++ b/packages/core/src/annotations.test.ts
@@ -192,12 +192,35 @@ describe("getAnnotations", () => {
       assert.ok(annotations !== undefined);
       const protectedRegExp = annotations[marker] as RegExp;
 
-      assert.equal(protectedRegExp.test("ab ab"), true);
+      assert.ok(protectedRegExp.test("ab ab"));
       assert.equal(protectedRegExp.lastIndex, 2);
       assert.equal(rawRegExp.lastIndex, 0);
 
       assert.equal(protectedRegExp.exec("ab ab")?.[0], "ab");
       assert.equal(rawRegExp.lastIndex, 0);
+    });
+
+    it("should not reuse protected views across separate injectAnnotations() calls", () => {
+      const marker = Symbol.for("@test/issue-491/per-run-cache");
+      const sharedAnnotations = { [marker]: /ab+/g };
+
+      const firstState = injectAnnotations(undefined, sharedAnnotations);
+      const secondState = injectAnnotations(undefined, sharedAnnotations);
+
+      const firstAnnotations = getAnnotations(firstState);
+      const secondAnnotations = getAnnotations(secondState);
+
+      assert.ok(firstAnnotations !== undefined);
+      assert.ok(secondAnnotations !== undefined);
+
+      const firstRegExp = firstAnnotations[marker] as RegExp;
+      const secondRegExp = secondAnnotations[marker] as RegExp;
+
+      assert.notEqual(firstRegExp, secondRegExp);
+      assert.ok(firstRegExp.test("ab ab"));
+      assert.equal(firstRegExp.lastIndex, 2);
+      assert.equal(secondRegExp.lastIndex, 0);
+      assert.equal((sharedAnnotations[marker] as RegExp).lastIndex, 0);
     });
 
     it("should throw when mutating URL-like annotations", () => {
@@ -237,6 +260,23 @@ describe("getAnnotations", () => {
         { name: "TypeError" },
       );
       assert.equal(rawValue.value, 1);
+    });
+
+    it("should preserve self-referential plain annotation objects", () => {
+      const marker = Symbol.for("@test/issue-491/cycle");
+      const rawValue: { self?: unknown; readonly value: number } = { value: 1 };
+      rawValue.self = rawValue;
+
+      const state = injectAnnotations(undefined, { [marker]: rawValue });
+      const annotations = getAnnotations(state);
+
+      assert.ok(annotations !== undefined);
+      const protectedValue = annotations[marker] as {
+        readonly self?: unknown;
+        readonly value: number;
+      };
+      assert.equal(protectedValue.value, 1);
+      assert.equal(protectedValue.self, protectedValue);
     });
 
     it("should keep URLSearchParams callbacks on the protected view", () => {

--- a/packages/core/src/annotations.ts
+++ b/packages/core/src/annotations.ts
@@ -262,6 +262,13 @@ function createProtectedMapView(
       if (key === "size") {
         return clonedTarget.size;
       }
+      if (key === "valueOf") {
+        return cacheProtectedMethod(
+          methodCache,
+          key,
+          () => () => view,
+        );
+      }
       if (key === "set" || key === "delete" || key === "clear") {
         return cacheProtectedMethod(
           methodCache,
@@ -273,11 +280,15 @@ function createProtectedMapView(
         return cacheProtectedMethod(
           methodCache,
           key,
-          () => (lookup: unknown) =>
-            protectAnnotationValue(
+          () => (lookup: unknown) => {
+            if (clonedTarget.has(lookup)) {
+              return protectAnnotationValue(clonedTarget.get(lookup), context);
+            }
+            return protectAnnotationValue(
               clonedTarget.get(unwrapProtectedAnnotationTarget(lookup)),
               context,
-            ),
+            );
+          },
         );
       }
       if (key === "has") {
@@ -285,6 +296,7 @@ function createProtectedMapView(
           methodCache,
           key,
           () => (lookup: unknown) =>
+            clonedTarget.has(lookup) ||
             clonedTarget.has(unwrapProtectedAnnotationTarget(lookup)),
         );
       }
@@ -395,6 +407,13 @@ function createProtectedSetView(
       if (key === "size") {
         return clonedTarget.size;
       }
+      if (key === "valueOf") {
+        return cacheProtectedMethod(
+          methodCache,
+          key,
+          () => () => view,
+        );
+      }
       if (key === "add" || key === "delete" || key === "clear") {
         return cacheProtectedMethod(
           methodCache,
@@ -407,6 +426,7 @@ function createProtectedSetView(
           methodCache,
           key,
           () => (lookup: unknown) =>
+            clonedTarget.has(lookup) ||
             clonedTarget.has(unwrapProtectedAnnotationTarget(lookup)),
         );
       }
@@ -550,6 +570,13 @@ function createProtectedRegExpView(
           () => (..._args: unknown[]) => throwReadonlyAnnotationMutation(),
         );
       }
+      if (key === "valueOf") {
+        return cacheProtectedMethod(
+          methodCache,
+          key,
+          () => () => view,
+        );
+      }
       const ownDescriptor = Object.getOwnPropertyDescriptor(clonedTarget, key);
       if (ownDescriptor != null && "value" in ownDescriptor) {
         return ownDescriptor.value;
@@ -603,6 +630,13 @@ function createProtectedURLSearchParamsView(
           methodCache,
           key,
           () => (..._args: unknown[]) => throwReadonlyAnnotationMutation(),
+        );
+      }
+      if (key === "valueOf") {
+        return cacheProtectedMethod(
+          methodCache,
+          key,
+          () => () => view,
         );
       }
       if (key === "forEach") {
@@ -688,6 +722,9 @@ function createProtectedURLView(
   const cloned = new URL(target.href);
   const view = new Proxy(cloned, {
     get(clonedTarget, key) {
+      if (key === "valueOf") {
+        return () => view;
+      }
       if (key === "searchParams") {
         return protectAnnotationValue(clonedTarget.searchParams, context);
       }

--- a/packages/core/src/annotations.ts
+++ b/packages/core/src/annotations.ts
@@ -59,6 +59,476 @@ const annotationWrapperKeys: ReadonlySet<PropertyKey> = new Set<
 ]);
 
 const injectedAnnotationWrappers = new WeakSet<object>();
+const protectedAnnotationTargets = new WeakMap<object, object>();
+const annotationProtectionCache = new WeakMap<object, object>();
+
+function throwReadonlyAnnotationMutation(): never {
+  throw new TypeError("Cannot mutate read-only annotation data.");
+}
+
+function registerProtectedAnnotationView<T extends object>(
+  target: T,
+  view: T,
+): T {
+  annotationProtectionCache.set(target, view);
+  protectedAnnotationTargets.set(view, target);
+  return view;
+}
+
+function isProtectedAnnotationView(value: unknown): value is object {
+  return value != null &&
+    typeof value === "object" &&
+    protectedAnnotationTargets.has(value);
+}
+
+function unwrapProtectedAnnotationTarget<T>(value: T): T {
+  if (value == null || typeof value !== "object") {
+    return value;
+  }
+  return (protectedAnnotationTargets.get(value) as T | undefined) ?? value;
+}
+
+function cacheProtectedMethod<T>(
+  cache: Map<PropertyKey, unknown>,
+  key: PropertyKey,
+  factory: () => T,
+): T {
+  const cached = cache.get(key);
+  if (cached !== undefined) {
+    return cached as T;
+  }
+  const created = factory();
+  cache.set(key, created);
+  return created;
+}
+
+function protectDescriptor(
+  descriptor: PropertyDescriptor | undefined,
+): PropertyDescriptor | undefined {
+  if (descriptor == null || !("value" in descriptor)) {
+    return descriptor;
+  }
+  return {
+    ...descriptor,
+    value: protectAnnotationValue(descriptor.value),
+  };
+}
+
+function createProtectedObjectView<T extends object>(target: T): T {
+  const view = new Proxy(target, {
+    get(target, key, receiver) {
+      return protectAnnotationValue(Reflect.get(target, key, receiver));
+    },
+    set() {
+      throwReadonlyAnnotationMutation();
+    },
+    defineProperty() {
+      throwReadonlyAnnotationMutation();
+    },
+    deleteProperty() {
+      throwReadonlyAnnotationMutation();
+    },
+    setPrototypeOf() {
+      throwReadonlyAnnotationMutation();
+    },
+    preventExtensions() {
+      throwReadonlyAnnotationMutation();
+    },
+    getOwnPropertyDescriptor(target, key) {
+      return protectDescriptor(Reflect.getOwnPropertyDescriptor(target, key));
+    },
+  });
+  return registerProtectedAnnotationView(target, view);
+}
+
+function createProtectedMapView(
+  target: Map<unknown, unknown>,
+): Map<unknown, unknown> {
+  const methodCache = new Map<PropertyKey, unknown>();
+  const view = new Proxy(target, {
+    get(target, key) {
+      if (key === "size") {
+        return target.size;
+      }
+      if (key === "set" || key === "delete" || key === "clear") {
+        return cacheProtectedMethod(
+          methodCache,
+          key,
+          () => (..._args: unknown[]) => throwReadonlyAnnotationMutation(),
+        );
+      }
+      if (key === "get") {
+        return cacheProtectedMethod(
+          methodCache,
+          key,
+          () => (lookup: unknown) =>
+            protectAnnotationValue(
+              target.get(unwrapProtectedAnnotationTarget(lookup)),
+            ),
+        );
+      }
+      if (key === "has") {
+        return cacheProtectedMethod(
+          methodCache,
+          key,
+          () => (lookup: unknown) =>
+            target.has(unwrapProtectedAnnotationTarget(lookup)),
+        );
+      }
+      if (key === "forEach") {
+        return cacheProtectedMethod(
+          methodCache,
+          key,
+          () =>
+          (
+            callback: (
+              value: unknown,
+              key: unknown,
+              map: Map<unknown, unknown>,
+            ) => void,
+            thisArg?: unknown,
+          ) =>
+            target.forEach((value, mapKey) => {
+              callback.call(
+                thisArg,
+                protectAnnotationValue(value),
+                protectAnnotationValue(mapKey),
+                view,
+              );
+            }),
+        );
+      }
+      if (key === "keys") {
+        return cacheProtectedMethod(
+          methodCache,
+          key,
+          () =>
+            function* (): IterableIterator<unknown> {
+              for (const value of target.keys()) {
+                yield protectAnnotationValue(value);
+              }
+            },
+        );
+      }
+      if (key === "values") {
+        return cacheProtectedMethod(
+          methodCache,
+          key,
+          () =>
+            function* (): IterableIterator<unknown> {
+              for (const value of target.values()) {
+                yield protectAnnotationValue(value);
+              }
+            },
+        );
+      }
+      if (key === "entries" || key === Symbol.iterator) {
+        return cacheProtectedMethod(
+          methodCache,
+          key,
+          () =>
+            function* (): IterableIterator<readonly [unknown, unknown]> {
+              for (const [entryKey, entryValue] of target.entries()) {
+                yield [
+                  protectAnnotationValue(entryKey),
+                  protectAnnotationValue(entryValue),
+                ] as const;
+              }
+            },
+        );
+      }
+      const value = Reflect.get(target, key, target);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+    set() {
+      throwReadonlyAnnotationMutation();
+    },
+    defineProperty() {
+      throwReadonlyAnnotationMutation();
+    },
+    deleteProperty() {
+      throwReadonlyAnnotationMutation();
+    },
+    setPrototypeOf() {
+      throwReadonlyAnnotationMutation();
+    },
+    preventExtensions() {
+      throwReadonlyAnnotationMutation();
+    },
+  });
+  return registerProtectedAnnotationView(target, view);
+}
+
+function createProtectedSetView(
+  target: Set<unknown>,
+): Set<unknown> {
+  const methodCache = new Map<PropertyKey, unknown>();
+  const view = new Proxy(target, {
+    get(target, key) {
+      if (key === "size") {
+        return target.size;
+      }
+      if (key === "add" || key === "delete" || key === "clear") {
+        return cacheProtectedMethod(
+          methodCache,
+          key,
+          () => (..._args: unknown[]) => throwReadonlyAnnotationMutation(),
+        );
+      }
+      if (key === "has") {
+        return cacheProtectedMethod(
+          methodCache,
+          key,
+          () => (lookup: unknown) =>
+            target.has(unwrapProtectedAnnotationTarget(lookup)),
+        );
+      }
+      if (key === "forEach") {
+        return cacheProtectedMethod(
+          methodCache,
+          key,
+          () =>
+          (
+            callback: (
+              value: unknown,
+              key: unknown,
+              set: Set<unknown>,
+            ) => void,
+            thisArg?: unknown,
+          ) =>
+            target.forEach((value) => {
+              const protectedValue = protectAnnotationValue(value);
+              callback.call(thisArg, protectedValue, protectedValue, view);
+            }),
+        );
+      }
+      if (
+        key === "keys" ||
+        key === "values" ||
+        key === Symbol.iterator
+      ) {
+        return cacheProtectedMethod(
+          methodCache,
+          key,
+          () =>
+            function* (): IterableIterator<unknown> {
+              for (const value of target.values()) {
+                yield protectAnnotationValue(value);
+              }
+            },
+        );
+      }
+      if (key === "entries") {
+        return cacheProtectedMethod(
+          methodCache,
+          key,
+          () =>
+            function* (): IterableIterator<readonly [unknown, unknown]> {
+              for (const value of target.values()) {
+                const protectedValue = protectAnnotationValue(value);
+                yield [protectedValue, protectedValue] as const;
+              }
+            },
+        );
+      }
+      const value = Reflect.get(target, key, target);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+    set() {
+      throwReadonlyAnnotationMutation();
+    },
+    defineProperty() {
+      throwReadonlyAnnotationMutation();
+    },
+    deleteProperty() {
+      throwReadonlyAnnotationMutation();
+    },
+    setPrototypeOf() {
+      throwReadonlyAnnotationMutation();
+    },
+    preventExtensions() {
+      throwReadonlyAnnotationMutation();
+    },
+  });
+  return registerProtectedAnnotationView(target, view);
+}
+
+function createProtectedDateView(target: Date): Date {
+  const methodCache = new Map<PropertyKey, unknown>();
+  const view = new Proxy(target, {
+    get(target, key) {
+      const value = Reflect.get(target, key, target);
+      if (typeof key === "string" && key.startsWith("set")) {
+        return cacheProtectedMethod(
+          methodCache,
+          key,
+          () => (..._args: unknown[]) => throwReadonlyAnnotationMutation(),
+        );
+      }
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+    set() {
+      throwReadonlyAnnotationMutation();
+    },
+    defineProperty() {
+      throwReadonlyAnnotationMutation();
+    },
+    deleteProperty() {
+      throwReadonlyAnnotationMutation();
+    },
+    setPrototypeOf() {
+      throwReadonlyAnnotationMutation();
+    },
+    preventExtensions() {
+      throwReadonlyAnnotationMutation();
+    },
+  });
+  return registerProtectedAnnotationView(target, view);
+}
+
+function createProtectedRegExpView(target: RegExp): RegExp {
+  const methodCache = new Map<PropertyKey, unknown>();
+  const view = new Proxy(target, {
+    get(target, key) {
+      const value = Reflect.get(target, key, target);
+      if (key === "compile") {
+        return cacheProtectedMethod(
+          methodCache,
+          key,
+          () => (..._args: unknown[]) => throwReadonlyAnnotationMutation(),
+        );
+      }
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+    set() {
+      throwReadonlyAnnotationMutation();
+    },
+    defineProperty() {
+      throwReadonlyAnnotationMutation();
+    },
+    deleteProperty() {
+      throwReadonlyAnnotationMutation();
+    },
+    setPrototypeOf() {
+      throwReadonlyAnnotationMutation();
+    },
+    preventExtensions() {
+      throwReadonlyAnnotationMutation();
+    },
+  });
+  return registerProtectedAnnotationView(target, view);
+}
+
+function createProtectedURLSearchParamsView(
+  target: URLSearchParams,
+): URLSearchParams {
+  const methodCache = new Map<PropertyKey, unknown>();
+  const view = new Proxy(target, {
+    get(target, key) {
+      if (
+        key === "append" ||
+        key === "delete" ||
+        key === "set" ||
+        key === "sort"
+      ) {
+        return cacheProtectedMethod(
+          methodCache,
+          key,
+          () => (..._args: unknown[]) => throwReadonlyAnnotationMutation(),
+        );
+      }
+      const value = Reflect.get(target, key, target);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+    set() {
+      throwReadonlyAnnotationMutation();
+    },
+    defineProperty() {
+      throwReadonlyAnnotationMutation();
+    },
+    deleteProperty() {
+      throwReadonlyAnnotationMutation();
+    },
+    setPrototypeOf() {
+      throwReadonlyAnnotationMutation();
+    },
+    preventExtensions() {
+      throwReadonlyAnnotationMutation();
+    },
+  });
+  return registerProtectedAnnotationView(target, view);
+}
+
+function createProtectedURLView(target: URL): URL {
+  const view = new Proxy(target, {
+    get(target, key) {
+      if (key === "searchParams") {
+        return protectAnnotationValue(target.searchParams);
+      }
+      const value = Reflect.get(target, key, target);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+    set() {
+      throwReadonlyAnnotationMutation();
+    },
+    defineProperty() {
+      throwReadonlyAnnotationMutation();
+    },
+    deleteProperty() {
+      throwReadonlyAnnotationMutation();
+    },
+    setPrototypeOf() {
+      throwReadonlyAnnotationMutation();
+    },
+    preventExtensions() {
+      throwReadonlyAnnotationMutation();
+    },
+  });
+  return registerProtectedAnnotationView(target, view);
+}
+
+function protectAnnotationValue<T>(value: T): T {
+  if (value == null || typeof value !== "object") {
+    return value;
+  }
+  const target = value as object;
+  if (isProtectedAnnotationView(value)) {
+    return value;
+  }
+  const cached = annotationProtectionCache.get(target);
+  if (cached !== undefined) {
+    return cached as T;
+  }
+  if (target instanceof Map) {
+    return createProtectedMapView(target) as T;
+  }
+  if (target instanceof Set) {
+    return createProtectedSetView(target) as T;
+  }
+  if (target instanceof Date) {
+    return createProtectedDateView(target) as T;
+  }
+  if (target instanceof RegExp) {
+    return createProtectedRegExpView(target) as T;
+  }
+  if (
+    typeof URLSearchParams === "function" &&
+    target instanceof URLSearchParams
+  ) {
+    return createProtectedURLSearchParamsView(target) as T;
+  }
+  if (typeof URL === "function" && target instanceof URL) {
+    return createProtectedURLView(target) as T;
+  }
+  if (Array.isArray(target)) {
+    return createProtectedObjectView(target) as T;
+  }
+  const proto = Object.getPrototypeOf(target);
+  if (proto === Object.prototype || proto === null) {
+    return createProtectedObjectView(target) as T;
+  }
+  return value;
+}
 
 /**
  * Annotations that can be passed to parsers during execution.
@@ -79,6 +549,21 @@ const injectedAnnotationWrappers = new WeakSet<object>();
 export type Annotations = Record<symbol, unknown>;
 
 /**
+ * Read-only annotation view returned from parser state.
+ *
+ * Top-level annotation records are exposed as read-only objects, and supported
+ * nested container values (plain objects, arrays, `Map`, `Set`, `Date`,
+ * `RegExp`, `URL`, and `URLSearchParams`) are surfaced through protected
+ * views that throw on ordinary mutation attempts.
+ *
+ * Opaque live objects and functions remain reference-preserving.
+ *
+ * @since 1.0.0
+ */
+export type ReadonlyAnnotations = Readonly<Annotations>;
+type AnnotationInput = Annotations | ReadonlyAnnotations;
+
+/**
  * Options for parse functions.
  * @since 0.10.0
  */
@@ -86,6 +571,9 @@ export interface ParseOptions {
   /**
    * Annotations to attach to the parsing session.
    * Parsers can access these annotations via getAnnotations(state).
+   *
+   * Optique treats these values as immutable input and exposes them back to
+   * parsers only through protected read-only views.
    */
   annotations?: Annotations;
 }
@@ -94,8 +582,11 @@ export interface ParseOptions {
  * Extracts annotations from parser state.
  *
  * @param state Parser state that may contain annotations
- * @returns Annotations object or undefined if no annotations are present
+ * @returns Read-only annotations view or undefined if no annotations are
+ *          present
  * @since 0.10.0
+ * @since 1.0.0 Returns protected read-only annotation views instead of
+ *              caller-owned objects.
  *
  * @example
  * ```typescript
@@ -103,14 +594,16 @@ export interface ParseOptions {
  * const myData = annotations?.[myDataKey];
  * ```
  */
-export function getAnnotations(state: unknown): Annotations | undefined {
+export function getAnnotations(
+  state: unknown,
+): ReadonlyAnnotations | undefined {
   if (state == null || typeof state !== "object") {
     return undefined;
   }
   const stateObj = state as Record<symbol, unknown>;
   const annotations = stateObj[annotationKey];
   if (annotations != null && typeof annotations === "object") {
-    return annotations as Annotations;
+    return protectAnnotationValue(annotations as AnnotationInput);
   }
   return undefined;
 }
@@ -226,8 +719,8 @@ export function inheritAnnotations<T>(source: unknown, target: T): T {
  * @internal
  */
 export function hasMeaningfulAnnotations(
-  annotations: Annotations | null | undefined,
-): annotations is Annotations {
+  annotations: AnnotationInput | null | undefined,
+): annotations is AnnotationInput {
   return annotations != null &&
     Object.getOwnPropertySymbols(annotations).length > 0;
 }
@@ -250,16 +743,17 @@ export function hasMeaningfulAnnotations(
  */
 export function injectAnnotations<TState>(
   state: TState,
-  annotations: Annotations,
+  annotations: AnnotationInput,
 ): TState {
   if (!hasMeaningfulAnnotations(annotations)) {
     return state;
   }
+  const protectedAnnotations = protectAnnotationValue(annotations);
   if (state == null || typeof state !== "object") {
     const wrapper: Record<PropertyKey, unknown> = {};
     Object.defineProperties(wrapper, {
       [annotationKey]: {
-        value: annotations,
+        value: protectedAnnotations,
         enumerable: true,
         writable: true,
         configurable: true,
@@ -285,7 +779,7 @@ export function injectAnnotations<TState>(
     const cloned = [...state];
     (cloned as typeof cloned & { [annotationKey]?: Annotations })[
       annotationKey
-    ] = annotations;
+    ] = protectedAnnotations;
     return cloned as TState;
   }
   if (isInjectedAnnotationWrapper(state)) {
@@ -293,49 +787,49 @@ export function injectAnnotations<TState>(
       state as TState & {
         [annotationKey]?: Annotations;
       }
-    )[annotationKey] = annotations;
+    )[annotationKey] = protectedAnnotations;
     return state;
   }
   if (state instanceof Date) {
     const cloned = new Date(state.getTime()) as Date & {
       [annotationKey]?: Annotations;
     };
-    cloned[annotationKey] = annotations;
+    cloned[annotationKey] = protectedAnnotations;
     return cloned as TState;
   }
   if (state instanceof Map) {
     const cloned = new Map(state) as Map<unknown, unknown> & {
       [annotationKey]?: Annotations;
     };
-    cloned[annotationKey] = annotations;
+    cloned[annotationKey] = protectedAnnotations;
     return cloned as TState;
   }
   if (state instanceof Set) {
     const cloned = new Set(state) as Set<unknown> & {
       [annotationKey]?: Annotations;
     };
-    cloned[annotationKey] = annotations;
+    cloned[annotationKey] = protectedAnnotations;
     return cloned as TState;
   }
   if (state instanceof RegExp) {
     const cloned = new RegExp(state) as RegExp & {
       [annotationKey]?: Annotations;
     };
-    cloned[annotationKey] = annotations;
+    cloned[annotationKey] = protectedAnnotations;
     return cloned as TState;
   }
   const proto = Object.getPrototypeOf(state);
   if (proto === Object.prototype || proto === null) {
     return {
       ...(state as Record<PropertyKey, unknown>),
-      [annotationKey]: annotations,
+      [annotationKey]: protectedAnnotations,
     } as TState;
   }
   const cloned = Object.create(
     proto,
     Object.getOwnPropertyDescriptors(state as Record<PropertyKey, unknown>),
   ) as TState & { [annotationKey]?: Annotations };
-  cloned[annotationKey] = annotations;
+  cloned[annotationKey] = protectedAnnotations;
   return cloned;
 }
 

--- a/packages/core/src/annotations.ts
+++ b/packages/core/src/annotations.ts
@@ -165,6 +165,15 @@ function copyOwnProperties(
   }
 }
 
+function normalizeProtectedCollectionItem<T>(
+  value: T,
+  context: AnnotationProtectionContext,
+): T {
+  return context.rewrapProtectedViews && isProtectedAnnotationView(value)
+    ? unwrapProtectedAnnotationTarget(value)
+    : value;
+}
+
 const regExpExcludedKeys = new Set<PropertyKey>(["lastIndex"]);
 
 function copyRegExpMetadata(
@@ -241,7 +250,13 @@ function createProtectedMapView(
   context: AnnotationProtectionContext,
 ): Map<unknown, unknown> {
   const methodCache = new Map<PropertyKey, unknown>();
-  const cloned = new Map(target);
+  const cloned = new Map<unknown, unknown>();
+  for (const [entryKey, entryValue] of target.entries()) {
+    cloned.set(
+      normalizeProtectedCollectionItem(entryKey, context),
+      normalizeProtectedCollectionItem(entryValue, context),
+    );
+  }
   const view = new Proxy(cloned, {
     get(clonedTarget, key) {
       if (key === "size") {
@@ -371,7 +386,10 @@ function createProtectedSetView(
   context: AnnotationProtectionContext,
 ): Set<unknown> {
   const methodCache = new Map<PropertyKey, unknown>();
-  const cloned = new Set(target);
+  const cloned = new Set<unknown>();
+  for (const value of target.values()) {
+    cloned.add(normalizeProtectedCollectionItem(value, context));
+  }
   const view = new Proxy(cloned, {
     get(clonedTarget, key) {
       if (key === "size") {
@@ -907,7 +925,7 @@ export interface ParseOptions {
    * Optique treats these values as immutable input and exposes them back to
    * parsers only through protected read-only views.
    */
-  annotations?: Annotations | ReadonlyAnnotations;
+  readonly annotations?: Annotations | ReadonlyAnnotations;
 }
 
 /**

--- a/packages/core/src/annotations.ts
+++ b/packages/core/src/annotations.ts
@@ -1030,6 +1030,7 @@ function createProtectedURLView(
   context: AnnotationProtectionContext,
 ): URL {
   const syncPrototype = !hasBuiltInSubclassPrototype(target, URL.prototype);
+  const methodCache = new Map<PropertyKey, unknown>();
   const cloned = syncPrototype
     ? new URL(target.href)
     : tryCloneURLSubclass(target) ?? new URL(target.href);
@@ -1042,9 +1043,13 @@ function createProtectedURLView(
         return protectAnnotationValue(clonedTarget.searchParams, context);
       }
       const value = Reflect.get(clonedTarget, key, clonedTarget);
-      return typeof value === "function"
-        ? value.bind(clonedTarget)
-        : protectAnnotationValue(value, context);
+      return getProtectedClonePropertyValue(
+        methodCache,
+        clonedTarget,
+        key,
+        value,
+        context,
+      );
     },
     set() {
       throwReadonlyAnnotationMutation();

--- a/packages/core/src/annotations.ts
+++ b/packages/core/src/annotations.ts
@@ -145,9 +145,10 @@ function copyOwnProperties(
   target: object,
   transformValue?: (value: unknown) => unknown,
   excludedKeys?: ReadonlySet<PropertyKey>,
+  syncPrototype = true,
 ): void {
   const sourcePrototype = Object.getPrototypeOf(source);
-  if (Object.getPrototypeOf(target) !== sourcePrototype) {
+  if (syncPrototype && Object.getPrototypeOf(target) !== sourcePrototype) {
     Object.setPrototypeOf(target, sourcePrototype);
   }
   for (const key of Reflect.ownKeys(source)) {
@@ -174,107 +175,207 @@ function normalizeProtectedCollectionItem<T>(
     : value;
 }
 
-function getProtectedProxyFallbackValue(
-  target: object,
-  key: PropertyKey,
-  context: AnnotationProtectionContext,
-): unknown {
-  const ownDescriptor = Reflect.getOwnPropertyDescriptor(target, key);
-  if (ownDescriptor != null && "value" in ownDescriptor) {
-    if (
-      ownDescriptor.configurable === false && ownDescriptor.writable === false
-    ) {
-      return ownDescriptor.value;
-    }
-    const value = ownDescriptor.value;
-    return typeof value === "function"
-      ? value.bind(target)
-      : protectAnnotationValue(value, context);
+type DynamicCloneConstructor = new (...args: readonly unknown[]) => object;
+
+function resolveCloneConstructor(
+  source: object,
+): DynamicCloneConstructor | undefined {
+  const constructorValue = source.constructor;
+  if (typeof constructorValue !== "function") {
+    return undefined;
   }
-  const value = Reflect.get(target, key, target);
-  return typeof value === "function"
-    ? value.bind(target)
-    : protectAnnotationValue(value, context);
+  const species = Reflect.get(constructorValue, Symbol.species);
+  const cloneConstructor = species == null ? constructorValue : species;
+  return typeof cloneConstructor === "function"
+    ? cloneConstructor as DynamicCloneConstructor
+    : undefined;
 }
 
-function getProtectedProxyOwnPropertyDescriptor(
-  target: object,
-  key: PropertyKey,
-  context: AnnotationProtectionContext,
-): PropertyDescriptor | undefined {
-  const descriptor = Reflect.getOwnPropertyDescriptor(target, key);
-  if (descriptor == null || !("value" in descriptor)) {
-    return descriptor;
-  }
-  if (descriptor.configurable === false && descriptor.writable === false) {
-    return descriptor;
-  }
-  const value = protectAnnotationValue(descriptor.value, context);
-  return value === descriptor.value ? descriptor : { ...descriptor, value };
-}
-
-function resolveProtectedMapLookup(
-  target: ReadonlyMap<unknown, unknown>,
-  lookup: unknown,
-): { readonly found: false } | {
-  readonly found: true;
-  readonly value: unknown;
-} {
-  if (target.has(lookup)) {
-    return { found: true, value: target.get(lookup) };
-  }
-  const rawLookup = unwrapProtectedAnnotationTarget(lookup);
-  if (rawLookup !== lookup && target.has(rawLookup)) {
-    return { found: true, value: target.get(rawLookup) };
-  }
-  for (const [entryKey, entryValue] of target.entries()) {
-    if (unwrapProtectedAnnotationTarget(entryKey) === rawLookup) {
-      return { found: true, value: entryValue };
-    }
-  }
-  return { found: false };
-}
-
-function hasProtectedSetLookup(
-  target: ReadonlySet<unknown>,
-  lookup: unknown,
-): boolean {
-  if (target.has(lookup)) {
-    return true;
-  }
-  const rawLookup = unwrapProtectedAnnotationTarget(lookup);
-  if (rawLookup !== lookup && target.has(rawLookup)) {
-    return true;
-  }
-  for (const value of target.values()) {
-    if (unwrapProtectedAnnotationTarget(value) === rawLookup) {
-      return true;
-    }
-  }
-  return false;
-}
-
-function usesSubclassProxyFallback(
+function hasBuiltInSubclassPrototype(
   target: object,
   basePrototype: object,
 ): boolean {
   return Object.getPrototypeOf(target) !== basePrototype;
 }
 
+function tryCloneMapSubclass(
+  source: Map<unknown, unknown>,
+  entries: Iterable<readonly [unknown, unknown]>,
+): Map<unknown, unknown> | undefined {
+  const cloneConstructor = resolveCloneConstructor(source);
+  if (cloneConstructor == null) {
+    return undefined;
+  }
+  try {
+    const cloned = new cloneConstructor(entries);
+    return cloned instanceof Map ? cloned : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function tryCloneSetSubclass(
+  source: Set<unknown>,
+  values: Iterable<unknown>,
+): Set<unknown> | undefined {
+  const cloneConstructor = resolveCloneConstructor(source);
+  if (cloneConstructor == null) {
+    return undefined;
+  }
+  try {
+    const cloned = new cloneConstructor(values);
+    return cloned instanceof Set ? cloned : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function tryCloneDateSubclass(source: Date): Date | undefined {
+  const cloneConstructor = resolveCloneConstructor(source);
+  if (cloneConstructor == null) {
+    return undefined;
+  }
+  try {
+    const cloned = new cloneConstructor(source.getTime());
+    return cloned instanceof Date ? cloned : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function tryCloneRegExpSubclass(source: RegExp): RegExp | undefined {
+  const cloneConstructor = resolveCloneConstructor(source);
+  if (cloneConstructor == null) {
+    return undefined;
+  }
+  try {
+    const cloned = new cloneConstructor(source.source, source.flags);
+    return cloned instanceof RegExp ? cloned : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function tryCloneURLSearchParamsSubclass(
+  source: URLSearchParams,
+): URLSearchParams | undefined {
+  const cloneConstructor = resolveCloneConstructor(source);
+  if (cloneConstructor == null) {
+    return undefined;
+  }
+  try {
+    const cloned = new cloneConstructor(source);
+    return cloned instanceof URLSearchParams ? cloned : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function tryCloneURLSubclass(source: URL): URL | undefined {
+  const cloneConstructor = resolveCloneConstructor(source);
+  if (cloneConstructor == null) {
+    return undefined;
+  }
+  try {
+    const cloned = new cloneConstructor(source.href);
+    return cloned instanceof URL ? cloned : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 const regExpExcludedKeys = new Set<PropertyKey>(["lastIndex"]);
+const mapMutationMethodKeys = ["set", "delete", "clear"] as const;
+const setMutationMethodKeys = ["add", "delete", "clear"] as const;
+const urlSearchParamsMutationMethodKeys = [
+  "append",
+  "delete",
+  "set",
+  "sort",
+] as const;
+const urlMutationPropertyKeys = [
+  "hash",
+  "host",
+  "hostname",
+  "href",
+  "password",
+  "pathname",
+  "port",
+  "protocol",
+  "search",
+  "username",
+] as const;
+const dateMutationMethodKeys = Object.getOwnPropertyNames(Date.prototype)
+  .filter((key) => key.startsWith("set"));
+
+function installReadonlyMutationMethodGuards(
+  target: object,
+  keys: readonly string[],
+): void {
+  for (const key of keys) {
+    const descriptor = Object.getOwnPropertyDescriptor(target, key);
+    if (descriptor?.configurable === false) continue;
+    Object.defineProperty(target, key, {
+      configurable: true,
+      enumerable: false,
+      writable: true,
+      value: (..._args: readonly unknown[]) =>
+        throwReadonlyAnnotationMutation(),
+    });
+  }
+}
+
+function installReadonlyURLGuards(
+  target: URL,
+  context: AnnotationProtectionContext,
+): void {
+  const searchParams = target.searchParams;
+  const searchParamsDescriptor = Object.getOwnPropertyDescriptor(
+    target,
+    "searchParams",
+  );
+  if (searchParamsDescriptor?.configurable !== false) {
+    Object.defineProperty(target, "searchParams", {
+      configurable: true,
+      enumerable: false,
+      get: () => protectAnnotationValue(searchParams, context),
+      set: () => throwReadonlyAnnotationMutation(),
+    });
+  }
+  for (const key of urlMutationPropertyKeys) {
+    const descriptor = Object.getOwnPropertyDescriptor(target, key);
+    if (descriptor?.configurable === false) continue;
+    Object.defineProperty(target, key, {
+      configurable: true,
+      enumerable: false,
+      get: () => Reflect.get(URL.prototype, key, target),
+      set: () => throwReadonlyAnnotationMutation(),
+    });
+  }
+}
 
 function copyRegExpMetadata(
   source: RegExp,
   target: RegExp,
   transformValue?: (value: unknown) => unknown,
+  syncPrototype = true,
 ): void {
-  copyOwnProperties(source, target, transformValue, regExpExcludedKeys);
+  copyOwnProperties(
+    source,
+    target,
+    transformValue,
+    regExpExcludedKeys,
+    syncPrototype,
+  );
   target.lastIndex = source.lastIndex;
 }
 
-function cloneRegExpShape<T extends RegExp>(source: T): T {
-  const cloned = new RegExp(source) as T;
-  copyRegExpMetadata(source, cloned);
+function cloneRegExpShape(source: RegExp): RegExp {
+  const syncPrototype = !hasBuiltInSubclassPrototype(source, RegExp.prototype);
+  const cloned = syncPrototype
+    ? new RegExp(source)
+    : tryCloneRegExpSubclass(source) ?? new RegExp(source);
+  copyRegExpMetadata(source, cloned, undefined, syncPrototype);
   return cloned;
 }
 
@@ -336,137 +437,18 @@ function createProtectedMapView(
   target: Map<unknown, unknown>,
   context: AnnotationProtectionContext,
 ): Map<unknown, unknown> {
-  if (usesSubclassProxyFallback(target, Map.prototype)) {
-    const methodCache = new Map<PropertyKey, unknown>();
-    const view = new Proxy(target, {
-      get(target, key) {
-        if (key === "size") {
-          return target.size;
-        }
-        if (key === "valueOf") {
-          return cacheProtectedMethod(methodCache, key, () => () => view);
-        }
-        if (key === "set" || key === "delete" || key === "clear") {
-          return cacheProtectedMethod(
-            methodCache,
-            key,
-            () => (..._args: unknown[]) => throwReadonlyAnnotationMutation(),
-          );
-        }
-        if (key === "get") {
-          return cacheProtectedMethod(
-            methodCache,
-            key,
-            () => (lookup: unknown) => {
-              const resolved = resolveProtectedMapLookup(target, lookup);
-              return resolved.found
-                ? protectAnnotationValue(resolved.value, context)
-                : undefined;
-            },
-          );
-        }
-        if (key === "has") {
-          return cacheProtectedMethod(
-            methodCache,
-            key,
-            () => (lookup: unknown) =>
-              resolveProtectedMapLookup(target, lookup).found,
-          );
-        }
-        if (key === "forEach") {
-          return cacheProtectedMethod(
-            methodCache,
-            key,
-            () =>
-            (
-              callback: (
-                value: unknown,
-                key: unknown,
-                map: Map<unknown, unknown>,
-              ) => void,
-              thisArg?: unknown,
-            ) =>
-              target.forEach((value, mapKey) => {
-                callback.call(
-                  thisArg,
-                  protectAnnotationValue(value, context),
-                  protectAnnotationValue(mapKey, context),
-                  view,
-                );
-              }),
-          );
-        }
-        if (key === "keys") {
-          return cacheProtectedMethod(
-            methodCache,
-            key,
-            () =>
-              function* (): IterableIterator<unknown> {
-                for (const value of target.keys()) {
-                  yield protectAnnotationValue(value, context);
-                }
-              },
-          );
-        }
-        if (key === "values") {
-          return cacheProtectedMethod(
-            methodCache,
-            key,
-            () =>
-              function* (): IterableIterator<unknown> {
-                for (const value of target.values()) {
-                  yield protectAnnotationValue(value, context);
-                }
-              },
-          );
-        }
-        if (key === "entries" || key === Symbol.iterator) {
-          return cacheProtectedMethod(
-            methodCache,
-            key,
-            () =>
-              function* (): IterableIterator<readonly [unknown, unknown]> {
-                for (const [entryKey, entryValue] of target.entries()) {
-                  yield [
-                    protectAnnotationValue(entryKey, context),
-                    protectAnnotationValue(entryValue, context),
-                  ] as const;
-                }
-              },
-          );
-        }
-        return getProtectedProxyFallbackValue(target, key, context);
-      },
-      getOwnPropertyDescriptor(target, key) {
-        return getProtectedProxyOwnPropertyDescriptor(target, key, context);
-      },
-      set() {
-        throwReadonlyAnnotationMutation();
-      },
-      defineProperty() {
-        throwReadonlyAnnotationMutation();
-      },
-      deleteProperty() {
-        throwReadonlyAnnotationMutation();
-      },
-      setPrototypeOf() {
-        throwReadonlyAnnotationMutation();
-      },
-      preventExtensions() {
-        throwReadonlyAnnotationMutation();
-      },
-    });
-    return registerProtectedAnnotationView(context, target, view);
-  }
-
-  const methodCache = new Map<PropertyKey, unknown>();
-  const cloned = new Map<unknown, unknown>();
-  for (const [entryKey, entryValue] of target.entries()) {
-    cloned.set(
+  const syncPrototype = !hasBuiltInSubclassPrototype(target, Map.prototype);
+  const entries = [...target.entries()].map(([entryKey, entryValue]) =>
+    [
       normalizeProtectedCollectionItem(entryKey, context),
       normalizeProtectedCollectionItem(entryValue, context),
-    );
-  }
+    ] as const
+  );
+  const methodCache = new Map<PropertyKey, unknown>();
+  const cloned = syncPrototype
+    ? new Map<unknown, unknown>(entries)
+    : tryCloneMapSubclass(target, entries) ??
+      new Map<unknown, unknown>(entries);
   const view = new Proxy(cloned, {
     get(clonedTarget, key) {
       if (key === "size") {
@@ -599,7 +581,10 @@ function createProtectedMapView(
     target,
     cloned,
     (value) => protectAnnotationValue(value, context),
+    undefined,
+    syncPrototype,
   );
+  installReadonlyMutationMethodGuards(cloned, mapMutationMethodKeys);
   return view;
 }
 
@@ -607,107 +592,14 @@ function createProtectedSetView(
   target: Set<unknown>,
   context: AnnotationProtectionContext,
 ): Set<unknown> {
-  if (usesSubclassProxyFallback(target, Set.prototype)) {
-    const methodCache = new Map<PropertyKey, unknown>();
-    const view = new Proxy(target, {
-      get(target, key) {
-        if (key === "size") {
-          return target.size;
-        }
-        if (key === "valueOf") {
-          return cacheProtectedMethod(methodCache, key, () => () => view);
-        }
-        if (key === "add" || key === "delete" || key === "clear") {
-          return cacheProtectedMethod(
-            methodCache,
-            key,
-            () => (..._args: unknown[]) => throwReadonlyAnnotationMutation(),
-          );
-        }
-        if (key === "has") {
-          return cacheProtectedMethod(
-            methodCache,
-            key,
-            () => (lookup: unknown) => hasProtectedSetLookup(target, lookup),
-          );
-        }
-        if (key === "forEach") {
-          return cacheProtectedMethod(
-            methodCache,
-            key,
-            () =>
-            (
-              callback: (
-                value: unknown,
-                key: unknown,
-                set: Set<unknown>,
-              ) => void,
-              thisArg?: unknown,
-            ) =>
-              target.forEach((value) => {
-                const protectedValue = protectAnnotationValue(value, context);
-                callback.call(thisArg, protectedValue, protectedValue, view);
-              }),
-          );
-        }
-        if (
-          key === "keys" ||
-          key === "values" ||
-          key === Symbol.iterator
-        ) {
-          return cacheProtectedMethod(
-            methodCache,
-            key,
-            () =>
-              function* (): IterableIterator<unknown> {
-                for (const value of target.values()) {
-                  yield protectAnnotationValue(value, context);
-                }
-              },
-          );
-        }
-        if (key === "entries") {
-          return cacheProtectedMethod(
-            methodCache,
-            key,
-            () =>
-              function* (): IterableIterator<readonly [unknown, unknown]> {
-                for (const value of target.values()) {
-                  const protectedValue = protectAnnotationValue(value, context);
-                  yield [protectedValue, protectedValue] as const;
-                }
-              },
-          );
-        }
-        return getProtectedProxyFallbackValue(target, key, context);
-      },
-      getOwnPropertyDescriptor(target, key) {
-        return getProtectedProxyOwnPropertyDescriptor(target, key, context);
-      },
-      set() {
-        throwReadonlyAnnotationMutation();
-      },
-      defineProperty() {
-        throwReadonlyAnnotationMutation();
-      },
-      deleteProperty() {
-        throwReadonlyAnnotationMutation();
-      },
-      setPrototypeOf() {
-        throwReadonlyAnnotationMutation();
-      },
-      preventExtensions() {
-        throwReadonlyAnnotationMutation();
-      },
-    });
-    return registerProtectedAnnotationView(context, target, view);
-  }
-
+  const syncPrototype = !hasBuiltInSubclassPrototype(target, Set.prototype);
+  const values = [...target.values()].map((value) =>
+    normalizeProtectedCollectionItem(value, context)
+  );
   const methodCache = new Map<PropertyKey, unknown>();
-  const cloned = new Set<unknown>();
-  for (const value of target.values()) {
-    cloned.add(normalizeProtectedCollectionItem(value, context));
-  }
+  const cloned = syncPrototype
+    ? new Set<unknown>(values)
+    : tryCloneSetSubclass(target, values) ?? new Set<unknown>(values);
   const view = new Proxy(cloned, {
     get(clonedTarget, key) {
       if (key === "size") {
@@ -811,7 +703,10 @@ function createProtectedSetView(
     target,
     cloned,
     (value) => protectAnnotationValue(value, context),
+    undefined,
+    syncPrototype,
   );
+  installReadonlyMutationMethodGuards(cloned, setMutationMethodKeys);
   return view;
 }
 
@@ -819,43 +714,11 @@ function createProtectedDateView(
   target: Date,
   context: AnnotationProtectionContext,
 ): Date {
-  if (usesSubclassProxyFallback(target, Date.prototype)) {
-    const methodCache = new Map<PropertyKey, unknown>();
-    const view = new Proxy(target, {
-      get(target, key) {
-        if (typeof key === "string" && key.startsWith("set")) {
-          return cacheProtectedMethod(
-            methodCache,
-            key,
-            () => (..._args: unknown[]) => throwReadonlyAnnotationMutation(),
-          );
-        }
-        return getProtectedProxyFallbackValue(target, key, context);
-      },
-      getOwnPropertyDescriptor(target, key) {
-        return getProtectedProxyOwnPropertyDescriptor(target, key, context);
-      },
-      set() {
-        throwReadonlyAnnotationMutation();
-      },
-      defineProperty() {
-        throwReadonlyAnnotationMutation();
-      },
-      deleteProperty() {
-        throwReadonlyAnnotationMutation();
-      },
-      setPrototypeOf() {
-        throwReadonlyAnnotationMutation();
-      },
-      preventExtensions() {
-        throwReadonlyAnnotationMutation();
-      },
-    });
-    return registerProtectedAnnotationView(context, target, view);
-  }
-
+  const syncPrototype = !hasBuiltInSubclassPrototype(target, Date.prototype);
   const methodCache = new Map<PropertyKey, unknown>();
-  const cloned = new Date(target.getTime());
+  const cloned = syncPrototype
+    ? new Date(target.getTime())
+    : tryCloneDateSubclass(target) ?? new Date(target.getTime());
   const view = new Proxy(cloned, {
     get(clonedTarget, key) {
       const value = Reflect.get(clonedTarget, key, clonedTarget);
@@ -892,7 +755,10 @@ function createProtectedDateView(
     target,
     cloned,
     (value) => protectAnnotationValue(value, context),
+    undefined,
+    syncPrototype,
   );
+  installReadonlyMutationMethodGuards(cloned, dateMutationMethodKeys);
   return view;
 }
 
@@ -900,8 +766,11 @@ function createProtectedRegExpView(
   target: RegExp,
   context: AnnotationProtectionContext,
 ): RegExp {
+  const syncPrototype = !hasBuiltInSubclassPrototype(target, RegExp.prototype);
   const methodCache = new Map<PropertyKey, unknown>();
-  const cloned = new RegExp(target) as RegExp;
+  const cloned = syncPrototype
+    ? new RegExp(target)
+    : tryCloneRegExpSubclass(target) ?? new RegExp(target);
   const view = new Proxy(cloned, {
     get(clonedTarget, key) {
       if (key === "compile") {
@@ -949,6 +818,7 @@ function createProtectedRegExpView(
     target,
     cloned,
     (value) => protectAnnotationValue(value, context),
+    syncPrototype,
   );
   return view;
 }
@@ -957,96 +827,14 @@ function createProtectedURLSearchParamsView(
   target: URLSearchParams,
   context: AnnotationProtectionContext,
 ): URLSearchParams {
-  if (usesSubclassProxyFallback(target, URLSearchParams.prototype)) {
-    const methodCache = new Map<PropertyKey, unknown>();
-    const view = new Proxy(target, {
-      get(target, key) {
-        if (
-          key === "append" ||
-          key === "delete" ||
-          key === "set" ||
-          key === "sort"
-        ) {
-          return cacheProtectedMethod(
-            methodCache,
-            key,
-            () => (..._args: unknown[]) => throwReadonlyAnnotationMutation(),
-          );
-        }
-        if (key === "valueOf") {
-          return cacheProtectedMethod(methodCache, key, () => () => view);
-        }
-        if (key === "forEach") {
-          return cacheProtectedMethod(
-            methodCache,
-            key,
-            () =>
-            (
-              callback: (
-                value: string,
-                key: string,
-                searchParams: URLSearchParams,
-              ) => void,
-              thisArg?: unknown,
-            ) =>
-              target.forEach((value, name) => {
-                callback.call(thisArg, value, name, view);
-              }),
-          );
-        }
-        if (key === "keys" || key === "values") {
-          return cacheProtectedMethod(
-            methodCache,
-            key,
-            () =>
-              function* (): IterableIterator<string> {
-                const iterator = key === "keys"
-                  ? target.keys()
-                  : target.values();
-                for (const value of iterator) {
-                  yield value;
-                }
-              },
-          );
-        }
-        if (key === "entries" || key === Symbol.iterator) {
-          return cacheProtectedMethod(
-            methodCache,
-            key,
-            () =>
-              function* (): IterableIterator<readonly [string, string]> {
-                for (const entry of target.entries()) {
-                  yield entry;
-                }
-              },
-          );
-        }
-        return getProtectedProxyFallbackValue(target, key, context);
-      },
-      getOwnPropertyDescriptor(target, key) {
-        return getProtectedProxyOwnPropertyDescriptor(target, key, context);
-      },
-      set() {
-        throwReadonlyAnnotationMutation();
-      },
-      defineProperty() {
-        throwReadonlyAnnotationMutation();
-      },
-      deleteProperty() {
-        throwReadonlyAnnotationMutation();
-      },
-      setPrototypeOf() {
-        throwReadonlyAnnotationMutation();
-      },
-      preventExtensions() {
-        throwReadonlyAnnotationMutation();
-      },
-    });
-    return registerProtectedAnnotationView(context, target, view);
-  }
-
+  const syncPrototype = !hasBuiltInSubclassPrototype(
+    target,
+    URLSearchParams.prototype,
+  );
   const methodCache = new Map<PropertyKey, unknown>();
-  const cloned = new URLSearchParams(target);
+  const cloned = syncPrototype
+    ? new URLSearchParams(target)
+    : tryCloneURLSearchParamsSubclass(target) ?? new URLSearchParams(target);
   const view = new Proxy(cloned, {
     get(clonedTarget, key) {
       if (
@@ -1140,6 +928,12 @@ function createProtectedURLSearchParamsView(
     target,
     cloned,
     (value) => protectAnnotationValue(value, context),
+    undefined,
+    syncPrototype,
+  );
+  installReadonlyMutationMethodGuards(
+    cloned,
+    urlSearchParamsMutationMethodKeys,
   );
   return view;
 }
@@ -1148,41 +942,10 @@ function createProtectedURLView(
   target: URL,
   context: AnnotationProtectionContext,
 ): URL {
-  if (usesSubclassProxyFallback(target, URL.prototype)) {
-    const methodCache = new Map<PropertyKey, unknown>();
-    const view = new Proxy(target, {
-      get(target, key) {
-        if (key === "valueOf") {
-          return cacheProtectedMethod(methodCache, key, () => () => view);
-        }
-        if (key === "searchParams") {
-          return protectAnnotationValue(target.searchParams, context);
-        }
-        return getProtectedProxyFallbackValue(target, key, context);
-      },
-      getOwnPropertyDescriptor(target, key) {
-        return getProtectedProxyOwnPropertyDescriptor(target, key, context);
-      },
-      set() {
-        throwReadonlyAnnotationMutation();
-      },
-      defineProperty() {
-        throwReadonlyAnnotationMutation();
-      },
-      deleteProperty() {
-        throwReadonlyAnnotationMutation();
-      },
-      setPrototypeOf() {
-        throwReadonlyAnnotationMutation();
-      },
-      preventExtensions() {
-        throwReadonlyAnnotationMutation();
-      },
-    });
-    return registerProtectedAnnotationView(context, target, view);
-  }
-
-  const cloned = new URL(target.href);
+  const syncPrototype = !hasBuiltInSubclassPrototype(target, URL.prototype);
+  const cloned = syncPrototype
+    ? new URL(target.href)
+    : tryCloneURLSubclass(target) ?? new URL(target.href);
   const view = new Proxy(cloned, {
     get(clonedTarget, key) {
       if (key === "valueOf") {
@@ -1218,7 +981,10 @@ function createProtectedURLView(
     target,
     cloned,
     (value) => protectAnnotationValue(value, context),
+    undefined,
+    syncPrototype,
   );
+  installReadonlyURLGuards(cloned, context);
   return view;
 }
 

--- a/packages/core/src/annotations.ts
+++ b/packages/core/src/annotations.ts
@@ -801,6 +801,7 @@ export function inheritAnnotations<T>(source: unknown, target: T): T {
     const cloned = new RegExp(target) as RegExp & {
       [annotationKey]?: Annotations;
     };
+    cloned.lastIndex = target.lastIndex;
     cloned[annotationKey] = annotations;
     return cloned as T;
   }
@@ -932,6 +933,7 @@ export function injectAnnotations<TState>(
     const cloned = new RegExp(state) as RegExp & {
       [annotationKey]?: Annotations;
     };
+    cloned.lastIndex = state.lastIndex;
     cloned[annotationKey] = protectedAnnotations;
     return cloned as TState;
   }

--- a/packages/core/src/annotations.ts
+++ b/packages/core/src/annotations.ts
@@ -705,6 +705,25 @@ export type ReadonlyAnnotations = Readonly<Annotations>;
 type AnnotationInput = Annotations | ReadonlyAnnotations;
 
 /**
+ * Normalizes annotation input for a fresh parse run.
+ *
+ * When callers feed a protected annotation view returned by `getAnnotations()`
+ * back into a new parse entrypoint, Optique unwraps it to the caller-owned
+ * record first so the new run gets its own protected views.
+ *
+ * @param annotations The caller-supplied annotations input.
+ * @returns The raw annotation record to inject for the new run.
+ * @internal
+ */
+export function normalizeRunAnnotationInput(
+  annotations: AnnotationInput,
+): AnnotationInput {
+  return isProtectedAnnotationView(annotations)
+    ? unwrapProtectedAnnotationTarget(annotations)
+    : annotations;
+}
+
+/**
  * Options for parse functions.
  * @since 0.10.0
  */

--- a/packages/core/src/annotations.ts
+++ b/packages/core/src/annotations.ts
@@ -60,17 +60,29 @@ const annotationWrapperKeys: ReadonlySet<PropertyKey> = new Set<
 
 const injectedAnnotationWrappers = new WeakSet<object>();
 const protectedAnnotationTargets = new WeakMap<object, object>();
-const annotationProtectionCache = new WeakMap<object, object>();
+const protectedAnnotationStateViews = new WeakMap<object, {
+  readonly raw: object;
+  readonly view: object;
+}>();
+
+interface AnnotationProtectionContext {
+  readonly cache: WeakMap<object, object>;
+}
 
 function throwReadonlyAnnotationMutation(): never {
   throw new TypeError("Cannot mutate read-only annotation data.");
 }
 
+function createAnnotationProtectionContext(): AnnotationProtectionContext {
+  return { cache: new WeakMap<object, object>() };
+}
+
 function registerProtectedAnnotationView<T extends object>(
-  target: T,
+  context: AnnotationProtectionContext,
+  target: object,
   view: T,
 ): T {
-  annotationProtectionCache.set(target, view);
+  context.cache.set(target, view);
   protectedAnnotationTargets.set(view, target);
   return view;
 }
@@ -103,11 +115,12 @@ function cacheProtectedMethod<T>(
 }
 
 function defineProtectedDataProperty(
+  context: AnnotationProtectionContext,
   target: object,
   key: PropertyKey,
   descriptor: PropertyDescriptor,
 ): void {
-  const value = protectAnnotationValue(descriptor.value);
+  const value = protectAnnotationValue(descriptor.value, context);
   Object.defineProperty(target, key, {
     configurable: descriptor.configurable,
     enumerable: descriptor.enumerable,
@@ -116,15 +129,19 @@ function defineProtectedDataProperty(
   });
 }
 
-function createProtectedObjectView<T extends object>(target: T): T {
+function createProtectedObjectView<T extends object>(
+  target: T,
+  context: AnnotationProtectionContext,
+): T {
   if (Array.isArray(target)) {
-    const view = new Array(target.length) as unknown as T;
+    const view: unknown[] = new Array(target.length);
+    registerProtectedAnnotationView(context, target, view);
     for (const key of Reflect.ownKeys(target)) {
       if (key === "length") continue;
       const descriptor = Object.getOwnPropertyDescriptor(target, key);
       if (descriptor == null) continue;
       if ("value" in descriptor) {
-        defineProtectedDataProperty(view, key, descriptor);
+        defineProtectedDataProperty(context, view, key, descriptor);
         continue;
       }
       Object.defineProperty(view, key, {
@@ -132,19 +149,22 @@ function createProtectedObjectView<T extends object>(target: T): T {
         enumerable: descriptor.enumerable,
         get: descriptor.get == null
           ? undefined
-          : () => protectAnnotationValue(descriptor.get!.call(target)),
+          : () => protectAnnotationValue(descriptor.get!.call(target), context),
         set: () => throwReadonlyAnnotationMutation(),
       });
     }
-    return registerProtectedAnnotationView(target, Object.freeze(view));
+    return Object.freeze(view) as T;
   }
 
-  const view = Object.create(Object.getPrototypeOf(target)) as T;
+  const view = Object.create(
+    Object.getPrototypeOf(target),
+  ) as Record<PropertyKey, unknown>;
+  registerProtectedAnnotationView(context, target, view);
   for (const key of Reflect.ownKeys(target)) {
     const descriptor = Object.getOwnPropertyDescriptor(target, key);
     if (descriptor == null) continue;
     if ("value" in descriptor) {
-      defineProtectedDataProperty(view, key, descriptor);
+      defineProtectedDataProperty(context, view, key, descriptor);
       continue;
     }
     Object.defineProperty(view, key, {
@@ -152,15 +172,16 @@ function createProtectedObjectView<T extends object>(target: T): T {
       enumerable: descriptor.enumerable,
       get: descriptor.get == null
         ? undefined
-        : () => protectAnnotationValue(descriptor.get!.call(target)),
+        : () => protectAnnotationValue(descriptor.get!.call(target), context),
       set: () => throwReadonlyAnnotationMutation(),
     });
   }
-  return registerProtectedAnnotationView(target, Object.freeze(view));
+  return Object.freeze(view) as T;
 }
 
 function createProtectedMapView(
   target: Map<unknown, unknown>,
+  context: AnnotationProtectionContext,
 ): Map<unknown, unknown> {
   const methodCache = new Map<PropertyKey, unknown>();
   const view = new Proxy(target, {
@@ -182,6 +203,7 @@ function createProtectedMapView(
           () => (lookup: unknown) =>
             protectAnnotationValue(
               target.get(unwrapProtectedAnnotationTarget(lookup)),
+              context,
             ),
         );
       }
@@ -209,8 +231,8 @@ function createProtectedMapView(
             target.forEach((value, mapKey) => {
               callback.call(
                 thisArg,
-                protectAnnotationValue(value),
-                protectAnnotationValue(mapKey),
+                protectAnnotationValue(value, context),
+                protectAnnotationValue(mapKey, context),
                 view,
               );
             }),
@@ -223,7 +245,7 @@ function createProtectedMapView(
           () =>
             function* (): IterableIterator<unknown> {
               for (const value of target.keys()) {
-                yield protectAnnotationValue(value);
+                yield protectAnnotationValue(value, context);
               }
             },
         );
@@ -235,7 +257,7 @@ function createProtectedMapView(
           () =>
             function* (): IterableIterator<unknown> {
               for (const value of target.values()) {
-                yield protectAnnotationValue(value);
+                yield protectAnnotationValue(value, context);
               }
             },
         );
@@ -248,8 +270,8 @@ function createProtectedMapView(
             function* (): IterableIterator<readonly [unknown, unknown]> {
               for (const [entryKey, entryValue] of target.entries()) {
                 yield [
-                  protectAnnotationValue(entryKey),
-                  protectAnnotationValue(entryValue),
+                  protectAnnotationValue(entryKey, context),
+                  protectAnnotationValue(entryValue, context),
                 ] as const;
               }
             },
@@ -274,11 +296,12 @@ function createProtectedMapView(
       throwReadonlyAnnotationMutation();
     },
   });
-  return registerProtectedAnnotationView(target, view);
+  return registerProtectedAnnotationView(context, target, view);
 }
 
 function createProtectedSetView(
   target: Set<unknown>,
+  context: AnnotationProtectionContext,
 ): Set<unknown> {
   const methodCache = new Map<PropertyKey, unknown>();
   const view = new Proxy(target, {
@@ -315,7 +338,7 @@ function createProtectedSetView(
             thisArg?: unknown,
           ) =>
             target.forEach((value) => {
-              const protectedValue = protectAnnotationValue(value);
+              const protectedValue = protectAnnotationValue(value, context);
               callback.call(thisArg, protectedValue, protectedValue, view);
             }),
         );
@@ -331,7 +354,7 @@ function createProtectedSetView(
           () =>
             function* (): IterableIterator<unknown> {
               for (const value of target.values()) {
-                yield protectAnnotationValue(value);
+                yield protectAnnotationValue(value, context);
               }
             },
         );
@@ -343,7 +366,7 @@ function createProtectedSetView(
           () =>
             function* (): IterableIterator<readonly [unknown, unknown]> {
               for (const value of target.values()) {
-                const protectedValue = protectAnnotationValue(value);
+                const protectedValue = protectAnnotationValue(value, context);
                 yield [protectedValue, protectedValue] as const;
               }
             },
@@ -368,10 +391,13 @@ function createProtectedSetView(
       throwReadonlyAnnotationMutation();
     },
   });
-  return registerProtectedAnnotationView(target, view);
+  return registerProtectedAnnotationView(context, target, view);
 }
 
-function createProtectedDateView(target: Date): Date {
+function createProtectedDateView(
+  target: Date,
+  context: AnnotationProtectionContext,
+): Date {
   const methodCache = new Map<PropertyKey, unknown>();
   const view = new Proxy(target, {
     get(target, key) {
@@ -401,10 +427,13 @@ function createProtectedDateView(target: Date): Date {
       throwReadonlyAnnotationMutation();
     },
   });
-  return registerProtectedAnnotationView(target, view);
+  return registerProtectedAnnotationView(context, target, view);
 }
 
-function createProtectedRegExpView(target: RegExp): RegExp {
+function createProtectedRegExpView(
+  target: RegExp,
+  context: AnnotationProtectionContext,
+): RegExp {
   const methodCache = new Map<PropertyKey, unknown>();
   const cloned = new RegExp(target) as RegExp;
   cloned.lastIndex = target.lastIndex;
@@ -436,11 +465,12 @@ function createProtectedRegExpView(target: RegExp): RegExp {
       throwReadonlyAnnotationMutation();
     },
   });
-  return registerProtectedAnnotationView(target, view);
+  return registerProtectedAnnotationView(context, target, view);
 }
 
 function createProtectedURLSearchParamsView(
   target: URLSearchParams,
+  context: AnnotationProtectionContext,
 ): URLSearchParams {
   const methodCache = new Map<PropertyKey, unknown>();
   const view = new Proxy(target, {
@@ -519,14 +549,17 @@ function createProtectedURLSearchParamsView(
       throwReadonlyAnnotationMutation();
     },
   });
-  return registerProtectedAnnotationView(target, view);
+  return registerProtectedAnnotationView(context, target, view);
 }
 
-function createProtectedURLView(target: URL): URL {
+function createProtectedURLView(
+  target: URL,
+  context: AnnotationProtectionContext,
+): URL {
   const view = new Proxy(target, {
     get(target, key) {
       if (key === "searchParams") {
-        return protectAnnotationValue(target.searchParams);
+        return protectAnnotationValue(target.searchParams, context);
       }
       const value = Reflect.get(target, key, target);
       return typeof value === "function" ? value.bind(target) : value;
@@ -547,10 +580,13 @@ function createProtectedURLView(target: URL): URL {
       throwReadonlyAnnotationMutation();
     },
   });
-  return registerProtectedAnnotationView(target, view);
+  return registerProtectedAnnotationView(context, target, view);
 }
 
-function protectAnnotationValue<T>(value: T): T {
+function protectAnnotationValue<T>(
+  value: T,
+  context: AnnotationProtectionContext,
+): T {
   if (value == null || typeof value !== "object") {
     return value;
   }
@@ -558,37 +594,37 @@ function protectAnnotationValue<T>(value: T): T {
   if (isProtectedAnnotationView(value)) {
     return value;
   }
-  const cached = annotationProtectionCache.get(target);
+  const cached = context.cache.get(target);
   if (cached !== undefined) {
     return cached as T;
   }
   if (target instanceof Map) {
-    return createProtectedMapView(target) as T;
+    return createProtectedMapView(target, context) as T;
   }
   if (target instanceof Set) {
-    return createProtectedSetView(target) as T;
+    return createProtectedSetView(target, context) as T;
   }
   if (target instanceof Date) {
-    return createProtectedDateView(target) as T;
+    return createProtectedDateView(target, context) as T;
   }
   if (target instanceof RegExp) {
-    return createProtectedRegExpView(target) as T;
+    return createProtectedRegExpView(target, context) as T;
   }
   if (
     typeof URLSearchParams === "function" &&
     target instanceof URLSearchParams
   ) {
-    return createProtectedURLSearchParamsView(target) as T;
+    return createProtectedURLSearchParamsView(target, context) as T;
   }
   if (typeof URL === "function" && target instanceof URL) {
-    return createProtectedURLView(target) as T;
+    return createProtectedURLView(target, context) as T;
   }
   if (Array.isArray(target)) {
-    return createProtectedObjectView(target) as T;
+    return createProtectedObjectView(target, context) as T;
   }
   const proto = Object.getPrototypeOf(target);
   if (proto === Object.prototype || proto === null) {
-    return createProtectedObjectView(target) as T;
+    return createProtectedObjectView(target, context) as T;
   }
   return value;
 }
@@ -666,7 +702,22 @@ export function getAnnotations(
   const stateObj = state as Record<symbol, unknown>;
   const annotations = stateObj[annotationKey];
   if (annotations != null && typeof annotations === "object") {
-    return protectAnnotationValue(annotations as AnnotationInput);
+    if (isProtectedAnnotationView(annotations)) {
+      return annotations as ReadonlyAnnotations;
+    }
+    const cached = protectedAnnotationStateViews.get(stateObj);
+    if (cached?.raw === annotations) {
+      return cached.view as ReadonlyAnnotations;
+    }
+    const protectedView = protectAnnotationValue(
+      annotations as AnnotationInput,
+      createAnnotationProtectionContext(),
+    );
+    protectedAnnotationStateViews.set(stateObj, {
+      raw: annotations as object,
+      view: protectedView as object,
+    });
+    return protectedView;
   }
   return undefined;
 }
@@ -811,7 +862,10 @@ export function injectAnnotations<TState>(
   if (!hasMeaningfulAnnotations(annotations)) {
     return state;
   }
-  const protectedAnnotations = protectAnnotationValue(annotations);
+  const protectedAnnotations = protectAnnotationValue(
+    annotations,
+    createAnnotationProtectionContext(),
+  );
   if (state == null || typeof state !== "object") {
     const wrapper: Record<PropertyKey, unknown> = {};
     Object.defineProperties(wrapper, {

--- a/packages/core/src/annotations.ts
+++ b/packages/core/src/annotations.ts
@@ -102,43 +102,61 @@ function cacheProtectedMethod<T>(
   return created;
 }
 
-function protectDescriptor(
-  descriptor: PropertyDescriptor | undefined,
-): PropertyDescriptor | undefined {
-  if (descriptor == null || !("value" in descriptor)) {
-    return descriptor;
-  }
-  return {
-    ...descriptor,
-    value: protectAnnotationValue(descriptor.value),
-  };
+function defineProtectedDataProperty(
+  target: object,
+  key: PropertyKey,
+  descriptor: PropertyDescriptor,
+): void {
+  const value = protectAnnotationValue(descriptor.value);
+  Object.defineProperty(target, key, {
+    configurable: descriptor.configurable,
+    enumerable: descriptor.enumerable,
+    get: () => value,
+    set: () => throwReadonlyAnnotationMutation(),
+  });
 }
 
 function createProtectedObjectView<T extends object>(target: T): T {
-  const view = new Proxy(target, {
-    get(target, key, receiver) {
-      return protectAnnotationValue(Reflect.get(target, key, receiver));
-    },
-    set() {
-      throwReadonlyAnnotationMutation();
-    },
-    defineProperty() {
-      throwReadonlyAnnotationMutation();
-    },
-    deleteProperty() {
-      throwReadonlyAnnotationMutation();
-    },
-    setPrototypeOf() {
-      throwReadonlyAnnotationMutation();
-    },
-    preventExtensions() {
-      throwReadonlyAnnotationMutation();
-    },
-    getOwnPropertyDescriptor(target, key) {
-      return protectDescriptor(Reflect.getOwnPropertyDescriptor(target, key));
-    },
-  });
-  return registerProtectedAnnotationView(target, view);
+  if (Array.isArray(target)) {
+    const view = new Array(target.length) as unknown as T;
+    for (const key of Reflect.ownKeys(target)) {
+      if (key === "length") continue;
+      const descriptor = Object.getOwnPropertyDescriptor(target, key);
+      if (descriptor == null) continue;
+      if ("value" in descriptor) {
+        defineProtectedDataProperty(view, key, descriptor);
+        continue;
+      }
+      Object.defineProperty(view, key, {
+        configurable: descriptor.configurable,
+        enumerable: descriptor.enumerable,
+        get: descriptor.get == null
+          ? undefined
+          : () => protectAnnotationValue(descriptor.get!.call(target)),
+        set: () => throwReadonlyAnnotationMutation(),
+      });
+    }
+    return registerProtectedAnnotationView(target, Object.freeze(view));
+  }
+
+  const view = Object.create(Object.getPrototypeOf(target)) as T;
+  for (const key of Reflect.ownKeys(target)) {
+    const descriptor = Object.getOwnPropertyDescriptor(target, key);
+    if (descriptor == null) continue;
+    if ("value" in descriptor) {
+      defineProtectedDataProperty(view, key, descriptor);
+      continue;
+    }
+    Object.defineProperty(view, key, {
+      configurable: descriptor.configurable,
+      enumerable: descriptor.enumerable,
+      get: descriptor.get == null
+        ? undefined
+        : () => protectAnnotationValue(descriptor.get!.call(target)),
+      set: () => throwReadonlyAnnotationMutation(),
+    });
+  }
+  return registerProtectedAnnotationView(target, Object.freeze(view));
 }
 
 function createProtectedMapView(
@@ -435,6 +453,49 @@ function createProtectedURLSearchParamsView(
           methodCache,
           key,
           () => (..._args: unknown[]) => throwReadonlyAnnotationMutation(),
+        );
+      }
+      if (key === "forEach") {
+        return cacheProtectedMethod(
+          methodCache,
+          key,
+          () =>
+          (
+            callback: (
+              value: string,
+              key: string,
+              searchParams: URLSearchParams,
+            ) => void,
+            thisArg?: unknown,
+          ) =>
+            target.forEach((value, name) => {
+              callback.call(thisArg, value, name, view);
+            }),
+        );
+      }
+      if (key === "keys" || key === "values") {
+        return cacheProtectedMethod(
+          methodCache,
+          key,
+          () =>
+            function* (): IterableIterator<string> {
+              const iterator = key === "keys" ? target.keys() : target.values();
+              for (const value of iterator) {
+                yield value;
+              }
+            },
+        );
+      }
+      if (key === "entries" || key === Symbol.iterator) {
+        return cacheProtectedMethod(
+          methodCache,
+          key,
+          () =>
+            function* (): IterableIterator<readonly [string, string]> {
+              for (const entry of target.entries()) {
+                yield entry;
+              }
+            },
         );
       }
       const value = Reflect.get(target, key, target);

--- a/packages/core/src/annotations.ts
+++ b/packages/core/src/annotations.ts
@@ -125,6 +125,22 @@ function cacheProtectedMethod<T>(
   return created;
 }
 
+function getProtectedClonePropertyValue(
+  cache: Map<PropertyKey, unknown>,
+  target: object,
+  key: PropertyKey,
+  value: unknown,
+  context: AnnotationProtectionContext,
+): unknown {
+  if (typeof value !== "function") {
+    return protectAnnotationValue(value, context);
+  }
+  if (key === "constructor") {
+    return value;
+  }
+  return cacheProtectedMethod(cache, key, () => value.bind(target));
+}
+
 function defineProtectedDataProperty(
   context: AnnotationProtectionContext,
   target: object,
@@ -202,13 +218,22 @@ function tryCloneMapSubclass(
   source: Map<unknown, unknown>,
   entries: Iterable<readonly [unknown, unknown]>,
 ): Map<unknown, unknown> | undefined {
+  const entriesArray = [...entries];
   const cloneConstructor = resolveCloneConstructor(source);
   if (cloneConstructor == null) {
     return undefined;
   }
   try {
-    const cloned = new cloneConstructor(entries);
-    return cloned instanceof Map ? cloned : undefined;
+    const cloned = new cloneConstructor(entriesArray);
+    if (!(cloned instanceof Map) || cloned.size !== entriesArray.length) {
+      return undefined;
+    }
+    for (const [key, value] of entriesArray) {
+      if (!cloned.has(key) || !Object.is(cloned.get(key), value)) {
+        return undefined;
+      }
+    }
+    return cloned;
   } catch {
     return undefined;
   }
@@ -218,13 +243,22 @@ function tryCloneSetSubclass(
   source: Set<unknown>,
   values: Iterable<unknown>,
 ): Set<unknown> | undefined {
+  const valuesArray = [...values];
   const cloneConstructor = resolveCloneConstructor(source);
   if (cloneConstructor == null) {
     return undefined;
   }
   try {
-    const cloned = new cloneConstructor(values);
-    return cloned instanceof Set ? cloned : undefined;
+    const cloned = new cloneConstructor(valuesArray);
+    if (!(cloned instanceof Set) || cloned.size !== valuesArray.length) {
+      return undefined;
+    }
+    for (const value of valuesArray) {
+      if (!cloned.has(value)) {
+        return undefined;
+      }
+    }
+    return cloned;
   } catch {
     return undefined;
   }
@@ -237,7 +271,9 @@ function tryCloneDateSubclass(source: Date): Date | undefined {
   }
   try {
     const cloned = new cloneConstructor(source.getTime());
-    return cloned instanceof Date ? cloned : undefined;
+    return cloned instanceof Date && cloned.getTime() === source.getTime()
+      ? cloned
+      : undefined;
   } catch {
     return undefined;
   }
@@ -250,7 +286,11 @@ function tryCloneRegExpSubclass(source: RegExp): RegExp | undefined {
   }
   try {
     const cloned = new cloneConstructor(source.source, source.flags);
-    return cloned instanceof RegExp ? cloned : undefined;
+    return cloned instanceof RegExp &&
+        cloned.source === source.source &&
+        cloned.flags === source.flags
+      ? cloned
+      : undefined;
   } catch {
     return undefined;
   }
@@ -259,13 +299,18 @@ function tryCloneRegExpSubclass(source: RegExp): RegExp | undefined {
 function tryCloneArraySubclass<T>(
   source: readonly T[],
 ): readonly T[] | undefined {
+  const entries = [...source];
   const cloneConstructor = resolveCloneConstructor(source as object);
   if (cloneConstructor == null) {
     return undefined;
   }
   try {
-    const cloned = Reflect.apply(Array.from, cloneConstructor, [source]);
-    return Array.isArray(cloned) ? cloned as readonly T[] : undefined;
+    const cloned = Reflect.apply(Array.from, cloneConstructor, [entries]);
+    return Array.isArray(cloned) &&
+        cloned.length === entries.length &&
+        entries.every((value, index) => Object.is(cloned[index], value))
+      ? cloned as readonly T[]
+      : undefined;
   } catch {
     return undefined;
   }
@@ -280,7 +325,10 @@ function tryCloneURLSearchParamsSubclass(
   }
   try {
     const cloned = new cloneConstructor(source);
-    return cloned instanceof URLSearchParams ? cloned : undefined;
+    return cloned instanceof URLSearchParams &&
+        cloned.toString() === source.toString()
+      ? cloned
+      : undefined;
   } catch {
     return undefined;
   }
@@ -293,7 +341,9 @@ function tryCloneURLSubclass(source: URL): URL | undefined {
   }
   try {
     const cloned = new cloneConstructor(source.href);
-    return cloned instanceof URL ? cloned : undefined;
+    return cloned instanceof URL && cloned.href === source.href
+      ? cloned
+      : undefined;
   } catch {
     return undefined;
   }
@@ -570,9 +620,13 @@ function createProtectedMapView(
         );
       }
       const value = Reflect.get(clonedTarget, key, clonedTarget);
-      return typeof value === "function"
-        ? value.bind(clonedTarget)
-        : protectAnnotationValue(value, context);
+      return getProtectedClonePropertyValue(
+        methodCache,
+        clonedTarget,
+        key,
+        value,
+        context,
+      );
     },
     set() {
       throwReadonlyAnnotationMutation();
@@ -692,9 +746,13 @@ function createProtectedSetView(
         );
       }
       const value = Reflect.get(clonedTarget, key, clonedTarget);
-      return typeof value === "function"
-        ? value.bind(clonedTarget)
-        : protectAnnotationValue(value, context);
+      return getProtectedClonePropertyValue(
+        methodCache,
+        clonedTarget,
+        key,
+        value,
+        context,
+      );
     },
     set() {
       throwReadonlyAnnotationMutation();
@@ -745,7 +803,13 @@ function createProtectedDateView(
         );
       }
       return typeof value === "function"
-        ? value.bind(clonedTarget)
+        ? getProtectedClonePropertyValue(
+          methodCache,
+          clonedTarget,
+          key,
+          value,
+          context,
+        )
         : protectAnnotationValue(value, context);
     },
     set() {
@@ -807,9 +871,13 @@ function createProtectedRegExpView(
         return ownDescriptor.value;
       }
       const value = Reflect.get(clonedTarget, key, clonedTarget);
-      return typeof value === "function"
-        ? value.bind(clonedTarget)
-        : protectAnnotationValue(value, context);
+      return getProtectedClonePropertyValue(
+        methodCache,
+        clonedTarget,
+        key,
+        value,
+        context,
+      );
     },
     set() {
       throwReadonlyAnnotationMutation();
@@ -917,9 +985,13 @@ function createProtectedURLSearchParamsView(
         );
       }
       const value = Reflect.get(clonedTarget, key, clonedTarget);
-      return typeof value === "function"
-        ? value.bind(clonedTarget)
-        : protectAnnotationValue(value, context);
+      return getProtectedClonePropertyValue(
+        methodCache,
+        clonedTarget,
+        key,
+        value,
+        context,
+      );
     },
     set() {
       throwReadonlyAnnotationMutation();

--- a/packages/core/src/annotations.ts
+++ b/packages/core/src/annotations.ts
@@ -406,9 +406,11 @@ function createProtectedDateView(target: Date): Date {
 
 function createProtectedRegExpView(target: RegExp): RegExp {
   const methodCache = new Map<PropertyKey, unknown>();
-  const view = new Proxy(target, {
-    get(target, key) {
-      const value = Reflect.get(target, key, target);
+  const cloned = new RegExp(target) as RegExp;
+  cloned.lastIndex = target.lastIndex;
+  const view = new Proxy(cloned, {
+    get(clonedTarget, key) {
+      const value = Reflect.get(clonedTarget, key, clonedTarget);
       if (key === "compile") {
         return cacheProtectedMethod(
           methodCache,
@@ -416,7 +418,7 @@ function createProtectedRegExpView(target: RegExp): RegExp {
           () => (..._args: unknown[]) => throwReadonlyAnnotationMutation(),
         );
       }
-      return typeof value === "function" ? value.bind(target) : value;
+      return typeof value === "function" ? value.bind(clonedTarget) : value;
     },
     set() {
       throwReadonlyAnnotationMutation();

--- a/packages/core/src/annotations.ts
+++ b/packages/core/src/annotations.ts
@@ -174,6 +174,93 @@ function normalizeProtectedCollectionItem<T>(
     : value;
 }
 
+function getProtectedProxyFallbackValue(
+  target: object,
+  key: PropertyKey,
+  context: AnnotationProtectionContext,
+): unknown {
+  const ownDescriptor = Reflect.getOwnPropertyDescriptor(target, key);
+  if (ownDescriptor != null && "value" in ownDescriptor) {
+    if (
+      ownDescriptor.configurable === false && ownDescriptor.writable === false
+    ) {
+      return ownDescriptor.value;
+    }
+    const value = ownDescriptor.value;
+    return typeof value === "function"
+      ? value.bind(target)
+      : protectAnnotationValue(value, context);
+  }
+  const value = Reflect.get(target, key, target);
+  return typeof value === "function"
+    ? value.bind(target)
+    : protectAnnotationValue(value, context);
+}
+
+function getProtectedProxyOwnPropertyDescriptor(
+  target: object,
+  key: PropertyKey,
+  context: AnnotationProtectionContext,
+): PropertyDescriptor | undefined {
+  const descriptor = Reflect.getOwnPropertyDescriptor(target, key);
+  if (descriptor == null || !("value" in descriptor)) {
+    return descriptor;
+  }
+  if (descriptor.configurable === false && descriptor.writable === false) {
+    return descriptor;
+  }
+  const value = protectAnnotationValue(descriptor.value, context);
+  return value === descriptor.value ? descriptor : { ...descriptor, value };
+}
+
+function resolveProtectedMapLookup(
+  target: ReadonlyMap<unknown, unknown>,
+  lookup: unknown,
+): { readonly found: false } | {
+  readonly found: true;
+  readonly value: unknown;
+} {
+  if (target.has(lookup)) {
+    return { found: true, value: target.get(lookup) };
+  }
+  const rawLookup = unwrapProtectedAnnotationTarget(lookup);
+  if (rawLookup !== lookup && target.has(rawLookup)) {
+    return { found: true, value: target.get(rawLookup) };
+  }
+  for (const [entryKey, entryValue] of target.entries()) {
+    if (unwrapProtectedAnnotationTarget(entryKey) === rawLookup) {
+      return { found: true, value: entryValue };
+    }
+  }
+  return { found: false };
+}
+
+function hasProtectedSetLookup(
+  target: ReadonlySet<unknown>,
+  lookup: unknown,
+): boolean {
+  if (target.has(lookup)) {
+    return true;
+  }
+  const rawLookup = unwrapProtectedAnnotationTarget(lookup);
+  if (rawLookup !== lookup && target.has(rawLookup)) {
+    return true;
+  }
+  for (const value of target.values()) {
+    if (unwrapProtectedAnnotationTarget(value) === rawLookup) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function usesSubclassProxyFallback(
+  target: object,
+  basePrototype: object,
+): boolean {
+  return Object.getPrototypeOf(target) !== basePrototype;
+}
+
 const regExpExcludedKeys = new Set<PropertyKey>(["lastIndex"]);
 
 function copyRegExpMetadata(
@@ -249,6 +336,129 @@ function createProtectedMapView(
   target: Map<unknown, unknown>,
   context: AnnotationProtectionContext,
 ): Map<unknown, unknown> {
+  if (usesSubclassProxyFallback(target, Map.prototype)) {
+    const methodCache = new Map<PropertyKey, unknown>();
+    const view = new Proxy(target, {
+      get(target, key) {
+        if (key === "size") {
+          return target.size;
+        }
+        if (key === "valueOf") {
+          return cacheProtectedMethod(methodCache, key, () => () => view);
+        }
+        if (key === "set" || key === "delete" || key === "clear") {
+          return cacheProtectedMethod(
+            methodCache,
+            key,
+            () => (..._args: unknown[]) => throwReadonlyAnnotationMutation(),
+          );
+        }
+        if (key === "get") {
+          return cacheProtectedMethod(
+            methodCache,
+            key,
+            () => (lookup: unknown) => {
+              const resolved = resolveProtectedMapLookup(target, lookup);
+              return resolved.found
+                ? protectAnnotationValue(resolved.value, context)
+                : undefined;
+            },
+          );
+        }
+        if (key === "has") {
+          return cacheProtectedMethod(
+            methodCache,
+            key,
+            () => (lookup: unknown) =>
+              resolveProtectedMapLookup(target, lookup).found,
+          );
+        }
+        if (key === "forEach") {
+          return cacheProtectedMethod(
+            methodCache,
+            key,
+            () =>
+            (
+              callback: (
+                value: unknown,
+                key: unknown,
+                map: Map<unknown, unknown>,
+              ) => void,
+              thisArg?: unknown,
+            ) =>
+              target.forEach((value, mapKey) => {
+                callback.call(
+                  thisArg,
+                  protectAnnotationValue(value, context),
+                  protectAnnotationValue(mapKey, context),
+                  view,
+                );
+              }),
+          );
+        }
+        if (key === "keys") {
+          return cacheProtectedMethod(
+            methodCache,
+            key,
+            () =>
+              function* (): IterableIterator<unknown> {
+                for (const value of target.keys()) {
+                  yield protectAnnotationValue(value, context);
+                }
+              },
+          );
+        }
+        if (key === "values") {
+          return cacheProtectedMethod(
+            methodCache,
+            key,
+            () =>
+              function* (): IterableIterator<unknown> {
+                for (const value of target.values()) {
+                  yield protectAnnotationValue(value, context);
+                }
+              },
+          );
+        }
+        if (key === "entries" || key === Symbol.iterator) {
+          return cacheProtectedMethod(
+            methodCache,
+            key,
+            () =>
+              function* (): IterableIterator<readonly [unknown, unknown]> {
+                for (const [entryKey, entryValue] of target.entries()) {
+                  yield [
+                    protectAnnotationValue(entryKey, context),
+                    protectAnnotationValue(entryValue, context),
+                  ] as const;
+                }
+              },
+          );
+        }
+        return getProtectedProxyFallbackValue(target, key, context);
+      },
+      getOwnPropertyDescriptor(target, key) {
+        return getProtectedProxyOwnPropertyDescriptor(target, key, context);
+      },
+      set() {
+        throwReadonlyAnnotationMutation();
+      },
+      defineProperty() {
+        throwReadonlyAnnotationMutation();
+      },
+      deleteProperty() {
+        throwReadonlyAnnotationMutation();
+      },
+      setPrototypeOf() {
+        throwReadonlyAnnotationMutation();
+      },
+      preventExtensions() {
+        throwReadonlyAnnotationMutation();
+      },
+    });
+    return registerProtectedAnnotationView(context, target, view);
+  }
+
   const methodCache = new Map<PropertyKey, unknown>();
   const cloned = new Map<unknown, unknown>();
   for (const [entryKey, entryValue] of target.entries()) {
@@ -397,6 +607,102 @@ function createProtectedSetView(
   target: Set<unknown>,
   context: AnnotationProtectionContext,
 ): Set<unknown> {
+  if (usesSubclassProxyFallback(target, Set.prototype)) {
+    const methodCache = new Map<PropertyKey, unknown>();
+    const view = new Proxy(target, {
+      get(target, key) {
+        if (key === "size") {
+          return target.size;
+        }
+        if (key === "valueOf") {
+          return cacheProtectedMethod(methodCache, key, () => () => view);
+        }
+        if (key === "add" || key === "delete" || key === "clear") {
+          return cacheProtectedMethod(
+            methodCache,
+            key,
+            () => (..._args: unknown[]) => throwReadonlyAnnotationMutation(),
+          );
+        }
+        if (key === "has") {
+          return cacheProtectedMethod(
+            methodCache,
+            key,
+            () => (lookup: unknown) => hasProtectedSetLookup(target, lookup),
+          );
+        }
+        if (key === "forEach") {
+          return cacheProtectedMethod(
+            methodCache,
+            key,
+            () =>
+            (
+              callback: (
+                value: unknown,
+                key: unknown,
+                set: Set<unknown>,
+              ) => void,
+              thisArg?: unknown,
+            ) =>
+              target.forEach((value) => {
+                const protectedValue = protectAnnotationValue(value, context);
+                callback.call(thisArg, protectedValue, protectedValue, view);
+              }),
+          );
+        }
+        if (
+          key === "keys" ||
+          key === "values" ||
+          key === Symbol.iterator
+        ) {
+          return cacheProtectedMethod(
+            methodCache,
+            key,
+            () =>
+              function* (): IterableIterator<unknown> {
+                for (const value of target.values()) {
+                  yield protectAnnotationValue(value, context);
+                }
+              },
+          );
+        }
+        if (key === "entries") {
+          return cacheProtectedMethod(
+            methodCache,
+            key,
+            () =>
+              function* (): IterableIterator<readonly [unknown, unknown]> {
+                for (const value of target.values()) {
+                  const protectedValue = protectAnnotationValue(value, context);
+                  yield [protectedValue, protectedValue] as const;
+                }
+              },
+          );
+        }
+        return getProtectedProxyFallbackValue(target, key, context);
+      },
+      getOwnPropertyDescriptor(target, key) {
+        return getProtectedProxyOwnPropertyDescriptor(target, key, context);
+      },
+      set() {
+        throwReadonlyAnnotationMutation();
+      },
+      defineProperty() {
+        throwReadonlyAnnotationMutation();
+      },
+      deleteProperty() {
+        throwReadonlyAnnotationMutation();
+      },
+      setPrototypeOf() {
+        throwReadonlyAnnotationMutation();
+      },
+      preventExtensions() {
+        throwReadonlyAnnotationMutation();
+      },
+    });
+    return registerProtectedAnnotationView(context, target, view);
+  }
+
   const methodCache = new Map<PropertyKey, unknown>();
   const cloned = new Set<unknown>();
   for (const value of target.values()) {
@@ -513,6 +819,41 @@ function createProtectedDateView(
   target: Date,
   context: AnnotationProtectionContext,
 ): Date {
+  if (usesSubclassProxyFallback(target, Date.prototype)) {
+    const methodCache = new Map<PropertyKey, unknown>();
+    const view = new Proxy(target, {
+      get(target, key) {
+        if (typeof key === "string" && key.startsWith("set")) {
+          return cacheProtectedMethod(
+            methodCache,
+            key,
+            () => (..._args: unknown[]) => throwReadonlyAnnotationMutation(),
+          );
+        }
+        return getProtectedProxyFallbackValue(target, key, context);
+      },
+      getOwnPropertyDescriptor(target, key) {
+        return getProtectedProxyOwnPropertyDescriptor(target, key, context);
+      },
+      set() {
+        throwReadonlyAnnotationMutation();
+      },
+      defineProperty() {
+        throwReadonlyAnnotationMutation();
+      },
+      deleteProperty() {
+        throwReadonlyAnnotationMutation();
+      },
+      setPrototypeOf() {
+        throwReadonlyAnnotationMutation();
+      },
+      preventExtensions() {
+        throwReadonlyAnnotationMutation();
+      },
+    });
+    return registerProtectedAnnotationView(context, target, view);
+  }
+
   const methodCache = new Map<PropertyKey, unknown>();
   const cloned = new Date(target.getTime());
   const view = new Proxy(cloned, {
@@ -616,6 +957,94 @@ function createProtectedURLSearchParamsView(
   target: URLSearchParams,
   context: AnnotationProtectionContext,
 ): URLSearchParams {
+  if (usesSubclassProxyFallback(target, URLSearchParams.prototype)) {
+    const methodCache = new Map<PropertyKey, unknown>();
+    const view = new Proxy(target, {
+      get(target, key) {
+        if (
+          key === "append" ||
+          key === "delete" ||
+          key === "set" ||
+          key === "sort"
+        ) {
+          return cacheProtectedMethod(
+            methodCache,
+            key,
+            () => (..._args: unknown[]) => throwReadonlyAnnotationMutation(),
+          );
+        }
+        if (key === "valueOf") {
+          return cacheProtectedMethod(methodCache, key, () => () => view);
+        }
+        if (key === "forEach") {
+          return cacheProtectedMethod(
+            methodCache,
+            key,
+            () =>
+            (
+              callback: (
+                value: string,
+                key: string,
+                searchParams: URLSearchParams,
+              ) => void,
+              thisArg?: unknown,
+            ) =>
+              target.forEach((value, name) => {
+                callback.call(thisArg, value, name, view);
+              }),
+          );
+        }
+        if (key === "keys" || key === "values") {
+          return cacheProtectedMethod(
+            methodCache,
+            key,
+            () =>
+              function* (): IterableIterator<string> {
+                const iterator = key === "keys"
+                  ? target.keys()
+                  : target.values();
+                for (const value of iterator) {
+                  yield value;
+                }
+              },
+          );
+        }
+        if (key === "entries" || key === Symbol.iterator) {
+          return cacheProtectedMethod(
+            methodCache,
+            key,
+            () =>
+              function* (): IterableIterator<readonly [string, string]> {
+                for (const entry of target.entries()) {
+                  yield entry;
+                }
+              },
+          );
+        }
+        return getProtectedProxyFallbackValue(target, key, context);
+      },
+      getOwnPropertyDescriptor(target, key) {
+        return getProtectedProxyOwnPropertyDescriptor(target, key, context);
+      },
+      set() {
+        throwReadonlyAnnotationMutation();
+      },
+      defineProperty() {
+        throwReadonlyAnnotationMutation();
+      },
+      deleteProperty() {
+        throwReadonlyAnnotationMutation();
+      },
+      setPrototypeOf() {
+        throwReadonlyAnnotationMutation();
+      },
+      preventExtensions() {
+        throwReadonlyAnnotationMutation();
+      },
+    });
+    return registerProtectedAnnotationView(context, target, view);
+  }
+
   const methodCache = new Map<PropertyKey, unknown>();
   const cloned = new URLSearchParams(target);
   const view = new Proxy(cloned, {
@@ -719,6 +1148,40 @@ function createProtectedURLView(
   target: URL,
   context: AnnotationProtectionContext,
 ): URL {
+  if (usesSubclassProxyFallback(target, URL.prototype)) {
+    const methodCache = new Map<PropertyKey, unknown>();
+    const view = new Proxy(target, {
+      get(target, key) {
+        if (key === "valueOf") {
+          return cacheProtectedMethod(methodCache, key, () => () => view);
+        }
+        if (key === "searchParams") {
+          return protectAnnotationValue(target.searchParams, context);
+        }
+        return getProtectedProxyFallbackValue(target, key, context);
+      },
+      getOwnPropertyDescriptor(target, key) {
+        return getProtectedProxyOwnPropertyDescriptor(target, key, context);
+      },
+      set() {
+        throwReadonlyAnnotationMutation();
+      },
+      defineProperty() {
+        throwReadonlyAnnotationMutation();
+      },
+      deleteProperty() {
+        throwReadonlyAnnotationMutation();
+      },
+      setPrototypeOf() {
+        throwReadonlyAnnotationMutation();
+      },
+      preventExtensions() {
+        throwReadonlyAnnotationMutation();
+      },
+    });
+    return registerProtectedAnnotationView(context, target, view);
+  }
+
   const cloned = new URL(target.href);
   const view = new Proxy(cloned, {
     get(clonedTarget, key) {

--- a/packages/core/src/annotations.ts
+++ b/packages/core/src/annotations.ts
@@ -67,14 +67,17 @@ const protectedAnnotationStateViews = new WeakMap<object, {
 
 interface AnnotationProtectionContext {
   readonly cache: WeakMap<object, object>;
+  readonly rewrapProtectedViews: boolean;
 }
 
 function throwReadonlyAnnotationMutation(): never {
   throw new TypeError("Cannot mutate read-only annotation data.");
 }
 
-function createAnnotationProtectionContext(): AnnotationProtectionContext {
-  return { cache: new WeakMap<object, object>() };
+function createAnnotationProtectionContext(
+  rewrapProtectedViews = false,
+): AnnotationProtectionContext {
+  return { cache: new WeakMap<object, object>(), rewrapProtectedViews };
 }
 
 function registerProtectedAnnotationView<T extends object>(
@@ -85,6 +88,14 @@ function registerProtectedAnnotationView<T extends object>(
   context.cache.set(target, view);
   protectedAnnotationTargets.set(view, target);
   return view;
+}
+
+function cacheProtectedAnnotationViewAlias(
+  context: AnnotationProtectionContext,
+  alias: object,
+  view: object,
+): void {
+  context.cache.set(alias, view);
 }
 
 function isProtectedAnnotationView(value: unknown): value is object {
@@ -129,17 +140,18 @@ function defineProtectedDataProperty(
   });
 }
 
-function copyRegExpMetadata(
-  source: RegExp,
-  target: RegExp,
+function copyOwnProperties(
+  source: object,
+  target: object,
   transformValue?: (value: unknown) => unknown,
+  excludedKeys?: ReadonlySet<PropertyKey>,
 ): void {
   const sourcePrototype = Object.getPrototypeOf(source);
   if (Object.getPrototypeOf(target) !== sourcePrototype) {
     Object.setPrototypeOf(target, sourcePrototype);
   }
   for (const key of Reflect.ownKeys(source)) {
-    if (key === "lastIndex") continue;
+    if (excludedKeys?.has(key) === true) continue;
     const descriptor = Object.getOwnPropertyDescriptor(source, key);
     if (descriptor == null) continue;
     if ("value" in descriptor && transformValue != null) {
@@ -151,6 +163,16 @@ function copyRegExpMetadata(
     }
     Object.defineProperty(target, key, descriptor);
   }
+}
+
+const regExpExcludedKeys = new Set<PropertyKey>(["lastIndex"]);
+
+function copyRegExpMetadata(
+  source: RegExp,
+  target: RegExp,
+  transformValue?: (value: unknown) => unknown,
+): void {
+  copyOwnProperties(source, target, transformValue, regExpExcludedKeys);
   target.lastIndex = source.lastIndex;
 }
 
@@ -165,7 +187,11 @@ function createProtectedObjectView<T extends object>(
   context: AnnotationProtectionContext,
 ): T {
   if (Array.isArray(target)) {
-    const view: unknown[] = new Array(target.length);
+    const view = Object.setPrototypeOf(
+      [],
+      Object.getPrototypeOf(target),
+    ) as unknown[];
+    view.length = target.length;
     registerProtectedAnnotationView(context, target, view);
     for (const key of Reflect.ownKeys(target)) {
       if (key === "length") continue;
@@ -215,10 +241,11 @@ function createProtectedMapView(
   context: AnnotationProtectionContext,
 ): Map<unknown, unknown> {
   const methodCache = new Map<PropertyKey, unknown>();
-  const view = new Proxy(target, {
-    get(target, key) {
+  const cloned = new Map(target);
+  const view = new Proxy(cloned, {
+    get(clonedTarget, key) {
       if (key === "size") {
-        return target.size;
+        return clonedTarget.size;
       }
       if (key === "set" || key === "delete" || key === "clear") {
         return cacheProtectedMethod(
@@ -233,7 +260,7 @@ function createProtectedMapView(
           key,
           () => (lookup: unknown) =>
             protectAnnotationValue(
-              target.get(unwrapProtectedAnnotationTarget(lookup)),
+              clonedTarget.get(unwrapProtectedAnnotationTarget(lookup)),
               context,
             ),
         );
@@ -243,7 +270,7 @@ function createProtectedMapView(
           methodCache,
           key,
           () => (lookup: unknown) =>
-            target.has(unwrapProtectedAnnotationTarget(lookup)),
+            clonedTarget.has(unwrapProtectedAnnotationTarget(lookup)),
         );
       }
       if (key === "forEach") {
@@ -259,7 +286,7 @@ function createProtectedMapView(
             ) => void,
             thisArg?: unknown,
           ) =>
-            target.forEach((value, mapKey) => {
+            clonedTarget.forEach((value, mapKey) => {
               callback.call(
                 thisArg,
                 protectAnnotationValue(value, context),
@@ -275,7 +302,7 @@ function createProtectedMapView(
           key,
           () =>
             function* (): IterableIterator<unknown> {
-              for (const value of target.keys()) {
+              for (const value of clonedTarget.keys()) {
                 yield protectAnnotationValue(value, context);
               }
             },
@@ -287,7 +314,7 @@ function createProtectedMapView(
           key,
           () =>
             function* (): IterableIterator<unknown> {
-              for (const value of target.values()) {
+              for (const value of clonedTarget.values()) {
                 yield protectAnnotationValue(value, context);
               }
             },
@@ -299,7 +326,7 @@ function createProtectedMapView(
           key,
           () =>
             function* (): IterableIterator<readonly [unknown, unknown]> {
-              for (const [entryKey, entryValue] of target.entries()) {
+              for (const [entryKey, entryValue] of clonedTarget.entries()) {
                 yield [
                   protectAnnotationValue(entryKey, context),
                   protectAnnotationValue(entryValue, context),
@@ -308,8 +335,10 @@ function createProtectedMapView(
             },
         );
       }
-      const value = Reflect.get(target, key, target);
-      return typeof value === "function" ? value.bind(target) : value;
+      const value = Reflect.get(clonedTarget, key, clonedTarget);
+      return typeof value === "function"
+        ? value.bind(clonedTarget)
+        : protectAnnotationValue(value, context);
     },
     set() {
       throwReadonlyAnnotationMutation();
@@ -327,7 +356,14 @@ function createProtectedMapView(
       throwReadonlyAnnotationMutation();
     },
   });
-  return registerProtectedAnnotationView(context, target, view);
+  registerProtectedAnnotationView(context, target, view);
+  cacheProtectedAnnotationViewAlias(context, cloned, view);
+  copyOwnProperties(
+    target,
+    cloned,
+    (value) => protectAnnotationValue(value, context),
+  );
+  return view;
 }
 
 function createProtectedSetView(
@@ -335,10 +371,11 @@ function createProtectedSetView(
   context: AnnotationProtectionContext,
 ): Set<unknown> {
   const methodCache = new Map<PropertyKey, unknown>();
-  const view = new Proxy(target, {
-    get(target, key) {
+  const cloned = new Set(target);
+  const view = new Proxy(cloned, {
+    get(clonedTarget, key) {
       if (key === "size") {
-        return target.size;
+        return clonedTarget.size;
       }
       if (key === "add" || key === "delete" || key === "clear") {
         return cacheProtectedMethod(
@@ -352,7 +389,7 @@ function createProtectedSetView(
           methodCache,
           key,
           () => (lookup: unknown) =>
-            target.has(unwrapProtectedAnnotationTarget(lookup)),
+            clonedTarget.has(unwrapProtectedAnnotationTarget(lookup)),
         );
       }
       if (key === "forEach") {
@@ -368,7 +405,7 @@ function createProtectedSetView(
             ) => void,
             thisArg?: unknown,
           ) =>
-            target.forEach((value) => {
+            clonedTarget.forEach((value) => {
               const protectedValue = protectAnnotationValue(value, context);
               callback.call(thisArg, protectedValue, protectedValue, view);
             }),
@@ -384,7 +421,7 @@ function createProtectedSetView(
           key,
           () =>
             function* (): IterableIterator<unknown> {
-              for (const value of target.values()) {
+              for (const value of clonedTarget.values()) {
                 yield protectAnnotationValue(value, context);
               }
             },
@@ -396,15 +433,17 @@ function createProtectedSetView(
           key,
           () =>
             function* (): IterableIterator<readonly [unknown, unknown]> {
-              for (const value of target.values()) {
+              for (const value of clonedTarget.values()) {
                 const protectedValue = protectAnnotationValue(value, context);
                 yield [protectedValue, protectedValue] as const;
               }
             },
         );
       }
-      const value = Reflect.get(target, key, target);
-      return typeof value === "function" ? value.bind(target) : value;
+      const value = Reflect.get(clonedTarget, key, clonedTarget);
+      return typeof value === "function"
+        ? value.bind(clonedTarget)
+        : protectAnnotationValue(value, context);
     },
     set() {
       throwReadonlyAnnotationMutation();
@@ -422,7 +461,14 @@ function createProtectedSetView(
       throwReadonlyAnnotationMutation();
     },
   });
-  return registerProtectedAnnotationView(context, target, view);
+  registerProtectedAnnotationView(context, target, view);
+  cacheProtectedAnnotationViewAlias(context, cloned, view);
+  copyOwnProperties(
+    target,
+    cloned,
+    (value) => protectAnnotationValue(value, context),
+  );
+  return view;
 }
 
 function createProtectedDateView(
@@ -430,9 +476,10 @@ function createProtectedDateView(
   context: AnnotationProtectionContext,
 ): Date {
   const methodCache = new Map<PropertyKey, unknown>();
-  const view = new Proxy(target, {
-    get(target, key) {
-      const value = Reflect.get(target, key, target);
+  const cloned = new Date(target.getTime());
+  const view = new Proxy(cloned, {
+    get(clonedTarget, key) {
+      const value = Reflect.get(clonedTarget, key, clonedTarget);
       if (typeof key === "string" && key.startsWith("set")) {
         return cacheProtectedMethod(
           methodCache,
@@ -440,7 +487,9 @@ function createProtectedDateView(
           () => (..._args: unknown[]) => throwReadonlyAnnotationMutation(),
         );
       }
-      return typeof value === "function" ? value.bind(target) : value;
+      return typeof value === "function"
+        ? value.bind(clonedTarget)
+        : protectAnnotationValue(value, context);
     },
     set() {
       throwReadonlyAnnotationMutation();
@@ -458,7 +507,14 @@ function createProtectedDateView(
       throwReadonlyAnnotationMutation();
     },
   });
-  return registerProtectedAnnotationView(context, target, view);
+  registerProtectedAnnotationView(context, target, view);
+  cacheProtectedAnnotationViewAlias(context, cloned, view);
+  copyOwnProperties(
+    target,
+    cloned,
+    (value) => protectAnnotationValue(value, context),
+  );
+  return view;
 }
 
 function createProtectedRegExpView(
@@ -502,6 +558,7 @@ function createProtectedRegExpView(
     },
   });
   registerProtectedAnnotationView(context, target, view);
+  cacheProtectedAnnotationViewAlias(context, cloned, view);
   copyRegExpMetadata(
     target,
     cloned,
@@ -515,8 +572,9 @@ function createProtectedURLSearchParamsView(
   context: AnnotationProtectionContext,
 ): URLSearchParams {
   const methodCache = new Map<PropertyKey, unknown>();
-  const view = new Proxy(target, {
-    get(target, key) {
+  const cloned = new URLSearchParams(target);
+  const view = new Proxy(cloned, {
+    get(clonedTarget, key) {
       if (
         key === "append" ||
         key === "delete" ||
@@ -542,7 +600,7 @@ function createProtectedURLSearchParamsView(
             ) => void,
             thisArg?: unknown,
           ) =>
-            target.forEach((value, name) => {
+            clonedTarget.forEach((value, name) => {
               callback.call(thisArg, value, name, view);
             }),
         );
@@ -553,7 +611,9 @@ function createProtectedURLSearchParamsView(
           key,
           () =>
             function* (): IterableIterator<string> {
-              const iterator = key === "keys" ? target.keys() : target.values();
+              const iterator = key === "keys"
+                ? clonedTarget.keys()
+                : clonedTarget.values();
               for (const value of iterator) {
                 yield value;
               }
@@ -566,14 +626,16 @@ function createProtectedURLSearchParamsView(
           key,
           () =>
             function* (): IterableIterator<readonly [string, string]> {
-              for (const entry of target.entries()) {
+              for (const entry of clonedTarget.entries()) {
                 yield entry;
               }
             },
         );
       }
-      const value = Reflect.get(target, key, target);
-      return typeof value === "function" ? value.bind(target) : value;
+      const value = Reflect.get(clonedTarget, key, clonedTarget);
+      return typeof value === "function"
+        ? value.bind(clonedTarget)
+        : protectAnnotationValue(value, context);
     },
     set() {
       throwReadonlyAnnotationMutation();
@@ -591,20 +653,30 @@ function createProtectedURLSearchParamsView(
       throwReadonlyAnnotationMutation();
     },
   });
-  return registerProtectedAnnotationView(context, target, view);
+  registerProtectedAnnotationView(context, target, view);
+  cacheProtectedAnnotationViewAlias(context, cloned, view);
+  copyOwnProperties(
+    target,
+    cloned,
+    (value) => protectAnnotationValue(value, context),
+  );
+  return view;
 }
 
 function createProtectedURLView(
   target: URL,
   context: AnnotationProtectionContext,
 ): URL {
-  const view = new Proxy(target, {
-    get(target, key) {
+  const cloned = new URL(target.href);
+  const view = new Proxy(cloned, {
+    get(clonedTarget, key) {
       if (key === "searchParams") {
-        return protectAnnotationValue(target.searchParams, context);
+        return protectAnnotationValue(clonedTarget.searchParams, context);
       }
-      const value = Reflect.get(target, key, target);
-      return typeof value === "function" ? value.bind(target) : value;
+      const value = Reflect.get(clonedTarget, key, clonedTarget);
+      return typeof value === "function"
+        ? value.bind(clonedTarget)
+        : protectAnnotationValue(value, context);
     },
     set() {
       throwReadonlyAnnotationMutation();
@@ -622,7 +694,14 @@ function createProtectedURLView(
       throwReadonlyAnnotationMutation();
     },
   });
-  return registerProtectedAnnotationView(context, target, view);
+  registerProtectedAnnotationView(context, target, view);
+  cacheProtectedAnnotationViewAlias(context, cloned, view);
+  copyOwnProperties(
+    target,
+    cloned,
+    (value) => protectAnnotationValue(value, context),
+  );
+  return view;
 }
 
 function protectAnnotationValue<T>(
@@ -632,10 +711,13 @@ function protectAnnotationValue<T>(
   if (value == null || typeof value !== "object") {
     return value;
   }
-  const target = value as object;
-  if (isProtectedAnnotationView(value)) {
+  const isProtectedView = isProtectedAnnotationView(value);
+  if (isProtectedView && !context.rewrapProtectedViews) {
     return value;
   }
+  const target = isProtectedView
+    ? unwrapProtectedAnnotationTarget(value as object)
+    : value as object;
   const cached = context.cache.get(target);
   if (cached !== undefined) {
     return cached as T;
@@ -721,6 +803,96 @@ export function normalizeRunAnnotationInput(
   return isProtectedAnnotationView(annotations)
     ? unwrapProtectedAnnotationTarget(annotations)
     : annotations;
+}
+
+function injectAnnotationsWithContext<TState>(
+  state: TState,
+  annotations: AnnotationInput,
+  context: AnnotationProtectionContext,
+): TState {
+  const protectedAnnotations = protectAnnotationValue(annotations, context);
+  if (state == null || typeof state !== "object") {
+    const wrapper: Record<PropertyKey, unknown> = {};
+    Object.defineProperties(wrapper, {
+      [annotationKey]: {
+        value: protectedAnnotations,
+        enumerable: true,
+        writable: true,
+        configurable: true,
+      },
+      // Internal wrapper markers should not be copied by object spread.
+      [annotationStateValueKey]: {
+        value: state,
+        enumerable: false,
+        writable: true,
+        configurable: true,
+      },
+      [annotationWrapperKey]: {
+        value: true,
+        enumerable: false,
+        writable: true,
+        configurable: true,
+      },
+    });
+    injectedAnnotationWrappers.add(wrapper);
+    return wrapper as TState;
+  }
+  if (Array.isArray(state)) {
+    const cloned = [...state];
+    (cloned as typeof cloned & { [annotationKey]?: ReadonlyAnnotations })[
+      annotationKey
+    ] = protectedAnnotations;
+    return cloned as TState;
+  }
+  if (isInjectedAnnotationWrapper(state)) {
+    (
+      state as TState & {
+        [annotationKey]?: ReadonlyAnnotations;
+      }
+    )[annotationKey] = protectedAnnotations;
+    return state;
+  }
+  if (state instanceof Date) {
+    const cloned = new Date(state.getTime()) as Date & {
+      [annotationKey]?: ReadonlyAnnotations;
+    };
+    cloned[annotationKey] = protectedAnnotations;
+    return cloned as TState;
+  }
+  if (state instanceof Map) {
+    const cloned = new Map(state) as Map<unknown, unknown> & {
+      [annotationKey]?: ReadonlyAnnotations;
+    };
+    cloned[annotationKey] = protectedAnnotations;
+    return cloned as TState;
+  }
+  if (state instanceof Set) {
+    const cloned = new Set(state) as Set<unknown> & {
+      [annotationKey]?: ReadonlyAnnotations;
+    };
+    cloned[annotationKey] = protectedAnnotations;
+    return cloned as TState;
+  }
+  if (state instanceof RegExp) {
+    const cloned = cloneRegExpShape(state) as RegExp & {
+      [annotationKey]?: ReadonlyAnnotations;
+    };
+    cloned[annotationKey] = protectedAnnotations;
+    return cloned as TState;
+  }
+  const proto = Object.getPrototypeOf(state);
+  if (proto === Object.prototype || proto === null) {
+    return {
+      ...(state as Record<PropertyKey, unknown>),
+      [annotationKey]: protectedAnnotations,
+    } as TState;
+  }
+  const cloned = Object.create(
+    proto,
+    Object.getOwnPropertyDescriptors(state as Record<PropertyKey, unknown>),
+  ) as TState & { [annotationKey]?: ReadonlyAnnotations };
+  cloned[annotationKey] = protectedAnnotations;
+  return cloned;
 }
 
 /**
@@ -925,92 +1097,36 @@ export function injectAnnotations<TState>(
   if (!hasMeaningfulAnnotations(annotations)) {
     return state;
   }
-  const protectedAnnotations = protectAnnotationValue(
+  return injectAnnotationsWithContext(
+    state,
     annotations,
     createAnnotationProtectionContext(),
   );
-  if (state == null || typeof state !== "object") {
-    const wrapper: Record<PropertyKey, unknown> = {};
-    Object.defineProperties(wrapper, {
-      [annotationKey]: {
-        value: protectedAnnotations,
-        enumerable: true,
-        writable: true,
-        configurable: true,
-      },
-      // Internal wrapper markers should not be copied by object spread.
-      [annotationStateValueKey]: {
-        value: state,
-        enumerable: false,
-        writable: true,
-        configurable: true,
-      },
-      [annotationWrapperKey]: {
-        value: true,
-        enumerable: false,
-        writable: true,
-        configurable: true,
-      },
-    });
-    injectedAnnotationWrappers.add(wrapper);
-    return wrapper as TState;
-  }
-  if (Array.isArray(state)) {
-    const cloned = [...state];
-    (cloned as typeof cloned & { [annotationKey]?: ReadonlyAnnotations })[
-      annotationKey
-    ] = protectedAnnotations;
-    return cloned as TState;
-  }
-  if (isInjectedAnnotationWrapper(state)) {
-    (
-      state as TState & {
-        [annotationKey]?: ReadonlyAnnotations;
-      }
-    )[annotationKey] = protectedAnnotations;
+}
+
+/**
+ * Injects annotations for a fresh parse run.
+ *
+ * This path re-wraps protected views from previous runs so stateful container
+ * internals remain isolated across parse entrypoints.
+ *
+ * @param state The parser state to annotate.
+ * @param annotations The annotations to inject.
+ * @returns Annotated state for the fresh run.
+ * @internal
+ */
+export function injectFreshRunAnnotations<TState>(
+  state: TState,
+  annotations: AnnotationInput,
+): TState {
+  if (!hasMeaningfulAnnotations(annotations)) {
     return state;
   }
-  if (state instanceof Date) {
-    const cloned = new Date(state.getTime()) as Date & {
-      [annotationKey]?: ReadonlyAnnotations;
-    };
-    cloned[annotationKey] = protectedAnnotations;
-    return cloned as TState;
-  }
-  if (state instanceof Map) {
-    const cloned = new Map(state) as Map<unknown, unknown> & {
-      [annotationKey]?: ReadonlyAnnotations;
-    };
-    cloned[annotationKey] = protectedAnnotations;
-    return cloned as TState;
-  }
-  if (state instanceof Set) {
-    const cloned = new Set(state) as Set<unknown> & {
-      [annotationKey]?: ReadonlyAnnotations;
-    };
-    cloned[annotationKey] = protectedAnnotations;
-    return cloned as TState;
-  }
-  if (state instanceof RegExp) {
-    const cloned = cloneRegExpShape(state) as RegExp & {
-      [annotationKey]?: ReadonlyAnnotations;
-    };
-    cloned[annotationKey] = protectedAnnotations;
-    return cloned as TState;
-  }
-  const proto = Object.getPrototypeOf(state);
-  if (proto === Object.prototype || proto === null) {
-    return {
-      ...(state as Record<PropertyKey, unknown>),
-      [annotationKey]: protectedAnnotations,
-    } as TState;
-  }
-  const cloned = Object.create(
-    proto,
-    Object.getOwnPropertyDescriptors(state as Record<PropertyKey, unknown>),
-  ) as TState & { [annotationKey]?: ReadonlyAnnotations };
-  cloned[annotationKey] = protectedAnnotations;
-  return cloned;
+  return injectAnnotationsWithContext(
+    state,
+    normalizeRunAnnotationInput(annotations),
+    createAnnotationProtectionContext(true),
+  );
 }
 
 /**

--- a/packages/core/src/annotations.ts
+++ b/packages/core/src/annotations.ts
@@ -1129,31 +1129,35 @@ function injectAnnotationsWithContext<TState>(
     return cloned as TState;
   }
   if (isInjectedAnnotationWrapper(state)) {
-    (
-      state as TState & {
-        [annotationKey]?: ReadonlyAnnotations;
-      }
-    )[annotationKey] = protectedAnnotations;
-    return state;
+    const cloned = Object.create(
+      Object.getPrototypeOf(state),
+      Object.getOwnPropertyDescriptors(state as Record<PropertyKey, unknown>),
+    ) as TState & { [annotationKey]?: ReadonlyAnnotations };
+    cloned[annotationKey] = protectedAnnotations;
+    injectedAnnotationWrappers.add(cloned as object);
+    return cloned;
   }
   if (state instanceof Date) {
-    const cloned = new Date(state.getTime()) as Date & {
-      [annotationKey]?: ReadonlyAnnotations;
-    };
+    const cloned = (tryCloneDateSubclass(state) ??
+      new Date(state.getTime())) as Date & {
+        [annotationKey]?: ReadonlyAnnotations;
+      };
     cloned[annotationKey] = protectedAnnotations;
     return cloned as TState;
   }
   if (state instanceof Map) {
-    const cloned = new Map(state) as Map<unknown, unknown> & {
-      [annotationKey]?: ReadonlyAnnotations;
-    };
+    const cloned = (tryCloneMapSubclass(state, state) ??
+      new Map(state)) as Map<unknown, unknown> & {
+        [annotationKey]?: ReadonlyAnnotations;
+      };
     cloned[annotationKey] = protectedAnnotations;
     return cloned as TState;
   }
   if (state instanceof Set) {
-    const cloned = new Set(state) as Set<unknown> & {
-      [annotationKey]?: ReadonlyAnnotations;
-    };
+    const cloned = (tryCloneSetSubclass(state, state) ??
+      new Set(state)) as Set<unknown> & {
+        [annotationKey]?: ReadonlyAnnotations;
+      };
     cloned[annotationKey] = protectedAnnotations;
     return cloned as TState;
   }
@@ -1296,23 +1300,26 @@ export function inheritAnnotations<T>(source: unknown, target: T): T {
     return cloned as T;
   }
   if (target instanceof Date) {
-    const cloned = new Date(target.getTime()) as Date & {
-      [annotationKey]?: ReadonlyAnnotations;
-    };
+    const cloned = (tryCloneDateSubclass(target) ??
+      new Date(target.getTime())) as Date & {
+        [annotationKey]?: ReadonlyAnnotations;
+      };
     cloned[annotationKey] = annotations;
     return cloned as T;
   }
   if (target instanceof Map) {
-    const cloned = new Map(target) as Map<unknown, unknown> & {
-      [annotationKey]?: ReadonlyAnnotations;
-    };
+    const cloned = (tryCloneMapSubclass(target, target) ??
+      new Map(target)) as Map<unknown, unknown> & {
+        [annotationKey]?: ReadonlyAnnotations;
+      };
     cloned[annotationKey] = annotations;
     return cloned as T;
   }
   if (target instanceof Set) {
-    const cloned = new Set(target) as Set<unknown> & {
-      [annotationKey]?: ReadonlyAnnotations;
-    };
+    const cloned = (tryCloneSetSubclass(target, target) ??
+      new Set(target)) as Set<unknown> & {
+        [annotationKey]?: ReadonlyAnnotations;
+      };
     cloned[annotationKey] = annotations;
     return cloned as T;
   }

--- a/packages/core/src/annotations.ts
+++ b/packages/core/src/annotations.ts
@@ -129,6 +129,37 @@ function defineProtectedDataProperty(
   });
 }
 
+function copyRegExpMetadata(
+  source: RegExp,
+  target: RegExp,
+  transformValue?: (value: unknown) => unknown,
+): void {
+  const sourcePrototype = Object.getPrototypeOf(source);
+  if (Object.getPrototypeOf(target) !== sourcePrototype) {
+    Object.setPrototypeOf(target, sourcePrototype);
+  }
+  for (const key of Reflect.ownKeys(source)) {
+    if (key === "lastIndex") continue;
+    const descriptor = Object.getOwnPropertyDescriptor(source, key);
+    if (descriptor == null) continue;
+    if ("value" in descriptor && transformValue != null) {
+      Object.defineProperty(target, key, {
+        ...descriptor,
+        value: transformValue(descriptor.value),
+      });
+      continue;
+    }
+    Object.defineProperty(target, key, descriptor);
+  }
+  target.lastIndex = source.lastIndex;
+}
+
+function cloneRegExpShape<T extends RegExp>(source: T): T {
+  const cloned = new RegExp(source) as T;
+  copyRegExpMetadata(source, cloned);
+  return cloned;
+}
+
 function createProtectedObjectView<T extends object>(
   target: T,
   context: AnnotationProtectionContext,
@@ -436,10 +467,8 @@ function createProtectedRegExpView(
 ): RegExp {
   const methodCache = new Map<PropertyKey, unknown>();
   const cloned = new RegExp(target) as RegExp;
-  cloned.lastIndex = target.lastIndex;
   const view = new Proxy(cloned, {
     get(clonedTarget, key) {
-      const value = Reflect.get(clonedTarget, key, clonedTarget);
       if (key === "compile") {
         return cacheProtectedMethod(
           methodCache,
@@ -447,7 +476,14 @@ function createProtectedRegExpView(
           () => (..._args: unknown[]) => throwReadonlyAnnotationMutation(),
         );
       }
-      return typeof value === "function" ? value.bind(clonedTarget) : value;
+      const ownDescriptor = Object.getOwnPropertyDescriptor(clonedTarget, key);
+      if (ownDescriptor != null && "value" in ownDescriptor) {
+        return ownDescriptor.value;
+      }
+      const value = Reflect.get(clonedTarget, key, clonedTarget);
+      return typeof value === "function"
+        ? value.bind(clonedTarget)
+        : protectAnnotationValue(value, context);
     },
     set() {
       throwReadonlyAnnotationMutation();
@@ -465,7 +501,13 @@ function createProtectedRegExpView(
       throwReadonlyAnnotationMutation();
     },
   });
-  return registerProtectedAnnotationView(context, target, view);
+  registerProtectedAnnotationView(context, target, view);
+  copyRegExpMetadata(
+    target,
+    cloned,
+    (value) => protectAnnotationValue(value, context),
+  );
+  return view;
 }
 
 function createProtectedURLSearchParamsView(
@@ -674,7 +716,7 @@ export interface ParseOptions {
    * Optique treats these values as immutable input and exposes them back to
    * parsers only through protected read-only views.
    */
-  annotations?: Annotations;
+  annotations?: Annotations | ReadonlyAnnotations;
 }
 
 /**
@@ -741,7 +783,9 @@ export function annotateFreshArray<T>(
   if (annotations === undefined) {
     return target;
   }
-  const annotated = target as readonly T[] & { [annotationKey]?: Annotations };
+  const annotated = target as readonly T[] & {
+    [annotationKey]?: ReadonlyAnnotations;
+  };
   annotated[annotationKey] = annotations;
   return annotated as readonly T[];
 }
@@ -771,37 +815,36 @@ export function inheritAnnotations<T>(source: unknown, target: T): T {
   }
   if (Array.isArray(target)) {
     const cloned = [...target];
-    (cloned as typeof cloned & { [annotationKey]?: Annotations })[
+    (cloned as typeof cloned & { [annotationKey]?: ReadonlyAnnotations })[
       annotationKey
     ] = annotations;
     return cloned as T;
   }
   if (target instanceof Date) {
     const cloned = new Date(target.getTime()) as Date & {
-      [annotationKey]?: Annotations;
+      [annotationKey]?: ReadonlyAnnotations;
     };
     cloned[annotationKey] = annotations;
     return cloned as T;
   }
   if (target instanceof Map) {
     const cloned = new Map(target) as Map<unknown, unknown> & {
-      [annotationKey]?: Annotations;
+      [annotationKey]?: ReadonlyAnnotations;
     };
     cloned[annotationKey] = annotations;
     return cloned as T;
   }
   if (target instanceof Set) {
     const cloned = new Set(target) as Set<unknown> & {
-      [annotationKey]?: Annotations;
+      [annotationKey]?: ReadonlyAnnotations;
     };
     cloned[annotationKey] = annotations;
     return cloned as T;
   }
   if (target instanceof RegExp) {
-    const cloned = new RegExp(target) as RegExp & {
-      [annotationKey]?: Annotations;
+    const cloned = cloneRegExpShape(target) as RegExp & {
+      [annotationKey]?: ReadonlyAnnotations;
     };
-    cloned.lastIndex = target.lastIndex;
     cloned[annotationKey] = annotations;
     return cloned as T;
   }
@@ -816,7 +859,7 @@ export function inheritAnnotations<T>(source: unknown, target: T): T {
   const cloned = Object.create(
     Object.getPrototypeOf(target),
     Object.getOwnPropertyDescriptors(target),
-  ) as T & { [annotationKey]?: Annotations };
+  ) as T & { [annotationKey]?: ReadonlyAnnotations };
   cloned[annotationKey] = annotations;
   return cloned;
 }
@@ -895,7 +938,7 @@ export function injectAnnotations<TState>(
   }
   if (Array.isArray(state)) {
     const cloned = [...state];
-    (cloned as typeof cloned & { [annotationKey]?: Annotations })[
+    (cloned as typeof cloned & { [annotationKey]?: ReadonlyAnnotations })[
       annotationKey
     ] = protectedAnnotations;
     return cloned as TState;
@@ -903,37 +946,36 @@ export function injectAnnotations<TState>(
   if (isInjectedAnnotationWrapper(state)) {
     (
       state as TState & {
-        [annotationKey]?: Annotations;
+        [annotationKey]?: ReadonlyAnnotations;
       }
     )[annotationKey] = protectedAnnotations;
     return state;
   }
   if (state instanceof Date) {
     const cloned = new Date(state.getTime()) as Date & {
-      [annotationKey]?: Annotations;
+      [annotationKey]?: ReadonlyAnnotations;
     };
     cloned[annotationKey] = protectedAnnotations;
     return cloned as TState;
   }
   if (state instanceof Map) {
     const cloned = new Map(state) as Map<unknown, unknown> & {
-      [annotationKey]?: Annotations;
+      [annotationKey]?: ReadonlyAnnotations;
     };
     cloned[annotationKey] = protectedAnnotations;
     return cloned as TState;
   }
   if (state instanceof Set) {
     const cloned = new Set(state) as Set<unknown> & {
-      [annotationKey]?: Annotations;
+      [annotationKey]?: ReadonlyAnnotations;
     };
     cloned[annotationKey] = protectedAnnotations;
     return cloned as TState;
   }
   if (state instanceof RegExp) {
-    const cloned = new RegExp(state) as RegExp & {
-      [annotationKey]?: Annotations;
+    const cloned = cloneRegExpShape(state) as RegExp & {
+      [annotationKey]?: ReadonlyAnnotations;
     };
-    cloned.lastIndex = state.lastIndex;
     cloned[annotationKey] = protectedAnnotations;
     return cloned as TState;
   }
@@ -947,7 +989,7 @@ export function injectAnnotations<TState>(
   const cloned = Object.create(
     proto,
     Object.getOwnPropertyDescriptors(state as Record<PropertyKey, unknown>),
-  ) as TState & { [annotationKey]?: Annotations };
+  ) as TState & { [annotationKey]?: ReadonlyAnnotations };
   cloned[annotationKey] = protectedAnnotations;
   return cloned;
 }

--- a/packages/core/src/annotations.ts
+++ b/packages/core/src/annotations.ts
@@ -1037,7 +1037,11 @@ function createProtectedURLView(
   const view = new Proxy(cloned, {
     get(clonedTarget, key) {
       if (key === "valueOf") {
-        return () => view;
+        return cacheProtectedMethod(
+          methodCache,
+          key,
+          () => () => view,
+        );
       }
       if (key === "searchParams") {
         return protectAnnotationValue(clonedTarget.searchParams, context);

--- a/packages/core/src/annotations.ts
+++ b/packages/core/src/annotations.ts
@@ -256,6 +256,21 @@ function tryCloneRegExpSubclass(source: RegExp): RegExp | undefined {
   }
 }
 
+function tryCloneArraySubclass<T>(
+  source: readonly T[],
+): readonly T[] | undefined {
+  const cloneConstructor = resolveCloneConstructor(source as object);
+  if (cloneConstructor == null) {
+    return undefined;
+  }
+  try {
+    const cloned = Reflect.apply(Array.from, cloneConstructor, [source]);
+    return Array.isArray(cloned) ? cloned as readonly T[] : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 function tryCloneURLSearchParamsSubclass(
   source: URLSearchParams,
 ): URLSearchParams | undefined {
@@ -384,10 +399,10 @@ function createProtectedObjectView<T extends object>(
   context: AnnotationProtectionContext,
 ): T {
   if (Array.isArray(target)) {
-    const view = Object.setPrototypeOf(
-      [],
-      Object.getPrototypeOf(target),
-    ) as unknown[];
+    const targetPrototype = Object.getPrototypeOf(target);
+    const view = targetPrototype === Array.prototype || targetPrototype === null
+      ? Object.setPrototypeOf([], targetPrototype) as unknown[]
+      : tryCloneArraySubclass(target) as unknown[] ?? [];
     view.length = target.length;
     registerProtectedAnnotationView(context, target, view);
     for (const key of Reflect.ownKeys(target)) {

--- a/packages/core/src/annotations.ts
+++ b/packages/core/src/annotations.ts
@@ -132,6 +132,15 @@ function getProtectedClonePropertyValue(
   value: unknown,
   context: AnnotationProtectionContext,
 ): unknown {
+  const ownDescriptor = Reflect.getOwnPropertyDescriptor(target, key);
+  if (
+    ownDescriptor != null &&
+    "value" in ownDescriptor &&
+    ownDescriptor.configurable === false &&
+    ownDescriptor.writable === false
+  ) {
+    return ownDescriptor.value;
+  }
   if (typeof value !== "function") {
     return protectAnnotationValue(value, context);
   }

--- a/packages/core/src/completion.test.ts
+++ b/packages/core/src/completion.test.ts
@@ -77,6 +77,45 @@ function isShellAvailable(shell: string): boolean {
   }
 }
 
+let pwshCompletionUsable: boolean | undefined;
+
+function isPwshCompletionUsable(): boolean {
+  if (pwshCompletionUsable !== undefined) {
+    return pwshCompletionUsable;
+  }
+  if (!isShellAvailable("pwsh")) {
+    pwshCompletionUsable = false;
+    return false;
+  }
+
+  const tempDir = mkdtempSync(join(tmpdir(), "pwsh-availability-"));
+
+  try {
+    const scriptPath = join(tempDir, "completion.ps1");
+    writeFileSync(scriptPath, pwsh.generateScript("availability-probe"));
+
+    const pathSep = process.platform === "win32" ? ";" : ":";
+    const testScript = `
+$env:PATH = "${tempDir}${pathSep}$env:PATH"
+. "${scriptPath}"
+Write-Output "loaded"
+`;
+
+    const result = runCommand(
+      "pwsh",
+      ["-NoProfile", "-NonInteractive", "-Command", testScript],
+      { cwd: tempDir },
+    );
+    pwshCompletionUsable = result.trim().includes("loaded");
+    return pwshCompletionUsable;
+  } catch {
+    pwshCompletionUsable = false;
+    return false;
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
 function createTestCli(tempDir: string): string {
   const cliScript = `#!/bin/bash
 case "$1" in
@@ -2092,11 +2131,10 @@ _nohidden_cli 2>/dev/null
       );
     });
 
-    it("should work with actual pwsh shell", (t) => {
-      if (!isShellAvailable("pwsh")) {
-        t.skip("pwsh not available");
-        return;
-      }
+    it("should work with actual pwsh shell", {
+      skip: !isPwshCompletionUsable(),
+    }, () => {
+      if (!isPwshCompletionUsable()) return;
 
       const tempDir = mkdtempSync(join(tmpdir(), "pwsh-completion-"));
 
@@ -2333,11 +2371,10 @@ _nohidden_cli 2>/dev/null
       ok(fileBlock.includes('-split "`t"'));
     });
 
-    it("should parse hidden field correctly with tab-delimited metadata", (t) => {
-      if (!isShellAvailable("pwsh")) {
-        t.skip("pwsh not available");
-        return;
-      }
+    it("should parse hidden field correctly with tab-delimited metadata", {
+      skip: !isPwshCompletionUsable(),
+    }, () => {
+      if (!isPwshCompletionUsable()) return;
 
       const tempDir = mkdtempSync(
         join(tmpdir(), "pwsh-hidden-completion-"),
@@ -2383,12 +2420,12 @@ printf '__FILE__:file:::1\\t[file]\\tConfiguration file\\n'
     });
 
     it("should preserve directory prefix in nested file completions", {
-      skip: process.platform === "win32" || !isShellAvailable("pwsh"),
+      skip: process.platform === "win32" || !isPwshCompletionUsable(),
       timeout: 10000,
     }, () => {
       // Bun ignores the skip option, so we need an early return as well:
       if (process.platform === "win32") return;
-      if (!isShellAvailable("pwsh")) return;
+      if (!isPwshCompletionUsable()) return;
 
       const tempDir = mkdtempSync(
         join(tmpdir(), "pwsh-nested-dir-"),
@@ -2444,11 +2481,11 @@ printf '__FILE__:file::src/:0\\n'
     });
 
     it("should preserve backslash directory prefix on Windows", {
-      skip: process.platform !== "win32" || !isShellAvailable("pwsh"),
+      skip: process.platform !== "win32" || !isPwshCompletionUsable(),
     }, () => {
       // Bun ignores the skip option, so we need an early return as well:
       if (process.platform !== "win32") return;
-      if (!isShellAvailable("pwsh")) return;
+      if (!isPwshCompletionUsable()) return;
 
       const tempDir = mkdtempSync(
         join(tmpdir(), "pwsh-nested-backslash-"),
@@ -2502,12 +2539,12 @@ printf '__FILE__:file::src/:0\\n'
     });
 
     it("should filter files by dot-prefixed extensions in pwsh", {
-      skip: process.platform === "win32" || !isShellAvailable("pwsh"),
+      skip: process.platform === "win32" || !isPwshCompletionUsable(),
       timeout: 10000,
     }, () => {
       // Bun ignores the skip option, so we need an early return as well:
       if (process.platform === "win32") return;
-      if (!isShellAvailable("pwsh")) return;
+      if (!isPwshCompletionUsable()) return;
 
       const tempDir = mkdtempSync(
         join(tmpdir(), "pwsh-ext-dot-filter-"),

--- a/packages/core/src/completion.test.ts
+++ b/packages/core/src/completion.test.ts
@@ -87,10 +87,10 @@ function isPwshCompletionUsable(): boolean {
     pwshCompletionUsable = false;
     return false;
   }
-
-  const tempDir = mkdtempSync(join(tmpdir(), "pwsh-availability-"));
+  let tempDir: string | undefined;
 
   try {
+    tempDir = mkdtempSync(join(tmpdir(), "pwsh-availability-"));
     const scriptPath = join(tempDir, "completion.ps1");
     writeFileSync(scriptPath, pwsh.generateScript("availability-probe"));
 
@@ -112,7 +112,9 @@ Write-Output "loaded"
     pwshCompletionUsable = false;
     return false;
   } finally {
-    rmSync(tempDir, { recursive: true, force: true });
+    if (tempDir !== undefined) {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
   }
 }
 

--- a/packages/core/src/context.test.ts
+++ b/packages/core/src/context.test.ts
@@ -1,4 +1,8 @@
-import type { Annotations } from "@optique/core/annotations";
+import {
+  type Annotations,
+  getAnnotations,
+  injectAnnotations,
+} from "@optique/core/annotations";
 import type {
   SourceContext,
   SourceContextRequest,
@@ -190,6 +194,35 @@ describe("SourceContext", () => {
       };
 
       assert.equal(context.getInternalAnnotations, undefined);
+    });
+
+    it("should allow read-only annotation views through context hooks", () => {
+      const key = Symbol("@test/readonly-context");
+      const seedState = injectAnnotations(undefined, {
+        [key]: { value: 1 },
+      });
+      const readonlyAnnotations = getAnnotations(seedState);
+
+      assert.ok(readonlyAnnotations !== undefined);
+
+      const context: SourceContext = {
+        id: key,
+        phase: "single-pass",
+        getAnnotations() {
+          return readonlyAnnotations;
+        },
+        getInternalAnnotations(_request, annotations) {
+          return annotations;
+        },
+      };
+
+      const annotations = context.getAnnotations();
+
+      assert.equal(annotations, readonlyAnnotations);
+      assert.equal(
+        context.getInternalAnnotations?.({ phase: "phase1" }, annotations),
+        readonlyAnnotations,
+      );
     });
   });
 

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -12,7 +12,7 @@
 
 import type { Annotations } from "./annotations.ts";
 
-export type { Annotations } from "./annotations.ts";
+export type { Annotations, ReadonlyAnnotations } from "./annotations.ts";
 
 /**
  * Declares whether a {@link SourceContext} participates only in the initial

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -10,7 +10,7 @@
  * @since 0.10.0
  */
 
-import type { Annotations } from "./annotations.ts";
+import type { Annotations, ReadonlyAnnotations } from "./annotations.ts";
 
 export type { Annotations, ReadonlyAnnotations } from "./annotations.ts";
 
@@ -224,7 +224,10 @@ export interface SourceContext<TRequiredOptions = void> {
   getAnnotations(
     request?: SourceContextRequest,
     options?: unknown,
-  ): Promise<Annotations> | Annotations;
+  ):
+    | Promise<Annotations | ReadonlyAnnotations>
+    | Annotations
+    | ReadonlyAnnotations;
 
   /**
    * Optional hook to provide additional internal annotations during
@@ -242,8 +245,8 @@ export interface SourceContext<TRequiredOptions = void> {
    */
   getInternalAnnotations?(
     request: SourceContextRequest,
-    annotations: Annotations,
-  ): Annotations | undefined;
+    annotations: Annotations | ReadonlyAnnotations,
+  ): Annotations | ReadonlyAnnotations | undefined;
 
   /**
    * Optional synchronous cleanup method.  Called by `runWith()` and

--- a/packages/core/src/facade.test.ts
+++ b/packages/core/src/facade.test.ts
@@ -10349,7 +10349,10 @@ describe("branch coverage: facade.ts edge cases", () => {
           [context],
           { args: [] },
         ),
-      { name: "TypeError" },
+      {
+        name: "TypeError",
+        message: "Cannot mutate read-only annotation data.",
+      },
     );
     assert.equal(shared.value, 1);
   });
@@ -11962,7 +11965,10 @@ describe("branch coverage: facade.ts edge cases", () => {
           [context],
           { args: [] },
         ),
-      { name: "TypeError" },
+      {
+        name: "TypeError",
+        message: "Cannot mutate read-only annotation data.",
+      },
     );
     assert.equal(shared.value, 1);
   });

--- a/packages/core/src/facade.test.ts
+++ b/packages/core/src/facade.test.ts
@@ -10276,7 +10276,7 @@ describe("branch coverage: facade.ts edge cases", () => {
 
     assert.ok(
       (result as { readonly phase2?: boolean; readonly phase1?: boolean })
-        .phase2 === true,
+        .phase2,
     );
     assert.ok(
       !("phase1" in

--- a/packages/core/src/facade.test.ts
+++ b/packages/core/src/facade.test.ts
@@ -10270,7 +10270,14 @@ describe("branch coverage: facade.ts edge cases", () => {
       args: [],
     });
 
-    assert.equal((result as { readonly phase2?: boolean }).phase2, true);
+    assert.ok(
+      (result as { readonly phase2?: boolean; readonly phase1?: boolean })
+        .phase2 === true,
+    );
+    assert.ok(
+      !("phase1" in
+        (result as { readonly phase2?: boolean; readonly phase1?: boolean })),
+    );
     assert.ok(phase2Called, "phase 2 context should be called");
   });
 
@@ -11876,7 +11883,14 @@ describe("branch coverage: facade.ts edge cases", () => {
       args: [],
     });
 
-    assert.equal((result as { readonly phase2?: boolean }).phase2, true);
+    assert.ok(
+      (result as { readonly phase2?: boolean; readonly phase1?: boolean })
+        .phase2 === true,
+    );
+    assert.ok(
+      !("phase1" in
+        (result as { readonly phase2?: boolean; readonly phase1?: boolean })),
+    );
     assert.ok(phase2Called, "phase 2 context should be called");
   });
 

--- a/packages/core/src/facade.test.ts
+++ b/packages/core/src/facade.test.ts
@@ -7,7 +7,11 @@ import {
   or,
   tuple,
 } from "@optique/core/constructs";
-import { getAnnotations, inheritAnnotations } from "@optique/core/annotations";
+import {
+  getAnnotations,
+  inheritAnnotations,
+  injectAnnotations,
+} from "@optique/core/annotations";
 import type {
   SourceContext,
   SourceContextPhase2Request,
@@ -10357,6 +10361,57 @@ describe("branch coverage: facade.ts edge cases", () => {
     assert.equal(shared.value, 1);
   });
 
+  it("runWith should isolate reused read-only annotations across runs", async () => {
+    const marker = Symbol.for("@test/issue-491/run-with-readonly-reuse");
+    const seedState = injectAnnotations(undefined, { [marker]: /ab+/g });
+    const annotations = getAnnotations(seedState);
+
+    assert.ok(annotations !== undefined);
+
+    const parser: Parser<"sync", number, undefined> = {
+      $mode: "sync",
+      $valueType: [] as const,
+      $stateType: [] as const,
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(),
+      acceptingAnyToken: false,
+      initialState: undefined,
+      parse(context) {
+        return {
+          success: true as const,
+          next: { ...context, buffer: [] },
+          consumed: [],
+        };
+      },
+      complete(state) {
+        const regex = getAnnotations(state)?.[marker] as RegExp | undefined;
+
+        assert.ok(regex !== undefined);
+        assert.ok(regex.test("ab ab"));
+        return { success: true as const, value: regex.lastIndex };
+      },
+      *suggest() {},
+      getDocFragments() {
+        return { fragments: [] };
+      },
+    };
+
+    const context: SourceContext = {
+      id: marker,
+      phase: "single-pass",
+      getAnnotations() {
+        return annotations;
+      },
+    };
+
+    const first = await runWith(parser, "test", [context], { args: [] });
+    const second = await runWith(parser, "test", [context], { args: [] });
+
+    assert.equal(first, 2);
+    assert.equal(second, 2);
+  });
+
   it("runWith: phase two can recover from first-pass completion failure", async () => {
     const tokenKey = Symbol.for("@test/dyn-phase-two-recovery");
     let phase2Parsed: unknown;
@@ -11971,6 +12026,57 @@ describe("branch coverage: facade.ts edge cases", () => {
       },
     );
     assert.equal(shared.value, 1);
+  });
+
+  it("runWithSync should isolate reused read-only annotations across runs", () => {
+    const marker = Symbol.for("@test/issue-491/run-with-sync-readonly-reuse");
+    const seedState = injectAnnotations(undefined, { [marker]: /ab+/g });
+    const annotations = getAnnotations(seedState);
+
+    assert.ok(annotations !== undefined);
+
+    const parser: Parser<"sync", number, undefined> = {
+      $mode: "sync",
+      $valueType: [] as const,
+      $stateType: [] as const,
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(),
+      acceptingAnyToken: false,
+      initialState: undefined,
+      parse(context) {
+        return {
+          success: true as const,
+          next: { ...context, buffer: [] },
+          consumed: [],
+        };
+      },
+      complete(state) {
+        const regex = getAnnotations(state)?.[marker] as RegExp | undefined;
+
+        assert.ok(regex !== undefined);
+        assert.ok(regex.test("ab ab"));
+        return { success: true as const, value: regex.lastIndex };
+      },
+      *suggest() {},
+      getDocFragments() {
+        return { fragments: [] };
+      },
+    };
+
+    const context: SourceContext = {
+      id: marker,
+      phase: "single-pass",
+      getAnnotations() {
+        return annotations;
+      },
+    };
+
+    const first = runWithSync(parser, "test", [context], { args: [] });
+    const second = runWithSync(parser, "test", [context], { args: [] });
+
+    assert.equal(first, 2);
+    assert.equal(second, 2);
   });
 
   it("runWithSync: should reject contexts without explicit phase", () => {

--- a/packages/core/src/facade.test.ts
+++ b/packages/core/src/facade.test.ts
@@ -86,6 +86,40 @@ function getRuntimeExtractPhase2SeedKey(): symbol {
   return key;
 }
 
+function createMutatingAnnotationRunnerParser(
+  marker: symbol,
+): Parser<"sync", number, undefined> {
+  return {
+    $mode: "sync",
+    $valueType: [] as const,
+    $stateType: [] as const,
+    priority: 0,
+    usage: [],
+    leadingNames: new Set(),
+    acceptingAnyToken: false,
+    initialState: undefined,
+    parse(context) {
+      return {
+        success: true as const,
+        next: context,
+        consumed: [],
+      };
+    },
+    complete(state) {
+      const payload = getAnnotations(state)?.[marker] as
+        | { value: number }
+        | undefined;
+      assert.ok(payload != null);
+      payload.value = 2;
+      return { success: true as const, value: payload.value };
+    },
+    *suggest() {},
+    getDocFragments() {
+      return { fragments: [] };
+    },
+  };
+}
+
 describe("runParser", () => {
   describe("basic parsing", () => {
     it("should parse simple arguments", () => {
@@ -10236,7 +10270,7 @@ describe("branch coverage: facade.ts edge cases", () => {
       args: [],
     });
 
-    assert.deepEqual(result, { phase2: true });
+    assert.equal((result as { readonly phase2?: boolean }).phase2, true);
     assert.ok(phase2Called, "phase 2 context should be called");
   });
 
@@ -10287,6 +10321,30 @@ describe("branch coverage: facade.ts edge cases", () => {
     assert.deepEqual(result, {
       config: "optique.json",
     });
+  });
+
+  it("runWith should not let parsers mutate context-owned annotations", async () => {
+    const marker = Symbol.for("@test/issue-491/run-with");
+    const shared = { value: 1 };
+    const context: SourceContext = {
+      id: marker,
+      phase: "single-pass",
+      getAnnotations() {
+        return { [marker]: shared };
+      },
+    };
+
+    await assert.rejects(
+      () =>
+        runWith(
+          createMutatingAnnotationRunnerParser(marker),
+          "test",
+          [context],
+          { args: [] },
+        ),
+      { name: "TypeError" },
+    );
+    assert.equal(shared.value, 1);
   });
 
   it("runWith: phase two can recover from first-pass completion failure", async () => {
@@ -11818,7 +11876,7 @@ describe("branch coverage: facade.ts edge cases", () => {
       args: [],
     });
 
-    assert.deepEqual(result, { phase2: true });
+    assert.equal((result as { readonly phase2?: boolean }).phase2, true);
     assert.ok(phase2Called, "phase 2 context should be called");
   });
 
@@ -11869,6 +11927,30 @@ describe("branch coverage: facade.ts edge cases", () => {
     assert.deepEqual(result, {
       config: "optique.json",
     });
+  });
+
+  it("runWithSync should not let parsers mutate context-owned annotations", () => {
+    const marker = Symbol.for("@test/issue-491/run-with-sync");
+    const shared = { value: 1 };
+    const context: SourceContext = {
+      id: marker,
+      phase: "single-pass",
+      getAnnotations() {
+        return { [marker]: shared };
+      },
+    };
+
+    assert.throws(
+      () =>
+        runWithSync(
+          createMutatingAnnotationRunnerParser(marker),
+          "test",
+          [context],
+          { args: [] },
+        ),
+      { name: "TypeError" },
+    );
+    assert.equal(shared.value, 1);
   });
 
   it("runWithSync: should reject contexts without explicit phase", () => {

--- a/packages/core/src/facade.ts
+++ b/packages/core/src/facade.ts
@@ -57,6 +57,7 @@ import {
   type Annotations,
   injectFreshRunAnnotations,
   isInjectedAnnotationWrapper,
+  type ReadonlyAnnotations,
   unwrapInjectedAnnotationWrapper,
 } from "./annotations.ts";
 import {
@@ -2821,7 +2822,7 @@ async function needsEarlyExitAsync<THelp, TError>(
  * @returns Merged annotations object.
  */
 function mergeAnnotations(
-  annotationsList: readonly Annotations[],
+  annotationsList: readonly (Annotations | ReadonlyAnnotations)[],
 ): Annotations {
   const result: Record<symbol, unknown> = {};
   // Process in reverse order so earlier contexts override later ones
@@ -2837,7 +2838,7 @@ function mergeAnnotations(
 type CollectedPhase1Annotations = {
   readonly annotations: Annotations;
   readonly needsTwoPhase: boolean;
-  readonly snapshots: readonly Annotations[];
+  readonly snapshots: readonly (Annotations | ReadonlyAnnotations)[];
 };
 
 function validateContextPhases(
@@ -2867,8 +2868,8 @@ async function collectPhase1Annotations(
   contexts: readonly SourceContext<unknown>[],
   options?: unknown,
 ): Promise<CollectedPhase1Annotations> {
-  const annotationsList: Annotations[] = [];
-  let snapshots: Annotations[] | undefined;
+  const annotationsList: (Annotations | ReadonlyAnnotations)[] = [];
+  let snapshots: (Annotations | ReadonlyAnnotations)[] | undefined;
 
   for (const context of contexts) {
     const request: SourceContextRequest = { phase: "phase1" };
@@ -2911,13 +2912,13 @@ async function collectPhase1Annotations(
  */
 async function collectFinalAnnotations(
   contexts: readonly SourceContext<unknown>[],
-  phase1Snapshots: readonly Annotations[],
+  phase1Snapshots: readonly (Annotations | ReadonlyAnnotations)[],
   parsed?: unknown,
   options?: unknown,
   deferred?: true,
   deferredKeys?: DeferredMap,
 ): Promise<{ readonly annotations: Annotations }> {
-  const annotationsList: Annotations[] = [];
+  const annotationsList: (Annotations | ReadonlyAnnotations)[] = [];
   const preparedParsed = prepareParsedForContexts(
     parsed,
     deferred,
@@ -2965,8 +2966,8 @@ function collectPhase1AnnotationsSync(
   contexts: readonly SourceContext<unknown>[],
   options?: unknown,
 ): CollectedPhase1Annotations {
-  const annotationsList: Annotations[] = [];
-  let snapshots: Annotations[] | undefined;
+  const annotationsList: (Annotations | ReadonlyAnnotations)[] = [];
+  let snapshots: (Annotations | ReadonlyAnnotations)[] | undefined;
 
   for (const context of contexts) {
     const request: SourceContextRequest = { phase: "phase1" };
@@ -3015,13 +3016,13 @@ function collectPhase1AnnotationsSync(
  */
 function collectFinalAnnotationsSync(
   contexts: readonly SourceContext<unknown>[],
-  phase1Snapshots: readonly Annotations[],
+  phase1Snapshots: readonly (Annotations | ReadonlyAnnotations)[],
   parsed?: unknown,
   options?: unknown,
   deferred?: true,
   deferredKeys?: DeferredMap,
 ): { readonly annotations: Annotations } {
-  const annotationsList: Annotations[] = [];
+  const annotationsList: (Annotations | ReadonlyAnnotations)[] = [];
   const preparedParsed = prepareParsedForContexts(
     parsed,
     deferred,
@@ -3733,7 +3734,7 @@ function injectAnnotationsIntoParser<
   TState,
 >(
   parser: Parser<M, TValue, TState>,
-  annotations: Annotations,
+  annotations: Annotations | ReadonlyAnnotations,
 ): Parser<M, TValue, TState> {
   const newInitialState = injectFreshRunAnnotations(
     parser.initialState,

--- a/packages/core/src/facade.ts
+++ b/packages/core/src/facade.ts
@@ -55,7 +55,7 @@ import {
 import { type DeferredMap, string } from "./valueparser.ts";
 import {
   type Annotations,
-  injectAnnotations,
+  injectFreshRunAnnotations,
   isInjectedAnnotationWrapper,
   unwrapInjectedAnnotationWrapper,
 } from "./annotations.ts";
@@ -3735,7 +3735,7 @@ function injectAnnotationsIntoParser<
   parser: Parser<M, TValue, TState>,
   annotations: Annotations,
 ): Parser<M, TValue, TState> {
-  const newInitialState = injectAnnotations(
+  const newInitialState = injectFreshRunAnnotations(
     parser.initialState,
     annotations,
   ) as TState;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,7 @@ export {
   type Annotations,
   getAnnotations,
   type ParseOptions,
+  type ReadonlyAnnotations,
 } from "./annotations.ts";
 export * from "./completion.ts";
 export * from "./dependency.ts";

--- a/packages/core/src/modifiers.test.ts
+++ b/packages/core/src/modifiers.test.ts
@@ -7517,7 +7517,7 @@ describe("branch coverage: modifiers edge cases", () => {
 
     assert.ok(seenState != null && typeof seenState === "object");
     const marker = Object.getOwnPropertySymbols(annotations)[0];
-    assert.equal(getAnnotations(seenState)?.[marker], true);
+    assert.ok(getAnnotations(seenState)?.[marker] === true);
     assert.equal((seenState as { readonly kind: "value" }).kind, "value");
   });
 
@@ -7556,7 +7556,7 @@ describe("branch coverage: modifiers edge cases", () => {
 
     assert.equal(seenState, wrappedState);
     const marker = Object.getOwnPropertySymbols(annotations)[0];
-    assert.equal(getAnnotations(seenState)?.[marker], true);
+    assert.ok(getAnnotations(seenState)?.[marker] === true);
   });
 
   it("withDefault: transformed complete(undefined) catches callback errors", async () => {

--- a/packages/core/src/modifiers.test.ts
+++ b/packages/core/src/modifiers.test.ts
@@ -7486,7 +7486,8 @@ describe("branch coverage: modifiers edge cases", () => {
   });
 
   it("optional: getSuggestRuntimeNodes preserves outer annotations", () => {
-    const annotations = { [Symbol("annotation")]: true };
+    const marker = Symbol("annotation");
+    const annotations = { [marker]: true };
     let seenState: unknown;
     const inner = {
       $mode: "sync" as const,
@@ -7516,13 +7517,13 @@ describe("branch coverage: modifiers edge cases", () => {
     parser.getSuggestRuntimeNodes?.(state as [unknown], ["root"]);
 
     assert.ok(seenState != null && typeof seenState === "object");
-    const marker = Object.getOwnPropertySymbols(annotations)[0];
     assert.ok(getAnnotations(seenState)?.[marker] === true);
     assert.equal((seenState as { readonly kind: "value" }).kind, "value");
   });
 
   it("withDefault: getSuggestRuntimeNodes preserves object wrapper state", () => {
-    const annotations = { [Symbol("annotation")]: true };
+    const marker = Symbol("annotation");
+    const annotations = { [marker]: true };
     const wrappedState = injectAnnotations(undefined, annotations);
     let seenState: unknown;
     const inner = {
@@ -7555,7 +7556,6 @@ describe("branch coverage: modifiers edge cases", () => {
     );
 
     assert.equal(seenState, wrappedState);
-    const marker = Object.getOwnPropertySymbols(annotations)[0];
     assert.ok(getAnnotations(seenState)?.[marker] === true);
   });
 

--- a/packages/core/src/modifiers.test.ts
+++ b/packages/core/src/modifiers.test.ts
@@ -7516,7 +7516,8 @@ describe("branch coverage: modifiers edge cases", () => {
     parser.getSuggestRuntimeNodes?.(state as [unknown], ["root"]);
 
     assert.ok(seenState != null && typeof seenState === "object");
-    assert.deepEqual(getAnnotations(seenState), annotations);
+    const marker = Object.getOwnPropertySymbols(annotations)[0];
+    assert.equal(getAnnotations(seenState)?.[marker], true);
     assert.equal((seenState as { readonly kind: "value" }).kind, "value");
   });
 
@@ -7554,7 +7555,8 @@ describe("branch coverage: modifiers edge cases", () => {
     );
 
     assert.equal(seenState, wrappedState);
-    assert.deepEqual(getAnnotations(seenState), annotations);
+    const marker = Object.getOwnPropertySymbols(annotations)[0];
+    assert.equal(getAnnotations(seenState)?.[marker], true);
   });
 
   it("withDefault: transformed complete(undefined) catches callback errors", async () => {
@@ -7742,9 +7744,9 @@ describe("shouldDeferCompletion forwarding", () => {
       assert.equal(inner.receivedStates.length, 1);
       const received = inner.receivedStates[0];
       assert.ok(received != null && typeof received === "object");
-      assert.deepEqual(
-        getAnnotations(received as Record<PropertyKey, unknown>),
-        annotations,
+      assert.equal(
+        getAnnotations(received as Record<PropertyKey, unknown>)?.[testCtxKey],
+        "phase1",
       );
     });
 
@@ -7823,9 +7825,9 @@ describe("shouldDeferCompletion forwarding", () => {
       assert.equal(inner.receivedStates.length, 1);
       const received = inner.receivedStates[0];
       assert.ok(received != null && typeof received === "object");
-      assert.deepEqual(
-        getAnnotations(received as Record<PropertyKey, unknown>),
-        annotations,
+      assert.equal(
+        getAnnotations(received as Record<PropertyKey, unknown>)?.[testCtxKey],
+        "phase1",
       );
     });
 

--- a/packages/core/src/parser.test.ts
+++ b/packages/core/src/parser.test.ts
@@ -2505,7 +2505,9 @@ describe("Annotations system", () => {
 
     const annotations = getAnnotations(capturedState);
     assert.ok(annotations !== undefined);
-    assert.deepEqual(annotations[testKey], testData);
+    const injected = annotations[testKey] as { value: number } | undefined;
+    assert.ok(injected !== undefined);
+    assert.equal(injected.value, testData.value);
   });
 
   it("should extract annotations using getAnnotations()", async () => {
@@ -2519,7 +2521,9 @@ describe("Annotations system", () => {
     };
     const annotations1 = getAnnotations(stateWithAnnotations);
     assert.ok(annotations1 !== undefined);
-    assert.deepEqual(annotations1[testKey], testData);
+    const injected = annotations1[testKey] as { foo: string } | undefined;
+    assert.ok(injected !== undefined);
+    assert.equal(injected.foo, testData.foo);
 
     // Test with state without annotations (returns undefined)
     const stateWithoutAnnotations = { someField: "value" };
@@ -2593,9 +2597,18 @@ describe("Annotations system", () => {
     assert.ok(result.success);
     const annotations = getAnnotations(capturedState);
     assert.ok(annotations !== undefined);
-    assert.deepEqual(annotations[key1], data1);
-    assert.deepEqual(annotations[key2], data2);
-    assert.deepEqual(annotations[key3], data3);
+    assert.equal(
+      (annotations[key1] as { pkg1: string } | undefined)?.pkg1,
+      data1.pkg1,
+    );
+    assert.equal(
+      (annotations[key2] as { pkg2: string } | undefined)?.pkg2,
+      data2.pkg2,
+    );
+    assert.equal(
+      (annotations[key3] as { pkg3: string } | undefined)?.pkg3,
+      data3.pkg3,
+    );
   });
 
   it("should support annotations in parseSync()", async () => {
@@ -2658,6 +2671,316 @@ describe("Annotations system", () => {
     const annotations = getAnnotations(capturedState);
     assert.ok(annotations !== undefined);
     assert.equal(annotations[testKey], testData);
+  });
+
+  describe("annotation mutation isolation (issue #491)", () => {
+    function mutateAnnotationPayload(state: unknown, marker: symbol): number {
+      const payload = getAnnotations(state)?.[marker] as
+        | { value: number }
+        | undefined;
+      assert.ok(payload != null);
+      payload.value = 2;
+      return payload.value;
+    }
+
+    function createCompleteMutationSyncParser(
+      marker: symbol,
+    ): Parser<"sync", number, undefined> {
+      return {
+        $mode: "sync",
+        $valueType: [] as const,
+        $stateType: [] as const,
+        priority: 0,
+        usage: [],
+        leadingNames: new Set(),
+        acceptingAnyToken: false,
+        initialState: undefined,
+        parse(context) {
+          return {
+            success: true as const,
+            next: { ...context, buffer: [] },
+            consumed: [],
+          };
+        },
+        complete(state) {
+          return {
+            success: true as const,
+            value: mutateAnnotationPayload(state, marker),
+          };
+        },
+        *suggest() {},
+        getDocFragments() {
+          return { fragments: [] };
+        },
+      };
+    }
+
+    function createCompleteMutationAsyncParser(
+      marker: symbol,
+    ): Parser<"async", number, undefined> {
+      return {
+        $mode: "async",
+        $valueType: [] as const,
+        $stateType: [] as const,
+        priority: 0,
+        usage: [],
+        leadingNames: new Set(),
+        acceptingAnyToken: false,
+        initialState: undefined,
+        parse(context) {
+          return Promise.resolve({
+            success: true as const,
+            next: { ...context, buffer: [] },
+            consumed: [],
+          });
+        },
+        complete(state) {
+          return Promise.resolve({
+            success: true as const,
+            value: mutateAnnotationPayload(state, marker),
+          });
+        },
+        async *suggest() {},
+        getDocFragments() {
+          return { fragments: [] };
+        },
+      };
+    }
+
+    function createSuggestMutationSyncParser(
+      marker: symbol,
+    ): Parser<"sync", number, undefined> {
+      return {
+        $mode: "sync",
+        $valueType: [] as const,
+        $stateType: [] as const,
+        priority: 0,
+        usage: [],
+        leadingNames: new Set(),
+        acceptingAnyToken: false,
+        initialState: undefined,
+        parse(context) {
+          return {
+            success: true as const,
+            next: { ...context, buffer: [] },
+            consumed: [],
+          };
+        },
+        complete() {
+          return { success: true as const, value: 1 };
+        },
+        *suggest(context) {
+          mutateAnnotationPayload(context.state, marker);
+          yield { kind: "literal" as const, text: "ok" };
+        },
+        getDocFragments() {
+          return { fragments: [] };
+        },
+      };
+    }
+
+    function createSuggestMutationAsyncParser(
+      marker: symbol,
+    ): Parser<"async", number, undefined> {
+      return {
+        $mode: "async",
+        $valueType: [] as const,
+        $stateType: [] as const,
+        priority: 0,
+        usage: [],
+        leadingNames: new Set(),
+        acceptingAnyToken: false,
+        initialState: undefined,
+        parse(context) {
+          return Promise.resolve({
+            success: true as const,
+            next: { ...context, buffer: [] },
+            consumed: [],
+          });
+        },
+        complete() {
+          return Promise.resolve({ success: true as const, value: 1 });
+        },
+        async *suggest(context) {
+          mutateAnnotationPayload(context.state, marker);
+          yield { kind: "literal" as const, text: "ok" };
+        },
+        getDocFragments() {
+          return { fragments: [] };
+        },
+      };
+    }
+
+    function createDocMutationSyncParser(
+      marker: symbol,
+    ): Parser<"sync", number, undefined> {
+      return {
+        $mode: "sync",
+        $valueType: [] as const,
+        $stateType: [] as const,
+        priority: 0,
+        usage: [],
+        leadingNames: new Set(),
+        acceptingAnyToken: false,
+        initialState: undefined,
+        parse(context) {
+          return {
+            success: true as const,
+            next: { ...context, buffer: [] },
+            consumed: [],
+          };
+        },
+        complete() {
+          return { success: true as const, value: 1 };
+        },
+        *suggest() {},
+        getDocFragments(state) {
+          if (state.kind === "available") {
+            mutateAnnotationPayload(state.state, marker);
+          }
+          return { fragments: [] };
+        },
+      };
+    }
+
+    function createDocMutationAsyncParser(
+      marker: symbol,
+    ): Parser<"async", number, undefined> {
+      return {
+        $mode: "async",
+        $valueType: [] as const,
+        $stateType: [] as const,
+        priority: 0,
+        usage: [],
+        leadingNames: new Set(),
+        acceptingAnyToken: false,
+        initialState: undefined,
+        parse(context) {
+          return Promise.resolve({
+            success: true as const,
+            next: { ...context, buffer: [] },
+            consumed: [],
+          });
+        },
+        complete() {
+          return Promise.resolve({ success: true as const, value: 1 });
+        },
+        async *suggest() {},
+        getDocFragments(state) {
+          if (state.kind === "available") {
+            mutateAnnotationPayload(state.state, marker);
+          }
+          return { fragments: [] };
+        },
+      };
+    }
+
+    it("parse() should not let custom parsers mutate caller annotations", () => {
+      const marker = Symbol.for("@test/issue-491/parse");
+      const annotations = { [marker]: { value: 1 } };
+
+      assert.throws(
+        () =>
+          parse(createCompleteMutationSyncParser(marker), [], {
+            annotations,
+          }),
+        { name: "TypeError" },
+      );
+      assert.equal(annotations[marker].value, 1);
+    });
+
+    it("parseSync() should not let custom parsers mutate caller annotations", () => {
+      const marker = Symbol.for("@test/issue-491/parse-sync");
+      const annotations = { [marker]: { value: 1 } };
+
+      assert.throws(
+        () =>
+          parseSync(createCompleteMutationSyncParser(marker), [], {
+            annotations,
+          }),
+        { name: "TypeError" },
+      );
+      assert.equal(annotations[marker].value, 1);
+    });
+
+    it("parseAsync() should not let custom parsers mutate caller annotations", async () => {
+      const marker = Symbol.for("@test/issue-491/parse-async");
+      const annotations = { [marker]: { value: 1 } };
+
+      await assert.rejects(
+        () =>
+          parseAsync(createCompleteMutationAsyncParser(marker), [], {
+            annotations,
+          }),
+        { name: "TypeError" },
+      );
+      assert.equal(annotations[marker].value, 1);
+    });
+
+    it("suggestSync() should not let custom parsers mutate caller annotations", () => {
+      const marker = Symbol.for("@test/issue-491/suggest-sync");
+      const annotations = { [marker]: { value: 1 } };
+
+      assert.throws(
+        () =>
+          suggestSync(createSuggestMutationSyncParser(marker), [""], {
+            annotations,
+          }),
+        { name: "TypeError" },
+      );
+      assert.equal(annotations[marker].value, 1);
+    });
+
+    it("suggestAsync() should not let custom parsers mutate caller annotations", async () => {
+      const marker = Symbol.for("@test/issue-491/suggest-async");
+      const annotations = { [marker]: { value: 1 } };
+
+      await assert.rejects(
+        () =>
+          suggestAsync(createSuggestMutationAsyncParser(marker), [""], {
+            annotations,
+          }),
+        { name: "TypeError" },
+      );
+      assert.equal(annotations[marker].value, 1);
+    });
+
+    it("getDocPage() should not let custom parsers mutate caller annotations", () => {
+      const marker = Symbol.for("@test/issue-491/doc");
+      const annotations = { [marker]: { value: 1 } };
+
+      assert.throws(
+        () => getDocPage(createDocMutationSyncParser(marker), { annotations }),
+        { name: "TypeError" },
+      );
+      assert.equal(annotations[marker].value, 1);
+    });
+
+    it("getDocPageSync() should not let custom parsers mutate caller annotations", () => {
+      const marker = Symbol.for("@test/issue-491/doc-sync");
+      const annotations = { [marker]: { value: 1 } };
+
+      assert.throws(
+        () =>
+          getDocPageSync(createDocMutationSyncParser(marker), { annotations }),
+        { name: "TypeError" },
+      );
+      assert.equal(annotations[marker].value, 1);
+    });
+
+    it("getDocPageAsync() should not let custom parsers mutate caller annotations", async () => {
+      const marker = Symbol.for("@test/issue-491/doc-async");
+      const annotations = { [marker]: { value: 1 } };
+
+      await assert.rejects(
+        () =>
+          getDocPageAsync(createDocMutationAsyncParser(marker), {
+            annotations,
+          }),
+        { name: "TypeError" },
+      );
+      assert.equal(annotations[marker].value, 1);
+    });
   });
 
   it("should parseAsync or() with annotations on the initial state", async () => {
@@ -2753,7 +3076,13 @@ describe("Annotations system", () => {
 
     assert.ok(result.success);
     if (result.success) {
-      assert.deepEqual(result.value, value);
+      const actual = result.value as typeof value;
+      assert.ok(actual.ok);
+      assert.equal(actual[annotationStateValueKey], "not-wrapper");
+      assert.equal(
+        (actual[annotationKey] as Record<symbol, unknown>)[testKey],
+        "value",
+      );
     }
   });
 
@@ -2776,7 +3105,14 @@ describe("Annotations system", () => {
 
     assert.ok(result.success);
     if (result.success) {
-      assert.deepEqual(result.value, value);
+      const actual = result.value as typeof value;
+      assert.ok(actual.ok);
+      assert.equal(actual[annotationStateValueKey], "not-wrapper");
+      assert.equal(actual[annotationWrapperKey], false);
+      assert.equal(
+        (actual[annotationKey] as Record<symbol, unknown>)[testKey],
+        "value",
+      );
     }
   });
 
@@ -2799,7 +3135,14 @@ describe("Annotations system", () => {
 
     assert.ok(result.success);
     if (result.success) {
-      assert.deepEqual(result.value, value);
+      const actual = result.value as typeof value;
+      assert.ok(actual.ok);
+      assert.equal(actual[annotationStateValueKey], "not-injected");
+      assert.equal(actual[annotationWrapperKey], true);
+      assert.equal(
+        (actual[annotationKey] as Record<symbol, unknown>)[testKey],
+        "value",
+      );
     }
   });
 

--- a/packages/core/src/parser.test.ts
+++ b/packages/core/src/parser.test.ts
@@ -2579,6 +2579,50 @@ describe("Annotations system", () => {
     assert.ok(result.success);
   });
 
+  it("should isolate reused read-only annotations across parse runs", () => {
+    const marker = Symbol.for("@test/readonly-parse-options-isolation");
+    const seedState = injectAnnotations(undefined, { [marker]: /ab+/g });
+    const annotations = getAnnotations(seedState);
+
+    assert.ok(annotations !== undefined);
+
+    const parser: Parser<"sync", number, undefined> = {
+      $mode: "sync",
+      $valueType: [] as const,
+      $stateType: [] as const,
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(),
+      acceptingAnyToken: false,
+      initialState: undefined,
+      parse(context) {
+        return {
+          success: true as const,
+          next: { ...context, buffer: [] },
+          consumed: [],
+        };
+      },
+      complete(state) {
+        const regex = getAnnotations(state)?.[marker] as RegExp | undefined;
+        assert.ok(regex !== undefined);
+        assert.ok(regex.test("ab ab"));
+        return { success: true as const, value: regex.lastIndex };
+      },
+      *suggest() {},
+      getDocFragments() {
+        return { fragments: [] };
+      },
+    };
+
+    const first = parse(parser, [], { annotations });
+    const second = parse(parser, [], { annotations });
+
+    assert.ok(first.success);
+    assert.ok(second.success);
+    assert.equal(first.value, 2);
+    assert.equal(second.value, 2);
+  });
+
   it("should support multiple annotation keys", async () => {
     const key1 = Symbol.for("@package1/data");
     const key2 = Symbol.for("@package2/data");

--- a/packages/core/src/parser.test.ts
+++ b/packages/core/src/parser.test.ts
@@ -2623,6 +2623,63 @@ describe("Annotations system", () => {
     assert.equal(second.value, 2);
   });
 
+  it("should isolate nested reused read-only annotations across parse runs", () => {
+    const innerMarker = Symbol.for(
+      "@test/readonly-parse-options-nested-isolation/inner",
+    );
+    const outerMarker = Symbol.for(
+      "@test/readonly-parse-options-nested-isolation/outer",
+    );
+    const seedState = injectAnnotations(undefined, { [innerMarker]: /ab+/g });
+    const protectedAnnotations = getAnnotations(seedState);
+
+    assert.ok(protectedAnnotations !== undefined);
+
+    const annotations = {
+      [outerMarker]: {
+        regex: protectedAnnotations[innerMarker],
+      },
+    };
+
+    const parser: Parser<"sync", number, undefined> = {
+      $mode: "sync",
+      $valueType: [] as const,
+      $stateType: [] as const,
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(),
+      acceptingAnyToken: false,
+      initialState: undefined,
+      parse(context) {
+        return {
+          success: true as const,
+          next: { ...context, buffer: [] },
+          consumed: [],
+        };
+      },
+      complete(state) {
+        const payload = getAnnotations(state)?.[outerMarker] as
+          | { regex: RegExp }
+          | undefined;
+        assert.ok(payload !== undefined);
+        assert.ok(payload.regex.test("ab ab"));
+        return { success: true as const, value: payload.regex.lastIndex };
+      },
+      *suggest() {},
+      getDocFragments() {
+        return { fragments: [] };
+      },
+    };
+
+    const first = parse(parser, [], { annotations });
+    const second = parse(parser, [], { annotations });
+
+    assert.ok(first.success);
+    assert.ok(second.success);
+    assert.equal(first.value, 2);
+    assert.equal(second.value, 2);
+  });
+
   it("should support multiple annotation keys", async () => {
     const key1 = Symbol.for("@package1/data");
     const key2 = Symbol.for("@package2/data");

--- a/packages/core/src/parser.test.ts
+++ b/packages/core/src/parser.test.ts
@@ -34,6 +34,7 @@ import {
 import { dependency, deriveFromSync } from "@optique/core/dependency";
 import {
   getAnnotations,
+  injectAnnotations,
   isInjectedAnnotationWrapper,
   type ParseOptions,
 } from "@optique/core/annotations";
@@ -2564,6 +2565,18 @@ describe("Annotations system", () => {
     if (result.success) {
       assert.equal(result.value, true);
     }
+  });
+
+  it("should accept read-only annotations from getAnnotations() in ParseOptions", () => {
+    const marker = Symbol.for("@test/readonly-parse-options");
+    const injectedState = injectAnnotations(undefined, {
+      [marker]: { value: 1 },
+    });
+    const annotations = getAnnotations(injectedState);
+
+    assert.ok(annotations !== undefined);
+    const result = parse(constant("ok"), [], { annotations });
+    assert.ok(result.success);
   });
 
   it("should support multiple annotation keys", async () => {

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -19,6 +19,7 @@ import {
   hasMeaningfulAnnotations,
   injectAnnotations,
   isInjectedAnnotationWrapper,
+  normalizeRunAnnotationInput,
   type ParseOptions,
   unwrapInjectedAnnotationWrapper,
 } from "./annotations.ts";
@@ -838,7 +839,7 @@ function injectAnnotationsIntoState<TState>(
   if (!hasMeaningfulAnnotations(annotations)) {
     return state;
   }
-  return injectAnnotations(state, annotations);
+  return injectAnnotations(state, normalizeRunAnnotationInput(annotations));
 }
 
 /**

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -17,9 +17,8 @@ import {
 import type { DeferredMap, ValueParserResult } from "./valueparser.ts";
 import {
   hasMeaningfulAnnotations,
-  injectAnnotations,
+  injectFreshRunAnnotations,
   isInjectedAnnotationWrapper,
-  normalizeRunAnnotationInput,
   type ParseOptions,
   unwrapInjectedAnnotationWrapper,
 } from "./annotations.ts";
@@ -839,7 +838,7 @@ function injectAnnotationsIntoState<TState>(
   if (!hasMeaningfulAnnotations(annotations)) {
     return state;
   }
-  return injectAnnotations(state, normalizeRunAnnotationInput(annotations));
+  return injectFreshRunAnnotations(state, annotations);
 }
 
 /**


### PR DESCRIPTION
This PR fixes annotation isolation across Optique’s public parser entrypoints and runner-driven context injection. Before this change, caller-supplied or context-supplied annotation objects could be exposed by reference through `getAnnotations(state)`, which meant a custom parser could mutate data that it did not own. That behavior was reproducible through `parse()`, `parseSync()`, `parseAsync()`, `suggest()`, `suggestSync()`, `suggestAsync()`, `getDocPage()`, `getDocPageSync()`, `getDocPageAsync()`, `runWith()`, and `runWithSync()`. This PR closes that gap by moving the fix to the shared annotation boundary instead of patching individual parser families.

The core change is in *packages/core/src/annotations.ts*. Annotations are now exposed through protected read-only views owned by the current parse run. `getAnnotations()` returns `ReadonlyAnnotations`, and supported nested container values such as plain objects, arrays, `Map`, `Set`, `Date`, `RegExp`, `URL`, and `URLSearchParams` are surfaced through memoized protected views that fail fast on ordinary mutation attempts with `TypeError`. This preserves the existing “annotations as runtime context” model for live objects and functions, while preventing low-level parsers from mutating caller-owned annotation payloads through parser state.

This PR also expands regression coverage around the issue. *packages/core/src/parser.test.ts* now verifies that custom parsers cannot mutate caller-owned annotations through the public parser and documentation entrypoints. *packages/core/src/facade.test.ts* adds the equivalent coverage for runner-collected context annotations. *packages/core/src/annotations.test.ts* adds focused unit coverage for the new protection layer, including stable view reuse and mutation failures for representative container types. Existing tests that previously assumed raw object identity have been updated to assert the new read-only-view contract instead.

The public API and docs were updated to match the new behavior. *packages/core/src/index.ts* now re-exports `ReadonlyAnnotations`, *packages/core/src/context.ts* re-exports the readonly type for context consumers, *docs/concepts/extend.md* now documents `getAnnotations()` as returning a protected read-only view, and *CHANGES.md* includes a changelog entry for this fix. The docs now make the contract explicit: supported mutation attempts fail fast, while opaque live objects remain reference-preserving and keep their own runtime behavior.

While validating the change, I also tightened the verification workflow in this workspace. *mise.toml* now runs the top-level test workflow sequentially instead of depending on parallel subtask expansion, which avoids misleading aggregate failures during local verification. In addition, *packages/core/src/completion.test.ts* now skips PowerShell completion integration checks when `pwsh` is present but cannot actually load the generated completion script in the current environment. That keeps `mise test` stable without weakening the normal completion coverage.

A minimal example of the new behavior looks like this:

```typescript
const marker = Symbol.for("@test/marker");
const annotations = { [marker]: { value: 1 } };

const seen = getAnnotations(injectAnnotations(undefined, annotations));
(seen?.[marker] as { value: number }).value = 2; // TypeError
```

Fixes https://github.com/dahlia/optique/issues/491

## Verification

`mise test` now passes on this branch.

`pnpm build` in *docs/* also passes.