### PR TITLE
Preserve delegated annotations in `optional()` and `withDefault()`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -995,6 +995,15 @@ To be released.
     `bindConfig()` from resolving config values through wrapper combinators.
     [[#385], [#535]]
 
+ -  Fixed `optional()` and `withDefault()` still dropping outer annotations
+    for primitive and non-plain object inner states during `complete()` and
+    `shouldDeferCompletion()`. Primitive inner states now use the same
+    internal annotation carrier path as other annotation-enabled flows, and
+    non-plain objects now receive short-lived annotation views that preserve
+    class methods and private fields. This lets annotation-aware parsers and
+    `prompt(optional(...))` / `prompt(withDefault(...))` compositions observe
+    outer annotations consistently across all state shapes. [[#594]]
+
  -  Fixed proxy-based sanitization of deferred prompt values breaking class
     methods that access private fields.  Methods on non-plain objects are now
     invoked with temporarily sanitized own properties on the original instance,

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1002,7 +1002,7 @@ To be released.
     non-plain objects now receive short-lived annotation views that preserve
     class methods and private fields. This lets annotation-aware parsers and
     `prompt(optional(...))` / `prompt(withDefault(...))` compositions observe
-    outer annotations consistently across all state shapes. [[#594]]
+    outer annotations consistently across all state shapes. [[#594], [#789]]
 
  -  Fixed proxy-based sanitization of deferred prompt values breaking class
     methods that access private fields.  Methods on non-plain objects are now
@@ -1560,6 +1560,7 @@ To be released.
 [#589]: https://github.com/dahlia/optique/pull/589
 [#590]: https://github.com/dahlia/optique/issues/590
 [#592]: https://github.com/dahlia/optique/pull/592
+[#594]: https://github.com/dahlia/optique/issues/594
 [#595]: https://github.com/dahlia/optique/pull/595
 [#599]: https://github.com/dahlia/optique/pull/599
 [#606]: https://github.com/dahlia/optique/pull/606
@@ -1698,6 +1699,7 @@ To be released.
 [#784]: https://github.com/dahlia/optique/pull/784
 [#786]: https://github.com/dahlia/optique/pull/786
 [#788]: https://github.com/dahlia/optique/pull/788
+[#789]: https://github.com/dahlia/optique/pull/789
 
 ### @optique/config
 

--- a/packages/core/src/annotation-state.test.ts
+++ b/packages/core/src/annotation-state.test.ts
@@ -211,6 +211,35 @@ describe("annotation-state", () => {
   );
 
   it(
+    "getDelegatedAnnotationState() preserves Array subclasses via annotation views",
+    () => {
+      class StatefulArray<T> extends Array<T> {
+        #secret = "private-value";
+
+        read(): string {
+          return this.#secret;
+        }
+      }
+
+      const marker = Symbol.for(
+        "@test/getDelegatedAnnotationState-array-subclass",
+      );
+      const annotations = { [marker]: true } satisfies Annotations;
+      const parentState = injectAnnotations(undefined, annotations);
+      const state = new StatefulArray<string>("value");
+      const delegated = getDelegatedAnnotationState(parentState, state);
+
+      assert.ok(hasDelegatedAnnotationCarrier(delegated));
+      assert.ok(getAnnotations(delegated)?.[marker]);
+      assert.ok(delegated instanceof StatefulArray);
+      assert.equal(delegated[0], "value");
+      assert.equal(delegated.read(), "private-value");
+      assert.equal(getAnnotations(state), undefined);
+      assert.equal(normalizeDelegatedAnnotationState(delegated), state);
+    },
+  );
+
+  it(
     "getDelegatedAnnotationState() tracks delegated plain-object clones",
     () => {
       const marker = Symbol.for(

--- a/packages/core/src/annotation-state.test.ts
+++ b/packages/core/src/annotation-state.test.ts
@@ -329,6 +329,106 @@ describe("annotation-state", () => {
   );
 
   it(
+    "normalizeNestedDelegatedAnnotationState() unwraps nested carriers in Map entries",
+    () => {
+      class StatefulObject {
+        #secret = "private-value";
+
+        read(): string {
+          return this.#secret;
+        }
+      }
+
+      const mapMarker = Symbol.for(
+        "@test/normalizeNestedDelegatedAnnotationState-map",
+      );
+      const delegatedParent = injectAnnotations(undefined, {
+        [
+          Symbol.for(
+            "@test/normalizeNestedDelegatedAnnotationState-map-parent",
+          )
+        ]: true,
+      });
+      const state = new StatefulObject();
+      const map = injectAnnotations(
+        new Map<
+          string,
+          string | { inner: StatefulObject }
+        >([
+          ["plain", getDelegatedAnnotationState(delegatedParent, "value")],
+          [
+            getDelegatedAnnotationState(delegatedParent, "wrapped-key"),
+            { inner: getDelegatedAnnotationState(delegatedParent, state) },
+          ],
+        ]),
+        {
+          [mapMarker]: true,
+        },
+      );
+
+      const normalized = normalizeNestedDelegatedAnnotationState(map);
+
+      assert.notStrictEqual(normalized, map);
+      assert.ok(getAnnotations(normalized)?.[mapMarker]);
+      assert.equal(normalized.get("plain"), "value");
+      const wrappedEntry = normalized.get("wrapped-key");
+      assert.deepEqual(wrappedEntry, { inner: state });
+      if (
+        wrappedEntry == null ||
+        typeof wrappedEntry !== "object" ||
+        !("inner" in wrappedEntry)
+      ) {
+        assert.fail(
+          "Expected normalized map entry to preserve the class state.",
+        );
+      }
+      assert.strictEqual(wrappedEntry.inner, state);
+    },
+  );
+
+  it(
+    "normalizeNestedDelegatedAnnotationState() unwraps nested carriers in Set entries",
+    () => {
+      class StatefulObject {
+        #secret = "private-value";
+
+        read(): string {
+          return this.#secret;
+        }
+      }
+
+      const setMarker = Symbol.for(
+        "@test/normalizeNestedDelegatedAnnotationState-set",
+      );
+      const delegatedParent = injectAnnotations(undefined, {
+        [
+          Symbol.for(
+            "@test/normalizeNestedDelegatedAnnotationState-set-parent",
+          )
+        ]: true,
+      });
+      const state = new StatefulObject();
+      const set = injectAnnotations(
+        new Set([
+          getDelegatedAnnotationState(delegatedParent, "seed"),
+          getDelegatedAnnotationState(delegatedParent, state),
+        ]),
+        {
+          [setMarker]: true,
+        },
+      );
+
+      const normalized = normalizeNestedDelegatedAnnotationState(set);
+
+      assert.notStrictEqual(normalized, set);
+      assert.ok(getAnnotations(normalized)?.[setMarker]);
+      assert.ok(normalized.has("seed"));
+      const objectEntry = [...normalized].find((value) => value === state);
+      assert.strictEqual(objectEntry, state);
+    },
+  );
+
+  it(
     "normalizeNestedDelegatedAnnotationState() preserves identity for cyclic values without carriers",
     () => {
       const cyclic: { self?: unknown } = {};

--- a/packages/core/src/annotation-state.test.ts
+++ b/packages/core/src/annotation-state.test.ts
@@ -436,6 +436,39 @@ describe("annotation-state", () => {
   );
 
   it(
+    "normalizeNestedDelegatedAnnotationState() preserves Map subclasses while unwrapping entries",
+    () => {
+      class StatefulMap extends Map<string, unknown> {
+        #secret = "private-value";
+
+        read(): string {
+          return this.#secret;
+        }
+      }
+
+      const delegatedParent = injectAnnotations(undefined, {
+        [
+          Symbol.for(
+            "@test/normalizeNestedDelegatedAnnotationState-map-subclass-parent",
+          )
+        ]: true,
+      });
+      const state = new StatefulMap([
+        ["plain", getDelegatedAnnotationState(delegatedParent, "value")],
+        ["self", getDelegatedAnnotationState(delegatedParent, "seed")],
+      ]);
+
+      const normalized = normalizeNestedDelegatedAnnotationState(state);
+
+      assert.notStrictEqual(normalized, state);
+      assert.ok(normalized instanceof StatefulMap);
+      assert.equal(normalized.read(), "private-value");
+      assert.equal(normalized.get("plain"), "value");
+      assert.equal(normalized.get("self"), "seed");
+    },
+  );
+
+  it(
     "normalizeNestedDelegatedAnnotationState() unwraps nested carriers in Set entries",
     () => {
       class StatefulObject {
@@ -474,6 +507,39 @@ describe("annotation-state", () => {
       assert.ok(normalized.has("seed"));
       const objectEntry = [...normalized].find((value) => value === state);
       assert.strictEqual(objectEntry, state);
+    },
+  );
+
+  it(
+    "normalizeNestedDelegatedAnnotationState() preserves Set subclasses while unwrapping entries",
+    () => {
+      class StatefulSet extends Set<unknown> {
+        #secret = "private-value";
+
+        read(): string {
+          return this.#secret;
+        }
+      }
+
+      const delegatedParent = injectAnnotations(undefined, {
+        [
+          Symbol.for(
+            "@test/normalizeNestedDelegatedAnnotationState-set-subclass-parent",
+          )
+        ]: true,
+      });
+      const state = new StatefulSet([
+        getDelegatedAnnotationState(delegatedParent, "seed"),
+        getDelegatedAnnotationState(delegatedParent, "value"),
+      ]);
+
+      const normalized = normalizeNestedDelegatedAnnotationState(state);
+
+      assert.notStrictEqual(normalized, state);
+      assert.ok(normalized instanceof StatefulSet);
+      assert.equal(normalized.read(), "private-value");
+      assert.ok(normalized.has("seed"));
+      assert.ok(normalized.has("value"));
     },
   );
 

--- a/packages/core/src/annotation-state.test.ts
+++ b/packages/core/src/annotation-state.test.ts
@@ -2,12 +2,9 @@ import {
   type Annotations,
   getAnnotations,
   injectAnnotations,
-} from "@optique/core/annotations";
-import { message } from "@optique/core/message";
-import {
-  defineInheritedAnnotationParser,
-  type Parser,
-} from "@optique/core/parser";
+} from "./annotations.ts";
+import { message } from "./message.ts";
+import { defineInheritedAnnotationParser, type Parser } from "./parser.ts";
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {

--- a/packages/core/src/annotation-state.test.ts
+++ b/packages/core/src/annotation-state.test.ts
@@ -219,6 +219,14 @@ describe("annotation-state", () => {
         object: { inner: state },
         array: ["seed-array", { inner: state }],
       });
+      assert.strictEqual(normalized.object.inner, state);
+      const arrayEntry = normalized.array[1];
+      assert.ok(
+        arrayEntry != null &&
+          typeof arrayEntry === "object" &&
+          "inner" in arrayEntry,
+      );
+      assert.strictEqual(arrayEntry.inner, state);
     },
   );
 

--- a/packages/core/src/annotation-state.test.ts
+++ b/packages/core/src/annotation-state.test.ts
@@ -11,8 +11,11 @@ import {
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
+  getDelegatedAnnotationState,
   getWrappedChildParseState,
   getWrappedChildState,
+  hasDelegatedAnnotationCarrier,
+  normalizeDelegatedAnnotationState,
   normalizeInjectedAnnotationState,
 } from "./annotation-state.ts";
 
@@ -99,6 +102,42 @@ describe("annotation-state", () => {
         );
         assert.ok(getAnnotations(wrapped)?.[marker]);
       }
+    },
+  );
+
+  it("getDelegatedAnnotationState() preserves primitive sentinels", () => {
+    const marker = Symbol.for("@test/getDelegatedAnnotationState-primitive");
+    const annotations = { [marker]: true } satisfies Annotations;
+    const parentState = injectAnnotations(undefined, annotations);
+    const delegated = getDelegatedAnnotationState(parentState, "seed");
+
+    assert.ok(hasDelegatedAnnotationCarrier(delegated));
+    assert.ok(getAnnotations(delegated)?.[marker]);
+    assert.equal(normalizeDelegatedAnnotationState(delegated), "seed");
+  });
+
+  it(
+    "getDelegatedAnnotationState() preserves class instances via annotation views",
+    () => {
+      class StatefulObject {
+        #secret = "private-value";
+
+        read(): string {
+          return this.#secret;
+        }
+      }
+
+      const marker = Symbol.for("@test/getDelegatedAnnotationState-class");
+      const annotations = { [marker]: true } satisfies Annotations;
+      const parentState = injectAnnotations(undefined, annotations);
+      const state = new StatefulObject();
+      const delegated = getDelegatedAnnotationState(parentState, state);
+
+      assert.ok(hasDelegatedAnnotationCarrier(delegated));
+      assert.ok(getAnnotations(delegated)?.[marker]);
+      assert.equal(delegated.read(), "private-value");
+      assert.equal(getAnnotations(state), undefined);
+      assert.equal(normalizeDelegatedAnnotationState(delegated), state);
     },
   );
 });

--- a/packages/core/src/annotation-state.test.ts
+++ b/packages/core/src/annotation-state.test.ts
@@ -183,6 +183,34 @@ describe("annotation-state", () => {
   );
 
   it(
+    "getDelegatedAnnotationState() preserves built-in subclasses via annotation views",
+    () => {
+      class StatefulMap extends Map<string, string> {
+        #secret = "private-value";
+
+        read(): string {
+          return this.#secret;
+        }
+      }
+
+      const marker = Symbol.for(
+        "@test/getDelegatedAnnotationState-map-subclass",
+      );
+      const annotations = { [marker]: true } satisfies Annotations;
+      const parentState = injectAnnotations(undefined, annotations);
+      const state = new StatefulMap([["key", "value"]]);
+      const delegated = getDelegatedAnnotationState(parentState, state);
+
+      assert.ok(hasDelegatedAnnotationCarrier(delegated));
+      assert.ok(getAnnotations(delegated)?.[marker]);
+      assert.equal(delegated.get("key"), "value");
+      assert.equal(delegated.read(), "private-value");
+      assert.equal(getAnnotations(state), undefined);
+      assert.equal(normalizeDelegatedAnnotationState(delegated), state);
+    },
+  );
+
+  it(
     "normalizeNestedDelegatedAnnotationState() unwraps nested carriers in arrays and plain objects",
     () => {
       class StatefulObject {

--- a/packages/core/src/annotation-state.test.ts
+++ b/packages/core/src/annotation-state.test.ts
@@ -307,6 +307,42 @@ describe("annotation-state", () => {
   );
 
   it(
+    "normalizeNestedDelegatedAnnotationState() preserves Array subclasses while unwrapping entries",
+    () => {
+      class StatefulArray<T> extends Array<T> {
+        #secret = "private-value";
+
+        read(): string {
+          return this.#secret;
+        }
+      }
+
+      const delegatedParent = injectAnnotations(undefined, {
+        [
+          Symbol.for(
+            "@test/normalizeNestedDelegatedAnnotationState-array-subclass-parent",
+          )
+        ]: true,
+      });
+      const state = new StatefulArray<unknown>();
+      state.push(
+        getDelegatedAnnotationState(delegatedParent, "seed"),
+        { inner: getDelegatedAnnotationState(delegatedParent, "value") },
+      );
+
+      const normalized = normalizeNestedDelegatedAnnotationState(state);
+
+      assert.notStrictEqual(normalized, state);
+      assert.ok(normalized instanceof StatefulArray);
+      assert.equal(normalized.read(), "private-value");
+      assert.deepEqual([...normalized], [
+        "seed",
+        { inner: "value" },
+      ]);
+    },
+  );
+
+  it(
     "normalizeNestedDelegatedAnnotationState() preserves array metadata and normalizes nested custom properties",
     () => {
       const arrayMarker = Symbol.for(
@@ -469,6 +505,76 @@ describe("annotation-state", () => {
   );
 
   it(
+    "normalizeNestedDelegatedAnnotationState() skips Map subclass clone construction when nothing changes",
+    () => {
+      class RequiredArgMap extends Map<string, string> {
+        readonly label: string;
+
+        constructor(
+          label: string,
+          entries?: Iterable<readonly [string, string]>,
+        ) {
+          if (label.length === 0) {
+            throw new TypeError("label must not be empty.");
+          }
+          super(entries);
+          this.label = label;
+        }
+      }
+
+      const state = new RequiredArgMap("required", [["key", "value"]]);
+
+      const normalized = normalizeNestedDelegatedAnnotationState(state);
+
+      assert.strictEqual(normalized, state);
+      assert.equal(normalized.label, "required");
+      assert.equal(normalized.get("key"), "value");
+    },
+  );
+
+  it(
+    "normalizeNestedDelegatedAnnotationState() falls back when Map subclass clone construction requires args",
+    () => {
+      class RequiredArgMap extends Map<string, unknown> {
+        readonly label: string;
+
+        constructor(
+          label: string,
+          entries?: Iterable<readonly [string, unknown]>,
+        ) {
+          if (label.length === 0) {
+            throw new TypeError("label must not be empty.");
+          }
+          super(entries);
+          this.label = label;
+        }
+      }
+
+      const delegatedParent = injectAnnotations(undefined, {
+        [
+          Symbol.for(
+            "@test/normalizeNestedDelegatedAnnotationState-map-required-arg-parent",
+          )
+        ]: true,
+      });
+      const state = new RequiredArgMap("required", [[
+        "key",
+        getDelegatedAnnotationState(delegatedParent, "value"),
+      ]]);
+
+      const normalized: unknown = normalizeNestedDelegatedAnnotationState(
+        state,
+      );
+
+      assert.notStrictEqual(normalized, state);
+      assert.ok(normalized instanceof Map);
+      assert.ok(!(normalized instanceof RequiredArgMap));
+      assert.equal(Reflect.get(normalized, "label"), "required");
+      assert.equal(normalized.get("key"), "value");
+    },
+  );
+
+  it(
     "normalizeNestedDelegatedAnnotationState() unwraps nested carriers in Set entries",
     () => {
       class StatefulObject {
@@ -539,6 +645,31 @@ describe("annotation-state", () => {
       assert.ok(normalized instanceof StatefulSet);
       assert.equal(normalized.read(), "private-value");
       assert.ok(normalized.has("seed"));
+      assert.ok(normalized.has("value"));
+    },
+  );
+
+  it(
+    "normalizeNestedDelegatedAnnotationState() skips Set subclass clone construction when nothing changes",
+    () => {
+      class RequiredArgSet extends Set<string> {
+        readonly label: string;
+
+        constructor(label: string, values?: Iterable<string>) {
+          if (label.length === 0) {
+            throw new TypeError("label must not be empty.");
+          }
+          super(values);
+          this.label = label;
+        }
+      }
+
+      const state = new RequiredArgSet("required", ["value"]);
+
+      const normalized = normalizeNestedDelegatedAnnotationState(state);
+
+      assert.strictEqual(normalized, state);
+      assert.equal(normalized.label, "required");
       assert.ok(normalized.has("value"));
     },
   );

--- a/packages/core/src/annotation-state.test.ts
+++ b/packages/core/src/annotation-state.test.ts
@@ -211,6 +211,27 @@ describe("annotation-state", () => {
   );
 
   it(
+    "getDelegatedAnnotationState() tracks delegated plain-object clones",
+    () => {
+      const marker = Symbol.for(
+        "@test/getDelegatedAnnotationState-plain-object",
+      );
+      const annotations = { [marker]: true } satisfies Annotations;
+      const parentState = injectAnnotations(undefined, annotations);
+      const state = { value: "seed" };
+
+      const delegated = getDelegatedAnnotationState(parentState, state);
+
+      assert.notStrictEqual(delegated, state);
+      assert.ok(hasDelegatedAnnotationCarrier(delegated));
+      assert.ok(getAnnotations(delegated)?.[marker]);
+      assert.equal(delegated.value, "seed");
+      assert.equal(getAnnotations(state), undefined);
+      assert.equal(normalizeDelegatedAnnotationState(delegated), state);
+    },
+  );
+
+  it(
     "normalizeNestedDelegatedAnnotationState() unwraps nested carriers in arrays and plain objects",
     () => {
       class StatefulObject {

--- a/packages/core/src/annotation-state.test.ts
+++ b/packages/core/src/annotation-state.test.ts
@@ -429,6 +429,42 @@ describe("annotation-state", () => {
   );
 
   it(
+    "normalizeNestedDelegatedAnnotationState() clones cyclic back-references when an ancestor changes",
+    () => {
+      const parentState = injectAnnotations(undefined, {
+        [
+          Symbol.for(
+            "@test/normalizeNestedDelegatedAnnotationState-cyclic-parent",
+          )
+        ]: true,
+      });
+      const cyclic: {
+        child?: { parent: unknown };
+        value?: unknown;
+      } = {};
+      const child = { parent: cyclic };
+      cyclic.child = child;
+      cyclic.value = getDelegatedAnnotationState(parentState, "seed");
+
+      const normalized = normalizeNestedDelegatedAnnotationState(cyclic);
+
+      assert.notStrictEqual(normalized, cyclic);
+      if (
+        normalized.child == null ||
+        typeof normalized.child !== "object" ||
+        !("parent" in normalized.child)
+      ) {
+        assert.fail(
+          "Expected normalized child to preserve the cyclic parent link.",
+        );
+      }
+      assert.notStrictEqual(normalized.child, child);
+      assert.strictEqual(normalized.child.parent, normalized);
+      assert.equal(normalized.value, "seed");
+    },
+  );
+
+  it(
     "normalizeNestedDelegatedAnnotationState() preserves identity for cyclic values without carriers",
     () => {
       const cyclic: { self?: unknown } = {};

--- a/packages/core/src/annotation-state.test.ts
+++ b/packages/core/src/annotation-state.test.ts
@@ -140,6 +140,24 @@ describe("annotation-state", () => {
   );
 
   it(
+    "getDelegatedAnnotationState() rewraps injected primitives even with identical annotations",
+    () => {
+      const marker = Symbol.for(
+        "@test/getDelegatedAnnotationState-shared-primitive",
+      );
+      const annotations = { [marker]: true } satisfies Annotations;
+      const parentState = injectAnnotations(undefined, annotations);
+      const childState = injectAnnotations("seed", annotations);
+
+      const delegated = getDelegatedAnnotationState(parentState, childState);
+
+      assert.notStrictEqual(delegated, childState);
+      assert.ok(getAnnotations(delegated)?.[marker]);
+      assert.equal(normalizeDelegatedAnnotationState(delegated), "seed");
+    },
+  );
+
+  it(
     "getDelegatedAnnotationState() preserves class instances via annotation views",
     () => {
       class StatefulObject {
@@ -187,6 +205,10 @@ describe("annotation-state", () => {
         object: {
           inner: getDelegatedAnnotationState(parentState, state),
         },
+        array: [
+          getDelegatedAnnotationState(parentState, "seed-array"),
+          { inner: getDelegatedAnnotationState(parentState, state) },
+        ],
       };
 
       const normalized = normalizeNestedDelegatedAnnotationState(nested);
@@ -195,7 +217,48 @@ describe("annotation-state", () => {
       assert.deepEqual(normalized, {
         primitive: "seed",
         object: { inner: state },
+        array: ["seed-array", { inner: state }],
       });
+    },
+  );
+
+  it(
+    "normalizeNestedDelegatedAnnotationState() preserves top-level array annotations",
+    () => {
+      const arrayMarker = Symbol.for(
+        "@test/normalizeNestedDelegatedAnnotationState-array",
+      );
+      const delegatedParent = injectAnnotations(undefined, {
+        [Symbol.for("@test/normalizeNestedDelegatedAnnotationState-delegated")]:
+          true,
+      });
+      const annotatedArray = injectAnnotations([
+        getDelegatedAnnotationState(delegatedParent, "seed"),
+      ], {
+        [arrayMarker]: true,
+      });
+
+      const normalized = normalizeNestedDelegatedAnnotationState(
+        annotatedArray,
+      );
+
+      assert.notStrictEqual(normalized, annotatedArray);
+      assert.equal(normalized.length, 1);
+      assert.equal(normalized[0], "seed");
+      assert.ok(getAnnotations(normalized)?.[arrayMarker]);
+    },
+  );
+
+  it(
+    "normalizeNestedDelegatedAnnotationState() preserves identity for cyclic values without carriers",
+    () => {
+      const cyclic: { self?: unknown } = {};
+      cyclic.self = cyclic;
+
+      const normalized = normalizeNestedDelegatedAnnotationState(cyclic);
+
+      assert.strictEqual(normalized, cyclic);
+      assert.strictEqual(normalized.self, cyclic);
     },
   );
 });

--- a/packages/core/src/annotation-state.test.ts
+++ b/packages/core/src/annotation-state.test.ts
@@ -17,6 +17,7 @@ import {
   hasDelegatedAnnotationCarrier,
   normalizeDelegatedAnnotationState,
   normalizeInjectedAnnotationState,
+  normalizeNestedDelegatedAnnotationState,
 } from "./annotation-state.ts";
 
 function createInheritedTestParser(): Parser<"sync", unknown, unknown> {
@@ -117,6 +118,31 @@ describe("annotation-state", () => {
   });
 
   it(
+    "getDelegatedAnnotationState() creates a fresh wrapper from wrapped primitives",
+    () => {
+      const parentMarker = Symbol.for(
+        "@test/getDelegatedAnnotationState-parent-primitive",
+      );
+      const childMarker = Symbol.for(
+        "@test/getDelegatedAnnotationState-child-primitive",
+      );
+      const childState = injectAnnotations("seed", {
+        [childMarker]: true,
+      });
+      const parentState = injectAnnotations(undefined, {
+        [parentMarker]: true,
+      });
+
+      const delegated = getDelegatedAnnotationState(parentState, childState);
+
+      assert.notStrictEqual(delegated, childState);
+      assert.ok(getAnnotations(childState)?.[childMarker]);
+      assert.ok(getAnnotations(delegated)?.[parentMarker]);
+      assert.equal(normalizeDelegatedAnnotationState(delegated), "seed");
+    },
+  );
+
+  it(
     "getDelegatedAnnotationState() preserves class instances via annotation views",
     () => {
       class StatefulObject {
@@ -138,6 +164,41 @@ describe("annotation-state", () => {
       assert.equal(delegated.read(), "private-value");
       assert.equal(getAnnotations(state), undefined);
       assert.equal(normalizeDelegatedAnnotationState(delegated), state);
+    },
+  );
+
+  it(
+    "normalizeNestedDelegatedAnnotationState() unwraps nested carriers in arrays and plain objects",
+    () => {
+      class StatefulObject {
+        #secret = "private-value";
+
+        read(): string {
+          return this.#secret;
+        }
+      }
+
+      const marker = Symbol.for(
+        "@test/normalizeNestedDelegatedAnnotationState",
+      );
+      const parentState = injectAnnotations(undefined, {
+        [marker]: true,
+      });
+      const state = new StatefulObject();
+      const nested = {
+        primitive: getDelegatedAnnotationState(parentState, "seed"),
+        object: {
+          inner: getDelegatedAnnotationState(parentState, state),
+        },
+      };
+
+      const normalized = normalizeNestedDelegatedAnnotationState(nested);
+
+      assert.notStrictEqual(normalized, nested);
+      assert.deepEqual(normalized, {
+        primitive: "seed",
+        object: { inner: state },
+      });
     },
   );
 });

--- a/packages/core/src/annotation-state.test.ts
+++ b/packages/core/src/annotation-state.test.ts
@@ -250,6 +250,77 @@ describe("annotation-state", () => {
   );
 
   it(
+    "normalizeNestedDelegatedAnnotationState() preserves array metadata and normalizes nested custom properties",
+    () => {
+      const arrayMarker = Symbol.for(
+        "@test/normalizeNestedDelegatedAnnotationState-array-metadata",
+      );
+      const extraKey = "extra";
+      const symbolKey = Symbol.for(
+        "@test/normalizeNestedDelegatedAnnotationState-array-symbol",
+      );
+      const delegatedParent = injectAnnotations(undefined, {
+        [
+          Symbol.for(
+            "@test/normalizeNestedDelegatedAnnotationState-array-metadata-parent",
+          )
+        ]: true,
+      });
+      const array = injectAnnotations([
+        getDelegatedAnnotationState(delegatedParent, "seed"),
+      ], {
+        [arrayMarker]: true,
+      });
+      Object.defineProperty(array, extraKey, {
+        value: {
+          inner: getDelegatedAnnotationState(delegatedParent, "extra"),
+        },
+        enumerable: false,
+        writable: false,
+        configurable: true,
+      });
+      Object.defineProperty(array, symbolKey, {
+        value: {
+          inner: getDelegatedAnnotationState(delegatedParent, "symbol"),
+        },
+        enumerable: false,
+        writable: true,
+        configurable: false,
+      });
+
+      const normalized = normalizeNestedDelegatedAnnotationState(array);
+
+      assert.notStrictEqual(normalized, array);
+      assert.equal(normalized[0], "seed");
+      assert.ok(getAnnotations(normalized)?.[arrayMarker]);
+      assert.deepEqual(Reflect.get(normalized, extraKey), {
+        inner: "extra",
+      });
+      assert.deepEqual(
+        Object.getOwnPropertyDescriptor(normalized, extraKey),
+        {
+          value: { inner: "extra" },
+          enumerable: false,
+          writable: false,
+          configurable: true,
+        },
+      );
+      assert.deepEqual(Reflect.get(normalized, symbolKey), {
+        inner: "symbol",
+      });
+      assert.deepEqual(
+        Object.getOwnPropertyDescriptor(normalized, symbolKey),
+        {
+          value: { inner: "symbol" },
+          enumerable: false,
+          writable: true,
+          configurable: false,
+        },
+      );
+    },
+  );
+
+  it(
     "normalizeNestedDelegatedAnnotationState() preserves identity for cyclic values without carriers",
     () => {
       const cyclic: { self?: unknown } = {};

--- a/packages/core/src/annotation-state.ts
+++ b/packages/core/src/annotation-state.ts
@@ -23,6 +23,8 @@ import {
  */
 export const annotationViewTargets = new WeakMap<object, object>();
 
+const delegatedAnnotationCloneTargets = new WeakMap<object, object>();
+
 /**
  * Unwraps an annotation-view proxy to its original target object.
  *
@@ -36,6 +38,16 @@ export function unwrapAnnotationView<T>(value: T): T {
     return value;
   }
   return (annotationViewTargets.get(value as object) as T | undefined) ?? value;
+}
+
+function unwrapDelegatedAnnotationClone<T>(value: T): T {
+  if (value == null || typeof value !== "object") {
+    return value;
+  }
+  return (delegatedAnnotationCloneTargets.get(value as object) as
+    | T
+    | undefined) ??
+    value;
 }
 
 /**
@@ -94,26 +106,43 @@ function isNonPlainDelegatedObject(state: object): boolean {
   return proto !== Object.prototype && proto !== null;
 }
 
+function inheritDelegatedAnnotations<TState extends object>(
+  parentState: unknown,
+  childState: TState,
+): TState {
+  const target = normalizeDelegatedAnnotationState(childState);
+  const delegatedState = inheritAnnotations(parentState, target);
+  if (delegatedState !== target) {
+    delegatedAnnotationCloneTargets.set(
+      delegatedState as object,
+      target as object,
+    );
+  }
+  return delegatedState as TState;
+}
+
 /**
  * Removes Optique's internal annotation carriers from a delegated state.
  *
- * This unwraps both primitive-state annotation wrappers and annotation-view
- * proxies used for non-plain object states.
+ * This unwraps primitive-state annotation wrappers, tracked delegated clones,
+ * and annotation-view proxies used for object states.
  *
  * @param state The delegated state to normalize.
  * @returns The original underlying state value.
  * @internal
  */
 export function normalizeDelegatedAnnotationState<T>(state: T): T {
-  return normalizeInjectedAnnotationState(unwrapAnnotationView(state));
+  return normalizeInjectedAnnotationState(
+    unwrapDelegatedAnnotationClone(unwrapAnnotationView(state)),
+  );
 }
 
 /**
  * Returns whether the given state uses an internal delegated annotation carrier.
  *
  * @param state The candidate state to inspect.
- * @returns `true` when the state is an injected primitive wrapper or an
- *          annotation-view proxy.
+ * @returns `true` when the state is an injected primitive wrapper, a tracked
+ *          delegated clone, or an annotation-view proxy.
  * @internal
  */
 export function hasDelegatedAnnotationCarrier(state: unknown): boolean {
@@ -121,6 +150,7 @@ export function hasDelegatedAnnotationCarrier(state: unknown): boolean {
     typeof state === "object" &&
     (
       isInjectedAnnotationWrapper(state) ||
+      delegatedAnnotationCloneTargets.has(state as object) ||
       annotationViewTargets.has(state as object)
     );
 }
@@ -479,10 +509,10 @@ export function normalizeNestedDelegatedAnnotationState<T>(
  * Creates a short-lived delegated state that exposes the parent's annotations
  * regardless of the child state's runtime shape.
  *
- * Primitive and nullish states use `injectAnnotations()`, plain objects and
- * built-ins use `inheritAnnotations()`, and non-plain objects use an
- * annotation-view proxy so class invariants such as private fields remain
- * intact.
+ * Primitive and nullish states use `injectAnnotations()`, clone-based object
+ * delegation is tracked so it can be normalized back out later, and non-plain
+ * objects use an annotation-view proxy so class invariants such as private
+ * fields remain intact.
  *
  * @param parentState The state carrying the annotations to delegate.
  * @param childState The child state that should observe those annotations.
@@ -503,16 +533,22 @@ export function getDelegatedAnnotationState<TState>(
       annotations,
     );
   }
-  if (getAnnotations(childState) === annotations) {
-    return childState;
-  }
   if (childState == null || typeof childState !== "object") {
     return injectAnnotations(childState, annotations);
+  }
+  if (
+    getAnnotations(childState) === annotations &&
+    (
+      delegatedAnnotationCloneTargets.has(childState as object) ||
+      annotationViewTargets.has(childState as object)
+    )
+  ) {
+    return childState;
   }
   if (isNonPlainDelegatedObject(childState)) {
     return withAnnotationView(childState, annotations) as TState;
   }
-  return inheritAnnotations(parentState, childState);
+  return inheritDelegatedAnnotations(parentState, childState);
 }
 
 /**

--- a/packages/core/src/annotation-state.ts
+++ b/packages/core/src/annotation-state.ts
@@ -156,10 +156,18 @@ export function hasDelegatedAnnotationCarrier(state: unknown): boolean {
 }
 
 interface NestedNormalizationEntry {
-  clone: object;
+  clone: object | undefined;
+  createClone: () => object;
   finalized: boolean;
   result: object;
   preferCloneOnRead: boolean;
+}
+
+function getOrCreateNestedNormalizationClone(
+  entry: NestedNormalizationEntry,
+): object {
+  entry.clone ??= entry.createClone();
+  return entry.clone;
 }
 
 function getPendingNestedNormalizationEntry(
@@ -171,23 +179,47 @@ function getPendingNestedNormalizationEntry(
     return undefined;
   }
   const entry = seen.get(originalValue as object);
-  return entry != null && entry.clone === normalizedValue &&
+  return entry != null && entry.clone != null &&
+      entry.clone === normalizedValue &&
       (!entry.finalized || entry.preferCloneOnRead)
     ? entry
     : undefined;
 }
 
 function createPendingNestedNormalizationClone(source: object): object {
-  return Array.isArray(source)
-    ? []
-    : Object.create(Object.getPrototypeOf(source));
+  if (!Array.isArray(source)) {
+    return Object.create(Object.getPrototypeOf(source));
+  }
+  if (Object.getPrototypeOf(source) === Array.prototype) {
+    return [];
+  }
+  try {
+    return source.slice(0, 0);
+  } catch {
+    return [];
+  }
 }
 
 function createPendingNestedNormalizationCollectionClone<
   T extends Map<unknown, unknown> | Set<unknown>,
 >(source: T): T {
-  const Constructor = source.constructor as new () => T;
-  return new Constructor();
+  const proto = Object.getPrototypeOf(source);
+  if (source instanceof Map && proto === Map.prototype) {
+    return new Map<unknown, unknown>() as T;
+  }
+  if (source instanceof Set && proto === Set.prototype) {
+    return new Set<unknown>() as T;
+  }
+  const Constructor = source.constructor as (new () => T) | undefined;
+  if (typeof Constructor === "function") {
+    try {
+      return new Constructor();
+    } catch {
+      // Fall through to a base collection when the subclass constructor
+      // requires arguments or performs unsupported construction.
+    }
+  }
+  return (source instanceof Map ? new Map() : new Set()) as T;
 }
 
 function normalizeNestedDelegatedStructuredState<T extends object>(
@@ -195,11 +227,11 @@ function normalizeNestedDelegatedStructuredState<T extends object>(
   seen: WeakMap<object, NestedNormalizationEntry>,
   preferPendingClone: boolean,
 ): T {
-  const clone = createPendingNestedNormalizationClone(source);
   const entry: NestedNormalizationEntry = {
-    clone,
+    clone: undefined,
+    createClone: () => createPendingNestedNormalizationClone(source),
     finalized: false,
-    result: clone,
+    result: source,
     preferCloneOnRead: false,
   };
   seen.set(source, entry);
@@ -249,6 +281,7 @@ function normalizeNestedDelegatedStructuredState<T extends object>(
     descriptors[key] = { ...descriptor, value: nextValue };
   }
 
+  const clone = getOrCreateNestedNormalizationClone(entry);
   Object.defineProperties(clone, descriptors);
   entry.finalized = true;
   entry.preferCloneOnRead = !changed && hasPendingAliasOverride;
@@ -261,11 +294,11 @@ function normalizeNestedDelegatedMapState<T extends Map<unknown, unknown>>(
   seen: WeakMap<object, NestedNormalizationEntry>,
   preferPendingClone: boolean,
 ): T {
-  const clone = createPendingNestedNormalizationCollectionClone(source);
   const entry: NestedNormalizationEntry = {
-    clone,
+    clone: undefined,
+    createClone: () => createPendingNestedNormalizationCollectionClone(source),
     finalized: false,
-    result: clone,
+    result: source,
     preferCloneOnRead: false,
   };
   seen.set(source, entry);
@@ -331,6 +364,7 @@ function normalizeNestedDelegatedMapState<T extends Map<unknown, unknown>>(
     return source;
   }
 
+  const clone = getOrCreateNestedNormalizationClone(entry) as T;
   for (const [key, value] of normalizedEntries) {
     clone.set(key, value);
   }
@@ -359,11 +393,11 @@ function normalizeNestedDelegatedSetState<T extends Set<unknown>>(
   seen: WeakMap<object, NestedNormalizationEntry>,
   preferPendingClone: boolean,
 ): T {
-  const clone = createPendingNestedNormalizationCollectionClone(source);
   const entry: NestedNormalizationEntry = {
-    clone,
+    clone: undefined,
+    createClone: () => createPendingNestedNormalizationCollectionClone(source),
     finalized: false,
-    result: clone,
+    result: source,
     preferCloneOnRead: false,
   };
   seen.set(source, entry);
@@ -420,6 +454,7 @@ function normalizeNestedDelegatedSetState<T extends Set<unknown>>(
     return source;
   }
 
+  const clone = getOrCreateNestedNormalizationClone(entry) as T;
   for (const value of normalizedValues) {
     clone.add(value);
   }
@@ -472,11 +507,11 @@ export function normalizeNestedDelegatedAnnotationState<T>(
   const existing = seen.get(source);
   if (existing != null) {
     if (!existing.finalized) {
-      return existing.clone as T;
+      return getOrCreateNestedNormalizationClone(existing) as T;
     }
     return (
       preferPendingClone && existing.preferCloneOnRead
-        ? existing.clone
+        ? getOrCreateNestedNormalizationClone(existing)
         : existing.result
     ) as T;
   }

--- a/packages/core/src/annotation-state.ts
+++ b/packages/core/src/annotation-state.ts
@@ -129,18 +129,22 @@ interface NestedNormalizationEntry {
   clone: object;
   finalized: boolean;
   result: object;
+  preferCloneOnRead: boolean;
 }
 
-function isPendingNestedNormalizationAlias(
+function getPendingNestedNormalizationEntry(
   originalValue: unknown,
   normalizedValue: unknown,
   seen: WeakMap<object, NestedNormalizationEntry>,
-): boolean {
+): NestedNormalizationEntry | undefined {
   if (originalValue == null || typeof originalValue !== "object") {
-    return false;
+    return undefined;
   }
   const entry = seen.get(originalValue as object);
-  return entry != null && !entry.finalized && entry.clone === normalizedValue;
+  return entry != null && entry.clone === normalizedValue &&
+      (!entry.finalized || entry.preferCloneOnRead)
+    ? entry
+    : undefined;
 }
 
 function createPendingNestedNormalizationClone(source: object): object {
@@ -152,17 +156,20 @@ function createPendingNestedNormalizationClone(source: object): object {
 function normalizeNestedDelegatedStructuredState<T extends object>(
   source: T,
   seen: WeakMap<object, NestedNormalizationEntry>,
+  preferPendingClone: boolean,
 ): T {
   const clone = createPendingNestedNormalizationClone(source);
   const entry: NestedNormalizationEntry = {
     clone,
     finalized: false,
     result: clone,
+    preferCloneOnRead: false,
   };
   seen.set(source, entry);
 
   const overrides = new Map<PropertyKey, unknown>();
   let changed = false;
+  let hasPendingAliasOverride = false;
   for (const key of Reflect.ownKeys(source)) {
     const descriptor = Object.getOwnPropertyDescriptor(source, key);
     if (descriptor == null || !("value" in descriptor)) {
@@ -171,17 +178,23 @@ function normalizeNestedDelegatedStructuredState<T extends object>(
     const nextValue = normalizeNestedDelegatedAnnotationState(
       descriptor.value,
       seen,
+      true,
     );
     if (nextValue === descriptor.value) {
       continue;
     }
     overrides.set(key, nextValue);
-    if (!isPendingNestedNormalizationAlias(descriptor.value, nextValue, seen)) {
+    if (
+      getPendingNestedNormalizationEntry(descriptor.value, nextValue, seen) ==
+        null
+    ) {
       changed = true;
+    } else {
+      hasPendingAliasOverride = true;
     }
   }
 
-  if (!changed) {
+  if (!changed && !hasPendingAliasOverride) {
     entry.finalized = true;
     entry.result = source;
     return source;
@@ -201,37 +214,53 @@ function normalizeNestedDelegatedStructuredState<T extends object>(
 
   Object.defineProperties(clone, descriptors);
   entry.finalized = true;
-  entry.result = clone;
-  return clone as T;
+  entry.preferCloneOnRead = !changed && hasPendingAliasOverride;
+  entry.result = changed ? clone : source;
+  return (changed || preferPendingClone ? clone : source) as T;
 }
 
 function normalizeNestedDelegatedMapState<T extends Map<unknown, unknown>>(
   source: T,
   seen: WeakMap<object, NestedNormalizationEntry>,
+  preferPendingClone: boolean,
 ): T {
   const clone = new Map<unknown, unknown>();
   const entry: NestedNormalizationEntry = {
     clone,
     finalized: false,
     result: clone,
+    preferCloneOnRead: false,
   };
   seen.set(source, entry);
 
   const normalizedEntries: Array<readonly [unknown, unknown]> = [];
   const overrides = new Map<PropertyKey, unknown>();
   let changed = false;
+  let hasPendingAliasOverride = false;
 
   for (const [key, value] of source) {
-    const nextKey = normalizeNestedDelegatedAnnotationState(key, seen);
-    const nextValue = normalizeNestedDelegatedAnnotationState(value, seen);
+    const nextKey = normalizeNestedDelegatedAnnotationState(key, seen, true);
+    const nextValue = normalizeNestedDelegatedAnnotationState(
+      value,
+      seen,
+      true,
+    );
     normalizedEntries.push([nextKey, nextValue]);
-    if (
-      (!isPendingNestedNormalizationAlias(key, nextKey, seen) &&
-        nextKey !== key) ||
-      (!isPendingNestedNormalizationAlias(value, nextValue, seen) &&
-        nextValue !== value)
-    ) {
-      changed = true;
+    if (nextKey !== key) {
+      if (getPendingNestedNormalizationEntry(key, nextKey, seen) == null) {
+        changed = true;
+      } else {
+        hasPendingAliasOverride = true;
+      }
+    }
+    if (nextValue !== value) {
+      if (
+        getPendingNestedNormalizationEntry(value, nextValue, seen) == null
+      ) {
+        changed = true;
+      } else {
+        hasPendingAliasOverride = true;
+      }
     }
   }
 
@@ -243,17 +272,23 @@ function normalizeNestedDelegatedMapState<T extends Map<unknown, unknown>>(
     const nextValue = normalizeNestedDelegatedAnnotationState(
       descriptor.value,
       seen,
+      true,
     );
     if (nextValue === descriptor.value) {
       continue;
     }
     overrides.set(key, nextValue);
-    if (!isPendingNestedNormalizationAlias(descriptor.value, nextValue, seen)) {
+    if (
+      getPendingNestedNormalizationEntry(descriptor.value, nextValue, seen) ==
+        null
+    ) {
       changed = true;
+    } else {
+      hasPendingAliasOverride = true;
     }
   }
 
-  if (!changed) {
+  if (!changed && !hasPendingAliasOverride) {
     entry.finalized = true;
     entry.result = source;
     return source;
@@ -277,34 +312,44 @@ function normalizeNestedDelegatedMapState<T extends Map<unknown, unknown>>(
 
   Object.defineProperties(clone, descriptors);
   entry.finalized = true;
-  entry.result = clone;
-  return clone as T;
+  entry.preferCloneOnRead = !changed && hasPendingAliasOverride;
+  entry.result = changed ? clone : source;
+  return (changed || preferPendingClone ? clone : source) as T;
 }
 
 function normalizeNestedDelegatedSetState<T extends Set<unknown>>(
   source: T,
   seen: WeakMap<object, NestedNormalizationEntry>,
+  preferPendingClone: boolean,
 ): T {
   const clone = new Set<unknown>();
   const entry: NestedNormalizationEntry = {
     clone,
     finalized: false,
     result: clone,
+    preferCloneOnRead: false,
   };
   seen.set(source, entry);
 
   const normalizedValues: unknown[] = [];
   const overrides = new Map<PropertyKey, unknown>();
   let changed = false;
+  let hasPendingAliasOverride = false;
 
   for (const value of source) {
-    const nextValue = normalizeNestedDelegatedAnnotationState(value, seen);
+    const nextValue = normalizeNestedDelegatedAnnotationState(
+      value,
+      seen,
+      true,
+    );
     normalizedValues.push(nextValue);
-    if (
-      nextValue !== value &&
-      !isPendingNestedNormalizationAlias(value, nextValue, seen)
-    ) {
+    if (nextValue === value) {
+      continue;
+    }
+    if (getPendingNestedNormalizationEntry(value, nextValue, seen) == null) {
       changed = true;
+    } else {
+      hasPendingAliasOverride = true;
     }
   }
 
@@ -316,17 +361,23 @@ function normalizeNestedDelegatedSetState<T extends Set<unknown>>(
     const nextValue = normalizeNestedDelegatedAnnotationState(
       descriptor.value,
       seen,
+      true,
     );
     if (nextValue === descriptor.value) {
       continue;
     }
     overrides.set(key, nextValue);
-    if (!isPendingNestedNormalizationAlias(descriptor.value, nextValue, seen)) {
+    if (
+      getPendingNestedNormalizationEntry(descriptor.value, nextValue, seen) ==
+        null
+    ) {
       changed = true;
+    } else {
+      hasPendingAliasOverride = true;
     }
   }
 
-  if (!changed) {
+  if (!changed && !hasPendingAliasOverride) {
     entry.finalized = true;
     entry.result = source;
     return source;
@@ -350,8 +401,9 @@ function normalizeNestedDelegatedSetState<T extends Set<unknown>>(
 
   Object.defineProperties(clone, descriptors);
   entry.finalized = true;
-  entry.result = clone;
-  return clone as T;
+  entry.preferCloneOnRead = !changed && hasPendingAliasOverride;
+  entry.result = changed ? clone : source;
+  return (changed || preferPendingClone ? clone : source) as T;
 }
 
 /**
@@ -373,6 +425,7 @@ function normalizeNestedDelegatedSetState<T extends Set<unknown>>(
 export function normalizeNestedDelegatedAnnotationState<T>(
   value: T,
   seen = new WeakMap<object, NestedNormalizationEntry>(),
+  preferPendingClone = false,
 ): T {
   const normalized = normalizeDelegatedAnnotationState(value);
   if (normalized == null || typeof normalized !== "object") {
@@ -381,22 +434,45 @@ export function normalizeNestedDelegatedAnnotationState<T>(
   const source = normalized as object;
   const existing = seen.get(source);
   if (existing != null) {
-    return (existing.finalized ? existing.result : existing.clone) as T;
+    if (!existing.finalized) {
+      return existing.clone as T;
+    }
+    return (
+      preferPendingClone && existing.preferCloneOnRead
+        ? existing.clone
+        : existing.result
+    ) as T;
   }
   if (Array.isArray(source)) {
-    return normalizeNestedDelegatedStructuredState(source, seen) as T;
+    return normalizeNestedDelegatedStructuredState(
+      source,
+      seen,
+      preferPendingClone,
+    ) as T;
   }
   if (source instanceof Map) {
-    return normalizeNestedDelegatedMapState(source, seen) as T;
+    return normalizeNestedDelegatedMapState(
+      source,
+      seen,
+      preferPendingClone,
+    ) as T;
   }
   if (source instanceof Set) {
-    return normalizeNestedDelegatedSetState(source, seen) as T;
+    return normalizeNestedDelegatedSetState(
+      source,
+      seen,
+      preferPendingClone,
+    ) as T;
   }
   const proto = Object.getPrototypeOf(source);
   if (proto !== Object.prototype && proto !== null) {
     return normalized;
   }
-  return normalizeNestedDelegatedStructuredState(source, seen) as T;
+  return normalizeNestedDelegatedStructuredState(
+    source,
+    seen,
+    preferPendingClone,
+  ) as T;
 }
 
 /**

--- a/packages/core/src/annotation-state.ts
+++ b/packages/core/src/annotation-state.ts
@@ -81,16 +81,16 @@ export function normalizeInjectedAnnotationState<T>(state: T): T {
 }
 
 function isNonPlainDelegatedObject(state: object): boolean {
+  const proto = Object.getPrototypeOf(state);
   if (
     Array.isArray(state) ||
-    state instanceof Date ||
-    state instanceof Map ||
-    state instanceof Set ||
-    state instanceof RegExp
+    proto === Date.prototype ||
+    proto === Map.prototype ||
+    proto === Set.prototype ||
+    proto === RegExp.prototype
   ) {
     return false;
   }
-  const proto = Object.getPrototypeOf(state);
   return proto !== Object.prototype && proto !== null;
 }
 

--- a/packages/core/src/annotation-state.ts
+++ b/packages/core/src/annotation-state.ts
@@ -95,7 +95,7 @@ export function normalizeInjectedAnnotationState<T>(state: T): T {
 function isNonPlainDelegatedObject(state: object): boolean {
   const proto = Object.getPrototypeOf(state);
   if (
-    Array.isArray(state) ||
+    proto === Array.prototype ||
     proto === Date.prototype ||
     proto === Map.prototype ||
     proto === Set.prototype ||

--- a/packages/core/src/annotation-state.ts
+++ b/packages/core/src/annotation-state.ts
@@ -1,4 +1,5 @@
 import {
+  annotateFreshArray,
   annotationKey,
   type Annotations,
   getAnnotations,
@@ -125,6 +126,24 @@ export function hasDelegatedAnnotationCarrier(state: unknown): boolean {
     );
 }
 
+interface NestedNormalizationEntry {
+  clone: object;
+  finalized: boolean;
+  result: object;
+}
+
+function isPendingNestedNormalizationAlias(
+  originalValue: unknown,
+  normalizedValue: unknown,
+  seen: WeakMap<object, NestedNormalizationEntry>,
+): boolean {
+  if (originalValue == null || typeof originalValue !== "object") {
+    return false;
+  }
+  const entry = seen.get(originalValue as object);
+  return entry != null && !entry.finalized && entry.clone === normalizedValue;
+}
+
 /**
  * Recursively removes delegated annotation carriers from plain-object and array
  * structures.
@@ -143,20 +162,26 @@ export function hasDelegatedAnnotationCarrier(state: unknown): boolean {
  */
 export function normalizeNestedDelegatedAnnotationState<T>(
   value: T,
-  seen = new WeakMap<object, unknown>(),
+  seen = new WeakMap<object, NestedNormalizationEntry>(),
 ): T {
   const normalized = normalizeDelegatedAnnotationState(value);
   if (normalized == null || typeof normalized !== "object") {
     return normalized;
   }
   const source = normalized as object;
-  if (seen.has(source)) {
-    return seen.get(source) as T;
+  const existing = seen.get(source);
+  if (existing != null) {
+    return (existing.finalized ? existing.result : existing.clone) as T;
   }
   if (Array.isArray(source)) {
     let changed = false;
-    const clone = [...source];
-    seen.set(source, clone);
+    const clone = annotateFreshArray(source, source.slice()) as unknown[];
+    const entry: NestedNormalizationEntry = {
+      clone: clone as object,
+      finalized: false,
+      result: clone as object,
+    };
+    seen.set(source, entry);
     for (let i = 0; i < source.length; i++) {
       const nextValue = normalizeNestedDelegatedAnnotationState(
         source[i],
@@ -164,14 +189,14 @@ export function normalizeNestedDelegatedAnnotationState<T>(
       );
       if (nextValue !== source[i]) {
         clone[i] = nextValue;
-        changed = true;
+        if (!isPendingNestedNormalizationAlias(source[i], nextValue, seen)) {
+          changed = true;
+        }
       }
     }
-    if (!changed) {
-      seen.set(source, source);
-      return source as T;
-    }
-    return clone as T;
+    entry.finalized = true;
+    entry.result = changed ? clone as object : source;
+    return (changed ? clone : source) as T;
   }
   const proto = Object.getPrototypeOf(source);
   if (proto !== Object.prototype && proto !== null) {
@@ -183,7 +208,12 @@ export function normalizeNestedDelegatedAnnotationState<T>(
   >;
   let changed = false;
   const clone = Object.create(proto);
-  seen.set(source, clone);
+  const entry: NestedNormalizationEntry = {
+    clone,
+    finalized: false,
+    result: clone,
+  };
+  seen.set(source, entry);
   for (const key of Reflect.ownKeys(descriptors)) {
     const descriptor = descriptors[key];
     if (descriptor != null && "value" in descriptor) {
@@ -193,12 +223,17 @@ export function normalizeNestedDelegatedAnnotationState<T>(
       );
       if (nextValue !== descriptor.value) {
         descriptors[key] = { ...descriptor, value: nextValue };
-        changed = true;
+        if (
+          !isPendingNestedNormalizationAlias(descriptor.value, nextValue, seen)
+        ) {
+          changed = true;
+        }
       }
     }
   }
+  entry.finalized = true;
+  entry.result = changed ? clone : source;
   if (!changed) {
-    seen.set(source, source);
     return source as T;
   }
   Object.defineProperties(clone, descriptors);
@@ -224,17 +259,20 @@ export function getDelegatedAnnotationState<TState>(
   childState: TState,
 ): TState {
   const annotations = getAnnotations(parentState);
-  if (annotations === undefined || getAnnotations(childState) === annotations) {
+  if (annotations === undefined) {
     return childState;
-  }
-  if (childState == null || typeof childState !== "object") {
-    return injectAnnotations(childState, annotations);
   }
   if (isInjectedAnnotationWrapper(childState)) {
     return injectAnnotations(
       normalizeInjectedAnnotationState(childState),
       annotations,
     );
+  }
+  if (getAnnotations(childState) === annotations) {
+    return childState;
+  }
+  if (childState == null || typeof childState !== "object") {
+    return injectAnnotations(childState, annotations);
   }
   if (isNonPlainDelegatedObject(childState)) {
     return withAnnotationView(childState, annotations) as TState;

--- a/packages/core/src/annotation-state.ts
+++ b/packages/core/src/annotation-state.ts
@@ -183,6 +183,13 @@ function createPendingNestedNormalizationClone(source: object): object {
     : Object.create(Object.getPrototypeOf(source));
 }
 
+function createPendingNestedNormalizationCollectionClone<
+  T extends Map<unknown, unknown> | Set<unknown>,
+>(source: T): T {
+  const Constructor = source.constructor as new () => T;
+  return new Constructor();
+}
+
 function normalizeNestedDelegatedStructuredState<T extends object>(
   source: T,
   seen: WeakMap<object, NestedNormalizationEntry>,
@@ -254,7 +261,7 @@ function normalizeNestedDelegatedMapState<T extends Map<unknown, unknown>>(
   seen: WeakMap<object, NestedNormalizationEntry>,
   preferPendingClone: boolean,
 ): T {
-  const clone = new Map<unknown, unknown>();
+  const clone = createPendingNestedNormalizationCollectionClone(source);
   const entry: NestedNormalizationEntry = {
     clone,
     finalized: false,
@@ -352,7 +359,7 @@ function normalizeNestedDelegatedSetState<T extends Set<unknown>>(
   seen: WeakMap<object, NestedNormalizationEntry>,
   preferPendingClone: boolean,
 ): T {
-  const clone = new Set<unknown>();
+  const clone = createPendingNestedNormalizationCollectionClone(source);
   const entry: NestedNormalizationEntry = {
     clone,
     finalized: false,

--- a/packages/core/src/annotation-state.ts
+++ b/packages/core/src/annotation-state.ts
@@ -4,6 +4,7 @@ import {
   getAnnotations,
   inheritAnnotations,
   injectAnnotations,
+  isInjectedAnnotationWrapper,
   unwrapInjectedAnnotationWrapper,
 } from "./annotations.ts";
 import {
@@ -77,6 +78,85 @@ export function withAnnotationView<T extends object>(
  */
 export function normalizeInjectedAnnotationState<T>(state: T): T {
   return unwrapInjectedAnnotationWrapper(state);
+}
+
+function isNonPlainDelegatedObject(state: object): boolean {
+  if (
+    Array.isArray(state) ||
+    state instanceof Date ||
+    state instanceof Map ||
+    state instanceof Set ||
+    state instanceof RegExp
+  ) {
+    return false;
+  }
+  const proto = Object.getPrototypeOf(state);
+  return proto !== Object.prototype && proto !== null;
+}
+
+/**
+ * Removes Optique's internal annotation carriers from a delegated state.
+ *
+ * This unwraps both primitive-state annotation wrappers and annotation-view
+ * proxies used for non-plain object states.
+ *
+ * @param state The delegated state to normalize.
+ * @returns The original underlying state value.
+ * @internal
+ */
+export function normalizeDelegatedAnnotationState<T>(state: T): T {
+  return normalizeInjectedAnnotationState(unwrapAnnotationView(state));
+}
+
+/**
+ * Returns whether the given state uses an internal delegated annotation carrier.
+ *
+ * @param state The candidate state to inspect.
+ * @returns `true` when the state is an injected primitive wrapper or an
+ *          annotation-view proxy.
+ * @internal
+ */
+export function hasDelegatedAnnotationCarrier(state: unknown): boolean {
+  return state != null &&
+    typeof state === "object" &&
+    (
+      isInjectedAnnotationWrapper(state) ||
+      annotationViewTargets.has(state as object)
+    );
+}
+
+/**
+ * Creates a short-lived delegated state that exposes the parent's annotations
+ * regardless of the child state's runtime shape.
+ *
+ * Primitive and nullish states use `injectAnnotations()`, plain objects and
+ * built-ins use `inheritAnnotations()`, and non-plain objects use an
+ * annotation-view proxy so class invariants such as private fields remain
+ * intact.
+ *
+ * @param parentState The state carrying the annotations to delegate.
+ * @param childState The child state that should observe those annotations.
+ * @returns A delegated child state that exposes the parent's annotations.
+ * @internal
+ */
+export function getDelegatedAnnotationState<TState>(
+  parentState: unknown,
+  childState: TState,
+): TState {
+  const annotations = getAnnotations(parentState);
+  if (annotations === undefined || getAnnotations(childState) === annotations) {
+    return childState;
+  }
+  if (childState == null || typeof childState !== "object") {
+    return injectAnnotations(childState, annotations);
+  }
+  if (isInjectedAnnotationWrapper(childState)) {
+    return injectAnnotations(childState, annotations);
+  }
+  if (isNonPlainDelegatedObject(childState)) {
+    return withAnnotationView(childState, annotations) as TState;
+  }
+  return inheritAnnotations(parentState, childState);
 }
 
 /**

--- a/packages/core/src/annotation-state.ts
+++ b/packages/core/src/annotation-state.ts
@@ -126,6 +126,86 @@ export function hasDelegatedAnnotationCarrier(state: unknown): boolean {
 }
 
 /**
+ * Recursively removes delegated annotation carriers from plain-object and array
+ * structures.
+ *
+ * Nested plain objects and arrays are shallow-cloned only when a delegated
+ * carrier is found below them. Non-plain objects are unwrapped at the top
+ * level and then preserved as-is to avoid mutating or reconstructing class
+ * instances.
+ *
+ * @param value The candidate value to normalize.
+ * @param seen Tracks already-normalized objects so cyclic values keep their
+ *             shape.
+ * @returns The original value when no delegated carriers are present, or a
+ *          normalized clone with delegated carriers removed.
+ * @internal
+ */
+export function normalizeNestedDelegatedAnnotationState<T>(
+  value: T,
+  seen = new WeakMap<object, unknown>(),
+): T {
+  const normalized = normalizeDelegatedAnnotationState(value);
+  if (normalized == null || typeof normalized !== "object") {
+    return normalized;
+  }
+  const source = normalized as object;
+  if (seen.has(source)) {
+    return seen.get(source) as T;
+  }
+  if (Array.isArray(source)) {
+    let changed = false;
+    const clone = [...source];
+    seen.set(source, clone);
+    for (let i = 0; i < source.length; i++) {
+      const nextValue = normalizeNestedDelegatedAnnotationState(
+        source[i],
+        seen,
+      );
+      if (nextValue !== source[i]) {
+        clone[i] = nextValue;
+        changed = true;
+      }
+    }
+    if (!changed) {
+      seen.set(source, source);
+      return source as T;
+    }
+    return clone as T;
+  }
+  const proto = Object.getPrototypeOf(source);
+  if (proto !== Object.prototype && proto !== null) {
+    return normalized;
+  }
+  const descriptors = Object.getOwnPropertyDescriptors(source) as Record<
+    PropertyKey,
+    PropertyDescriptor
+  >;
+  let changed = false;
+  const clone = Object.create(proto);
+  seen.set(source, clone);
+  for (const key of Reflect.ownKeys(descriptors)) {
+    const descriptor = descriptors[key];
+    if (descriptor != null && "value" in descriptor) {
+      const nextValue = normalizeNestedDelegatedAnnotationState(
+        descriptor.value,
+        seen,
+      );
+      if (nextValue !== descriptor.value) {
+        descriptors[key] = { ...descriptor, value: nextValue };
+        changed = true;
+      }
+    }
+  }
+  if (!changed) {
+    seen.set(source, source);
+    return source as T;
+  }
+  Object.defineProperties(clone, descriptors);
+  return clone as T;
+}
+
+/**
  * Creates a short-lived delegated state that exposes the parent's annotations
  * regardless of the child state's runtime shape.
  *
@@ -151,7 +231,10 @@ export function getDelegatedAnnotationState<TState>(
     return injectAnnotations(childState, annotations);
   }
   if (isInjectedAnnotationWrapper(childState)) {
-    return injectAnnotations(childState, annotations);
+    return injectAnnotations(
+      normalizeInjectedAnnotationState(childState),
+      annotations,
+    );
   }
   if (isNonPlainDelegatedObject(childState)) {
     return withAnnotationView(childState, annotations) as TState;

--- a/packages/core/src/annotation-state.ts
+++ b/packages/core/src/annotation-state.ts
@@ -205,14 +205,163 @@ function normalizeNestedDelegatedStructuredState<T extends object>(
   return clone as T;
 }
 
+function normalizeNestedDelegatedMapState<T extends Map<unknown, unknown>>(
+  source: T,
+  seen: WeakMap<object, NestedNormalizationEntry>,
+): T {
+  const clone = new Map<unknown, unknown>();
+  const entry: NestedNormalizationEntry = {
+    clone,
+    finalized: false,
+    result: clone,
+  };
+  seen.set(source, entry);
+
+  const normalizedEntries: Array<readonly [unknown, unknown]> = [];
+  const overrides = new Map<PropertyKey, unknown>();
+  let changed = false;
+
+  for (const [key, value] of source) {
+    const nextKey = normalizeNestedDelegatedAnnotationState(key, seen);
+    const nextValue = normalizeNestedDelegatedAnnotationState(value, seen);
+    normalizedEntries.push([nextKey, nextValue]);
+    if (
+      (!isPendingNestedNormalizationAlias(key, nextKey, seen) &&
+        nextKey !== key) ||
+      (!isPendingNestedNormalizationAlias(value, nextValue, seen) &&
+        nextValue !== value)
+    ) {
+      changed = true;
+    }
+  }
+
+  for (const key of Reflect.ownKeys(source)) {
+    const descriptor = Object.getOwnPropertyDescriptor(source, key);
+    if (descriptor == null || !("value" in descriptor)) {
+      continue;
+    }
+    const nextValue = normalizeNestedDelegatedAnnotationState(
+      descriptor.value,
+      seen,
+    );
+    if (nextValue === descriptor.value) {
+      continue;
+    }
+    overrides.set(key, nextValue);
+    if (!isPendingNestedNormalizationAlias(descriptor.value, nextValue, seen)) {
+      changed = true;
+    }
+  }
+
+  if (!changed) {
+    entry.finalized = true;
+    entry.result = source;
+    return source;
+  }
+
+  for (const [key, value] of normalizedEntries) {
+    clone.set(key, value);
+  }
+
+  const descriptors = Object.getOwnPropertyDescriptors(source) as Record<
+    PropertyKey,
+    PropertyDescriptor
+  >;
+  for (const [key, nextValue] of overrides) {
+    const descriptor = descriptors[key];
+    if (descriptor == null || !("value" in descriptor)) {
+      continue;
+    }
+    descriptors[key] = { ...descriptor, value: nextValue };
+  }
+
+  Object.defineProperties(clone, descriptors);
+  entry.finalized = true;
+  entry.result = clone;
+  return clone as T;
+}
+
+function normalizeNestedDelegatedSetState<T extends Set<unknown>>(
+  source: T,
+  seen: WeakMap<object, NestedNormalizationEntry>,
+): T {
+  const clone = new Set<unknown>();
+  const entry: NestedNormalizationEntry = {
+    clone,
+    finalized: false,
+    result: clone,
+  };
+  seen.set(source, entry);
+
+  const normalizedValues: unknown[] = [];
+  const overrides = new Map<PropertyKey, unknown>();
+  let changed = false;
+
+  for (const value of source) {
+    const nextValue = normalizeNestedDelegatedAnnotationState(value, seen);
+    normalizedValues.push(nextValue);
+    if (
+      nextValue !== value &&
+      !isPendingNestedNormalizationAlias(value, nextValue, seen)
+    ) {
+      changed = true;
+    }
+  }
+
+  for (const key of Reflect.ownKeys(source)) {
+    const descriptor = Object.getOwnPropertyDescriptor(source, key);
+    if (descriptor == null || !("value" in descriptor)) {
+      continue;
+    }
+    const nextValue = normalizeNestedDelegatedAnnotationState(
+      descriptor.value,
+      seen,
+    );
+    if (nextValue === descriptor.value) {
+      continue;
+    }
+    overrides.set(key, nextValue);
+    if (!isPendingNestedNormalizationAlias(descriptor.value, nextValue, seen)) {
+      changed = true;
+    }
+  }
+
+  if (!changed) {
+    entry.finalized = true;
+    entry.result = source;
+    return source;
+  }
+
+  for (const value of normalizedValues) {
+    clone.add(value);
+  }
+
+  const descriptors = Object.getOwnPropertyDescriptors(source) as Record<
+    PropertyKey,
+    PropertyDescriptor
+  >;
+  for (const [key, nextValue] of overrides) {
+    const descriptor = descriptors[key];
+    if (descriptor == null || !("value" in descriptor)) {
+      continue;
+    }
+    descriptors[key] = { ...descriptor, value: nextValue };
+  }
+
+  Object.defineProperties(clone, descriptors);
+  entry.finalized = true;
+  entry.result = clone;
+  return clone as T;
+}
+
 /**
- * Recursively removes delegated annotation carriers from plain-object and array
- * structures.
+ * Recursively removes delegated annotation carriers from plain-object, array,
+ * and built-in collection structures.
  *
- * Nested plain objects and arrays are shallow-cloned only when a delegated
- * carrier is found below them. Non-plain objects are unwrapped at the top
- * level and then preserved as-is to avoid mutating or reconstructing class
- * instances.
+ * Nested plain objects, arrays, Maps, and Sets are shallow-cloned only when a
+ * delegated carrier is found below them. Other non-plain objects are unwrapped
+ * at the top level and then preserved as-is to avoid mutating or reconstructing
+ * class instances.
  *
  * @param value The candidate value to normalize.
  * @param seen Tracks already-normalized objects so cyclic values keep their
@@ -236,6 +385,12 @@ export function normalizeNestedDelegatedAnnotationState<T>(
   }
   if (Array.isArray(source)) {
     return normalizeNestedDelegatedStructuredState(source, seen) as T;
+  }
+  if (source instanceof Map) {
+    return normalizeNestedDelegatedMapState(source, seen) as T;
+  }
+  if (source instanceof Set) {
+    return normalizeNestedDelegatedSetState(source, seen) as T;
   }
   const proto = Object.getPrototypeOf(source);
   if (proto !== Object.prototype && proto !== null) {

--- a/packages/core/src/annotation-state.ts
+++ b/packages/core/src/annotation-state.ts
@@ -1,5 +1,4 @@
 import {
-  annotateFreshArray,
   annotationKey,
   type Annotations,
   getAnnotations,
@@ -144,6 +143,68 @@ function isPendingNestedNormalizationAlias(
   return entry != null && !entry.finalized && entry.clone === normalizedValue;
 }
 
+function createPendingNestedNormalizationClone(source: object): object {
+  return Array.isArray(source)
+    ? []
+    : Object.create(Object.getPrototypeOf(source));
+}
+
+function normalizeNestedDelegatedStructuredState<T extends object>(
+  source: T,
+  seen: WeakMap<object, NestedNormalizationEntry>,
+): T {
+  const clone = createPendingNestedNormalizationClone(source);
+  const entry: NestedNormalizationEntry = {
+    clone,
+    finalized: false,
+    result: clone,
+  };
+  seen.set(source, entry);
+
+  const overrides = new Map<PropertyKey, unknown>();
+  let changed = false;
+  for (const key of Reflect.ownKeys(source)) {
+    const descriptor = Object.getOwnPropertyDescriptor(source, key);
+    if (descriptor == null || !("value" in descriptor)) {
+      continue;
+    }
+    const nextValue = normalizeNestedDelegatedAnnotationState(
+      descriptor.value,
+      seen,
+    );
+    if (nextValue === descriptor.value) {
+      continue;
+    }
+    overrides.set(key, nextValue);
+    if (!isPendingNestedNormalizationAlias(descriptor.value, nextValue, seen)) {
+      changed = true;
+    }
+  }
+
+  if (!changed) {
+    entry.finalized = true;
+    entry.result = source;
+    return source;
+  }
+
+  const descriptors = Object.getOwnPropertyDescriptors(source) as Record<
+    PropertyKey,
+    PropertyDescriptor
+  >;
+  for (const [key, nextValue] of overrides) {
+    const descriptor = descriptors[key];
+    if (descriptor == null || !("value" in descriptor)) {
+      continue;
+    }
+    descriptors[key] = { ...descriptor, value: nextValue };
+  }
+
+  Object.defineProperties(clone, descriptors);
+  entry.finalized = true;
+  entry.result = clone;
+  return clone as T;
+}
+
 /**
  * Recursively removes delegated annotation carriers from plain-object and array
  * structures.
@@ -174,70 +235,13 @@ export function normalizeNestedDelegatedAnnotationState<T>(
     return (existing.finalized ? existing.result : existing.clone) as T;
   }
   if (Array.isArray(source)) {
-    let changed = false;
-    const clone = annotateFreshArray(source, source.slice()) as unknown[];
-    const entry: NestedNormalizationEntry = {
-      clone: clone as object,
-      finalized: false,
-      result: clone as object,
-    };
-    seen.set(source, entry);
-    for (let i = 0; i < source.length; i++) {
-      const nextValue = normalizeNestedDelegatedAnnotationState(
-        source[i],
-        seen,
-      );
-      if (nextValue !== source[i]) {
-        clone[i] = nextValue;
-        if (!isPendingNestedNormalizationAlias(source[i], nextValue, seen)) {
-          changed = true;
-        }
-      }
-    }
-    entry.finalized = true;
-    entry.result = changed ? clone as object : source;
-    return (changed ? clone : source) as T;
+    return normalizeNestedDelegatedStructuredState(source, seen) as T;
   }
   const proto = Object.getPrototypeOf(source);
   if (proto !== Object.prototype && proto !== null) {
     return normalized;
   }
-  const descriptors = Object.getOwnPropertyDescriptors(source) as Record<
-    PropertyKey,
-    PropertyDescriptor
-  >;
-  let changed = false;
-  const clone = Object.create(proto);
-  const entry: NestedNormalizationEntry = {
-    clone,
-    finalized: false,
-    result: clone,
-  };
-  seen.set(source, entry);
-  for (const key of Reflect.ownKeys(descriptors)) {
-    const descriptor = descriptors[key];
-    if (descriptor != null && "value" in descriptor) {
-      const nextValue = normalizeNestedDelegatedAnnotationState(
-        descriptor.value,
-        seen,
-      );
-      if (nextValue !== descriptor.value) {
-        descriptors[key] = { ...descriptor, value: nextValue };
-        if (
-          !isPendingNestedNormalizationAlias(descriptor.value, nextValue, seen)
-        ) {
-          changed = true;
-        }
-      }
-    }
-  }
-  entry.finalized = true;
-  entry.result = changed ? clone : source;
-  if (!changed) {
-    return source as T;
-  }
-  Object.defineProperties(clone, descriptors);
-  return clone as T;
+  return normalizeNestedDelegatedStructuredState(source, seen) as T;
 }
 
 /**

--- a/packages/core/src/modifiers.test.ts
+++ b/packages/core/src/modifiers.test.ts
@@ -29,7 +29,12 @@ import {
   withDefault,
   WithDefaultError,
 } from "@optique/core/modifiers";
-import { map as mapLocal, multiple as multipleLocal } from "./modifiers.ts";
+import {
+  map as mapLocal,
+  multiple as multipleLocal,
+  optional as optionalLocal,
+  withDefault as withDefaultLocal,
+} from "./modifiers.ts";
 import {
   completeOrExtractPhase2Seed,
   extractPhase2SeedKey,
@@ -8012,7 +8017,7 @@ describe(
         wrap<TMode extends "sync" | "async", TValue, TState>(
           parser: Parser<TMode, TValue, TState>,
         ) {
-          return optional(parser);
+          return optionalLocal(parser);
         },
       },
       {
@@ -8020,7 +8025,7 @@ describe(
         wrap<TMode extends "sync" | "async", TValue, TState>(
           parser: Parser<TMode, TValue, TState>,
         ) {
-          return withDefault(parser, "fallback");
+          return withDefaultLocal(parser, "fallback");
         },
       },
     ] as const;

--- a/packages/core/src/modifiers.test.ts
+++ b/packages/core/src/modifiers.test.ts
@@ -37,6 +37,7 @@ import {
 } from "./modifiers.ts";
 import {
   completeOrExtractPhase2Seed,
+  extractPhase2Seed,
   extractPhase2SeedKey,
 } from "./phase2-seed.ts";
 import { createDependencyRuntimeContext } from "./dependency-runtime.ts";
@@ -8362,6 +8363,140 @@ describe(
         assert.deepEqual(seenStates, [outerState, undefined]);
       });
 
+      it(`${name} complete() does not retry plain undefined failures`, () => {
+        let callCount = 0;
+        const parser = wrap({
+          $mode: "sync" as const,
+          $valueType: [] as const,
+          $stateType: [] as const,
+          priority: 0,
+          usage: [],
+          leadingNames: new Set<string>(),
+          acceptingAnyToken: false,
+          initialState: undefined,
+          parse(context: ParserContext<unknown>) {
+            return { success: true as const, next: context, consumed: [] };
+          },
+          complete() {
+            callCount++;
+            return {
+              success: false as const,
+              error: message`Plain undefined failure.`,
+            };
+          },
+          shouldDeferCompletion(state: unknown) {
+            return state === undefined;
+          },
+          suggest: function* () {},
+          getDocFragments() {
+            return { fragments: [] };
+          },
+        });
+
+        const result = parser.complete([undefined] as unknown as [unknown]);
+
+        assert.equal(callCount, 1);
+        assert.deepEqual(result, {
+          success: false,
+          error: message`Plain undefined failure.`,
+        });
+      });
+
+      it(`${name} async complete() does not retry plain undefined failures`, async () => {
+        let callCount = 0;
+        const parser = wrap({
+          $mode: "async" as const,
+          $valueType: [] as const,
+          $stateType: [] as const,
+          priority: 0,
+          usage: [],
+          leadingNames: new Set<string>(),
+          acceptingAnyToken: false,
+          initialState: undefined,
+          parse(context: ParserContext<unknown>) {
+            return Promise.resolve({
+              success: true as const,
+              next: context,
+              consumed: [],
+            });
+          },
+          complete() {
+            callCount++;
+            return Promise.resolve({
+              success: false as const,
+              error: message`Plain async undefined failure.`,
+            });
+          },
+          shouldDeferCompletion(state: unknown) {
+            return state === undefined;
+          },
+          suggest: async function* () {},
+          getDocFragments() {
+            return { fragments: [] };
+          },
+        });
+
+        const result = await parser.complete(
+          [undefined] as unknown as [unknown],
+        );
+
+        assert.equal(callCount, 1);
+        assert.deepEqual(result, {
+          success: false,
+          error: message`Plain async undefined failure.`,
+        });
+      });
+
+      it(
+        `${name} complete() skips nested normalization when no delegated carrier is present`,
+        () => {
+          let ownKeysCalls = 0;
+          let descriptorCalls = 0;
+          const value = new Proxy(
+            { nested: { value: "ok" } },
+            {
+              ownKeys(target) {
+                ownKeysCalls++;
+                return Reflect.ownKeys(target);
+              },
+              getOwnPropertyDescriptor(target, key) {
+                descriptorCalls++;
+                return Reflect.getOwnPropertyDescriptor(target, key);
+              },
+            },
+          );
+          const parser = wrap({
+            $mode: "sync" as const,
+            $valueType: [] as const,
+            $stateType: [] as const,
+            priority: 0,
+            usage: [],
+            leadingNames: new Set<string>(),
+            acceptingAnyToken: false,
+            initialState: "seed",
+            parse(context: ParserContext<string>) {
+              return { success: true as const, next: context, consumed: [] };
+            },
+            complete() {
+              return { success: true as const, value };
+            },
+            suggest: function* () {},
+            getDocFragments() {
+              return { fragments: [] };
+            },
+          });
+
+          const result = parser.complete(["live"] as [string]);
+
+          assert.deepEqual(result, {
+            success: true,
+            value,
+          });
+          assert.equal(ownKeysCalls, 0);
+          assert.equal(descriptorCalls, 0);
+        },
+      );
+
       it(
         `${name} shouldDeferCompletion() retries wrapped initial-state false results`,
         () => {
@@ -8566,6 +8701,180 @@ describe(
           assert.deepEqual(seed, {
             value: { inner: "live" },
           });
+        },
+      );
+      it(
+        `${name} phase-two seed extraction retries wrapped initial-state failures before the extractor`,
+        () => {
+          let completeCalls = 0;
+          let extractCalls = 0;
+          const inner: Parser<"sync", string, undefined> = {
+            $mode: "sync",
+            $valueType: [] as readonly string[],
+            $stateType: [] as readonly undefined[],
+            priority: 0,
+            usage: [],
+            leadingNames: new Set<string>(),
+            acceptingAnyToken: false,
+            initialState: undefined,
+            parse(context) {
+              return {
+                success: true as const,
+                next: context,
+                consumed: [],
+              };
+            },
+            complete(state) {
+              completeCalls++;
+              return state === undefined
+                ? { success: true as const, value: "resolved" }
+                : {
+                  success: false as const,
+                  error: message`Wrapped phase-two failure.`,
+                };
+            },
+            suggest() {
+              return [];
+            },
+            getDocFragments() {
+              return { fragments: [] };
+            },
+          };
+          Object.defineProperty(inner, extractPhase2SeedKey, {
+            value() {
+              extractCalls++;
+              return null;
+            },
+          });
+          const parser = wrap(inner);
+          const outerState = injectAnnotations([undefined] as [undefined], {
+            [Symbol.for(`@test/issue-594/${name}/wrapped-phase2`)]: true,
+          });
+
+          const seed = extractPhase2Seed(parser, outerState);
+
+          assert.deepEqual(seed, {
+            value: "resolved",
+          });
+          assert.equal(completeCalls, 2);
+          assert.equal(extractCalls, 0);
+        },
+      );
+
+      it(
+        `${name} async phase-two seed extraction retries wrapped initial-state failures before the extractor`,
+        async () => {
+          let completeCalls = 0;
+          let extractCalls = 0;
+          const inner: Parser<"async", string, undefined> = {
+            $mode: "async",
+            $valueType: [] as readonly string[],
+            $stateType: [] as readonly undefined[],
+            priority: 0,
+            usage: [],
+            leadingNames: new Set<string>(),
+            acceptingAnyToken: false,
+            initialState: undefined,
+            parse(context) {
+              return Promise.resolve({
+                success: true as const,
+                next: context,
+                consumed: [],
+              });
+            },
+            complete(state) {
+              completeCalls++;
+              return Promise.resolve(
+                state === undefined
+                  ? { success: true as const, value: "resolved" }
+                  : {
+                    success: false as const,
+                    error: message`Wrapped async phase-two failure.`,
+                  },
+              );
+            },
+            suggest: async function* () {},
+            getDocFragments() {
+              return { fragments: [] };
+            },
+          };
+          Object.defineProperty(inner, extractPhase2SeedKey, {
+            value() {
+              extractCalls++;
+              return Promise.resolve(null);
+            },
+          });
+          const parser = wrap(inner);
+          const outerState = injectAnnotations([undefined] as [undefined], {
+            [Symbol.for(`@test/issue-594/${name}/wrapped-async-phase2`)]: true,
+          });
+
+          const seed = await extractPhase2Seed(parser, outerState);
+
+          assert.deepEqual(seed, {
+            value: "resolved",
+          });
+          assert.equal(completeCalls, 2);
+          assert.equal(extractCalls, 0);
+        },
+      );
+
+      it(
+        `${name} phase-two seed extraction skips nested normalization when no delegated carrier is present`,
+        () => {
+          let ownKeysCalls = 0;
+          let descriptorCalls = 0;
+          const value = new Proxy(
+            { nested: { value: "ok" } },
+            {
+              ownKeys(target) {
+                ownKeysCalls++;
+                return Reflect.ownKeys(target);
+              },
+              getOwnPropertyDescriptor(target, key) {
+                descriptorCalls++;
+                return Reflect.getOwnPropertyDescriptor(target, key);
+              },
+            },
+          );
+          const inner: Parser<"sync", typeof value, string> = {
+            $mode: "sync",
+            $valueType: [] as readonly (typeof value)[],
+            $stateType: [] as readonly string[],
+            priority: 0,
+            usage: [],
+            leadingNames: new Set<string>(),
+            acceptingAnyToken: false,
+            initialState: "seed",
+            parse(context) {
+              return {
+                success: true as const,
+                next: context,
+                consumed: [],
+              };
+            },
+            complete() {
+              return {
+                success: true as const,
+                value,
+              };
+            },
+            suggest() {
+              return [];
+            },
+            getDocFragments() {
+              return { fragments: [] };
+            },
+          };
+          const parser = wrap(inner);
+
+          const seed = extractPhase2Seed(parser, ["live"]);
+
+          assert.deepEqual(seed, {
+            value,
+          });
+          assert.equal(ownKeysCalls, 0);
+          assert.equal(descriptorCalls, 0);
         },
       );
     }

--- a/packages/core/src/modifiers.test.ts
+++ b/packages/core/src/modifiers.test.ts
@@ -8566,6 +8566,118 @@ describe(
         assert.equal(getAnnotations(state), undefined);
       });
 
+      it(`${name} complete() preserves Array subclass inner states`, () => {
+        const marker = Symbol.for(`@test/issue-594/${name}/complete-array`);
+
+        class DeferredArrayState extends Array<string> {
+          #secret = "private-value";
+
+          read(): string {
+            return this.#secret;
+          }
+        }
+
+        const state = new DeferredArrayState("live");
+        const parser = wrap({
+          $mode: "sync" as const,
+          $valueType: [] as const,
+          $stateType: [] as const,
+          priority: 0,
+          usage: [],
+          leadingNames: new Set<string>(),
+          acceptingAnyToken: false,
+          initialState: new DeferredArrayState("seed"),
+          parse(context: ParserContext<DeferredArrayState>) {
+            return { success: true as const, next: context, consumed: [] };
+          },
+          complete(innerState: DeferredArrayState) {
+            return {
+              success: true as const,
+              value: {
+                annotated: getAnnotations(innerState)?.[marker] === "ok",
+                secret: innerState.read(),
+                inner: innerState,
+              },
+            };
+          },
+          suggest() {
+            return [];
+          },
+          getDocFragments() {
+            return { fragments: [] };
+          },
+        });
+        const outerState = injectAnnotations([state] as [DeferredArrayState], {
+          [marker]: "ok",
+        });
+
+        const result = parser.complete(outerState);
+
+        assert.deepEqual(result, {
+          success: true,
+          value: {
+            annotated: true,
+            secret: "private-value",
+            inner: state,
+          },
+        });
+        if (
+          result.success &&
+          result.value != null &&
+          typeof result.value === "object" &&
+          "inner" in result.value
+        ) {
+          assert.strictEqual(result.value.inner, state);
+          assert.equal(getAnnotations(result.value.inner), undefined);
+        }
+      });
+
+      it(`${name} shouldDeferCompletion() preserves Array subclass inner states`, () => {
+        const marker = Symbol.for(`@test/issue-594/${name}/defer-array`);
+
+        class DeferredArrayState extends Array<string> {
+          #secret = "private-value";
+
+          read(): string {
+            return this.#secret;
+          }
+        }
+
+        const parser = wrap({
+          $mode: "sync" as const,
+          $valueType: [] as const,
+          $stateType: [] as const,
+          priority: 0,
+          usage: [],
+          leadingNames: new Set<string>(),
+          acceptingAnyToken: false,
+          initialState: new DeferredArrayState("seed"),
+          parse(context: ParserContext<DeferredArrayState>) {
+            return { success: true as const, next: context, consumed: [] };
+          },
+          complete(state: DeferredArrayState) {
+            return { success: true as const, value: state.read() };
+          },
+          shouldDeferCompletion(state: DeferredArrayState) {
+            return getAnnotations(state)?.[marker] === "ok" &&
+              state.read() === "private-value";
+          },
+          suggest() {
+            return [];
+          },
+          getDocFragments() {
+            return { fragments: [] };
+          },
+        });
+        const state = new DeferredArrayState("live");
+        const outerState = injectAnnotations([state] as [DeferredArrayState], {
+          [marker]: "ok",
+        });
+
+        assert.ok(parser.shouldDeferCompletion?.(outerState));
+        assert.equal(getAnnotations(state), undefined);
+      });
+
       it(`${name} complete() preserves annotation-aware exceptions`, () => {
         const marker = Symbol.for(`@test/issue-594/${name}/complete-throw`);
         let callCount = 0;

--- a/packages/core/src/modifiers.test.ts
+++ b/packages/core/src/modifiers.test.ts
@@ -8163,6 +8163,161 @@ describe(
         }
       });
 
+      it(`${name} complete() deep-normalizes nested delegated plain-object values`, () => {
+        const marker = Symbol.for(
+          `@test/issue-594/${name}/nested-plain-object`,
+        );
+        const state = { value: "live" };
+        const parser = wrap({
+          $mode: "sync" as const,
+          $valueType: [] as const,
+          $stateType: [] as const,
+          priority: 0,
+          usage: [],
+          leadingNames: new Set<string>(),
+          acceptingAnyToken: false,
+          initialState: { value: "seed" },
+          parse(context: ParserContext<{ value: string }>) {
+            return { success: true as const, next: context, consumed: [] };
+          },
+          complete(innerState: { value: string }) {
+            return {
+              success: true as const,
+              value: {
+                annotated: getAnnotations(innerState)?.[marker] === "ok",
+                inner: innerState,
+              },
+            };
+          },
+          suggest() {
+            return [];
+          },
+          getDocFragments() {
+            return { fragments: [] };
+          },
+        });
+        const outerState = injectAnnotations([state] as [{ value: string }], {
+          [marker]: "ok",
+        });
+
+        const result = parser.complete(outerState);
+
+        assert.deepEqual(result, {
+          success: true,
+          value: {
+            annotated: true,
+            inner: state,
+          },
+        });
+        if (
+          result.success &&
+          result.value != null &&
+          typeof result.value === "object" &&
+          "inner" in result.value
+        ) {
+          assert.strictEqual(result.value.inner, state);
+          assert.equal(getAnnotations(result.value.inner), undefined);
+        }
+      });
+
+      it(`${name} parse() strips annotations from plain-object initial states`, () => {
+        const marker = Symbol.for(
+          `@test/issue-594/${name}/parse-plain-object`,
+        );
+        const initialState = { value: "seed" };
+        const parser = wrap({
+          $mode: "sync" as const,
+          $valueType: [] as const,
+          $stateType: [] as const,
+          priority: 0,
+          usage: [],
+          leadingNames: new Set<string>(),
+          acceptingAnyToken: false,
+          initialState,
+          parse(context: ParserContext<{ value: string }>) {
+            return { success: true as const, next: context, consumed: [] };
+          },
+          complete(state: { value: string }) {
+            return {
+              success: true as const,
+              value: {
+                annotated: getAnnotations(state)?.[marker] === "ok",
+                inner: state,
+              },
+            };
+          },
+          suggest() {
+            return [];
+          },
+          getDocFragments() {
+            return { fragments: [] };
+          },
+        });
+
+        const result = parse(parser, [], {
+          annotations: { [marker]: "ok" },
+        });
+
+        assert.ok(result.success);
+        if (!result.success) return;
+        assert.deepEqual(result.value, {
+          annotated: true,
+          inner: initialState,
+        });
+        assert.strictEqual(result.value.inner, initialState);
+        assert.equal(getAnnotations(result.value.inner), undefined);
+      });
+
+      it(`${name} parseAsync() strips annotations from plain-object initial states`, async () => {
+        const marker = Symbol.for(
+          `@test/issue-594/${name}/parse-plain-object-async`,
+        );
+        const initialState = { value: "seed" };
+        const parser = wrap({
+          $mode: "async" as const,
+          $valueType: [] as const,
+          $stateType: [] as const,
+          priority: 0,
+          usage: [],
+          leadingNames: new Set<string>(),
+          acceptingAnyToken: false,
+          initialState,
+          parse(context: ParserContext<{ value: string }>) {
+            return Promise.resolve({
+              success: true as const,
+              next: context,
+              consumed: [],
+            });
+          },
+          complete(state: { value: string }) {
+            return Promise.resolve({
+              success: true as const,
+              value: {
+                annotated: getAnnotations(state)?.[marker] === "ok",
+                inner: state,
+              },
+            });
+          },
+          suggest: async function* () {},
+          getDocFragments() {
+            return { fragments: [] };
+          },
+        });
+
+        const result = await parseAsync(parser, [], {
+          annotations: { [marker]: "ok" },
+        });
+
+        assert.ok(result.success);
+        if (!result.success) return;
+        assert.deepEqual(result.value, {
+          annotated: true,
+          inner: initialState,
+        });
+        assert.strictEqual(result.value.inner, initialState);
+        assert.equal(getAnnotations(result.value.inner), undefined);
+      });
+
       it(`${name} suggest() keeps primitive inner states unwrapped`, () => {
         const parser = wrap({
           $mode: "sync" as const,

--- a/packages/core/src/modifiers.test.ts
+++ b/packages/core/src/modifiers.test.ts
@@ -8162,6 +8162,81 @@ describe(
         }
       });
 
+      it(`${name} suggest() keeps primitive inner states unwrapped`, () => {
+        const parser = wrap({
+          $mode: "sync" as const,
+          $valueType: [] as const,
+          $stateType: [] as const,
+          priority: 0,
+          usage: [],
+          leadingNames: new Set<string>(),
+          acceptingAnyToken: false,
+          initialState: "seed",
+          parse(context: ParserContext<string>) {
+            return { success: true as const, next: context, consumed: [] };
+          },
+          complete(state: string) {
+            return { success: true as const, value: state };
+          },
+          *suggest(context: ParserContext<string>) {
+            if (typeof context.state !== "string") {
+              throw new TypeError("Expected primitive suggest state.");
+            }
+            yield { kind: "literal" as const, text: context.state };
+          },
+          getDocFragments() {
+            return { fragments: [] };
+          },
+        });
+        const outerState = injectAnnotations(["live"] as [string], {
+          [Symbol.for(`@test/issue-594/${name}/suggest-primitive`)]: true,
+        });
+
+        const suggestions = [...parser.suggest({
+          buffer: [],
+          state: outerState,
+          optionsTerminated: false,
+          usage: parser.usage,
+        }, "")];
+
+        assert.deepEqual(suggestions, [{ kind: "literal", text: "live" }]);
+      });
+
+      it(`${name} getSuggestRuntimeNodes() keeps primitive inner states unwrapped`, () => {
+        let seenState: unknown;
+        const parser = wrap({
+          $mode: "sync" as const,
+          $valueType: [] as const,
+          $stateType: [] as const,
+          priority: 0,
+          usage: [],
+          leadingNames: new Set<string>(),
+          acceptingAnyToken: false,
+          initialState: "seed",
+          getSuggestRuntimeNodes(state: unknown) {
+            seenState = state;
+            return [];
+          },
+          parse(context: ParserContext<string>) {
+            return { success: true as const, next: context, consumed: [] };
+          },
+          complete(state: string) {
+            return { success: true as const, value: state };
+          },
+          suggest: function* () {},
+          getDocFragments() {
+            return { fragments: [] };
+          },
+        });
+        const outerState = injectAnnotations(["live"] as [string], {
+          [Symbol.for(`@test/issue-594/${name}/runtime-nodes-primitive`)]: true,
+        });
+
+        parser.getSuggestRuntimeNodes?.(outerState, ["root"]);
+
+        assert.equal(seenState, "live");
+      });
+
       it(
         `${name} shouldDeferCompletion() preserves annotations on primitive inner states`,
         () => {

--- a/packages/core/src/modifiers.test.ts
+++ b/packages/core/src/modifiers.test.ts
@@ -7867,6 +7867,223 @@ describe("shouldDeferCompletion forwarding", () => {
   });
 });
 
+describe(
+  "optional-like delegated annotation propagation (issue #594)",
+  () => {
+    class DeferredClassState {
+      #secret = "private-value";
+
+      read(): string {
+        return this.#secret;
+      }
+    }
+
+    function createPrimitiveCompletionParser(
+      marker: symbol,
+    ): Parser<"sync", string, string> {
+      return {
+        $mode: "sync",
+        $valueType: [] as readonly string[],
+        $stateType: [] as readonly string[],
+        priority: 0,
+        usage: [],
+        leadingNames: new Set<string>(),
+        acceptingAnyToken: false,
+        initialState: "seed",
+        parse(context) {
+          return { success: true as const, next: context, consumed: [] };
+        },
+        complete(state) {
+          return {
+            success: true as const,
+            value: getAnnotations(state)?.[marker] === "ok"
+              ? "annotated"
+              : "missing-annotations",
+          };
+        },
+        suggest() {
+          return [];
+        },
+        getDocFragments() {
+          return { fragments: [] };
+        },
+      };
+    }
+
+    function createClassCompletionParser(
+      marker: symbol,
+    ): Parser<"sync", string, DeferredClassState> {
+      return {
+        $mode: "sync",
+        $valueType: [] as readonly string[],
+        $stateType: [] as readonly DeferredClassState[],
+        priority: 0,
+        usage: [],
+        leadingNames: new Set<string>(),
+        acceptingAnyToken: false,
+        initialState: new DeferredClassState(),
+        parse(context) {
+          return { success: true as const, next: context, consumed: [] };
+        },
+        complete(state) {
+          return {
+            success: true as const,
+            value: getAnnotations(state)?.[marker] === "ok"
+              ? state.read()
+              : "missing-annotations",
+          };
+        },
+        suggest() {
+          return [];
+        },
+        getDocFragments() {
+          return { fragments: [] };
+        },
+      };
+    }
+
+    function createPrimitiveDeferralParser(
+      marker: symbol,
+    ): Parser<"sync", string, string> {
+      return {
+        $mode: "sync",
+        $valueType: [] as readonly string[],
+        $stateType: [] as readonly string[],
+        priority: 0,
+        usage: [],
+        leadingNames: new Set<string>(),
+        acceptingAnyToken: false,
+        initialState: "seed",
+        parse(context) {
+          return { success: true as const, next: context, consumed: [] };
+        },
+        complete(state) {
+          return {
+            success: true as const,
+            value: typeof state === "string" ? state : "wrapped",
+          };
+        },
+        shouldDeferCompletion(state) {
+          return getAnnotations(state)?.[marker] === "ok";
+        },
+        suggest() {
+          return [];
+        },
+        getDocFragments() {
+          return { fragments: [] };
+        },
+      };
+    }
+
+    function createClassDeferralParser(
+      marker: symbol,
+    ): Parser<"sync", string, DeferredClassState> {
+      return {
+        $mode: "sync",
+        $valueType: [] as readonly string[],
+        $stateType: [] as readonly DeferredClassState[],
+        priority: 0,
+        usage: [],
+        leadingNames: new Set<string>(),
+        acceptingAnyToken: false,
+        initialState: new DeferredClassState(),
+        parse(context) {
+          return { success: true as const, next: context, consumed: [] };
+        },
+        complete(state) {
+          return { success: true as const, value: state.read() };
+        },
+        shouldDeferCompletion(state) {
+          return state.read() === "private-value" &&
+            getAnnotations(state)?.[marker] === "ok";
+        },
+        suggest() {
+          return [];
+        },
+        getDocFragments() {
+          return { fragments: [] };
+        },
+      };
+    }
+
+    const wrappers = [
+      {
+        name: "optional()",
+        wrap<TState>(parser: Parser<"sync", string, TState>) {
+          return optional(parser);
+        },
+      },
+      {
+        name: "withDefault()",
+        wrap<TState>(parser: Parser<"sync", string, TState>) {
+          return withDefault(parser, "fallback");
+        },
+      },
+    ] as const;
+
+    for (const { name, wrap } of wrappers) {
+      it(`${name} complete() preserves annotations on primitive inner states`, () => {
+        const marker = Symbol.for(`@test/issue-594/${name}/complete-primitive`);
+        const parser = wrap(createPrimitiveCompletionParser(marker));
+        const outerState = injectAnnotations(["live"] as [string], {
+          [marker]: "ok",
+        });
+
+        const result = parser.complete(outerState);
+
+        assert.deepEqual(result, {
+          success: true,
+          value: "annotated",
+        });
+      });
+
+      it(`${name} complete() preserves annotations on class inner states`, () => {
+        const marker = Symbol.for(`@test/issue-594/${name}/complete-class`);
+        const parser = wrap(createClassCompletionParser(marker));
+        const state = new DeferredClassState();
+        const outerState = injectAnnotations([state] as [DeferredClassState], {
+          [marker]: "ok",
+        });
+
+        const result = parser.complete(outerState);
+
+        assert.deepEqual(result, {
+          success: true,
+          value: "private-value",
+        });
+        assert.equal(getAnnotations(state), undefined);
+      });
+
+      it(
+        `${name} shouldDeferCompletion() preserves annotations on primitive inner states`,
+        () => {
+          const marker = Symbol.for(
+            `@test/issue-594/${name}/defer-primitive`,
+          );
+          const parser = wrap(createPrimitiveDeferralParser(marker));
+          const outerState = injectAnnotations(["live"] as [string], {
+            [marker]: "ok",
+          });
+
+          assert.ok(parser.shouldDeferCompletion?.(outerState));
+        },
+      );
+
+      it(`${name} shouldDeferCompletion() preserves annotations on class inner states`, () => {
+        const marker = Symbol.for(`@test/issue-594/${name}/defer-class`);
+        const parser = wrap(createClassDeferralParser(marker));
+        const state = new DeferredClassState();
+        const outerState = injectAnnotations([state] as [DeferredClassState], {
+          [marker]: "ok",
+        });
+
+        assert.ok(parser.shouldDeferCompletion?.(outerState));
+        assert.equal(getAnnotations(state), undefined);
+      });
+    }
+  },
+);
+
 describe("leadingNames", () => {
   it("should forward from inner parser for optional()", () => {
     const inner = flag("--verbose");

--- a/packages/core/src/modifiers.test.ts
+++ b/packages/core/src/modifiers.test.ts
@@ -8009,13 +8009,17 @@ describe(
     const wrappers = [
       {
         name: "optional()",
-        wrap<TState>(parser: Parser<"sync", string, TState>) {
+        wrap<TMode extends "sync" | "async", TValue, TState>(
+          parser: Parser<TMode, TValue, TState>,
+        ) {
           return optional(parser);
         },
       },
       {
         name: "withDefault()",
-        wrap<TState>(parser: Parser<"sync", string, TState>) {
+        wrap<TMode extends "sync" | "async", TValue, TState>(
+          parser: Parser<TMode, TValue, TState>,
+        ) {
           return withDefault(parser, "fallback");
         },
       },
@@ -8054,6 +8058,97 @@ describe(
         assert.equal(getAnnotations(state), undefined);
       });
 
+      it(`${name} complete() deep-normalizes nested delegated primitive values`, () => {
+        const marker = Symbol.for(`@test/issue-594/${name}/nested-primitive`);
+        const parser = wrap({
+          $mode: "sync" as const,
+          $valueType: [] as const,
+          $stateType: [] as const,
+          priority: 0,
+          usage: [],
+          leadingNames: new Set<string>(),
+          acceptingAnyToken: false,
+          initialState: "seed",
+          parse(context: ParserContext<string>) {
+            return { success: true as const, next: context, consumed: [] };
+          },
+          complete(state: string) {
+            return {
+              success: true as const,
+              value: {
+                annotated: getAnnotations(state)?.[marker] === "ok",
+                inner: state,
+              },
+            };
+          },
+          suggest() {
+            return [];
+          },
+          getDocFragments() {
+            return { fragments: [] };
+          },
+        });
+        const outerState = injectAnnotations(["live"] as [string], {
+          [marker]: "ok",
+        });
+
+        const result = parser.complete(outerState);
+
+        assert.deepEqual(result, {
+          success: true,
+          value: {
+            annotated: true,
+            inner: "live",
+          },
+        });
+      });
+
+      it(`${name} complete() deep-normalizes nested delegated class values`, () => {
+        const marker = Symbol.for(`@test/issue-594/${name}/nested-class`);
+        const state = new DeferredClassState();
+        const parser = wrap({
+          $mode: "sync" as const,
+          $valueType: [] as const,
+          $stateType: [] as const,
+          priority: 0,
+          usage: [],
+          leadingNames: new Set<string>(),
+          acceptingAnyToken: false,
+          initialState: new DeferredClassState(),
+          parse(context: ParserContext<DeferredClassState>) {
+            return { success: true as const, next: context, consumed: [] };
+          },
+          complete(innerState: DeferredClassState) {
+            return {
+              success: true as const,
+              value: {
+                annotated: getAnnotations(innerState)?.[marker] === "ok",
+                inner: innerState,
+              },
+            };
+          },
+          suggest() {
+            return [];
+          },
+          getDocFragments() {
+            return { fragments: [] };
+          },
+        });
+        const outerState = injectAnnotations([state] as [DeferredClassState], {
+          [marker]: "ok",
+        });
+
+        const result = parser.complete(outerState);
+
+        assert.deepEqual(result, {
+          success: true,
+          value: {
+            annotated: true,
+            inner: state,
+          },
+        });
+      });
+
       it(
         `${name} shouldDeferCompletion() preserves annotations on primitive inner states`,
         () => {
@@ -8080,6 +8175,170 @@ describe(
         assert.ok(parser.shouldDeferCompletion?.(outerState));
         assert.equal(getAnnotations(state), undefined);
       });
+
+      it(
+        `${name} complete() preserves delegated completion failures without retrying`,
+        () => {
+          const marker = Symbol.for(`@test/issue-594/${name}/preserve-failure`);
+          let callCount = 0;
+          const parser = wrap({
+            $mode: "sync" as const,
+            $valueType: [] as const,
+            $stateType: [] as const,
+            priority: 0,
+            usage: [],
+            leadingNames: new Set<string>(),
+            acceptingAnyToken: false,
+            initialState: "seed",
+            parse(context: ParserContext<string>) {
+              return { success: true as const, next: context, consumed: [] };
+            },
+            complete(state: string) {
+              callCount++;
+              return getAnnotations(state)?.[marker] === "ok"
+                ? {
+                  success: false as const,
+                  error: message`Annotated failure.`,
+                }
+                : {
+                  success: true as const,
+                  value: "fallback-success",
+                };
+            },
+            suggest() {
+              return [];
+            },
+            getDocFragments() {
+              return { fragments: [] };
+            },
+          });
+          const outerState = injectAnnotations(["live"] as [string], {
+            [marker]: "ok",
+          });
+
+          const result = parser.complete(outerState);
+
+          assert.equal(callCount, 1);
+          assert.deepEqual(result, {
+            success: false,
+            error: message`Annotated failure.`,
+          });
+        },
+      );
+
+      it(
+        `${name} async complete() preserves delegated completion failures without retrying`,
+        async () => {
+          const marker = Symbol.for(
+            `@test/issue-594/${name}/async-preserve-failure`,
+          );
+          let callCount = 0;
+          const parser = wrap({
+            $mode: "async" as const,
+            $valueType: [] as const,
+            $stateType: [] as const,
+            priority: 0,
+            usage: [],
+            leadingNames: new Set<string>(),
+            acceptingAnyToken: false,
+            initialState: "seed",
+            parse(context: ParserContext<string>) {
+              return Promise.resolve({
+                success: true as const,
+                next: context,
+                consumed: [],
+              });
+            },
+            complete(state: string) {
+              callCount++;
+              return Promise.resolve(
+                getAnnotations(state)?.[marker] === "ok"
+                  ? {
+                    success: false as const,
+                    error: message`Annotated async failure.`,
+                  }
+                  : {
+                    success: true as const,
+                    value: "fallback-success",
+                  },
+              );
+            },
+            suggest: async function* () {},
+            getDocFragments() {
+              return { fragments: [] };
+            },
+          });
+          const outerState = injectAnnotations(["live"] as [string], {
+            [marker]: "ok",
+          });
+
+          const result = await parser.complete(outerState);
+
+          assert.equal(callCount, 1);
+          assert.deepEqual(result, {
+            success: false,
+            error: message`Annotated async failure.`,
+          });
+        },
+      );
+
+      it(
+        `${name} phase-two seed extraction retries the extractor without retrying failed completion`,
+        () => {
+          let completeCalls = 0;
+          let extractCalls = 0;
+          const inner: Parser<"sync", string, string> = {
+            $mode: "sync",
+            $valueType: [] as readonly string[],
+            $stateType: [] as readonly string[],
+            priority: 0,
+            usage: [],
+            leadingNames: new Set<string>(),
+            acceptingAnyToken: false,
+            initialState: "seed",
+            parse(context) {
+              return {
+                success: true as const,
+                next: context,
+                consumed: [],
+              };
+            },
+            complete() {
+              completeCalls++;
+              return {
+                success: false as const,
+                error: message`Missing value.`,
+              };
+            },
+            suggest() {
+              return [];
+            },
+            getDocFragments() {
+              return { fragments: [] };
+            },
+          };
+          Object.defineProperty(inner, extractPhase2SeedKey, {
+            value(state: string | object) {
+              extractCalls++;
+              return typeof state === "string"
+                ? { value: { inner: state } }
+                : null;
+            },
+          });
+          const parser = wrap(inner);
+          const outerState = injectAnnotations(["live"] as [string], {
+            [Symbol.for(`@test/issue-594/${name}/phase2`)]: true,
+          });
+
+          const seed = completeOrExtractPhase2Seed(parser, outerState);
+
+          assert.equal(completeCalls, 2);
+          assert.equal(extractCalls, 2);
+          assert.deepEqual(seed, {
+            value: { inner: "live" },
+          });
+        },
+      );
     }
   },
 );

--- a/packages/core/src/modifiers.test.ts
+++ b/packages/core/src/modifiers.test.ts
@@ -8265,6 +8265,265 @@ describe(
         assert.equal(getAnnotations(state), undefined);
       });
 
+      it(`${name} complete() preserves annotation-aware exceptions`, () => {
+        const marker = Symbol.for(`@test/issue-594/${name}/complete-throw`);
+        let callCount = 0;
+        const parser = wrap({
+          $mode: "sync" as const,
+          $valueType: [] as const,
+          $stateType: [] as const,
+          priority: 0,
+          usage: [],
+          leadingNames: new Set<string>(),
+          acceptingAnyToken: false,
+          initialState: "seed",
+          parse(context: ParserContext<string>) {
+            return { success: true as const, next: context, consumed: [] };
+          },
+          complete(state: string) {
+            callCount++;
+            if (getAnnotations(state)?.[marker] === "ok") {
+              throw new Error("Annotated complete failure.");
+            }
+            return { success: true as const, value: "fallback-success" };
+          },
+          suggest() {
+            return [];
+          },
+          getDocFragments() {
+            return { fragments: [] };
+          },
+        });
+        const outerState = injectAnnotations(["live"] as [string], {
+          [marker]: "ok",
+        });
+
+        assert.throws(
+          () => parser.complete(outerState),
+          /Annotated complete failure\./,
+        );
+        assert.equal(callCount, 1);
+      });
+
+      it(`${name} async complete() preserves annotation-aware exceptions`, async () => {
+        const marker = Symbol.for(
+          `@test/issue-594/${name}/async-complete-throw`,
+        );
+        let callCount = 0;
+        const parser = wrap({
+          $mode: "async" as const,
+          $valueType: [] as const,
+          $stateType: [] as const,
+          priority: 0,
+          usage: [],
+          leadingNames: new Set<string>(),
+          acceptingAnyToken: false,
+          initialState: "seed",
+          parse(context: ParserContext<string>) {
+            return Promise.resolve({
+              success: true as const,
+              next: context,
+              consumed: [],
+            });
+          },
+          complete(state: string) {
+            callCount++;
+            if (getAnnotations(state)?.[marker] === "ok") {
+              throw new Error("Annotated async complete failure.");
+            }
+            return Promise.resolve({
+              success: true as const,
+              value: "fallback-success",
+            });
+          },
+          suggest: async function* () {},
+          getDocFragments() {
+            return { fragments: [] };
+          },
+        });
+        const outerState = injectAnnotations(["live"] as [string], {
+          [marker]: "ok",
+        });
+
+        await assert.rejects(
+          () => parser.complete(outerState),
+          /Annotated async complete failure\./,
+        );
+        assert.equal(callCount, 1);
+      });
+
+      it(`${name} complete() retries primitive wrapper TypeErrors`, () => {
+        const marker = Symbol.for(
+          `@test/issue-594/${name}/complete-primitive-typeerror`,
+        );
+        let callCount = 0;
+        const parser = wrap({
+          $mode: "sync" as const,
+          $valueType: [] as const,
+          $stateType: [] as const,
+          priority: 0,
+          usage: [],
+          leadingNames: new Set<string>(),
+          acceptingAnyToken: false,
+          initialState: "seed",
+          parse(context: ParserContext<string>) {
+            return { success: true as const, next: context, consumed: [] };
+          },
+          complete(state: string) {
+            callCount++;
+            return {
+              success: true as const,
+              value: state.toUpperCase(),
+            };
+          },
+          suggest() {
+            return [];
+          },
+          getDocFragments() {
+            return { fragments: [] };
+          },
+        });
+        const outerState = injectAnnotations(["live"] as [string], {
+          [marker]: true,
+        });
+
+        const result = parser.complete(outerState);
+
+        assert.deepEqual(result, {
+          success: true,
+          value: "LIVE",
+        });
+        assert.equal(callCount, 2);
+      });
+
+      it(`${name} async complete() retries primitive wrapper TypeErrors`, async () => {
+        const marker = Symbol.for(
+          `@test/issue-594/${name}/async-complete-primitive-typeerror`,
+        );
+        let callCount = 0;
+        const parser = wrap({
+          $mode: "async" as const,
+          $valueType: [] as const,
+          $stateType: [] as const,
+          priority: 0,
+          usage: [],
+          leadingNames: new Set<string>(),
+          acceptingAnyToken: false,
+          initialState: "seed",
+          parse(context: ParserContext<string>) {
+            return Promise.resolve({
+              success: true as const,
+              next: context,
+              consumed: [],
+            });
+          },
+          complete(state: string) {
+            callCount++;
+            return Promise.resolve({
+              success: true as const,
+              value: state.toUpperCase(),
+            });
+          },
+          suggest: async function* () {},
+          getDocFragments() {
+            return { fragments: [] };
+          },
+        });
+        const outerState = injectAnnotations(["live"] as [string], {
+          [marker]: true,
+        });
+
+        const result = await parser.complete(outerState);
+
+        assert.deepEqual(result, {
+          success: true,
+          value: "LIVE",
+        });
+        assert.equal(callCount, 2);
+      });
+
+      it(`${name} shouldDeferCompletion() preserves annotation-aware exceptions`, () => {
+        const marker = Symbol.for(`@test/issue-594/${name}/defer-throw`);
+        let callCount = 0;
+        const parser = wrap({
+          $mode: "sync" as const,
+          $valueType: [] as const,
+          $stateType: [] as const,
+          priority: 0,
+          usage: [],
+          leadingNames: new Set<string>(),
+          acceptingAnyToken: false,
+          initialState: "seed",
+          parse(context: ParserContext<string>) {
+            return { success: true as const, next: context, consumed: [] };
+          },
+          complete(state: string) {
+            return { success: true as const, value: state };
+          },
+          shouldDeferCompletion(state: string) {
+            callCount++;
+            if (getAnnotations(state)?.[marker] === "ok") {
+              throw new Error("Annotated defer failure.");
+            }
+            return false;
+          },
+          suggest() {
+            return [];
+          },
+          getDocFragments() {
+            return { fragments: [] };
+          },
+        });
+        const outerState = injectAnnotations(["live"] as [string], {
+          [marker]: "ok",
+        });
+
+        assert.throws(
+          () => parser.shouldDeferCompletion?.(outerState),
+          /Annotated defer failure\./,
+        );
+        assert.equal(callCount, 1);
+      });
+
+      it(`${name} shouldDeferCompletion() retries primitive wrapper TypeErrors`, () => {
+        const marker = Symbol.for(
+          `@test/issue-594/${name}/defer-primitive-typeerror`,
+        );
+        let callCount = 0;
+        const parser = wrap({
+          $mode: "sync" as const,
+          $valueType: [] as const,
+          $stateType: [] as const,
+          priority: 0,
+          usage: [],
+          leadingNames: new Set<string>(),
+          acceptingAnyToken: false,
+          initialState: "seed",
+          parse(context: ParserContext<string>) {
+            return { success: true as const, next: context, consumed: [] };
+          },
+          complete(state: string) {
+            return { success: true as const, value: state };
+          },
+          shouldDeferCompletion(state: string) {
+            callCount++;
+            return state.toUpperCase() === "LIVE";
+          },
+          suggest() {
+            return [];
+          },
+          getDocFragments() {
+            return { fragments: [] };
+          },
+        });
+        const outerState = injectAnnotations(["live"] as [string], {
+          [marker]: true,
+        });
+
+        assert.ok(parser.shouldDeferCompletion?.(outerState));
+        assert.equal(callCount, 2);
+      });
+
       it(`${name} complete() retries wrapped initial-state failures`, () => {
         const seenStates: unknown[] = [];
         const parser = wrap({

--- a/packages/core/src/modifiers.test.ts
+++ b/packages/core/src/modifiers.test.ts
@@ -6118,6 +6118,93 @@ describe("state management edge cases", () => {
       assert.ok(second.success);
       assert.equal(lastSeenAnnotation, "reentry");
     });
+
+    class StatefulReentryState {
+      #secret = "private-value";
+
+      self(): StatefulReentryState {
+        return this;
+      }
+
+      read(): string {
+        return this.#secret;
+      }
+    }
+
+    for (
+      const [
+        name,
+        wrap,
+      ] of [
+        [
+          "optional",
+          (parser: Parser<"sync", string, StatefulReentryState>) =>
+            optional(parser),
+        ],
+        [
+          "withDefault",
+          (parser: Parser<"sync", string, StatefulReentryState>) =>
+            withDefault(parser, "fallback"),
+        ],
+      ] as const
+    ) {
+      it(`${name}() re-entry preserves unchanged class-state identity`, () => {
+        const marker = Symbol.for(`@test/issue-233/${name}/class-reentry`);
+        let seenAnnotation: string | undefined;
+        const inner: Parser<"sync", string, StatefulReentryState> = {
+          $valueType: [] as readonly string[],
+          $stateType: [] as readonly StatefulReentryState[],
+          $mode: "sync",
+          priority: 0,
+          usage: [],
+          leadingNames: new Set<string>(),
+          acceptingAnyToken: false,
+          initialState: new StatefulReentryState(),
+          parse(context) {
+            seenAnnotation = getAnnotations(context.state)?.[marker] as
+              | string
+              | undefined;
+            return {
+              success: true,
+              next: {
+                ...context,
+                state: context.state.self(),
+              },
+              consumed: ["token"],
+            };
+          },
+          complete(state) {
+            return { success: true, value: state.read() };
+          },
+          suggest() {
+            return [];
+          },
+          getDocFragments() {
+            return { fragments: [] };
+          },
+        };
+
+        const parser = wrap(inner);
+        const innerState = new StatefulReentryState();
+        const reentryState = injectAnnotations([innerState], {
+          [marker]: "reentry",
+        }) as [StatefulReentryState];
+
+        const result = parser.parse({
+          buffer: ["token"],
+          state: reentryState,
+          optionsTerminated: false,
+          usage: parser.usage,
+        });
+
+        assert.ok(result.success);
+        if (!result.success) return;
+        assert.equal(seenAnnotation, "reentry");
+        assert.strictEqual(result.next.state, reentryState);
+        assert.strictEqual(result.next.state[0], innerState);
+        assert.deepEqual(result.consumed, ["token"]);
+      });
+    }
   });
 });
 

--- a/packages/core/src/modifiers.test.ts
+++ b/packages/core/src/modifiers.test.ts
@@ -8220,6 +8220,65 @@ describe(
         }
       });
 
+      it(`${name} complete() preserves Map subclass results while unwrapping entries`, () => {
+        const marker = Symbol.for(
+          `@test/issue-594/${name}/map-subclass-result`,
+        );
+
+        class StatefulMap extends Map<string, unknown> {
+          #secret = "private-value";
+
+          read(): string {
+            return this.#secret;
+          }
+        }
+
+        const parser = wrap({
+          $mode: "sync" as const,
+          $valueType: [] as const,
+          $stateType: [] as const,
+          priority: 0,
+          usage: [],
+          leadingNames: new Set<string>(),
+          acceptingAnyToken: false,
+          initialState: new StatefulMap([["seed", "value"]]),
+          parse(context: ParserContext<StatefulMap>) {
+            return { success: true as const, next: context, consumed: [] };
+          },
+          complete(innerState: StatefulMap) {
+            return {
+              success: true as const,
+              value: new StatefulMap([
+                ["annotated", getAnnotations(innerState)?.[marker] === "ok"],
+                ["inner", innerState],
+              ]),
+            };
+          },
+          suggest() {
+            return [];
+          },
+          getDocFragments() {
+            return { fragments: [] };
+          },
+        });
+        const outerState = injectAnnotations(
+          [new StatefulMap([["live", "value"]])] as [StatefulMap],
+          { [marker]: "ok" },
+        );
+
+        const result = parser.complete(outerState);
+
+        assert.ok(result.success);
+        if (!result.success) return;
+        assert.ok(result.value instanceof StatefulMap);
+        assert.equal(result.value.read(), "private-value");
+        assert.equal(result.value.get("annotated"), true);
+        const inner = result.value.get("inner");
+        assert.ok(inner instanceof StatefulMap);
+        assert.equal(inner.read(), "private-value");
+        assert.equal(getAnnotations(inner), undefined);
+      });
+
       it(`${name} parse() strips annotations from plain-object initial states`, () => {
         const marker = Symbol.for(
           `@test/issue-594/${name}/parse-plain-object`,

--- a/packages/core/src/modifiers.test.ts
+++ b/packages/core/src/modifiers.test.ts
@@ -8152,6 +8152,14 @@ describe(
             inner: state,
           },
         });
+        if (
+          result.success &&
+          result.value != null &&
+          typeof result.value === "object" &&
+          "inner" in result.value
+        ) {
+          assert.strictEqual(result.value.inner, state);
+        }
       });
 
       it(

--- a/packages/core/src/modifiers.test.ts
+++ b/packages/core/src/modifiers.test.ts
@@ -8264,6 +8264,147 @@ describe(
         assert.equal(getAnnotations(state), undefined);
       });
 
+      it(`${name} complete() retries wrapped initial-state failures`, () => {
+        const seenStates: unknown[] = [];
+        const parser = wrap({
+          $mode: "sync" as const,
+          $valueType: [] as const,
+          $stateType: [] as const,
+          priority: 0,
+          usage: [],
+          leadingNames: new Set<string>(),
+          acceptingAnyToken: false,
+          initialState: undefined,
+          parse(context: ParserContext<unknown>) {
+            return { success: true as const, next: context, consumed: [] };
+          },
+          complete(state: unknown) {
+            seenStates.push(state);
+            return state === undefined
+              ? { success: true as const, value: "resolved" }
+              : { success: false as const, error: message`Wrapped failure.` };
+          },
+          shouldDeferCompletion(state: unknown) {
+            return state === undefined;
+          },
+          suggest: function* () {},
+          getDocFragments() {
+            return { fragments: [] };
+          },
+        });
+        const outerState = injectAnnotationsLocal(undefined, {
+          [Symbol.for(`@test/issue-594/${name}/wrapped-initial-complete`)]:
+            true,
+        });
+
+        const result = parser.complete(
+          outerState as unknown as [unknown] | undefined,
+        );
+
+        assert.deepEqual(result, {
+          success: true,
+          value: "resolved",
+        });
+        assert.deepEqual(seenStates, [outerState, undefined]);
+      });
+
+      it(`${name} async complete() retries wrapped initial-state failures`, async () => {
+        const seenStates: unknown[] = [];
+        const parser = wrap({
+          $mode: "async" as const,
+          $valueType: [] as const,
+          $stateType: [] as const,
+          priority: 0,
+          usage: [],
+          leadingNames: new Set<string>(),
+          acceptingAnyToken: false,
+          initialState: undefined,
+          parse(context: ParserContext<unknown>) {
+            return Promise.resolve({
+              success: true as const,
+              next: context,
+              consumed: [],
+            });
+          },
+          complete(state: unknown) {
+            seenStates.push(state);
+            return Promise.resolve(
+              state === undefined
+                ? { success: true as const, value: "resolved" }
+                : {
+                  success: false as const,
+                  error: message`Wrapped async failure.`,
+                },
+            );
+          },
+          shouldDeferCompletion(state: unknown) {
+            return state === undefined;
+          },
+          suggest: async function* () {},
+          getDocFragments() {
+            return { fragments: [] };
+          },
+        });
+        const outerState = injectAnnotationsLocal(undefined, {
+          [
+            Symbol.for(`@test/issue-594/${name}/wrapped-initial-async-complete`)
+          ]: true,
+        });
+
+        const result = await parser.complete(
+          outerState as unknown as [unknown] | undefined,
+        );
+
+        assert.deepEqual(result, {
+          success: true,
+          value: "resolved",
+        });
+        assert.deepEqual(seenStates, [outerState, undefined]);
+      });
+
+      it(
+        `${name} shouldDeferCompletion() retries wrapped initial-state false results`,
+        () => {
+          const seenStates: unknown[] = [];
+          const parser = wrap({
+            $mode: "sync" as const,
+            $valueType: [] as const,
+            $stateType: [] as const,
+            priority: 0,
+            usage: [],
+            leadingNames: new Set<string>(),
+            acceptingAnyToken: false,
+            initialState: undefined,
+            parse(context: ParserContext<unknown>) {
+              return { success: true as const, next: context, consumed: [] };
+            },
+            complete() {
+              return { success: true as const, value: "unused" };
+            },
+            shouldDeferCompletion(state: unknown) {
+              seenStates.push(state);
+              return state === undefined;
+            },
+            suggest: function* () {},
+            getDocFragments() {
+              return { fragments: [] };
+            },
+          });
+          const outerState = injectAnnotationsLocal(undefined, {
+            [
+              Symbol.for(`@test/issue-594/${name}/wrapped-initial-defer`)
+            ]: true,
+          });
+
+          assert.ok(
+            parser.shouldDeferCompletion?.(
+              outerState as unknown as [unknown] | undefined,
+            ),
+          );
+          assert.deepEqual(seenStates, [outerState, undefined]);
+        },
+      );
+
       it(
         `${name} complete() preserves delegated completion failures without retrying`,
         () => {

--- a/packages/core/src/modifiers.test.ts
+++ b/packages/core/src/modifiers.test.ts
@@ -8906,6 +8906,241 @@ describe(
       );
 
       it(
+        `${name} phase-two seed extraction preserves annotation-aware completion exceptions`,
+        () => {
+          const marker = Symbol.for(`@test/issue-594/${name}/phase2-throw`);
+          let completeCalls = 0;
+          let extractCalls = 0;
+          const inner: Parser<"sync", string, string> = {
+            $mode: "sync",
+            $valueType: [] as readonly string[],
+            $stateType: [] as readonly string[],
+            priority: 0,
+            usage: [],
+            leadingNames: new Set<string>(),
+            acceptingAnyToken: false,
+            initialState: "seed",
+            parse(context) {
+              return {
+                success: true as const,
+                next: context,
+                consumed: [],
+              };
+            },
+            complete(state) {
+              completeCalls++;
+              if (getAnnotations(state)?.[marker] === "ok") {
+                throw new Error("Annotated phase-two completion failure.");
+              }
+              return {
+                success: false as const,
+                error: message`Missing value.`,
+              };
+            },
+            suggest() {
+              return [];
+            },
+            getDocFragments() {
+              return { fragments: [] };
+            },
+          };
+          Object.defineProperty(inner, extractPhase2SeedKey, {
+            value(state: string | object) {
+              extractCalls++;
+              return typeof state === "string"
+                ? { value: { inner: state } }
+                : null;
+            },
+          });
+          const parser = wrap(inner);
+          const outerState = injectAnnotations(["live"] as [string], {
+            [marker]: "ok",
+          });
+
+          assert.throws(
+            () => extractPhase2Seed(parser, outerState),
+            /Annotated phase-two completion failure\./,
+          );
+          assert.equal(completeCalls, 1);
+          assert.equal(extractCalls, 0);
+        },
+      );
+
+      it(
+        `${name} async phase-two seed extraction preserves annotation-aware completion exceptions`,
+        async () => {
+          const marker = Symbol.for(
+            `@test/issue-594/${name}/async-phase2-throw`,
+          );
+          let completeCalls = 0;
+          let extractCalls = 0;
+          const inner: Parser<"async", string, string> = {
+            $mode: "async",
+            $valueType: [] as readonly string[],
+            $stateType: [] as readonly string[],
+            priority: 0,
+            usage: [],
+            leadingNames: new Set<string>(),
+            acceptingAnyToken: false,
+            initialState: "seed",
+            parse(context) {
+              return Promise.resolve({
+                success: true as const,
+                next: context,
+                consumed: [],
+              });
+            },
+            complete(state) {
+              completeCalls++;
+              if (getAnnotations(state)?.[marker] === "ok") {
+                throw new Error(
+                  "Annotated async phase-two completion failure.",
+                );
+              }
+              return Promise.resolve({
+                success: false as const,
+                error: message`Missing value.`,
+              });
+            },
+            suggest: async function* () {},
+            getDocFragments() {
+              return { fragments: [] };
+            },
+          };
+          Object.defineProperty(inner, extractPhase2SeedKey, {
+            value(state: string | object) {
+              extractCalls++;
+              return Promise.resolve(
+                typeof state === "string" ? { value: { inner: state } } : null,
+              );
+            },
+          });
+          const parser = wrap(inner);
+          const outerState = injectAnnotations(["live"] as [string], {
+            [marker]: "ok",
+          });
+
+          await assert.rejects(
+            () => extractPhase2Seed(parser, outerState),
+            /Annotated async phase-two completion failure\./,
+          );
+          assert.equal(completeCalls, 1);
+          assert.equal(extractCalls, 0);
+        },
+      );
+
+      it(
+        `${name} phase-two seed extraction retries primitive-wrapper extractor TypeErrors`,
+        () => {
+          let completeCalls = 0;
+          let extractCalls = 0;
+          const inner: Parser<"sync", string, string> = {
+            $mode: "sync",
+            $valueType: [] as readonly string[],
+            $stateType: [] as readonly string[],
+            priority: 0,
+            usage: [],
+            leadingNames: new Set<string>(),
+            acceptingAnyToken: false,
+            initialState: "seed",
+            parse(context) {
+              return {
+                success: true as const,
+                next: context,
+                consumed: [],
+              };
+            },
+            complete() {
+              completeCalls++;
+              return {
+                success: false as const,
+                error: message`Missing value.`,
+              };
+            },
+            suggest() {
+              return [];
+            },
+            getDocFragments() {
+              return { fragments: [] };
+            },
+          };
+          Object.defineProperty(inner, extractPhase2SeedKey, {
+            value(state: string) {
+              extractCalls++;
+              return { value: state.toUpperCase() };
+            },
+          });
+          const parser = wrap(inner);
+          const outerState = injectAnnotations(["live"] as [string], {
+            [Symbol.for(`@test/issue-594/${name}/phase2-extractor-typeerror`)]:
+              true,
+          });
+
+          const seed = extractPhase2Seed(parser, outerState);
+
+          assert.deepEqual(seed, { value: "LIVE" });
+          assert.equal(completeCalls, 2);
+          assert.equal(extractCalls, 2);
+        },
+      );
+
+      it(
+        `${name} async phase-two seed extraction retries primitive-wrapper extractor TypeErrors`,
+        async () => {
+          let completeCalls = 0;
+          let extractCalls = 0;
+          const inner: Parser<"async", string, string> = {
+            $mode: "async",
+            $valueType: [] as readonly string[],
+            $stateType: [] as readonly string[],
+            priority: 0,
+            usage: [],
+            leadingNames: new Set<string>(),
+            acceptingAnyToken: false,
+            initialState: "seed",
+            parse(context) {
+              return Promise.resolve({
+                success: true as const,
+                next: context,
+                consumed: [],
+              });
+            },
+            complete() {
+              completeCalls++;
+              return Promise.resolve({
+                success: false as const,
+                error: message`Missing value.`,
+              });
+            },
+            suggest: async function* () {},
+            getDocFragments() {
+              return { fragments: [] };
+            },
+          };
+          Object.defineProperty(inner, extractPhase2SeedKey, {
+            value(state: string) {
+              extractCalls++;
+              return Promise.resolve({ value: state.toUpperCase() });
+            },
+          });
+          const parser = wrap(inner);
+          const outerState = injectAnnotations(["live"] as [string], {
+            [
+              Symbol.for(
+                `@test/issue-594/${name}/async-phase2-extractor-typeerror`,
+              )
+            ]: true,
+          });
+
+          const seed = await extractPhase2Seed(parser, outerState);
+
+          assert.deepEqual(seed, { value: "LIVE" });
+          assert.equal(completeCalls, 2);
+          assert.equal(extractCalls, 2);
+        },
+      );
+
+      it(
         `${name} phase-two seed extraction retries the extractor without retrying failed completion`,
         () => {
           let completeCalls = 0;

--- a/packages/core/src/modifiers.ts
+++ b/packages/core/src/modifiers.ts
@@ -584,6 +584,20 @@ function normalizeOptionalLikeInnerState<TState>(
   return initialState;
 }
 
+function normalizeOptionalLikeSuggestState<TState>(
+  state: [TState] | TState | undefined,
+  initialState: TState,
+  parser?: Parser<Mode, unknown, TState>,
+): TState {
+  if (Array.isArray(state)) {
+    const innerState = state[0];
+    return innerState != null && typeof innerState === "object"
+      ? getDelegatedAnnotationState(state, innerState)
+      : innerState;
+  }
+  return normalizeOptionalLikeInnerState(state, initialState, parser);
+}
+
 /**
  * Creates a parser that makes another parser optional, allowing it to succeed
  * without consuming input if the wrapped parser fails to match.
@@ -607,7 +621,7 @@ export function optional<M extends Mode, TValue, TState>(
     context: ParserContext<[TState] | undefined>,
     prefix: string,
   ): Generator<Suggestion> {
-    const innerState = normalizeOptionalLikeInnerState(
+    const innerState = normalizeOptionalLikeSuggestState(
       context.state,
       syncParser.initialState,
       parser,
@@ -620,7 +634,7 @@ export function optional<M extends Mode, TValue, TState>(
     context: ParserContext<[TState] | undefined>,
     prefix: string,
   ): AsyncGenerator<Suggestion> {
-    const innerState = normalizeOptionalLikeInnerState(
+    const innerState = normalizeOptionalLikeSuggestState(
       context.state,
       syncParser.initialState,
       parser,
@@ -673,7 +687,7 @@ export function optional<M extends Mode, TValue, TState>(
       if (optionalParser.dependencyMetadata?.source != null) {
         return [{ path, parser: optionalParser, state }];
       }
-      const innerState = normalizeOptionalLikeInnerState(
+      const innerState = normalizeOptionalLikeSuggestState(
         state,
         parser.initialState,
         parser,
@@ -1030,7 +1044,7 @@ export function withDefault<
     context: ParserContext<[TState] | undefined>,
     prefix: string,
   ): Generator<Suggestion> {
-    const innerState = normalizeOptionalLikeInnerState(
+    const innerState = normalizeOptionalLikeSuggestState(
       context.state,
       syncParser.initialState,
       parser,
@@ -1043,7 +1057,7 @@ export function withDefault<
     context: ParserContext<[TState] | undefined>,
     prefix: string,
   ): AsyncGenerator<Suggestion> {
-    const innerState = normalizeOptionalLikeInnerState(
+    const innerState = normalizeOptionalLikeSuggestState(
       context.state,
       syncParser.initialState,
       parser,
@@ -1091,7 +1105,7 @@ export function withDefault<
       if (withDefaultParser.dependencyMetadata?.source != null) {
         return [{ path, parser: withDefaultParser, state }];
       }
-      const innerState = normalizeOptionalLikeInnerState(
+      const innerState = normalizeOptionalLikeSuggestState(
         state,
         parser.initialState,
         parser,

--- a/packages/core/src/modifiers.ts
+++ b/packages/core/src/modifiers.ts
@@ -439,11 +439,14 @@ function deriveOptionalInnerParseState<TState>(
     // `object()`'s `getAnnotatedChildState()` when the previous parse
     // iteration's wrapped state is re-committed to the parent object
     // (the parent stamps the array wrapper, not the inner element).
-    // Mirror `normalizeOptionalLikeInnerState()`'s array handling so
-    // that source-binding wrappers under `optional()` / `withDefault()`
-    // see the same annotations on parse-time re-entry that they see in
+    // Mirror the object-state part of
+    // `normalizeOptionalLikeInnerState()`'s array handling so that
+    // source-binding wrappers under `optional()` / `withDefault()` see
+    // the same annotations on parse-time re-entry that they see in
     // complete-time, instead of dropping them on the way back into the
-    // inner parser.
+    // inner parser. Primitive inner states still pass through verbatim
+    // here so parse-time re-entry does not reintroduce injected wrapper
+    // objects into echo-style parsers.
     if (
       getAnnotations(outerState) != null &&
       innerState != null &&

--- a/packages/core/src/modifiers.ts
+++ b/packages/core/src/modifiers.ts
@@ -526,6 +526,14 @@ async function parseOptionalStyleAsync<TState>(
  * Internal helper to process optional-style parse results.
  * @internal
  */
+function hasOptionalLikeParseStateChanged<TState>(
+  previousState: TState,
+  nextState: TState,
+): boolean {
+  return normalizeDelegatedAnnotationState(previousState) !==
+    normalizeDelegatedAnnotationState(nextState);
+}
+
 function processOptionalStyleResult<TState>(
   result: ParserResult<TState>,
   innerState: TState,
@@ -533,9 +541,11 @@ function processOptionalStyleResult<TState>(
 ): ParserResult<[TState] | undefined> {
   if (result.success) {
     // Check if the inner parser actually matched something (state changed)
-    // or if it consumed nothing (e.g. constant parser).
+    // or if it consumed nothing (e.g. constant parser). Internal delegated
+    // annotation carriers do not count as real state changes here.
     if (
-      result.next.state !== innerState || result.consumed.length === 0
+      hasOptionalLikeParseStateChanged(innerState, result.next.state) ||
+      result.consumed.length === 0
     ) {
       return {
         success: true,

--- a/packages/core/src/modifiers.ts
+++ b/packages/core/src/modifiers.ts
@@ -1,6 +1,7 @@
 import {
   getDelegatedAnnotationState,
   hasDelegatedAnnotationCarrier,
+  isAnnotationWrappedInitialState,
   normalizeDelegatedAnnotationState,
   normalizeNestedDelegatedAnnotationState,
 } from "./annotation-state.ts";
@@ -190,16 +191,20 @@ function completeOptionalLikeSync<TValue, TState>(
   exec?: ExecutionContext,
 ): ValueParserResult<TValue> {
   const hasCarrier = hasDelegatedAnnotationCarrier(state);
+  const shouldRetryFalseResult = isAnnotationWrappedInitialState(state);
+  const run = (candidate: TState) =>
+    normalizeOptionalLikeCompleteResult(parser.complete(candidate, exec));
   try {
-    return normalizeOptionalLikeCompleteResult(parser.complete(state, exec));
+    const result = run(state);
+    if (!result.success && shouldRetryFalseResult) {
+      return run(normalizeDelegatedAnnotationState(state));
+    }
+    return result;
   } catch (error) {
     if (!hasCarrier) {
       throw error;
     }
-    const fallbackState = normalizeDelegatedAnnotationState(state);
-    return normalizeOptionalLikeCompleteResult(
-      parser.complete(fallbackState, exec),
-    );
+    return run(normalizeDelegatedAnnotationState(state));
   }
 }
 
@@ -209,18 +214,20 @@ async function completeOptionalLikeAsync<TValue, TState>(
   exec?: ExecutionContext,
 ): Promise<ValueParserResult<TValue>> {
   const hasCarrier = hasDelegatedAnnotationCarrier(state);
+  const shouldRetryFalseResult = isAnnotationWrappedInitialState(state);
+  const run = async (candidate: TState) =>
+    normalizeOptionalLikeCompleteResult(await parser.complete(candidate, exec));
   try {
-    return normalizeOptionalLikeCompleteResult(
-      await parser.complete(state, exec),
-    );
+    const result = await run(state);
+    if (!result.success && shouldRetryFalseResult) {
+      return await run(normalizeDelegatedAnnotationState(state));
+    }
+    return result;
   } catch (error) {
     if (!hasCarrier) {
       throw error;
     }
-    const fallbackState = normalizeDelegatedAnnotationState(state);
-    return normalizeOptionalLikeCompleteResult(
-      await parser.complete(fallbackState, exec),
-    );
+    return await run(normalizeDelegatedAnnotationState(state));
   }
 }
 
@@ -528,10 +535,20 @@ function adaptShouldDeferCompletion<TState>(
         parser.initialState,
         parser,
       );
+      const hasCarrier = hasDelegatedAnnotationCarrier(innerState);
+      const shouldRetryFalseResult = hasCarrier &&
+        isAnnotationWrappedInitialState(innerState);
       try {
-        return innerCheck(innerState, exec);
+        const result = innerCheck(innerState, exec);
+        if (!result && shouldRetryFalseResult) {
+          return innerCheck(
+            normalizeDelegatedAnnotationState(innerState),
+            exec,
+          );
+        }
+        return result;
       } catch (error) {
-        if (!hasDelegatedAnnotationCarrier(innerState)) {
+        if (!hasCarrier) {
           throw error;
         }
         return innerCheck(normalizeDelegatedAnnotationState(innerState), exec);

--- a/packages/core/src/modifiers.ts
+++ b/packages/core/src/modifiers.ts
@@ -530,8 +530,9 @@ function hasOptionalLikeParseStateChanged<TState>(
   previousState: TState,
   nextState: TState,
 ): boolean {
-  return normalizeDelegatedAnnotationState(previousState) !==
-    normalizeDelegatedAnnotationState(nextState);
+  return previousState !== nextState &&
+    normalizeDelegatedAnnotationState(previousState) !==
+      normalizeDelegatedAnnotationState(nextState);
 }
 
 function processOptionalStyleResult<TState>(

--- a/packages/core/src/modifiers.ts
+++ b/packages/core/src/modifiers.ts
@@ -26,6 +26,7 @@ import {
   extractPhase2SeedKey,
   phase2SeedFromValueResult,
 } from "./phase2-seed.ts";
+import type { Phase2Seed } from "./phase2-seed.ts";
 import {
   defineInheritedAnnotationParser,
   defineSourceBindingOnlyAnnotationCompletionParser,
@@ -224,8 +225,8 @@ async function completeOptionalLikeAsync<TValue, TState>(
 }
 
 function normalizeOptionalLikePhase2Seed<T>(
-  seed: import("./phase2-seed.ts").Phase2Seed<T> | null,
-): import("./phase2-seed.ts").Phase2Seed<T> | null {
+  seed: Phase2Seed<T> | null,
+): Phase2Seed<T> | null {
   return seed == null ? null : {
     ...seed,
     value: normalizeNestedDelegatedAnnotationState(seed.value),
@@ -236,7 +237,7 @@ function extractOptionalLikePhase2Seed<M extends Mode, TValue, TState>(
   parser: Parser<M, TValue, TState>,
   state: [TState] | TState | undefined,
   exec?: ExecutionContext,
-): ModeValue<M, import("./phase2-seed.ts").Phase2Seed<TValue> | null> {
+): ModeValue<M, Phase2Seed<TValue> | null> {
   if (
     !Array.isArray(state) &&
     !(state != null && typeof state === "object")

--- a/packages/core/src/modifiers.ts
+++ b/packages/core/src/modifiers.ts
@@ -449,7 +449,7 @@ function deriveOptionalInnerParseState<TState>(
       innerState != null &&
       typeof innerState === "object"
     ) {
-      return inheritAnnotations(outerState, innerState) as TState;
+      return getDelegatedAnnotationState(outerState, innerState) as TState;
     }
     return innerState;
   }
@@ -467,12 +467,16 @@ function deriveOptionalInnerParseState<TState>(
   // (`undefined` / `null`, the "no state yet" signal used by
   // `option()` / `argument()` / `bindEnv()` / `bindConfig()`) still go
   // through `inheritAnnotations()` so source-binding wrappers can read
-  // the propagated annotations from their `parse()` context.
+  // the propagated annotations from their `parse()` context. Object-shaped
+  // initial states go through delegated annotation state tracking so any
+  // temporary clone can be normalized back out of completed values.
   const initial = parser.initialState;
   if (initial != null && typeof initial !== "object") {
     return initial;
   }
-  return inheritAnnotations(outerState, initial) as TState;
+  return initial != null && typeof initial === "object"
+    ? getDelegatedAnnotationState(outerState, initial) as TState
+    : inheritAnnotations(outerState, initial) as TState;
 }
 
 /**

--- a/packages/core/src/modifiers.ts
+++ b/packages/core/src/modifiers.ts
@@ -176,8 +176,9 @@ function isPromiseLike<T>(value: unknown): value is PromiseLike<T> {
 
 function normalizeOptionalLikeCompleteResult<T>(
   result: ValueParserResult<T>,
+  shouldNormalize: boolean,
 ): ValueParserResult<T> {
-  return result.success
+  return result.success && shouldNormalize
     ? {
       ...result,
       value: normalizeNestedDelegatedAnnotationState(result.value),
@@ -191,20 +192,24 @@ function completeOptionalLikeSync<TValue, TState>(
   exec?: ExecutionContext,
 ): ValueParserResult<TValue> {
   const hasCarrier = hasDelegatedAnnotationCarrier(state);
-  const shouldRetryFalseResult = isAnnotationWrappedInitialState(state);
-  const run = (candidate: TState) =>
-    normalizeOptionalLikeCompleteResult(parser.complete(candidate, exec));
+  const shouldRetryFalseResult = hasCarrier &&
+    isAnnotationWrappedInitialState(state);
+  const run = (candidate: TState, shouldNormalize: boolean) =>
+    normalizeOptionalLikeCompleteResult(
+      parser.complete(candidate, exec),
+      shouldNormalize,
+    );
   try {
-    const result = run(state);
+    const result = run(state, hasCarrier);
     if (!result.success && shouldRetryFalseResult) {
-      return run(normalizeDelegatedAnnotationState(state));
+      return run(normalizeDelegatedAnnotationState(state), false);
     }
     return result;
   } catch (error) {
     if (!hasCarrier) {
       throw error;
     }
-    return run(normalizeDelegatedAnnotationState(state));
+    return run(normalizeDelegatedAnnotationState(state), false);
   }
 }
 
@@ -214,30 +219,37 @@ async function completeOptionalLikeAsync<TValue, TState>(
   exec?: ExecutionContext,
 ): Promise<ValueParserResult<TValue>> {
   const hasCarrier = hasDelegatedAnnotationCarrier(state);
-  const shouldRetryFalseResult = isAnnotationWrappedInitialState(state);
-  const run = async (candidate: TState) =>
-    normalizeOptionalLikeCompleteResult(await parser.complete(candidate, exec));
+  const shouldRetryFalseResult = hasCarrier &&
+    isAnnotationWrappedInitialState(state);
+  const run = async (candidate: TState, shouldNormalize: boolean) =>
+    normalizeOptionalLikeCompleteResult(
+      await parser.complete(candidate, exec),
+      shouldNormalize,
+    );
   try {
-    const result = await run(state);
+    const result = await run(state, hasCarrier);
     if (!result.success && shouldRetryFalseResult) {
-      return await run(normalizeDelegatedAnnotationState(state));
+      return await run(normalizeDelegatedAnnotationState(state), false);
     }
     return result;
   } catch (error) {
     if (!hasCarrier) {
       throw error;
     }
-    return await run(normalizeDelegatedAnnotationState(state));
+    return await run(normalizeDelegatedAnnotationState(state), false);
   }
 }
 
 function normalizeOptionalLikePhase2Seed<T>(
   seed: Phase2Seed<T> | null,
+  shouldNormalize: boolean,
 ): Phase2Seed<T> | null {
-  return seed == null ? null : {
-    ...seed,
-    value: normalizeNestedDelegatedAnnotationState(seed.value),
-  };
+  return seed == null ? null : shouldNormalize
+    ? {
+      ...seed,
+      value: normalizeNestedDelegatedAnnotationState(seed.value),
+    }
+    : seed;
 }
 
 function extractOptionalLikePhase2Seed<M extends Mode, TValue, TState>(
@@ -257,6 +269,8 @@ function extractOptionalLikePhase2Seed<M extends Mode, TValue, TState>(
     parser,
   );
   const hasCarrier = hasDelegatedAnnotationCarrier(innerState);
+  const shouldRetryFalseResult = hasCarrier &&
+    isAnnotationWrappedInitialState(innerState);
   return dispatchByMode(
     parser.$mode,
     () => {
@@ -268,7 +282,20 @@ function extractOptionalLikePhase2Seed<M extends Mode, TValue, TState>(
         if (result.success) {
           return normalizeOptionalLikePhase2Seed(
             phase2SeedFromValueResult(result),
+            hasCarrier,
           );
+        }
+        if (shouldRetryFalseResult) {
+          const fallbackState = normalizeDelegatedAnnotationState(innerState);
+          const fallbackResult = (
+            parser as Parser<"sync", TValue, TState>
+          ).complete(fallbackState, exec);
+          if (fallbackResult.success) {
+            return normalizeOptionalLikePhase2Seed(
+              phase2SeedFromValueResult(fallbackResult),
+              false,
+            );
+          }
         }
         const seed = extractPhase2Seed(
           parser as Parser<"sync", TValue, TState>,
@@ -283,9 +310,10 @@ function extractOptionalLikePhase2Seed<M extends Mode, TValue, TState>(
               fallbackState,
               exec,
             ),
+            false,
           );
         }
-        return normalizeOptionalLikePhase2Seed(seed);
+        return normalizeOptionalLikePhase2Seed(seed, hasCarrier);
       } catch (error) {
         if (!hasCarrier) {
           throw error;
@@ -298,6 +326,7 @@ function extractOptionalLikePhase2Seed<M extends Mode, TValue, TState>(
         if (result.success) {
           return normalizeOptionalLikePhase2Seed(
             phase2SeedFromValueResult(result),
+            false,
           );
         }
         return normalizeOptionalLikePhase2Seed(
@@ -306,6 +335,7 @@ function extractOptionalLikePhase2Seed<M extends Mode, TValue, TState>(
             fallbackState,
             exec,
           ),
+          false,
         );
       }
     },
@@ -317,7 +347,20 @@ function extractOptionalLikePhase2Seed<M extends Mode, TValue, TState>(
         if (result.success) {
           return normalizeOptionalLikePhase2Seed(
             phase2SeedFromValueResult(result),
+            hasCarrier,
           );
+        }
+        if (shouldRetryFalseResult) {
+          const fallbackState = normalizeDelegatedAnnotationState(innerState);
+          const fallbackResult = await (
+            parser as Parser<"async", TValue, TState>
+          ).complete(fallbackState, exec);
+          if (fallbackResult.success) {
+            return normalizeOptionalLikePhase2Seed(
+              phase2SeedFromValueResult(fallbackResult),
+              false,
+            );
+          }
         }
         const seed = await extractPhase2Seed(
           parser as Parser<"async", TValue, TState>,
@@ -332,9 +375,10 @@ function extractOptionalLikePhase2Seed<M extends Mode, TValue, TState>(
               fallbackState,
               exec,
             ),
+            false,
           );
         }
-        return normalizeOptionalLikePhase2Seed(seed);
+        return normalizeOptionalLikePhase2Seed(seed, hasCarrier);
       } catch (error) {
         if (!hasCarrier) {
           throw error;
@@ -346,6 +390,7 @@ function extractOptionalLikePhase2Seed<M extends Mode, TValue, TState>(
         if (result.success) {
           return normalizeOptionalLikePhase2Seed(
             phase2SeedFromValueResult(result),
+            false,
           );
         }
         return normalizeOptionalLikePhase2Seed(
@@ -354,6 +399,7 @@ function extractOptionalLikePhase2Seed<M extends Mode, TValue, TState>(
             fallbackState,
             exec,
           ),
+          false,
         );
       }
     },
@@ -363,10 +409,10 @@ function extractOptionalLikePhase2Seed<M extends Mode, TValue, TState>(
 /**
  * Computes the inner state to pass through to the wrapped parser inside
  * {@link optional} / {@link withDefault}.  When the outer state is an
- * array, the inner state is `state[0]`.  Otherwise — including the
+ * array, the inner state is `state[0]`.  Otherwise, including the
  * common case where `optional()` sits at top level and the outer state
  * is either `undefined` or an annotation wrapper from `parseOptionalLike`
- * / `parse({ annotations })` — we use the wrapped parser's
+ * / `parse({ annotations })`, we use the wrapped parser's
  * `initialState`, propagating annotations from the outer state so that
  * source-binding wrappers under `optional()` / `withDefault()` (e.g.,
  * `bindEnv()` / `bindConfig()`) can resolve their fallbacks.
@@ -402,7 +448,7 @@ function deriveOptionalInnerParseState<TState>(
   // like `bindEnv()` / `bindConfig()` placed under
   // `optional()` / `withDefault()` can resolve from annotations at top
   // level.  Non-nullish primitive initial states (e.g. `constant("v")`
-  // whose `initialState` IS `"v"`) are returned verbatim: otherwise
+  // whose `initialState` is `"v"`) are returned verbatim: otherwise
   // `inheritAnnotations()` would wrap the primitive into an opaque
   // `injectAnnotations` wrapper object, and echo-semantics parsers
   // like `constant()` would return that wrapper from `complete()`
@@ -423,8 +469,8 @@ function deriveOptionalInnerParseState<TState>(
  * Internal helper for optional-style parsing logic shared by optional()
  * and withDefault(). Handles the common pattern of:
  * - Unwrapping optional state to inner parser state
- * - Detecting if inner parser actually matched (state changed or no consumption)
- * - Returning success with undefined state when inner parser fails without consuming
+ * - Detecting if the inner parser actually matched (state changed or no consumption)
+ * - Returning success with undefined state when the inner parser fails without consuming
  * @internal
  */
 function parseOptionalStyleSync<TState>(
@@ -469,8 +515,8 @@ function processOptionalStyleResult<TState>(
   context: ParserContext<[TState] | undefined>,
 ): ParserResult<[TState] | undefined> {
   if (result.success) {
-    // Check if inner parser actually matched something (state changed)
-    // or if it consumed nothing (e.g., constant parser)
+    // Check if the inner parser actually matched something (state changed)
+    // or if it consumed nothing (e.g. constant parser).
     if (
       result.next.state !== innerState || result.consumed.length === 0
     ) {
@@ -487,9 +533,9 @@ function processOptionalStyleResult<TState>(
         consumed: result.consumed,
       };
     }
-    // Inner parser returned success but state unchanged while consuming input
-    // (e.g., only consumed "--"). Treat as "not matched" but propagate side
-    // effects (optionsTerminated, buffer)
+    // The inner parser returned success but state unchanged while consuming input
+    // (e.g. only consumed "--"). Treat as "not matched" but propagate side
+    // effects (optionsTerminated, buffer).
     return {
       success: true,
       ...(result.provisional ? { provisional: true as const } : {}),
@@ -500,8 +546,8 @@ function processOptionalStyleResult<TState>(
       consumed: result.consumed,
     };
   }
-  // If inner parser failed without consuming input, return success
-  // with undefined state so complete() can provide the fallback value
+  // If the inner parser failed without consuming input, return success
+  // with undefined state so complete() can provide the fallback value.
   if (result.consumed === 0) {
     return {
       success: true,
@@ -518,7 +564,7 @@ function processOptionalStyleResult<TState>(
  * {@link withDefault} before delegating to the inner parser's hook.
  *
  * When state is an array, the adapter unwraps `state[0]` and propagates
- * annotations from the outer array.  Non-array objects (e.g., PromptBindState
+ * annotations from the outer array.  Non-array objects (e.g. PromptBindState
  * from `prompt()`) are passed through directly.  `undefined` returns `false`
  * without calling the inner hook.
  *

--- a/packages/core/src/modifiers.ts
+++ b/packages/core/src/modifiers.ts
@@ -186,6 +186,16 @@ function normalizeOptionalLikeCompleteResult<T>(
     : result;
 }
 
+function shouldRetryOptionalLikeCompatibilityError(
+  error: unknown,
+  state: unknown,
+): boolean {
+  return error instanceof TypeError &&
+    state != null &&
+    typeof state === "object" &&
+    isInjectedAnnotationWrapper(state);
+}
+
 function completeOptionalLikeSync<TValue, TState>(
   parser: Parser<"sync", TValue, TState>,
   state: TState,
@@ -206,7 +216,7 @@ function completeOptionalLikeSync<TValue, TState>(
     }
     return result;
   } catch (error) {
-    if (!hasCarrier) {
+    if (!shouldRetryOptionalLikeCompatibilityError(error, state)) {
       throw error;
     }
     return run(normalizeDelegatedAnnotationState(state), false);
@@ -233,7 +243,7 @@ async function completeOptionalLikeAsync<TValue, TState>(
     }
     return result;
   } catch (error) {
-    if (!hasCarrier) {
+    if (!shouldRetryOptionalLikeCompatibilityError(error, state)) {
       throw error;
     }
     return await run(normalizeDelegatedAnnotationState(state), false);
@@ -594,7 +604,7 @@ function adaptShouldDeferCompletion<TState>(
         }
         return result;
       } catch (error) {
-        if (!hasCarrier) {
+        if (!shouldRetryOptionalLikeCompatibilityError(error, innerState)) {
           throw error;
         }
         return innerCheck(normalizeDelegatedAnnotationState(innerState), exec);

--- a/packages/core/src/modifiers.ts
+++ b/packages/core/src/modifiers.ts
@@ -1,3 +1,8 @@
+import {
+  getDelegatedAnnotationState,
+  hasDelegatedAnnotationCarrier,
+  normalizeDelegatedAnnotationState,
+} from "./annotation-state.ts";
 import { composeDependencyMetadata } from "./dependency-metadata.ts";
 import { formatMessage, type Message, message, text } from "./message.ts";
 import {
@@ -165,6 +170,74 @@ function isPromiseLike<T>(value: unknown): value is PromiseLike<T> {
     typeof (value as Record<string, unknown>).then === "function";
 }
 
+function normalizeOptionalLikeCompleteResult<T>(
+  result: ValueParserResult<T>,
+): ValueParserResult<T> {
+  return result.success
+    ? {
+      ...result,
+      value: normalizeDelegatedAnnotationState(result.value),
+    }
+    : result;
+}
+
+function completeOptionalLikeSync<TValue, TState>(
+  parser: Parser<"sync", TValue, TState>,
+  state: TState,
+  exec?: ExecutionContext,
+): ValueParserResult<TValue> {
+  const fallbackState = normalizeDelegatedAnnotationState(state);
+  try {
+    const result = parser.complete(state, exec);
+    if (!result.success && hasDelegatedAnnotationCarrier(state)) {
+      return normalizeOptionalLikeCompleteResult(
+        parser.complete(fallbackState, exec),
+      );
+    }
+    return normalizeOptionalLikeCompleteResult(result);
+  } catch (error) {
+    if (!hasDelegatedAnnotationCarrier(state)) {
+      throw error;
+    }
+    return normalizeOptionalLikeCompleteResult(
+      parser.complete(fallbackState, exec),
+    );
+  }
+}
+
+async function completeOptionalLikeAsync<TValue, TState>(
+  parser: Parser<Mode, TValue, TState>,
+  state: TState,
+  exec?: ExecutionContext,
+): Promise<ValueParserResult<TValue>> {
+  const fallbackState = normalizeDelegatedAnnotationState(state);
+  try {
+    const result = await parser.complete(state, exec);
+    if (!result.success && hasDelegatedAnnotationCarrier(state)) {
+      return normalizeOptionalLikeCompleteResult(
+        await parser.complete(fallbackState, exec),
+      );
+    }
+    return normalizeOptionalLikeCompleteResult(result);
+  } catch (error) {
+    if (!hasDelegatedAnnotationCarrier(state)) {
+      throw error;
+    }
+    return normalizeOptionalLikeCompleteResult(
+      await parser.complete(fallbackState, exec),
+    );
+  }
+}
+
+function normalizeOptionalLikePhase2Seed<T>(
+  seed: import("./phase2-seed.ts").Phase2Seed<T> | null,
+): import("./phase2-seed.ts").Phase2Seed<T> | null {
+  return seed == null ? null : {
+    ...seed,
+    value: normalizeDelegatedAnnotationState(seed.value),
+  };
+}
+
 function extractOptionalLikePhase2Seed<M extends Mode, TValue, TState>(
   parser: Parser<M, TValue, TState>,
   state: [TState] | TState | undefined,
@@ -176,14 +249,74 @@ function extractOptionalLikePhase2Seed<M extends Mode, TValue, TState>(
   ) {
     return wrapForMode(parser.$mode, null);
   }
-  return completeOrExtractPhase2Seed(
+  const innerState = normalizeOptionalLikeInnerState(
+    state,
+    parser.initialState,
     parser,
-    normalizeOptionalLikeInnerState(
-      state,
-      parser.initialState,
-      parser,
-    ),
-    exec,
+  );
+  const fallbackState = normalizeDelegatedAnnotationState(innerState);
+  return dispatchByMode(
+    parser.$mode,
+    () => {
+      try {
+        const seed = completeOrExtractPhase2Seed(
+          parser as Parser<"sync", TValue, TState>,
+          innerState,
+          exec,
+        );
+        if (seed == null && hasDelegatedAnnotationCarrier(innerState)) {
+          return normalizeOptionalLikePhase2Seed(
+            completeOrExtractPhase2Seed(
+              parser as Parser<"sync", TValue, TState>,
+              fallbackState,
+              exec,
+            ),
+          );
+        }
+        return normalizeOptionalLikePhase2Seed(seed);
+      } catch (error) {
+        if (!hasDelegatedAnnotationCarrier(innerState)) {
+          throw error;
+        }
+        return normalizeOptionalLikePhase2Seed(
+          completeOrExtractPhase2Seed(
+            parser as Parser<"sync", TValue, TState>,
+            fallbackState,
+            exec,
+          ),
+        );
+      }
+    },
+    async () => {
+      try {
+        const seed = await completeOrExtractPhase2Seed(
+          parser as Parser<"async", TValue, TState>,
+          innerState,
+          exec,
+        );
+        if (seed == null && hasDelegatedAnnotationCarrier(innerState)) {
+          return normalizeOptionalLikePhase2Seed(
+            await completeOrExtractPhase2Seed(
+              parser as Parser<"async", TValue, TState>,
+              fallbackState,
+              exec,
+            ),
+          );
+        }
+        return normalizeOptionalLikePhase2Seed(seed);
+      } catch (error) {
+        if (!hasDelegatedAnnotationCarrier(innerState)) {
+          throw error;
+        }
+        return normalizeOptionalLikePhase2Seed(
+          await completeOrExtractPhase2Seed(
+            parser as Parser<"async", TValue, TState>,
+            fallbackState,
+            exec,
+          ),
+        );
+      }
+    },
   );
 }
 
@@ -357,14 +490,19 @@ function adaptShouldDeferCompletion<TState>(
 ): (state: [TState] | undefined, exec?: ExecutionContext) => boolean {
   return (state: [TState] | undefined, exec?: ExecutionContext): boolean => {
     if (Array.isArray(state) || (state != null && typeof state === "object")) {
-      return innerCheck(
-        normalizeOptionalLikeInnerState(
-          state,
-          parser.initialState,
-          parser,
-        ),
-        exec,
+      const innerState = normalizeOptionalLikeInnerState(
+        state,
+        parser.initialState,
+        parser,
       );
+      try {
+        return innerCheck(innerState, exec);
+      } catch (error) {
+        if (!hasDelegatedAnnotationCarrier(innerState)) {
+          throw error;
+        }
+        return innerCheck(normalizeDelegatedAnnotationState(innerState), exec);
+      }
     }
     return false;
   };
@@ -393,11 +531,7 @@ function normalizeOptionalLikeInnerState<TState>(
   parser?: Parser<Mode, unknown, TState>,
 ): TState {
   if (Array.isArray(state)) {
-    return getAnnotations(state) != null &&
-        state[0] != null &&
-        typeof state[0] === "object"
-      ? inheritAnnotations(state, state[0]) as TState
-      : state[0];
+    return getDelegatedAnnotationState(state, state[0]);
   }
   if (isAnnotationOnlyObjectState(state)) {
     if (
@@ -407,7 +541,7 @@ function normalizeOptionalLikeInnerState<TState>(
         typeof parser.shouldDeferCompletion === "function"
       )
     ) {
-      return inheritAnnotations(state, initialState);
+      return getDelegatedAnnotationState(state, initialState);
     }
     return initialState;
   }
@@ -540,12 +674,14 @@ export function optional<M extends Mode, TValue, TState>(
         ): ModeValue<M, ValueParserResult<TValue | undefined>> => {
           const innerResult = dispatchByMode(
             parser.$mode,
-            () => syncParser.complete(resolvedInnerState, exec),
+            () =>
+              completeOptionalLikeSync(syncParser, resolvedInnerState, exec),
             async () =>
-              (await parser.complete(
+              await completeOptionalLikeAsync(
+                parser,
                 resolvedInnerState,
                 exec,
-              )) as ValueParserResult<TValue | undefined>,
+              ) as ValueParserResult<TValue | undefined>,
           );
           return mapModeValue(
             parser.$mode,
@@ -585,12 +721,13 @@ export function optional<M extends Mode, TValue, TState>(
           );
           return dispatchByMode(
             parser.$mode,
-            () => syncParser.complete(delegatedState, exec),
+            () => completeOptionalLikeSync(syncParser, delegatedState, exec),
             async () =>
-              (await parser.complete(
+              await completeOptionalLikeAsync(
+                parser,
                 delegatedState,
                 exec,
-              )) as ValueParserResult<TValue | undefined>,
+              ) as ValueParserResult<TValue | undefined>,
           );
         }
         // When the inner parser is a non-CLI source binding (bindEnv,
@@ -620,11 +757,6 @@ export function optional<M extends Mode, TValue, TState>(
         }
         return { success: true, value: undefined };
       }
-      // Propagate annotations from the outer array state into the inner
-      // element so that source-binding wrappers like bindConfig can read
-      // them during phase-two resolution.  Only propagate when the inner
-      // element is an object; primitive states cannot carry annotations
-      // without changing their shape, which would break inner parsers.
       const innerElement = normalizeOptionalLikeInnerState(
         state,
         parser.initialState,
@@ -632,12 +764,14 @@ export function optional<M extends Mode, TValue, TState>(
       );
       return dispatchByMode(
         parser.$mode,
-        () => syncParser.complete(innerElement as TState, exec),
+        () =>
+          completeOptionalLikeSync(syncParser, innerElement as TState, exec),
         async () =>
-          (await parser.complete(
+          await completeOptionalLikeAsync(
+            parser,
             innerElement as TState,
             exec,
-          )) as ValueParserResult<TValue | undefined>,
+          ) as ValueParserResult<TValue | undefined>,
       );
     },
     suggest(
@@ -984,12 +1118,13 @@ export function withDefault<
           );
           const innerResult = dispatchByMode(
             parser.$mode,
-            () => syncParser.complete(innerState, exec),
+            () => completeOptionalLikeSync(syncParser, innerState, exec),
             async () =>
-              (await parser.complete(
+              await completeOptionalLikeAsync(
+                parser,
                 innerState,
                 exec,
-              )) as ValueParserResult<TValue>,
+              ) as ValueParserResult<TValue>,
           );
           // Propagate the inner result as-is.  When wrapping
           // bindConfig(), success means config resolved; failure means
@@ -1023,12 +1158,13 @@ export function withDefault<
           );
           const innerResult = dispatchByMode(
             parser.$mode,
-            () => syncParser.complete(innerState, exec),
+            () => completeOptionalLikeSync(syncParser, innerState, exec),
             async () =>
-              (await parser.complete(
+              await completeOptionalLikeAsync(
+                parser,
                 innerState,
                 exec,
-              )) as ValueParserResult<TValue>,
+              ) as ValueParserResult<TValue>,
           );
           const handleInnerResult = (
             result: ValueParserResult<TValue>,
@@ -1074,11 +1210,6 @@ export function withDefault<
           };
         }
       }
-      // Propagate annotations from the outer array state into the inner
-      // element so that source-binding wrappers like bindConfig can read
-      // them during phase-two resolution.  Only propagate when the inner
-      // element is an object; primitive states cannot carry annotations
-      // without changing their shape, which would break inner parsers.
       const innerElement = normalizeOptionalLikeInnerState(
         state,
         parser.initialState,
@@ -1086,12 +1217,14 @@ export function withDefault<
       );
       return dispatchByMode(
         parser.$mode,
-        () => syncParser.complete(innerElement as TState, exec),
+        () =>
+          completeOptionalLikeSync(syncParser, innerElement as TState, exec),
         async () =>
-          (await parser.complete(
+          await completeOptionalLikeAsync(
+            parser,
             innerElement as TState,
             exec,
-          )) as ValueParserResult<TValue | TDefault>,
+          ) as ValueParserResult<TValue | TDefault>,
       );
     },
     suggest(

--- a/packages/core/src/modifiers.ts
+++ b/packages/core/src/modifiers.ts
@@ -325,7 +325,7 @@ function extractOptionalLikePhase2Seed<M extends Mode, TValue, TState>(
         }
         return normalizeOptionalLikePhase2Seed(seed, hasCarrier);
       } catch (error) {
-        if (!hasCarrier) {
+        if (!shouldRetryOptionalLikeCompatibilityError(error, innerState)) {
           throw error;
         }
         const fallbackState = normalizeDelegatedAnnotationState(innerState);
@@ -390,7 +390,7 @@ function extractOptionalLikePhase2Seed<M extends Mode, TValue, TState>(
         }
         return normalizeOptionalLikePhase2Seed(seed, hasCarrier);
       } catch (error) {
-        if (!hasCarrier) {
+        if (!shouldRetryOptionalLikeCompatibilityError(error, innerState)) {
           throw error;
         }
         const fallbackState = normalizeDelegatedAnnotationState(innerState);

--- a/packages/core/src/modifiers.ts
+++ b/packages/core/src/modifiers.ts
@@ -2,6 +2,7 @@ import {
   getDelegatedAnnotationState,
   hasDelegatedAnnotationCarrier,
   normalizeDelegatedAnnotationState,
+  normalizeNestedDelegatedAnnotationState,
 } from "./annotation-state.ts";
 import { composeDependencyMetadata } from "./dependency-metadata.ts";
 import { formatMessage, type Message, message, text } from "./message.ts";
@@ -23,6 +24,7 @@ import {
   completeOrExtractPhase2Seed,
   extractPhase2Seed,
   extractPhase2SeedKey,
+  phase2SeedFromValueResult,
 } from "./phase2-seed.ts";
 import {
   defineInheritedAnnotationParser,
@@ -176,7 +178,7 @@ function normalizeOptionalLikeCompleteResult<T>(
   return result.success
     ? {
       ...result,
-      value: normalizeDelegatedAnnotationState(result.value),
+      value: normalizeNestedDelegatedAnnotationState(result.value),
     }
     : result;
 }
@@ -186,19 +188,14 @@ function completeOptionalLikeSync<TValue, TState>(
   state: TState,
   exec?: ExecutionContext,
 ): ValueParserResult<TValue> {
-  const fallbackState = normalizeDelegatedAnnotationState(state);
+  const hasCarrier = hasDelegatedAnnotationCarrier(state);
   try {
-    const result = parser.complete(state, exec);
-    if (!result.success && hasDelegatedAnnotationCarrier(state)) {
-      return normalizeOptionalLikeCompleteResult(
-        parser.complete(fallbackState, exec),
-      );
-    }
-    return normalizeOptionalLikeCompleteResult(result);
+    return normalizeOptionalLikeCompleteResult(parser.complete(state, exec));
   } catch (error) {
-    if (!hasDelegatedAnnotationCarrier(state)) {
+    if (!hasCarrier) {
       throw error;
     }
+    const fallbackState = normalizeDelegatedAnnotationState(state);
     return normalizeOptionalLikeCompleteResult(
       parser.complete(fallbackState, exec),
     );
@@ -210,19 +207,16 @@ async function completeOptionalLikeAsync<TValue, TState>(
   state: TState,
   exec?: ExecutionContext,
 ): Promise<ValueParserResult<TValue>> {
-  const fallbackState = normalizeDelegatedAnnotationState(state);
+  const hasCarrier = hasDelegatedAnnotationCarrier(state);
   try {
-    const result = await parser.complete(state, exec);
-    if (!result.success && hasDelegatedAnnotationCarrier(state)) {
-      return normalizeOptionalLikeCompleteResult(
-        await parser.complete(fallbackState, exec),
-      );
-    }
-    return normalizeOptionalLikeCompleteResult(result);
+    return normalizeOptionalLikeCompleteResult(
+      await parser.complete(state, exec),
+    );
   } catch (error) {
-    if (!hasDelegatedAnnotationCarrier(state)) {
+    if (!hasCarrier) {
       throw error;
     }
+    const fallbackState = normalizeDelegatedAnnotationState(state);
     return normalizeOptionalLikeCompleteResult(
       await parser.complete(fallbackState, exec),
     );
@@ -234,7 +228,7 @@ function normalizeOptionalLikePhase2Seed<T>(
 ): import("./phase2-seed.ts").Phase2Seed<T> | null {
   return seed == null ? null : {
     ...seed,
-    value: normalizeDelegatedAnnotationState(seed.value),
+    value: normalizeNestedDelegatedAnnotationState(seed.value),
   };
 }
 
@@ -254,19 +248,29 @@ function extractOptionalLikePhase2Seed<M extends Mode, TValue, TState>(
     parser.initialState,
     parser,
   );
-  const fallbackState = normalizeDelegatedAnnotationState(innerState);
+  const hasCarrier = hasDelegatedAnnotationCarrier(innerState);
   return dispatchByMode(
     parser.$mode,
     () => {
       try {
-        const seed = completeOrExtractPhase2Seed(
+        const result = (parser as Parser<"sync", TValue, TState>).complete(
+          innerState,
+          exec,
+        );
+        if (result.success) {
+          return normalizeOptionalLikePhase2Seed(
+            phase2SeedFromValueResult(result),
+          );
+        }
+        const seed = extractPhase2Seed(
           parser as Parser<"sync", TValue, TState>,
           innerState,
           exec,
         );
-        if (seed == null && hasDelegatedAnnotationCarrier(innerState)) {
+        if (seed == null && hasCarrier) {
+          const fallbackState = normalizeDelegatedAnnotationState(innerState);
           return normalizeOptionalLikePhase2Seed(
-            completeOrExtractPhase2Seed(
+            extractPhase2Seed(
               parser as Parser<"sync", TValue, TState>,
               fallbackState,
               exec,
@@ -275,11 +279,21 @@ function extractOptionalLikePhase2Seed<M extends Mode, TValue, TState>(
         }
         return normalizeOptionalLikePhase2Seed(seed);
       } catch (error) {
-        if (!hasDelegatedAnnotationCarrier(innerState)) {
+        if (!hasCarrier) {
           throw error;
         }
+        const fallbackState = normalizeDelegatedAnnotationState(innerState);
+        const result = (parser as Parser<"sync", TValue, TState>).complete(
+          fallbackState,
+          exec,
+        );
+        if (result.success) {
+          return normalizeOptionalLikePhase2Seed(
+            phase2SeedFromValueResult(result),
+          );
+        }
         return normalizeOptionalLikePhase2Seed(
-          completeOrExtractPhase2Seed(
+          extractPhase2Seed(
             parser as Parser<"sync", TValue, TState>,
             fallbackState,
             exec,
@@ -289,14 +303,23 @@ function extractOptionalLikePhase2Seed<M extends Mode, TValue, TState>(
     },
     async () => {
       try {
-        const seed = await completeOrExtractPhase2Seed(
+        const result = await (
+          parser as Parser<"async", TValue, TState>
+        ).complete(innerState, exec);
+        if (result.success) {
+          return normalizeOptionalLikePhase2Seed(
+            phase2SeedFromValueResult(result),
+          );
+        }
+        const seed = await extractPhase2Seed(
           parser as Parser<"async", TValue, TState>,
           innerState,
           exec,
         );
-        if (seed == null && hasDelegatedAnnotationCarrier(innerState)) {
+        if (seed == null && hasCarrier) {
+          const fallbackState = normalizeDelegatedAnnotationState(innerState);
           return normalizeOptionalLikePhase2Seed(
-            await completeOrExtractPhase2Seed(
+            await extractPhase2Seed(
               parser as Parser<"async", TValue, TState>,
               fallbackState,
               exec,
@@ -305,11 +328,20 @@ function extractOptionalLikePhase2Seed<M extends Mode, TValue, TState>(
         }
         return normalizeOptionalLikePhase2Seed(seed);
       } catch (error) {
-        if (!hasDelegatedAnnotationCarrier(innerState)) {
+        if (!hasCarrier) {
           throw error;
         }
+        const fallbackState = normalizeDelegatedAnnotationState(innerState);
+        const result = await (
+          parser as Parser<"async", TValue, TState>
+        ).complete(fallbackState, exec);
+        if (result.success) {
+          return normalizeOptionalLikePhase2Seed(
+            phase2SeedFromValueResult(result),
+          );
+        }
         return normalizeOptionalLikePhase2Seed(
-          await completeOrExtractPhase2Seed(
+          await extractPhase2Seed(
             parser as Parser<"async", TValue, TState>,
             fallbackState,
             exec,


### PR DESCRIPTION
Fixes https://github.com/dahlia/optique/issues/594

`optional()` and `withDefault()` already propagated outer annotations into plain object inner states, but they still dropped them when the delegated inner state was a primitive or a non-plain object such as a class instance. That left annotation-aware `complete()` paths and `shouldDeferCompletion()` hooks with inconsistent behavior, especially in compositions like `prompt(optional(...))` and `prompt(withDefault(...))`.

This change moves delegated annotation propagation into shared helpers in *annotation-state.ts* and routes both wrappers through that logic in *modifiers.ts*. Primitive and nullish inner states now use the injected annotation carrier path, while non-plain objects receive a short-lived annotation view that preserves methods and private fields. The wrappers also normalize those internal carriers back out before returning completed values or phase-two seeds, so the fix stays internal to the parser machinery.

I added regression coverage for both wrappers across the two state shapes that were still broken: primitive inner states and class-instance inner states. The new tests cover both `complete()` and `shouldDeferCompletion()`, and *annotation-state.test.ts* adds helper-level coverage for the delegated carrier behavior directly. I also updated *CHANGES.md* because this changes user-visible annotation behavior after 0.10.0.

For example, compositions like this now see the outer annotations consistently even when the wrapped parser keeps state as a string or a class instance:

```ts
const parser = prompt(optional(innerParser));
```

Before this change, `innerParser.complete()` or `innerParser.shouldDeferCompletion()` could miss the outer annotations depending on the runtime shape of the delegated state. After this change, the annotation propagation path is uniform across all supported state shapes.

Validation: `mise test`