### PR TITLE
Define a stable parser extension boundary

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,17 @@ To be released.
     workarounds and fixes custom two-pass contexts that previously could not
     distinguish phase 1 from a real `undefined` parse result. [[#271], [#786]]
 
+ -  Added a stable parser-extension surface for low-level integration authors.
+    `@optique/core/annotations` now documents and supports
+    `injectAnnotations()`, `inheritAnnotations()`,
+    `isInjectedAnnotationState()`, and `unwrapInjectedAnnotationState()` as
+    public helpers; `@optique/core/mode-dispatch` remains the public mode
+    helper module; and the new `@optique/core/extension` subpath exposes
+    `defineTraits()`, `getTraits()`, `delegateSuggestNodes()`, and
+    `mapSourceMetadata()` for parser traits and source-aware wrapper
+    composition. First-party integration packages now use these public helpers
+    instead of reaching into `@optique/core/parser` internals. [[#790]]
+
  -  Added the optional `Parser.validateValue()` method, which lets a
     parser check whether an arbitrary value satisfies its underlying
     `ValueParser`'s constraints (e.g., regex patterns, numeric bounds,
@@ -1700,6 +1711,7 @@ To be released.
 [#786]: https://github.com/dahlia/optique/pull/786
 [#788]: https://github.com/dahlia/optique/pull/788
 [#789]: https://github.com/dahlia/optique/pull/789
+[#790]: https://github.com/dahlia/optique/issues/790
 
 ### @optique/config
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,7 +33,7 @@ To be released.
     `defineTraits()`, `getTraits()`, `delegateSuggestNodes()`, and
     `mapSourceMetadata()` for parser traits and source-aware wrapper
     composition. First-party integration packages now use these public helpers
-    instead of reaching into `@optique/core/parser` internals. [[#790]]
+    instead of reaching into `@optique/core/parser` internals. [[#790], [#793]]
 
  -  Added the optional `Parser.validateValue()` method, which lets a
     parser check whether an arbitrary value satisfies its underlying
@@ -1712,6 +1712,7 @@ To be released.
 [#788]: https://github.com/dahlia/optique/pull/788
 [#789]: https://github.com/dahlia/optique/pull/789
 [#790]: https://github.com/dahlia/optique/issues/790
+[#793]: https://github.com/dahlia/optique/pull/793
 
 ### @optique/config
 

--- a/docs/concepts/extend.md
+++ b/docs/concepts/extend.md
@@ -228,6 +228,39 @@ composition semantics:
     for positional (non-option) tokens.
     Most custom parsers should set this to `false`.
 
+### Helper modules for custom parsers
+
+Optique exposes a few low-level helper modules for custom parser authors:
+
+ -  `@optique/core/context`: Implement `SourceContext` when runtime data should
+    be collected outside the parser itself and injected through `runWith()`.
+ -  `@optique/core/annotations`: Read and propagate annotation-bearing parser
+    state with `getAnnotations()`, `injectAnnotations()`,
+    `inheritAnnotations()`, `isInjectedAnnotationState()`, and
+    `unwrapInjectedAnnotationState()`.
+ -  `@optique/core/mode-dispatch`: Preserve sync/async mode semantics with
+    `dispatchByMode()`, `mapModeValue()`, and `wrapForMode()`.
+ -  `@optique/core/extension`: Coordinate parser traits and source-aware
+    wrapper behavior with `defineTraits()`, `getTraits()`,
+    `delegateSuggestNodes()`, and `mapSourceMetadata()`.
+
+Most custom parsers only need `annotations` and `context`.  The
+`extension` helpers are intended for parser wrappers that need to preserve
+annotation state or participate in source-backed completion and suggestion
+flows.
+
+`inheritsAnnotations`
+:   Use this trait when your parser rebuilds child state and needs parent
+    annotations injected into that rebuilt state.
+
+`completesFromSource`
+:   Use this trait when your parser can still produce a completion result from
+    a non-CLI source value even when it consumed no CLI input.
+
+`requiresSourceBinding`
+:   Use this trait when annotation-only primitive states should count as
+    completable only when they came from a nested source-bound parser.
+
 ### Provisional results
 
 When a custom parser succeeds in `parse()` without consuming any input

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -3217,6 +3217,28 @@ describe("bindConfig() with dependency sources", () => {
     }
   });
 
+  test("withDefault(map(bindConfig(...))) preserves config fallback", () => {
+    const context = createConfigContext({ schema });
+    const annotations: Annotations = {
+      [context.id]: { data: { mode: "prod" as const } },
+    };
+    const parser = withDefault(
+      map(
+        bindConfig(option("--mode", choice(["dev", "prod"] as const)), {
+          context,
+          key: "mode",
+        }),
+        (value) => value.toUpperCase() as Uppercase<typeof value>,
+      ),
+      "FALLBACK",
+    );
+    const result = parse(parser, [], { annotations });
+    assert.ok(result.success);
+    if (result.success) {
+      assert.equal(result.value, "PROD");
+    }
+  });
+
   test(
     "optional(bindConfig(flag)) at top level uses config via annotations",
     () => {

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -25,11 +25,11 @@ import type {
   Result,
 } from "@optique/core/parser";
 import {
-  composeWrappedSourceMetadata,
-  defineInheritedAnnotationParser,
-  getDelegatingSuggestRuntimeNodes,
-  unmatchedNonCliDependencySourceStateMarker,
-} from "@optique/core/parser";
+  defineTraits,
+  delegateSuggestNodes,
+  mapSourceMetadata,
+  type ParserSourceMetadata,
+} from "@optique/core/extension";
 import {
   annotationKey,
   getAnnotations,
@@ -702,7 +702,6 @@ export function bindConfig<
     $valueType: parser.$valueType,
     $stateType: parser.$stateType,
     priority: parser.priority,
-    [unmatchedNonCliDependencySourceStateMarker]: true,
     usage: options.default !== undefined
       ? [{ type: "optional", terms: parser.usage }]
       : parser.usage,
@@ -711,7 +710,7 @@ export function bindConfig<
     initialState: parser.initialState,
     getSuggestRuntimeNodes(state: TState, path: readonly PropertyKey[]) {
       const innerState = getSuggestInnerState(state);
-      return getDelegatingSuggestRuntimeNodes(
+      return delegateSuggestNodes(
         parser,
         boundParser,
         state,
@@ -815,6 +814,10 @@ export function bindConfig<
       return parser.getDocFragments(state, defaultValue);
     },
   };
+  defineTraits(boundParser, {
+    inheritsAnnotations: true,
+    completesFromSource: true,
+  });
 
   // Lazily forward placeholder from inner parser to avoid eagerly
   // evaluating derived value parser factories at construction time.
@@ -847,10 +850,9 @@ export function bindConfig<
       enumerable: false,
     });
   }
-  defineInheritedAnnotationParser(boundParser);
-  const dependencyMetadata = composeWrappedSourceMetadata(
-    parser.dependencyMetadata,
-    (sourceMetadata) => ({
+  const dependencyMetadata = mapSourceMetadata(
+    parser,
+    (sourceMetadata: ParserSourceMetadata<M, TValue, TState>) => ({
       ...sourceMetadata,
       getMissingSourceValue: sourceMetadata.preservesSourceValue !== false &&
           options.default !== undefined

--- a/packages/core/deno.json
+++ b/packages/core/deno.json
@@ -10,6 +10,7 @@
     "./constructs": "./src/constructs.ts",
     "./dependency": "./src/dependency.ts",
     "./doc": "./src/doc.ts",
+    "./extension": "./src/extension.ts",
     "./facade": "./src/facade.ts",
     "./message": "./src/message.ts",
     "./mode-dispatch": "./src/mode-dispatch.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -99,6 +99,14 @@
       "import": "./dist/doc.js",
       "require": "./dist/doc.cjs"
     },
+    "./extension": {
+      "types": {
+        "import": "./dist/extension.d.ts",
+        "require": "./dist/extension.d.cts"
+      },
+      "import": "./dist/extension.js",
+      "require": "./dist/extension.cjs"
+    },
     "./facade": {
       "types": {
         "import": "./dist/facade.d.ts",

--- a/packages/core/src/annotations.test.ts
+++ b/packages/core/src/annotations.test.ts
@@ -9,7 +9,9 @@ import {
   getAnnotations,
   inheritAnnotations,
   injectAnnotations,
+  isInjectedAnnotationState,
   isInjectedAnnotationWrapper,
+  unwrapInjectedAnnotationState,
   unwrapInjectedAnnotationWrapper,
 } from "./annotations.ts";
 
@@ -369,5 +371,27 @@ describe("unwrapInjectedAnnotationWrapper", () => {
     const value = { plain: true };
 
     assert.equal(unwrapInjectedAnnotationWrapper(value), value);
+  });
+});
+
+describe("public annotation-state aliases", () => {
+  it("isInjectedAnnotationState() matches the wrapper predicate", () => {
+    const wrapped = injectAnnotations(undefined, {
+      [Symbol.for("@test/a")]: 1,
+    });
+
+    assert.equal(
+      isInjectedAnnotationState(wrapped),
+      isInjectedAnnotationWrapper(wrapped),
+    );
+  });
+
+  it("unwrapInjectedAnnotationState() matches the wrapper unwrapping helper", () => {
+    const wrapped = injectAnnotations("value", { [Symbol.for("@test/a")]: 1 });
+
+    assert.equal(
+      unwrapInjectedAnnotationState(wrapped),
+      unwrapInjectedAnnotationWrapper(wrapped),
+    );
   });
 });

--- a/packages/core/src/annotations.ts
+++ b/packages/core/src/annotations.ts
@@ -144,11 +144,17 @@ export function annotateFreshArray<T>(
  *
  * This is mainly used by parsers that rebuild array states with spread syntax.
  * Array spread copies elements but drops custom symbol properties, so we need
- * to reattach annotations explicitly when present.
+ * to reattach annotations explicitly when present. `inheritAnnotations()`
+ * supports primitive and nullish targets via wrapper injection, plus arrays,
+ * plain objects, and built-in container/value types that Optique clones
+ * explicitly (`Date`, `Map`, `Set`, and `RegExp`). Non-plain custom objects
+ * are returned unchanged to avoid mutating shared parser state.
  *
  * @param source The original state that may carry annotations.
- * @param target The new state to receive annotations.
- * @returns The target state, with annotations copied when available.
+ * @param target The new state to receive annotations when it is a supported
+ *               target shape.
+ * @returns A cloned or wrapped target with annotations copied when available,
+ *          or the original unsupported non-plain target unchanged.
  * @since 1.0.0
  */
 export function inheritAnnotations<T>(source: unknown, target: T): T {

--- a/packages/core/src/annotations.ts
+++ b/packages/core/src/annotations.ts
@@ -149,7 +149,7 @@ export function annotateFreshArray<T>(
  * @param source The original state that may carry annotations.
  * @param target The new state to receive annotations.
  * @returns The target state, with annotations copied when available.
- * @internal
+ * @since 1.0.0
  */
 export function inheritAnnotations<T>(source: unknown, target: T): T {
   const annotations = getAnnotations(source);
@@ -246,7 +246,7 @@ export function hasMeaningfulAnnotations(
  * @param state The parser state to annotate.
  * @param annotations The annotations to inject.
  * @returns Annotated state.
- * @internal
+ * @since 1.0.0
  */
 export function injectAnnotations<TState>(
   state: TState,
@@ -378,4 +378,34 @@ export function isInjectedAnnotationWrapper(value: unknown): boolean {
   return value != null &&
     typeof value === "object" &&
     injectedAnnotationWrappers.has(value);
+}
+
+/**
+ * Returns whether the given value is an injected annotation state wrapper.
+ *
+ * This is the public name for Optique's primitive-state annotation wrapper
+ * predicate.  Use it when custom parsers need to detect whether annotations
+ * were attached by wrapping a primitive or nullish state value.
+ *
+ * @param value Value to check.
+ * @returns `true` if the value is an injected annotation state wrapper.
+ * @since 1.0.0
+ */
+export function isInjectedAnnotationState(value: unknown): boolean {
+  return isInjectedAnnotationWrapper(value);
+}
+
+/**
+ * Unwraps an injected annotation state wrapper when present.
+ *
+ * This is the public name for Optique's primitive-state annotation unwrapping
+ * helper.  It returns the original value unchanged for non-wrapper inputs.
+ *
+ * @param value Value to potentially unwrap.
+ * @returns The unwrapped primitive value when the input is an injected
+ *          annotation state wrapper; otherwise the original value.
+ * @since 1.0.0
+ */
+export function unwrapInjectedAnnotationState<T>(value: T): T {
+  return unwrapInjectedAnnotationWrapper(value);
 }

--- a/packages/core/src/extension.test.ts
+++ b/packages/core/src/extension.test.ts
@@ -166,7 +166,7 @@ describe("extension", () => {
       );
 
       assert.ok(mapped != null);
-      assert.equal(mapped.source?.preservesSourceValue, false);
+      assert.ok(!mapped.source?.preservesSourceValue);
       assert.equal(mapped.derived, derived);
       assert.equal(mapped.transform, transform);
     });

--- a/packages/core/src/extension.test.ts
+++ b/packages/core/src/extension.test.ts
@@ -141,6 +141,26 @@ describe("extension", () => {
       assert.equal(nodes[0].parser, outerParser);
       assert.equal(nodes[1].parser, innerParser);
     });
+
+    it("returns only inner nodes when outer parser has no source metadata", () => {
+      const innerParser = createTestParser({
+        source: createSourceMetadata(Symbol("inner-source")),
+      });
+      const outerParser = createTestParser();
+
+      const nodes = delegateSuggestNodes(
+        innerParser,
+        outerParser,
+        "outer-state",
+        ["field"],
+        "inner-state",
+      );
+
+      assert.equal(nodes.length, 1);
+      assert.equal(nodes[0].parser, innerParser);
+      assert.equal(nodes[0].state, "inner-state");
+      assert.deepEqual(nodes[0].path, ["field"]);
+    });
   });
 
   describe("mapSourceMetadata()", () => {
@@ -166,7 +186,8 @@ describe("extension", () => {
       );
 
       assert.ok(mapped != null);
-      assert.ok(!mapped.source?.preservesSourceValue);
+      assert.ok(mapped.source != null);
+      assert.ok(!mapped.source.preservesSourceValue);
       assert.equal(mapped.derived, derived);
       assert.equal(mapped.transform, transform);
     });

--- a/packages/core/src/extension.test.ts
+++ b/packages/core/src/extension.test.ts
@@ -81,6 +81,16 @@ describe("extension", () => {
         requiresSourceBinding: true,
       });
     });
+
+    it("preserves completesFromSource across parser spreads", () => {
+      const parser = createTestParser();
+
+      defineTraits(parser, { completesFromSource: true });
+
+      const clone = { ...parser };
+
+      assert.deepEqual(getTraits(clone), { completesFromSource: true });
+    });
   });
 
   describe("delegateSuggestNodes()", () => {

--- a/packages/core/src/extension.test.ts
+++ b/packages/core/src/extension.test.ts
@@ -64,6 +64,7 @@ describe("extension", () => {
       const parser = createTestParser();
 
       assert.deepEqual(getTraits(parser), {});
+      assert.ok(Object.isFrozen(getTraits(parser)));
     });
 
     it("defines and reads parser traits", () => {

--- a/packages/core/src/extension.test.ts
+++ b/packages/core/src/extension.test.ts
@@ -1,0 +1,191 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  defineTraits,
+  delegateSuggestNodes,
+  getTraits,
+  mapSourceMetadata,
+  type ParserSourceMetadata,
+} from "./extension.ts";
+import { message } from "./message.ts";
+import type { Parser } from "./parser.ts";
+
+function createTestParser(
+  dependencyMetadata?: Parser<"sync", unknown, unknown>["dependencyMetadata"],
+): Parser<"sync", unknown, unknown> {
+  return {
+    $mode: "sync",
+    $valueType: [] as const,
+    $stateType: [] as const,
+    priority: 0,
+    usage: [],
+    leadingNames: new Set(),
+    acceptingAnyToken: false,
+    initialState: undefined,
+    parse(context) {
+      return {
+        success: false as const,
+        consumed: 0,
+        error: message`unused parse: ${String(context.state)}`,
+      };
+    },
+    complete() {
+      return { success: true as const, value: undefined };
+    },
+    suggest() {
+      return [];
+    },
+    getDocFragments() {
+      return { fragments: [] };
+    },
+    ...(dependencyMetadata === undefined ? {} : { dependencyMetadata }),
+  };
+}
+
+function createSourceMetadata(
+  sourceId: symbol,
+): NonNullable<
+  Parser<"sync", unknown, unknown>["dependencyMetadata"]
+>["source"] {
+  return {
+    kind: "source",
+    sourceId,
+    preservesSourceValue: true,
+    extractSourceValue(state) {
+      if (typeof state !== "string") return undefined;
+      return { success: true as const, value: state };
+    },
+  };
+}
+
+describe("extension", () => {
+  describe("defineTraits() / getTraits()", () => {
+    it("returns an empty object when no traits are defined", () => {
+      const parser = createTestParser();
+
+      assert.deepEqual(getTraits(parser), {});
+    });
+
+    it("defines and reads parser traits", () => {
+      const parser = createTestParser();
+
+      defineTraits(parser, {
+        inheritsAnnotations: true,
+        completesFromSource: true,
+        requiresSourceBinding: true,
+      });
+
+      assert.deepEqual(getTraits(parser), {
+        inheritsAnnotations: true,
+        completesFromSource: true,
+        requiresSourceBinding: true,
+      });
+    });
+  });
+
+  describe("delegateSuggestNodes()", () => {
+    it("appends the outer source node after inner nodes by default", () => {
+      const innerParser = createTestParser({
+        source: createSourceMetadata(Symbol("inner-source")),
+      });
+      const outerParser = createTestParser({
+        source: createSourceMetadata(Symbol("outer-source")),
+      });
+
+      const nodes = delegateSuggestNodes(
+        innerParser,
+        outerParser,
+        "outer-state",
+        ["field"],
+        "inner-state",
+      );
+
+      assert.equal(nodes.length, 2);
+      assert.equal(nodes[0].parser, innerParser);
+      assert.equal(nodes[0].state, "inner-state");
+      assert.deepEqual(nodes[0].path, ["field"]);
+      assert.equal(nodes[1].parser, outerParser);
+      assert.equal(nodes[1].state, "outer-state");
+      assert.deepEqual(nodes[1].path, ["field"]);
+    });
+
+    it("prepends the outer source node when requested", () => {
+      const innerParser = createTestParser({
+        source: createSourceMetadata(Symbol("inner-source")),
+      });
+      const outerParser = createTestParser({
+        source: createSourceMetadata(Symbol("outer-source")),
+      });
+
+      const nodes = delegateSuggestNodes(
+        innerParser,
+        outerParser,
+        "outer-state",
+        ["field"],
+        "inner-state",
+        "prepend",
+      );
+
+      assert.equal(nodes.length, 2);
+      assert.equal(nodes[0].parser, outerParser);
+      assert.equal(nodes[1].parser, innerParser);
+    });
+  });
+
+  describe("mapSourceMetadata()", () => {
+    it("maps source metadata while preserving other dependency capabilities", () => {
+      const derived = {
+        kind: "derived" as const,
+        dependencyIds: [Symbol("dep")],
+        replayParse: () => ({ success: true as const, value: "ok" }),
+      };
+      const transform = { transformsSourceValue: true as const };
+      const parser = createTestParser({
+        source: createSourceMetadata(Symbol("source")),
+        derived,
+        transform,
+      });
+
+      const mapped = mapSourceMetadata(
+        parser,
+        (source: ParserSourceMetadata<"sync", unknown, unknown>) => ({
+          ...source,
+          preservesSourceValue: false,
+        }),
+      );
+
+      assert.ok(mapped != null);
+      assert.equal(mapped.source?.preservesSourceValue, false);
+      assert.equal(mapped.derived, derived);
+      assert.equal(mapped.transform, transform);
+    });
+
+    it("returns undefined when the parser has no source metadata", () => {
+      const parser = createTestParser();
+
+      const mapped = mapSourceMetadata(
+        parser,
+        (source: ParserSourceMetadata<"sync", unknown, unknown>) => source,
+      );
+
+      assert.equal(mapped, undefined);
+    });
+
+    it("preserves non-source dependency metadata unchanged", () => {
+      const derived = {
+        kind: "derived" as const,
+        dependencyIds: [Symbol("dep")],
+        replayParse: () => ({ success: true as const, value: "ok" }),
+      };
+      const transform = { transformsSourceValue: true as const };
+      const parser = createTestParser({ derived, transform });
+
+      const mapped = mapSourceMetadata(
+        parser,
+        (source: ParserSourceMetadata<"sync", unknown, unknown>) => source,
+      );
+
+      assert.deepEqual(mapped, { derived, transform });
+    });
+  });
+});

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -86,6 +86,7 @@ const emptyTraits: Readonly<ParserTraits> = Object.freeze({});
  *
  * @param parser The parser object to annotate.
  * @param traits Traits to enable.
+ * @returns Nothing.
  * @since 1.0.0
  */
 export function defineTraits(parser: object, traits: ParserTraits): void {

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -96,7 +96,9 @@ export function defineTraits(parser: object, traits: ParserTraits): void {
     Object.defineProperty(parser, unmatchedNonCliDependencySourceStateMarker, {
       value: true,
       configurable: true,
-      enumerable: false,
+      // Keep this trait enumerable so wrappers cloned with object spread, such
+      // as map(), preserve source-backed completion behavior.
+      enumerable: true,
     });
   }
   if (traits.requiresSourceBinding === true) {

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -1,0 +1,184 @@
+/**
+ * Public helpers for parser-extension authors.
+ *
+ * This module exposes the stable coordination points that first-party and
+ * custom parser extensions need when they preserve annotations, participate in
+ * source-backed completion, or compose suggest-time dependency metadata.
+ *
+ * @module
+ * @since 1.0.0
+ */
+
+import type { Mode, Parser } from "./parser.ts";
+import {
+  annotationWrapperRequiresSourceBindingKey,
+  composeWrappedSourceMetadata,
+  defineInheritedAnnotationParser,
+  getDelegatingSuggestRuntimeNodes,
+  inheritParentAnnotationsKey,
+  unmatchedNonCliDependencySourceStateMarker,
+} from "./parser.ts";
+
+/**
+ * Stable trait flags for custom parser extensions.
+ *
+ * @since 1.0.0
+ */
+export interface ParserTraits {
+  /**
+   * Whether parent-state annotations should be injected into rebuilt child
+   * states instead of relying on structural inheritance.
+   */
+  readonly inheritsAnnotations?: true;
+
+  /**
+   * Whether a missing CLI state can still complete from a source-backed
+   * fallback such as config or environment data.
+   */
+  readonly completesFromSource?: true;
+
+  /**
+   * Whether annotation-only primitive states should count as completable only
+   * when they come from a nested source-bound parser.
+   */
+  readonly requiresSourceBinding?: true;
+}
+
+/**
+ * Suggest-time runtime node used to seed dependency-aware completion.
+ *
+ * @since 1.0.0
+ */
+export interface SuggestNode {
+  /** Path from the root parser to this node. */
+  readonly path: readonly PropertyKey[];
+
+  /** The parser whose dependency metadata should be inspected. */
+  readonly parser: Parser<Mode, unknown, unknown>;
+
+  /** Current parser state for this node. */
+  readonly state: unknown;
+
+  /** Whether this node reflects explicit input consumption. */
+  readonly matched?: boolean;
+
+  /** Snapshotted default dependency values for derived parsers. */
+  readonly defaultDependencyValues?: readonly unknown[];
+}
+
+/**
+ * Public view of a parser's source capability metadata.
+ *
+ * @since 1.0.0
+ */
+export type ParserSourceMetadata<
+  M extends Mode = Mode,
+  TValue = unknown,
+  TState = unknown,
+> = NonNullable<
+  NonNullable<Parser<M, TValue, TState>["dependencyMetadata"]>["source"]
+>;
+
+const emptyTraits = {} as const satisfies ParserTraits;
+
+/**
+ * Defines stable extension traits on a parser object.
+ *
+ * @param parser The parser object to annotate.
+ * @param traits Traits to enable.
+ * @since 1.0.0
+ */
+export function defineTraits(parser: object, traits: ParserTraits): void {
+  if (traits.inheritsAnnotations === true) {
+    defineInheritedAnnotationParser(parser);
+  }
+  if (traits.completesFromSource === true) {
+    Object.defineProperty(parser, unmatchedNonCliDependencySourceStateMarker, {
+      value: true,
+      configurable: true,
+      enumerable: false,
+    });
+  }
+  if (traits.requiresSourceBinding === true) {
+    Object.defineProperty(parser, annotationWrapperRequiresSourceBindingKey, {
+      value: true,
+      configurable: true,
+      enumerable: false,
+    });
+  }
+}
+
+/**
+ * Reads the stable extension traits defined on a parser object.
+ *
+ * @param parser The parser object to inspect.
+ * @returns The enabled traits.  Returns an empty object when none are set.
+ * @since 1.0.0
+ */
+export function getTraits(parser: object): ParserTraits {
+  const traits: ParserTraits = {
+    ...(Reflect.get(parser, inheritParentAnnotationsKey) === true
+      ? { inheritsAnnotations: true as const }
+      : {}),
+    ...(Reflect.get(parser, unmatchedNonCliDependencySourceStateMarker) === true
+      ? { completesFromSource: true as const }
+      : {}),
+    ...(Reflect.get(parser, annotationWrapperRequiresSourceBindingKey) === true
+      ? { requiresSourceBinding: true as const }
+      : {}),
+  };
+  return Object.keys(traits).length > 0 ? traits : emptyTraits;
+}
+
+/**
+ * Delegates suggest-time runtime nodes to an inner parser while preserving an
+ * outer parser's own source metadata node.
+ *
+ * @param innerParser The wrapped parser that owns the underlying nodes.
+ * @param outerParser The outer parser that may contribute its own source node.
+ * @param state The outer parser state.
+ * @param path The parser path within the parse tree.
+ * @param innerState The state to use when collecting inner nodes.
+ * @param position Whether the outer node is appended or prepended.
+ * @returns The composed runtime nodes.
+ * @since 1.0.0
+ */
+export function delegateSuggestNodes<TInnerState>(
+  innerParser: Parser<Mode, unknown, TInnerState>,
+  outerParser: Parser<Mode, unknown, unknown>,
+  state: unknown,
+  path: readonly PropertyKey[],
+  innerState: TInnerState,
+  position: "append" | "prepend" = "append",
+): readonly SuggestNode[] {
+  return getDelegatingSuggestRuntimeNodes(
+    innerParser,
+    outerParser,
+    state,
+    path,
+    innerState,
+    position,
+  ) as readonly SuggestNode[];
+}
+
+/**
+ * Maps the source capability of a parser's dependency metadata while
+ * preserving any derived or transform capabilities unchanged.
+ *
+ * @param parser The parser whose source metadata should be transformed.
+ * @param mapSource Function that transforms the source capability.
+ * @returns The composed dependency metadata, or `undefined` if no source
+ *          capability exists.
+ * @since 1.0.0
+ */
+export function mapSourceMetadata<M extends Mode, TValue, TState>(
+  parser: Pick<Parser<M, TValue, TState>, "dependencyMetadata">,
+  mapSource: (
+    source: ParserSourceMetadata<M, TValue, TState>,
+  ) => ParserSourceMetadata<M, TValue, TState>,
+): Parser<M, TValue, TState>["dependencyMetadata"] | undefined {
+  return composeWrappedSourceMetadata(
+    parser.dependencyMetadata,
+    mapSource,
+  ) as Parser<M, TValue, TState>["dependencyMetadata"] | undefined;
+}

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -79,7 +79,7 @@ export type ParserSourceMetadata<
   NonNullable<Parser<M, TValue, TState>["dependencyMetadata"]>["source"]
 >;
 
-const emptyTraits = {} as const satisfies ParserTraits;
+const emptyTraits: Readonly<ParserTraits> = Object.freeze({});
 
 /**
  * Defines stable extension traits on a parser object.
@@ -169,8 +169,9 @@ export function delegateSuggestNodes<TInnerState>(
  *
  * @param parser The parser whose source metadata should be transformed.
  * @param mapSource Function that transforms the source capability.
- * @returns The composed dependency metadata, or `undefined` if no source
- *          capability exists.
+ * @returns The dependency metadata with its source capability transformed when
+ *          present; otherwise the original dependency metadata, or
+ *          `undefined` when the parser has no dependency metadata.
  * @since 1.0.0
  */
 export function mapSourceMetadata<M extends Mode, TValue, TState>(

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -86,7 +86,7 @@ const emptyTraits: Readonly<ParserTraits> = Object.freeze({});
  *
  * @param parser The parser object to annotate.
  * @param traits Traits to enable.
- * @returns Nothing.
+ * @throws {TypeError} If a trait property cannot be defined on `parser`.
  * @since 1.0.0
  */
 export function defineTraits(parser: object, traits: ParserTraits): void {

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     "src/constructs.ts",
     "src/dependency.ts",
     "src/doc.ts",
+    "src/extension.ts",
     "src/facade.ts",
     "src/message.ts",
     "src/mode-dispatch.ts",

--- a/packages/env/src/index.test.ts
+++ b/packages/env/src/index.test.ts
@@ -2456,6 +2456,29 @@ describe("bindEnv() with dependency sources", () => {
     }
   });
 
+  it("optional(map(bindEnv(...))) preserves env fallback via annotations", () => {
+    const envContext = createEnvContext({
+      prefix: "APP_",
+      source: (key) => ({ APP_MODE: "prod" })[key],
+    });
+    const annotations = envContext.getAnnotations() as Record<symbol, unknown>;
+    const parser = optional(
+      map(
+        bindEnv(option("--mode", choice(["dev", "prod"] as const)), {
+          context: envContext,
+          key: "MODE",
+          parser: choice(["dev", "prod"] as const),
+        }),
+        (value) => value.toUpperCase() as Uppercase<typeof value>,
+      ),
+    );
+    const result = parse(parser, [], { annotations });
+    assert.ok(result.success);
+    if (result.success) {
+      assert.equal(result.value, "PROD");
+    }
+  });
+
   it("optional(bindEnv(..., default)) uses bindEnv default when env absent", () => {
     const envContext = createEnvContext({
       prefix: "APP_",

--- a/packages/env/src/index.test.ts
+++ b/packages/env/src/index.test.ts
@@ -828,10 +828,12 @@ describe("bindEnv()", () => {
         usage: portParser.usage,
       });
       assert.ok(parseResult.success);
-      const extracted = portParser.dependencyMetadata?.source
-        ?.extractSourceValue(parseResult.next.state);
-      assert.ok(extracted != null && !(extracted instanceof Promise));
-      assert.ok(!extracted.success);
+      const getMissing = portParser.dependencyMetadata?.source
+        ?.getMissingSourceValue;
+      assert.ok(typeof getMissing === "function");
+      const missing = getMissing!();
+      assert.ok(missing != null && !(missing instanceof Promise));
+      assert.ok(!missing.success);
     });
 
     it("bindEnv fallback errors carry the option-name prefix", () => {

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -2,9 +2,16 @@ import {
   annotationKey,
   getAnnotations,
   injectAnnotations,
-  isInjectedAnnotationWrapper,
+  isInjectedAnnotationState,
 } from "@optique/core/annotations";
 import type { Annotations, SourceContext } from "@optique/core/context";
+import {
+  defineTraits,
+  delegateSuggestNodes,
+  getTraits,
+  mapSourceMetadata,
+  type ParserSourceMetadata,
+} from "@optique/core/extension";
 import { envVar, type Message, message, valueSet } from "@optique/core/message";
 import {
   dispatchByMode,
@@ -18,13 +25,6 @@ import type {
   Parser,
   ParserResult,
   Result,
-} from "@optique/core/parser";
-import {
-  composeWrappedSourceMetadata,
-  defineInheritedAnnotationParser,
-  getDelegatingSuggestRuntimeNodes,
-  inheritParentAnnotationsKey,
-  unmatchedNonCliDependencySourceStateMarker,
 } from "@optique/core/parser";
 import {
   ensureNonEmptyString,
@@ -280,7 +280,6 @@ export function bindEnv<
     $valueType: parser.$valueType,
     $stateType: parser.$stateType,
     priority: parser.priority,
-    [unmatchedNonCliDependencySourceStateMarker]: true,
     usage: options.default !== undefined
       ? [{ type: "optional", terms: parser.usage }]
       : parser.usage,
@@ -293,7 +292,7 @@ export function bindEnv<
           ? parser.initialState
           : state.cliState as TState)
         : state;
-      return getDelegatingSuggestRuntimeNodes(
+      return delegateSuggestNodes(
         parser,
         boundParser,
         state,
@@ -382,7 +381,7 @@ export function bindEnv<
         parser,
         isEnvBindState(state)
           ? state.cliState
-          : isInjectedAnnotationWrapper(state)
+          : isInjectedAnnotationState(state)
           ? undefined
           : state,
         exec,
@@ -403,7 +402,10 @@ export function bindEnv<
       return parser.getDocFragments(state, defaultValue);
     },
   };
-  defineInheritedAnnotationParser(boundParser);
+  defineTraits(boundParser, {
+    inheritsAnnotations: true,
+    completesFromSource: true,
+  });
   // Lazily forward placeholder from inner parser to avoid eagerly
   // evaluating derived value parser factories at construction time.
   if ("placeholder" in parser) {
@@ -435,22 +437,9 @@ export function bindEnv<
       enumerable: false,
     });
   }
-  const dependencyMetadata = composeWrappedSourceMetadata(
-    (
-      parser as Parser<M, TValue, TState> & {
-        readonly dependencyMetadata?: {
-          readonly source?: {
-            readonly extractSourceValue: (
-              state: unknown,
-            ) =>
-              | ValueParserResult<unknown>
-              | Promise<ValueParserResult<unknown> | undefined>
-              | undefined;
-          };
-        };
-      }
-    ).dependencyMetadata,
-    (sourceMetadata) => ({
+  const dependencyMetadata = mapSourceMetadata(
+    parser,
+    (sourceMetadata: ParserSourceMetadata<M, TValue, TState>) => ({
       ...sourceMetadata,
       extractSourceValue: (state: unknown) => {
         if (!isEnvBindState(state)) {
@@ -635,7 +624,7 @@ function getEnvOrDefault<M extends Mode, TValue>(
     const completeState = innerState ??
       (annotations != null &&
           innerParser.initialState == null &&
-          Reflect.get(innerParser, inheritParentAnnotationsKey) === true
+          getTraits(innerParser).inheritsAnnotations === true
         ? injectAnnotations(innerParser.initialState, annotations)
         : innerParser.initialState);
     return wrapForMode(mode, innerParser.complete(completeState, exec));

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -441,6 +441,19 @@ export function bindEnv<
     parser,
     (sourceMetadata: ParserSourceMetadata<M, TValue, TState>) => ({
       ...sourceMetadata,
+      getMissingSourceValue: sourceMetadata.preservesSourceValue !== false &&
+          options.default !== undefined
+        ? () => {
+          // Route the default through the inner parser's validateValue so that
+          // CLI constraints cannot be bypassed via bindEnv defaults (#414).
+          if (typeof parser.validateValue === "function") {
+            return parser.validateValue(options.default!) as
+              | ValueParserResult<unknown>
+              | Promise<ValueParserResult<unknown>>;
+          }
+          return { success: true as const, value: options.default };
+        }
+        : undefined,
       extractSourceValue: (state: unknown) => {
         if (!isEnvBindState(state)) {
           if (sourceMetadata.preservesSourceValue) {

--- a/packages/inquirer/src/index.ts
+++ b/packages/inquirer/src/index.ts
@@ -22,21 +22,21 @@ import {
   getAnnotations,
   inheritAnnotations,
   injectAnnotations,
-  unwrapInjectedAnnotationWrapper,
+  unwrapInjectedAnnotationState,
 } from "@optique/core/annotations";
+import {
+  defineTraits,
+  delegateSuggestNodes,
+  getTraits,
+  mapSourceMetadata,
+  type ParserSourceMetadata,
+} from "@optique/core/extension";
 import type {
   ExecutionContext,
   Mode,
   ModeValue,
   Parser,
   ParserResult,
-} from "@optique/core/parser";
-import {
-  annotationWrapperRequiresSourceBindingKey,
-  composeWrappedSourceMetadata,
-  defineInheritedAnnotationParser,
-  getDelegatingSuggestRuntimeNodes,
-  inheritParentAnnotationsKey,
 } from "@optique/core/parser";
 import { message } from "@optique/core/message";
 import type { ValueParserResult } from "@optique/core/valueparser";
@@ -745,9 +745,9 @@ export function prompt<M extends Mode, TValue, TState>(
   ): boolean {
     const cliStateIsInjectedAnnotationWrapper = cliState != null &&
       typeof cliState === "object" &&
-      unwrapInjectedAnnotationWrapper(cliState) !== cliState;
+      unwrapInjectedAnnotationState(cliState) !== cliState;
     const requiresSourceBindingForAnnotationWrapper =
-      Reflect.get(parser, annotationWrapperRequiresSourceBindingKey) === true;
+      getTraits(parser).requiresSourceBinding === true;
     const hasNestedSourceBinding = hasSourceBindingMarker(cliState) ||
       (Array.isArray(cliState) &&
         cliState.length === 1 &&
@@ -939,14 +939,11 @@ export function prompt<M extends Mode, TValue, TState>(
     return validatePromptedValue(result);
   }
 
-  const promptedParser: Parser<"async", TValue, TState> & {
-    readonly [inheritParentAnnotationsKey]: true;
-  } = {
+  const promptedParser: Parser<"async", TValue, TState> = {
     $mode: "async",
     $valueType: parser.$valueType,
     $stateType: parser.$stateType,
     priority: parser.priority,
-    [inheritParentAnnotationsKey]: true,
     // prompt() makes the CLI argument optional because missing values are
     // handled interactively.  If the inner parser is already optional
     // (e.g., wrapped in optional() or withDefault()), reuse its usage
@@ -962,7 +959,7 @@ export function prompt<M extends Mode, TValue, TState>(
           ? parser.initialState
           : state.cliState as TState)
         : state;
-      return getDelegatingSuggestRuntimeNodes(
+      return delegateSuggestNodes(
         parser,
         promptedParser,
         state,
@@ -998,7 +995,7 @@ export function prompt<M extends Mode, TValue, TState>(
         : context;
       const effectiveInnerState = annotations != null &&
           innerState == null &&
-          Reflect.get(parser, inheritParentAnnotationsKey) === true
+          getTraits(parser).inheritsAnnotations === true
         ? injectAnnotations(innerState, annotations)
         : innerState;
       // Propagate annotations into the inner context state so that source-
@@ -1216,7 +1213,7 @@ export function prompt<M extends Mode, TValue, TState>(
           : undefined;
         const cliStateIsInjected = cliState != null &&
           typeof cliState === "object" &&
-          unwrapInjectedAnnotationWrapper(cliState) !== cliState;
+          unwrapInjectedAnnotationState(cliState) !== cliState;
         const isSourceBinding = shouldCompleteFromSourceBinding(
           cliState,
           state,
@@ -1338,7 +1335,7 @@ export function prompt<M extends Mode, TValue, TState>(
       return parser.getDocFragments(state, defaultValue as TValue);
     },
   };
-  defineInheritedAnnotationParser(promptedParser);
+  defineTraits(promptedParser, { inheritsAnnotations: true });
 
   // Lazily forward placeholder from inner parser so that outer wrappers
   // (withDefault, group, etc.) can see it without triggering eager
@@ -1365,22 +1362,9 @@ export function prompt<M extends Mode, TValue, TState>(
       enumerable: false,
     });
   }
-  const dependencyMetadata = composeWrappedSourceMetadata(
-    (
-      parser as Parser<M, TValue, TState> & {
-        readonly dependencyMetadata?: {
-          readonly source?: {
-            readonly extractSourceValue: (
-              state: unknown,
-            ) =>
-              | ValueParserResult<unknown>
-              | Promise<ValueParserResult<unknown> | undefined>
-              | undefined;
-          };
-        };
-      }
-    ).dependencyMetadata,
-    (source) => ({
+  const dependencyMetadata = mapSourceMetadata(
+    parser,
+    (source: ParserSourceMetadata<M, TValue, TState>) => ({
       ...source,
       extractSourceValue: (state: unknown) => {
         if (!isPromptBindState(state)) {


### PR DESCRIPTION
## Summary
- Add a small public extension surface to `@optique/core` by introducing `@optique/core/extension`, and promote annotation-state helpers in *packages/core/src/annotations.ts* so first-party integrations no longer depend on non-public parser internals.
- Refactor *packages/env/src/index.ts*, *packages/config/src/index.ts*, and *packages/inquirer/src/index.ts* to use the public extension APIs for parser traits, source-backed completion, suggest-node delegation, and annotation-state handling.
- Document the new boundary in *docs/concepts/extend.md*, record it in *CHANGES.md*, and add regression coverage in *packages/core/src/extension.test.ts* and *packages/core/src/annotations.test.ts*.

## Rationale
Optique already documented an extension story around `annotations` and `SourceContext`, but the first-party integrations still had to reach into `@optique/core/parser` for coordination helpers that were never meant to be public.

That mismatch made the documented boundary incomplete, and it left integration code coupled to internal symbols and helper contracts.

This change makes the boundary explicit and stable: most custom parser authors can continue to work with `@optique/core/context`, `@optique/core/annotations`, and `@optique/core/mode-dispatch`, while low-level integration code gets a small public surface for the extra coordination points it actually needs.

## Design decisions
- Keep `@optique/core/context` focused on `SourceContext` rather than turning it into a general extension module.
- Put annotation-state transport helpers where they already conceptually belong, in *packages/core/src/annotations.ts*.
- Reuse the existing `@optique/core/mode-dispatch` subpath rather than moving mode helpers into a new module.
- Introduce `@optique/core/extension` only for the pieces that do not naturally belong under `context`, `annotations`, or `mode-dispatch`.
- Expose parser capabilities through `defineTraits()` and `getTraits()` instead of publishing raw marker symbols from *packages/core/src/parser.ts*.
- Keep the change behavior-preserving by reusing the existing internal implementation paths rather than rewriting the integrations around new abstractions.

## Alternatives considered
- Rewrite the integrations so they avoid all internal coordination helpers. We decided against this because it would either duplicate the same hidden contracts inside each integration package or weaken existing source-backed completion and suggestion behavior.
- Publish more of `@optique/core/parser` directly. We decided against this because it would stabilize internal markers and helper names that are harder to explain and easier to misuse.
- Put every low-level helper under `@optique/core/extension`. We decided against this because `context`, `annotations`, and `mode-dispatch` already have clear meanings, and only the remaining coordination helpers needed a new home.

## Notes
- The new public APIs added here are documented with `@since 1.0.0`.
- The goal of this refactoring is to stabilize the public extension boundary, not to change parser behavior.

## Testing
- `mise test`
- `pnpm build` (from *docs/*)

Closes https://github.com/dahlia/optique/issues/790