### PR TITLE
Honor hidden `option()` terms in duplicate checks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,7 @@ To be released.
     options in `object()`, `tuple()`, `merge()`, and wrapped `group()`
     parsers. Hidden options still consume CLI syntax, so hidden-visible
     and hidden-hidden collisions now throw `DuplicateOptionError` during
-    parser construction by default. [[#510]]
+    parser construction by default. [[#510], [#788]]
 
  -  Replaced the sentinel-based two-pass `SourceContext` contract with an
     explicit `SourceContextRequest` object. `getAnnotations()` and
@@ -1688,6 +1688,7 @@ To be released.
 [#783]: https://github.com/dahlia/optique/pull/783
 [#784]: https://github.com/dahlia/optique/pull/784
 [#786]: https://github.com/dahlia/optique/pull/786
+[#788]: https://github.com/dahlia/optique/pull/788
 
 ### @optique/config
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,12 @@ To be released.
 
 ### @optique/core
 
+ -  Fixed duplicate option-name validation to include `hidden: true`
+    options in `object()`, `tuple()`, `merge()`, and wrapped `group()`
+    parsers. Hidden options still consume CLI syntax, so hidden-visible
+    and hidden-hidden collisions now throw `DuplicateOptionError` during
+    parser construction by default. [[#510]]
+
  -  Replaced the sentinel-based two-pass `SourceContext` contract with an
     explicit `SourceContextRequest` object. `getAnnotations()` and
     `getInternalAnnotations()` now receive `phase: "phase1"` / `"phase2"`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1509,6 +1509,7 @@ To be released.
 [#507]: https://github.com/dahlia/optique/issues/507
 [#508]: https://github.com/dahlia/optique/issues/508
 [#509]: https://github.com/dahlia/optique/issues/509
+[#510]: https://github.com/dahlia/optique/issues/510
 [#512]: https://github.com/dahlia/optique/pull/512
 [#513]: https://github.com/dahlia/optique/issues/513
 [#516]: https://github.com/dahlia/optique/issues/516

--- a/docs/concepts/constructs.md
+++ b/docs/concepts/constructs.md
@@ -1916,8 +1916,7 @@ const parser = object({
   verbose: option("-v", "--verbose"),
   version: option("-v", "--version"),  // Duplicate: -v
 });
-// Error: Duplicate option name `-v` found in fields: "verbose", "version".
-// Each option name must be unique within a parser combinator.
+// Throws DuplicateOptionError because both fields use -v.
 ~~~~
 
 This applies to nested structures as well:
@@ -1946,8 +1945,8 @@ const parser = object({
   legacy: option("--output", string(), { hidden: true }),
   current: option("--output", string()),
 });
-// Error: Duplicate option name `--output` found in fields: "legacy",
-// "current". Hidden options still participate in parsing.
+// Throws DuplicateOptionError because both fields use --output.
+// Hidden options still participate in parsing.
 ~~~~
 
 ### Allowed duplicates in `or()`

--- a/docs/concepts/constructs.md
+++ b/docs/concepts/constructs.md
@@ -1924,7 +1924,6 @@ This applies to nested structures as well:
 
 ~~~~ typescript twoslash
 import { object, option } from "@optique/core";
-import { parse } from "@optique/core/parser";
 // ---cut-before---
 // ❌ Nested duplicate detected
 const parser = object({

--- a/docs/concepts/constructs.md
+++ b/docs/concepts/constructs.md
@@ -1899,7 +1899,9 @@ Duplicate option detection
 
 Optique automatically detects and prevents duplicate option names within parser
 combinators to avoid ambiguous behavior. When the same option name appears in
-multiple fields or parsers, an error is raised at parse time.
+multiple fields or parsers, parser construction throws an error before parsing
+begins. This check includes `hidden: true` options because hidden options still
+consume the same command-line syntax.
 
 ### Detected duplicates
 
@@ -1908,17 +1910,14 @@ are unique across their child parsers:
 
 ~~~~ typescript twoslash
 import { object, option } from "@optique/core";
-import { parse } from "@optique/core/parser";
 // ---cut-before---
-// ❌ This will error - duplicate "-v" option
+// ❌ This throws while constructing the parser
 const parser = object({
   verbose: option("-v", "--verbose"),
   version: option("-v", "--version"),  // Duplicate: -v
 });
-
-const result = parse(parser, ["-v"]);
-// Error: Duplicate option name `-v` found in fields: "verbose" "version".
-//        Each option name must be unique within a parser combinator.
+// Error: Duplicate option name `-v` found in fields: "verbose", "version".
+// Each option name must be unique within a parser combinator.
 ~~~~
 
 This applies to nested structures as well:
@@ -1936,6 +1935,20 @@ const parser = object({
     version: option("-v"),  // Duplicate across nested objects
   }),
 });
+~~~~
+
+Hidden options are checked the same way:
+
+~~~~ typescript twoslash
+import { object, option } from "@optique/core";
+import { string } from "@optique/core/valueparser";
+// ---cut-before---
+const parser = object({
+  legacy: option("--output", string(), { hidden: true }),
+  current: option("--output", string()),
+});
+// Error: Duplicate option name `--output` found in fields: "legacy",
+// "current". Hidden options still participate in parsing.
 ~~~~
 
 ### Allowed duplicates in `or()`

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -1885,7 +1885,9 @@ Hidden and deprecated options
 As CLIs evolve, you may need to deprecate old options while maintaining
 backward compatibility, or add internal debugging options that shouldn't
 appear in user-facing documentation. The `hidden` option lets you keep
-parsers functional while controlling visibility:
+parsers functional while controlling visibility. Hidden options still consume
+input normally, so they also still participate in duplicate option-name
+validation:
 
  -  `hidden: true`: hide from usage, help entries, completions, and
     “Did you mean?” suggestions
@@ -1920,6 +1922,10 @@ const parser = object({
 
 This approach ensures existing scripts using `--out` continue to work
 while new users learn the preferred `--output` form.
+
+If you keep a hidden legacy option, it still reserves that option name inside
+the same combinator. A visible parser using the same name is still treated as a
+duplicate unless you explicitly opt out with `allowDuplicates: true`.
 
 ### Internal debugging options
 

--- a/packages/core/src/constructs.test.ts
+++ b/packages/core/src/constructs.test.ts
@@ -3423,6 +3423,40 @@ describe("object() - duplicate option detection", () => {
     );
   });
 
+  it("should throw at construction time for hidden-visible collisions", () => {
+    assert.throws(
+      () =>
+        object({
+          legacy: option("--dup", string(), { hidden: true }),
+          current: option("--dup", string()),
+        }),
+      (error: DuplicateOptionError) => {
+        assert.ok(error instanceof DuplicateOptionError);
+        assert.equal(error.optionName, "--dup");
+        assert.ok(error.sources.includes("legacy"));
+        assert.ok(error.sources.includes("current"));
+        return true;
+      },
+    );
+  });
+
+  it("should throw at construction time for fully hidden duplicates", () => {
+    assert.throws(
+      () =>
+        object({
+          alpha: option("--dup", string(), { hidden: true }),
+          beta: option("--dup", string(), { hidden: true }),
+        }),
+      (error: DuplicateOptionError) => {
+        assert.ok(error instanceof DuplicateOptionError);
+        assert.equal(error.optionName, "--dup");
+        assert.ok(error.sources.includes("alpha"));
+        assert.ok(error.sources.includes("beta"));
+        return true;
+      },
+    );
+  });
+
   it("should throw at construction time for duplicates across 3+ fields", () => {
     assert.throws(
       () =>
@@ -3454,6 +3488,15 @@ describe("object() - duplicate option detection", () => {
       assert.equal(result.value.verbose, true);
       assert.equal(result.value.output, "file.txt");
     }
+  });
+
+  it("should allow hidden duplicates when allowDuplicates is true", () => {
+    assert.doesNotThrow(() =>
+      object({
+        internal: flag("--dup", { hidden: true }),
+        current: flag("--dup"),
+      }, { allowDuplicates: true })
+    );
   });
 
   it("should throw at construction time for duplicates in nested objects", () => {
@@ -4461,6 +4504,23 @@ describe("tuple() - duplicate option detection", () => {
       (error: DuplicateOptionError) => {
         assert.ok(error instanceof DuplicateOptionError);
         assert.equal(error.optionName, "-v");
+        assert.ok(error.sources.includes("0"));
+        assert.ok(error.sources.includes("1"));
+        return true;
+      },
+    );
+  });
+
+  it("should throw at construction time for hidden-visible collisions", () => {
+    assert.throws(
+      () =>
+        tuple([
+          option("--dup", string(), { hidden: true }),
+          option("--dup", string()),
+        ]),
+      (error: DuplicateOptionError) => {
+        assert.ok(error instanceof DuplicateOptionError);
+        assert.equal(error.optionName, "--dup");
         assert.ok(error.sources.includes("0"));
         assert.ok(error.sources.includes("1"));
         return true;
@@ -6444,6 +6504,24 @@ describe("merge() - duplicate option detection", () => {
       (error: DuplicateOptionError) => {
         assert.ok(error instanceof DuplicateOptionError);
         assert.equal(error.optionName, "-v");
+        return true;
+      },
+    );
+  });
+
+  it("should throw at construction time for hidden-visible collisions", () => {
+    const parser1 = object({
+      legacy: option("--dup", string(), { hidden: true }),
+    });
+    const parser2 = object({
+      current: option("--dup", string()),
+    });
+
+    assert.throws(
+      () => merge(parser1, parser2),
+      (error: DuplicateOptionError) => {
+        assert.ok(error instanceof DuplicateOptionError);
+        assert.equal(error.optionName, "--dup");
         return true;
       },
     );

--- a/packages/core/src/constructs.test.ts
+++ b/packages/core/src/constructs.test.ts
@@ -3499,6 +3499,23 @@ describe("object() - duplicate option detection", () => {
     );
   });
 
+  it("should throw at construction time for group-hidden collisions", () => {
+    assert.throws(
+      () =>
+        object({
+          legacy: group("Legacy", option("--dup", string()), { hidden: true }),
+          current: option("--dup", string()),
+        }),
+      (error: DuplicateOptionError) => {
+        assert.ok(error instanceof DuplicateOptionError);
+        assert.equal(error.optionName, "--dup");
+        assert.ok(error.sources.includes("legacy"));
+        assert.ok(error.sources.includes("current"));
+        return true;
+      },
+    );
+  });
+
   it("should throw at construction time for duplicates in nested objects", () => {
     assert.throws(
       () =>
@@ -4516,6 +4533,40 @@ describe("tuple() - duplicate option detection", () => {
       () =>
         tuple([
           option("--dup", string(), { hidden: true }),
+          option("--dup", string()),
+        ]),
+      (error: DuplicateOptionError) => {
+        assert.ok(error instanceof DuplicateOptionError);
+        assert.equal(error.optionName, "--dup");
+        assert.ok(error.sources.includes("0"));
+        assert.ok(error.sources.includes("1"));
+        return true;
+      },
+    );
+  });
+
+  it("should throw at construction time for fully hidden duplicates", () => {
+    assert.throws(
+      () =>
+        tuple([
+          option("--dup", string(), { hidden: true }),
+          option("--dup", string(), { hidden: true }),
+        ]),
+      (error: DuplicateOptionError) => {
+        assert.ok(error instanceof DuplicateOptionError);
+        assert.equal(error.optionName, "--dup");
+        assert.ok(error.sources.includes("0"));
+        assert.ok(error.sources.includes("1"));
+        return true;
+      },
+    );
+  });
+
+  it("should throw at construction time for group-hidden collisions", () => {
+    assert.throws(
+      () =>
+        tuple([
+          group("Legacy", option("--dup", string()), { hidden: true }),
           option("--dup", string()),
         ]),
       (error: DuplicateOptionError) => {
@@ -6522,6 +6573,52 @@ describe("merge() - duplicate option detection", () => {
       (error: DuplicateOptionError) => {
         assert.ok(error instanceof DuplicateOptionError);
         assert.equal(error.optionName, "--dup");
+        assert.ok(error.sources.includes("0"));
+        assert.ok(error.sources.includes("1"));
+        return true;
+      },
+    );
+  });
+
+  it("should throw at construction time for fully hidden duplicates", () => {
+    const parser1 = object({
+      alpha: option("--dup", string(), { hidden: true }),
+    });
+    const parser2 = object({
+      beta: option("--dup", string(), { hidden: true }),
+    });
+
+    assert.throws(
+      () => merge(parser1, parser2),
+      (error: DuplicateOptionError) => {
+        assert.ok(error instanceof DuplicateOptionError);
+        assert.equal(error.optionName, "--dup");
+        assert.ok(error.sources.includes("0"));
+        assert.ok(error.sources.includes("1"));
+        return true;
+      },
+    );
+  });
+
+  it("should throw at construction time for group-hidden collisions", () => {
+    const parser1 = group(
+      "Legacy",
+      object({
+        legacy: option("--dup", string()),
+      }),
+      { hidden: true },
+    );
+    const parser2 = object({
+      current: option("--dup", string()),
+    });
+
+    assert.throws(
+      () => merge(parser1, parser2),
+      (error: DuplicateOptionError) => {
+        assert.ok(error instanceof DuplicateOptionError);
+        assert.equal(error.optionName, "--dup");
+        assert.ok(error.sources.includes("0"));
+        assert.ok(error.sources.includes("1"));
         return true;
       },
     );

--- a/packages/core/src/constructs.ts
+++ b/packages/core/src/constructs.ts
@@ -1041,7 +1041,7 @@ function checkDuplicateOptionNames(
   const optionNameSources = new Map<string, (string | symbol)[]>();
 
   for (const [source, usage] of parserSources) {
-    const names = extractOptionNames(usage);
+    const names = extractParsableOptionNames(usage);
     for (const name of names) {
       if (!optionNameSources.has(name)) {
         optionNameSources.set(name, []);
@@ -1056,6 +1056,17 @@ function checkDuplicateOptionNames(
       throw new DuplicateOptionError(name, sources);
     }
   }
+}
+
+/**
+ * Extracts option names that participate in CLI syntax.
+ *
+ * Constructor-time collision checks must include fully hidden options because
+ * `hidden: true` only removes user-facing visibility. It does not remove the
+ * option from the accepted input grammar.
+ */
+function extractParsableOptionNames(usage: Usage): Set<string> {
+  return extractOptionNames(usage, true);
 }
 
 /**
@@ -4559,7 +4570,8 @@ export interface ObjectOptions {
 
   /**
    * When `true`, allows duplicate option names across different fields.
-   * By default (`false`), duplicate option names will cause a parse error.
+   * By default (`false`), duplicate option names cause a construction-time
+   * error.
    *
    * @default `false`
    * @since 0.7.0
@@ -6753,7 +6765,8 @@ export function object<
 export interface TupleOptions {
   /**
    * When `true`, allows duplicate option names across different parsers.
-   * By default (`false`), duplicate option names will cause a parse error.
+   * By default (`false`), duplicate option names cause a construction-time
+   * error.
    *
    * @default `false`
    * @since 0.7.0
@@ -8132,7 +8145,8 @@ type ExtractObjectTypes<P> = P extends Parser<Mode, infer V, unknown>
 export interface MergeOptions {
   /**
    * When `true`, allows duplicate option names across merged parsers.
-   * By default (`false`), duplicate option names will cause a parse error.
+   * By default (`false`), duplicate option names cause a construction-time
+   * error.
    *
    * @default `false`
    * @since 0.7.0


### PR DESCRIPTION
Fixes https://github.com/dahlia/optique/issues/510

This fixes a gap in constructor-time duplicate option validation for `object()`, `tuple()`, and `merge()`. Hidden options were still part of the accepted CLI grammar, but the duplicate-name check was reusing a visibility-filtered extractor, so collisions involving `hidden: true` terms were silently accepted. That allowed a hidden option to compete for the same runtime syntax as a visible option even though the combinator was supposed to reject ambiguous option names up front.

The implementation in *packages/core/src/constructs.ts* now routes constructor-time duplicate validation through a syntax-oriented helper that includes fully hidden option names. This keeps the user-facing visibility behavior unchanged. Hidden options are still omitted from help text, usage output, completion, and suggestion flows unless a caller explicitly opts into hidden terms. The change is scoped to duplicate detection only.

The regression coverage in *packages/core/src/constructs.test.ts* now covers hidden-visible and hidden-hidden collisions in `object()`, `tuple()`, and `merge()`, and it also keeps `allowDuplicates: true` as the explicit escape hatch.

For example, this now fails immediately when the parser is constructed:

~~~~ typescript
const parser = object({
  legacy: option("--output", string(), { hidden: true }),
  current: option("--output", string()),
});
~~~~

The docs in *docs/concepts/constructs.md* and *docs/cookbook.md* now describe duplicate detection as a construction-time check and make it explicit that `hidden: true` affects visibility, not whether an option reserves CLI syntax. Because this is a user-visible behavior change relative to earlier releases, *CHANGES.md* has been updated as well.

I ran `mise test`, `cd docs && pnpm build`, and `deno task hongdown --check`.