### PR TITLE
Fix 23 bugs in gitique example

### DIFF
--- a/examples/gitique/README.md
+++ b/examples/gitique/README.md
@@ -216,7 +216,7 @@ gitique completion zsh > ~/.zsh/completions/_gitique
 # Test completion
 gitique <TAB>                    # Shows: add, commit, diff, log, ...
 gitique add --<TAB>              # Shows: --all, --force, --verbose, --help
-gitique commit --author <TAB>    # Shows available author suggestions
+gitique commit --author <TAB>    # No completions (plain string option)
 ~~~~
 
 

--- a/examples/gitique/README.md
+++ b/examples/gitique/README.md
@@ -301,8 +301,9 @@ This example demonstrates key Optique patterns in a realistic CLI application:
 
 ~~~~ typescript
 import { run } from "@optique/run";
-import { command, constant, option } from "@optique/core/primitives";
 import { object, or } from "@optique/core/constructs";
+import { multiple, optional } from "@optique/core/modifiers";
+import { argument, command, constant, option } from "@optique/core/primitives";
 import { string } from "@optique/core/valueparser";
 
 const parser = or(

--- a/examples/gitique/README.md
+++ b/examples/gitique/README.md
@@ -119,7 +119,7 @@ gitique commit -a -m "Update documentation"
 **Viewing history:**
 
 ~~~~ bash
-# Show all commits (detailed)
+# Show recent commits (default: last 10)
 gitique log
 
 # Show commits in one line format

--- a/examples/gitique/src/commands/add.ts
+++ b/examples/gitique/src/commands/add.ts
@@ -92,6 +92,13 @@ export async function executeAdd(config: AddConfig): Promise<void> {
   try {
     const repo = await getRepository();
 
+    if (config.all && config.files.length > 0) {
+      throw new Error(
+        "Cannot combine --all with explicit file paths. Use --all alone " +
+          "or specify files without --all.",
+      );
+    }
+
     if (config.all) {
       // Add all files (equivalent to `git add .`)
       if (config.verbose) {

--- a/examples/gitique/src/commands/add.ts
+++ b/examples/gitique/src/commands/add.ts
@@ -23,7 +23,7 @@ const stagingOptions = group(
     }),
     force: option("-f", "--force", {
       description:
-        message`Force adding files, even if they would normally be ignored`,
+        message`Allow adding gitignore-excluded files by skipping ignore rules`,
     }),
   }),
 );
@@ -98,7 +98,7 @@ export async function executeAdd(config: AddConfig): Promise<void> {
         console.log("Adding all files to the index...");
       }
 
-      addAllFiles(repo);
+      addAllFiles(repo, config.force);
 
       if (config.verbose) {
         console.log(formatSuccess("Successfully added all files to the index"));
@@ -107,7 +107,7 @@ export async function executeAdd(config: AddConfig): Promise<void> {
       // Add specific files
       for (const file of config.files) {
         try {
-          addFile(repo, file);
+          addFile(repo, file, config.force);
 
           if (config.verbose) {
             console.log(formatAddedFile(file));

--- a/examples/gitique/src/commands/add.ts
+++ b/examples/gitique/src/commands/add.ts
@@ -1,3 +1,4 @@
+import process from "node:process";
 import { group, merge, object } from "@optique/core/constructs";
 import { multiple } from "@optique/core/modifiers";
 import type { InferValue } from "@optique/core/parser";
@@ -135,7 +136,8 @@ export async function executeAdd(config: AddConfig): Promise<void> {
       }
 
       if (hadError) {
-        throw new Error("One or more files could not be added.");
+        process.exitCode = 1;
+        return;
       }
 
       if (config.verbose) {

--- a/examples/gitique/src/commands/add.ts
+++ b/examples/gitique/src/commands/add.ts
@@ -2,7 +2,7 @@ import { group, merge, object } from "@optique/core/constructs";
 import { multiple } from "@optique/core/modifiers";
 import type { InferValue } from "@optique/core/parser";
 import { argument, command, constant, option } from "@optique/core/primitives";
-import { commandLine, message } from "@optique/core/message";
+import { commandLine, lineBreak, message } from "@optique/core/message";
 import { path, printError } from "@optique/run";
 import { addAllFiles, addFile, getRepository } from "../utils/git.ts";
 import {
@@ -66,14 +66,14 @@ const addOptionsParser = merge(
 export const addCommand = command("add", addOptionsParser, {
   brief: message`Add file contents to the index`,
   description: message`Add file contents to the index for the next commit`,
-  footer: message`Examples:
+  footer: message`Examples:${lineBreak()}
   ${
     commandLine("gitique add .")
-  }              Add all files in current directory
+  }              Add all files in current directory${lineBreak()}
   ${
     commandLine("gitique add -A")
-  }             Add all files (including deletions)
-  ${commandLine("gitique add file1.ts")}       Add a specific file
+  }             Add all files (including deletions)${lineBreak()}
+  ${commandLine("gitique add file1.ts")}       Add a specific file${lineBreak()}
   ${commandLine("gitique add -v *.ts")}        Add files with verbose output`,
 });
 

--- a/examples/gitique/src/commands/add.ts
+++ b/examples/gitique/src/commands/add.ts
@@ -136,7 +136,8 @@ export async function executeAdd(config: AddConfig): Promise<void> {
     } else {
       // No files specified and --all not used
       throw new Error(
-        "Nothing specified, nothing added.\nMaybe you wanted to say 'gitique add .'?",
+        "Nothing specified, nothing added.\n" +
+          "Maybe you wanted to say 'gitique add .' or 'gitique add -A'?",
       );
     }
   } catch (error) {

--- a/examples/gitique/src/commands/add.ts
+++ b/examples/gitique/src/commands/add.ts
@@ -104,7 +104,8 @@ export async function executeAdd(config: AddConfig): Promise<void> {
         console.log(formatSuccess("Successfully added all files to the index"));
       }
     } else if (config.files.length > 0) {
-      // Add specific files
+      // Add specific files; collect all per-file errors before failing.
+      let hadError = false;
       for (const file of config.files) {
         try {
           addFile(repo, file, config.force);
@@ -113,6 +114,7 @@ export async function executeAdd(config: AddConfig): Promise<void> {
             console.log(formatAddedFile(file));
           }
         } catch (error) {
+          hadError = true;
           printError(
             message`${
               formatError(
@@ -121,9 +123,12 @@ export async function executeAdd(config: AddConfig): Promise<void> {
                 }`,
               )
             }`,
-            config.force ? undefined : { exitCode: 1 },
           );
         }
+      }
+
+      if (hadError) {
+        throw new Error("One or more files could not be added.");
       }
 
       if (config.verbose) {

--- a/examples/gitique/src/commands/commit.ts
+++ b/examples/gitique/src/commands/commit.ts
@@ -175,10 +175,12 @@ export async function executeCommit(config: CommitConfig): Promise<void> {
 
     // Resolve branch name for the commit header
     let branchName = "(detached)";
-    try {
-      branchName = repo.head().name().replace("refs/heads/", "");
-    } catch {
-      // Detached HEAD or unborn branch — keep default
+    if (!repo.headDetached()) {
+      try {
+        branchName = repo.head().name().replace("refs/heads/", "");
+      } catch {
+        // Unborn branch — keep "(detached)" default
+      }
     }
 
     // Output success message

--- a/examples/gitique/src/commands/commit.ts
+++ b/examples/gitique/src/commands/commit.ts
@@ -106,7 +106,7 @@ function parseAuthor(authorString: string): { name: string; email: string } {
   const email = match?.[2]?.trim() ?? "";
   if (!name || !email) {
     throw new Error(
-      `Invalid author format: "${authorString}". Expected format: "Name <email>"`,
+      `Invalid author format: "${authorString}". Expected format: "Name <email>".`,
     );
   }
   return { name, email };

--- a/examples/gitique/src/commands/commit.ts
+++ b/examples/gitique/src/commands/commit.ts
@@ -130,7 +130,7 @@ export async function executeCommit(config: CommitConfig): Promise<void> {
     // Reject empty commits unless --allow-empty is set
     if (!config.allowEmpty && isIndexEmpty(repo)) {
       throw new Error(
-        "nothing to commit (create/copy files and use 'git add' to track)",
+        "nothing to commit (create/copy files and use 'gitique add' to track)",
       );
     }
 

--- a/examples/gitique/src/commands/commit.ts
+++ b/examples/gitique/src/commands/commit.ts
@@ -100,16 +100,14 @@ export type CommitConfig = InferValue<typeof commitCommand>;
  */
 function parseAuthor(authorString: string): { name: string; email: string } {
   const match = authorString.match(/^(.+?)\s*<(.+?)>$/);
-  if (!match) {
+  const name = match?.[1].trim() ?? "";
+  const email = match?.[2].trim() ?? "";
+  if (!name || !email) {
     throw new Error(
       `Invalid author format: "${authorString}". Expected format: "Name <email>"`,
     );
   }
-
-  return {
-    name: match[1].trim(),
-    email: match[2].trim(),
-  };
+  return { name, email };
 }
 
 /**

--- a/examples/gitique/src/commands/commit.ts
+++ b/examples/gitique/src/commands/commit.ts
@@ -3,7 +3,12 @@ import { optional } from "@optique/core/modifiers";
 import type { InferValue } from "@optique/core/parser";
 import { command, constant, option } from "@optique/core/primitives";
 import { string } from "@optique/core/valueparser";
-import { commandLine, message, optionName } from "@optique/core/message";
+import {
+  commandLine,
+  lineBreak,
+  message,
+  optionName,
+} from "@optique/core/message";
 import { printError } from "@optique/run";
 import {
   addAllFiles,
@@ -75,14 +80,14 @@ export const commitCommand = command("commit", commitOptionsParser, {
   description: message`Record changes to the repository with a commit. Use ${
     optionName("-m")
   } to provide a commit message.`,
-  footer: message`Examples:
-  ${commandLine('gitique commit -m "Initial commit"')}
-  ${commandLine('gitique commit -a -m "Fix bug"')}
+  footer: message`Examples:${lineBreak()}
+  ${commandLine('gitique commit -m "Initial commit"')}${lineBreak()}
+  ${commandLine('gitique commit -a -m "Fix bug"')}${lineBreak()}
   ${
     commandLine(
       'gitique commit --author "John <john@example.com>" -m "Co-authored"',
     )
-  }
+  }${lineBreak()}
   ${commandLine('gitique commit --allow-empty -m "Empty commit"')}`,
 });
 

--- a/examples/gitique/src/commands/commit.ts
+++ b/examples/gitique/src/commands/commit.ts
@@ -11,11 +11,11 @@ import {
 } from "@optique/core/message";
 import { printError } from "@optique/run";
 import {
-  addAllFiles,
   createCommit,
   createGitSignature,
   getRepository,
   isIndexEmpty,
+  stageTrackedFiles,
 } from "../utils/git.ts";
 import {
   formatCommitCreated,
@@ -138,10 +138,12 @@ export async function executeCommit(config: CommitConfig): Promise<void> {
   try {
     const repo = await getRepository();
 
-    // Stage all files if --all option is used
+    // Stage tracked (modified/deleted) files if --all option is used.
+    // Use stageTrackedFiles (index.updateAll) rather than addAllFiles so
+    // that untracked files are not accidentally staged, matching git -a.
     if (config.all) {
       console.log("Staging all modified and deleted files...");
-      await addAllFiles(repo);
+      stageTrackedFiles(repo);
     }
 
     // Reject empty commits unless --allow-empty is set

--- a/examples/gitique/src/commands/commit.ts
+++ b/examples/gitique/src/commands/commit.ts
@@ -132,7 +132,12 @@ export async function executeCommit(config: CommitConfig): Promise<void> {
       );
     }
 
-    const commitMessage = config.message;
+    const commitMessage = config.message.trim();
+    if (!commitMessage) {
+      throw new Error(
+        "Aborting commit due to empty commit message.",
+      );
+    }
 
     // Create author signature; pass repo so local config is checked first.
     let authorSignature;

--- a/examples/gitique/src/commands/commit.ts
+++ b/examples/gitique/src/commands/commit.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { group, merge, object } from "@optique/core/constructs";
 import { optional } from "@optique/core/modifiers";
 import type { InferValue } from "@optique/core/parser";
@@ -101,8 +102,8 @@ export type CommitConfig = InferValue<typeof commitCommand>;
  */
 function parseAuthor(authorString: string): { name: string; email: string } {
   const match = authorString.match(/^(.+?)\s*<(.+?)>$/);
-  const name = match?.[1].trim() ?? "";
-  const email = match?.[2].trim() ?? "";
+  const name = match?.[1]?.trim() ?? "";
+  const email = match?.[2]?.trim() ?? "";
   if (!name || !email) {
     throw new Error(
       `Invalid author format: "${authorString}". Expected format: "Name <email>"`,
@@ -173,7 +174,7 @@ export async function executeCommit(config: CommitConfig): Promise<void> {
         // Unborn/just-created branch — read from .git/HEAD directly
         try {
           const headContent = readFileSync(
-            repo.path() + "HEAD",
+            resolve(repo.path(), "HEAD"),
             "utf-8",
           ).trim();
           if (headContent.startsWith("ref: refs/heads/")) {

--- a/examples/gitique/src/commands/commit.ts
+++ b/examples/gitique/src/commands/commit.ts
@@ -101,7 +101,7 @@ export type CommitConfig = InferValue<typeof commitCommand>;
  * Parses author string in the format "Name <email>".
  */
 function parseAuthor(authorString: string): { name: string; email: string } {
-  const match = authorString.match(/^(.+?)\s*<(.+?)>$/);
+  const match = authorString.match(/^([^<]+)\s*<([^>]+)>$/);
   const name = match?.[1]?.trim() ?? "";
   const email = match?.[2]?.trim() ?? "";
   if (!name || !email) {

--- a/examples/gitique/src/commands/commit.ts
+++ b/examples/gitique/src/commands/commit.ts
@@ -165,12 +165,16 @@ export async function executeCommit(config: CommitConfig): Promise<void> {
       authorSignature = createGitSignature();
     }
 
+    // Committer is always the default identity; only the author can be
+    // overridden with --author.
+    const committerSignature = createGitSignature();
+
     // Create the commit
     const commitOid = createCommit(
       repo,
       commitMessage,
       authorSignature,
-      authorSignature, // Use same signature for committer
+      committerSignature,
     );
 
     // Resolve branch name for the commit header

--- a/examples/gitique/src/commands/commit.ts
+++ b/examples/gitique/src/commands/commit.ts
@@ -15,6 +15,7 @@ import {
   createCommit,
   createGitSignature,
   getRepository,
+  isIndexEmpty,
 } from "../utils/git.ts";
 import {
   formatCommitCreated,
@@ -141,6 +142,13 @@ export async function executeCommit(config: CommitConfig): Promise<void> {
     if (config.all) {
       console.log("Staging all modified and deleted files...");
       await addAllFiles(repo);
+    }
+
+    // Reject empty commits unless --allow-empty is set
+    if (!config.allowEmpty && isIndexEmpty(repo)) {
+      throw new Error(
+        "nothing to commit (create/copy files and use 'git add' to track)",
+      );
     }
 
     // Get commit message

--- a/examples/gitique/src/commands/commit.ts
+++ b/examples/gitique/src/commands/commit.ts
@@ -156,18 +156,18 @@ export async function executeCommit(config: CommitConfig): Promise<void> {
     // Get commit message
     const commitMessage = getCommitMessage(config.message);
 
-    // Create author signature
+    // Create author signature; pass repo so local config is checked first.
     let authorSignature;
     if (config.author) {
       const { name, email } = parseAuthor(config.author);
-      authorSignature = createGitSignature(name, email);
+      authorSignature = createGitSignature(name, email, repo);
     } else {
-      authorSignature = createGitSignature();
+      authorSignature = createGitSignature(undefined, undefined, repo);
     }
 
     // Committer is always the default identity; only the author can be
     // overridden with --author.
-    const committerSignature = createGitSignature();
+    const committerSignature = createGitSignature(undefined, undefined, repo);
 
     // Create the commit
     const commitOid = createCommit(

--- a/examples/gitique/src/commands/commit.ts
+++ b/examples/gitique/src/commands/commit.ts
@@ -163,14 +163,22 @@ export async function executeCommit(config: CommitConfig): Promise<void> {
       authorSignature, // Use same signature for committer
     );
 
-    // Output success message
-    console.log(formatCommitCreated(commitOid, commitMessage));
+    // Resolve branch name for the commit header
+    let branchName = "(detached)";
+    try {
+      branchName = repo.head().name().replace("refs/heads/", "");
+    } catch {
+      // Detached HEAD or unborn branch — keep default
+    }
 
-    // Show commit details
+    // Output success message
+    console.log(formatCommitCreated(commitOid, commitMessage, branchName));
+
+    // Show commit details using the actual commit timestamp
     const commit = repo.getCommit(commitOid);
     const author = commit.author();
     console.log(`Author: ${author.name} <${author.email}>`);
-    console.log(`Date: ${new Date().toISOString()}`);
+    console.log(`Date: ${commit.time().toISOString()}`);
 
     if (config.all) {
       console.log(formatSuccess("Changes automatically staged and committed"));

--- a/examples/gitique/src/commands/commit.ts
+++ b/examples/gitique/src/commands/commit.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { group, merge, object } from "@optique/core/constructs";
 import { optional } from "@optique/core/modifiers";
 import type { InferValue } from "@optique/core/parser";
@@ -160,13 +161,27 @@ export async function executeCommit(config: CommitConfig): Promise<void> {
       committerSignature,
     );
 
-    // Resolve branch name for the commit header
+    // Resolve branch name for the commit header.
+    // After creating a root commit on an unborn branch, repo.head() may
+    // still fail to resolve if it isn't cached yet; read .git/HEAD directly
+    // as a fallback so the output shows the real branch name.
     let branchName = "(detached)";
     if (!repo.headDetached()) {
       try {
         branchName = repo.head().name().replace("refs/heads/", "");
       } catch {
-        // Unborn branch — keep "(detached)" default
+        // Unborn/just-created branch — read from .git/HEAD directly
+        try {
+          const headContent = readFileSync(
+            repo.path() + "HEAD",
+            "utf-8",
+          ).trim();
+          if (headContent.startsWith("ref: refs/heads/")) {
+            branchName = headContent.slice("ref: refs/heads/".length);
+          }
+        } catch {
+          // Unable to determine branch name
+        }
       }
     }
 

--- a/examples/gitique/src/commands/commit.ts
+++ b/examples/gitique/src/commands/commit.ts
@@ -193,7 +193,7 @@ export async function executeCommit(config: CommitConfig): Promise<void> {
     const commit = repo.getCommit(commitOid);
     const author = commit.author();
     console.log(`Author: ${author.name} <${author.email}>`);
-    console.log(`Date: ${commit.time().toISOString()}`);
+    console.log(`Date: ${new Date(author.timestamp * 1000).toISOString()}`);
 
     if (config.all) {
       console.log(formatSuccess("Changes automatically staged and committed"));

--- a/examples/gitique/src/commands/commit.ts
+++ b/examples/gitique/src/commands/commit.ts
@@ -30,11 +30,9 @@ import {
 const commitOptions = group(
   "Commit Options",
   object({
-    message: optional(
-      option("-m", "--message", string({ metavar: "MESSAGE" }), {
-        description: message`Commit message to use for this commit`,
-      }),
-    ),
+    message: option("-m", "--message", string({ metavar: "MESSAGE" }), {
+      description: message`Commit message`,
+    }),
     all: option("-a", "--all", {
       description:
         message`Automatically stage all modified and deleted files before committing`,
@@ -115,23 +113,6 @@ function parseAuthor(authorString: string): { name: string; email: string } {
 }
 
 /**
- * Prompts user for commit message if not provided via -m option.
- * In a real implementation, this would open an editor.
- */
-function getCommitMessage(providedMessage?: string): string {
-  if (providedMessage) {
-    return providedMessage;
-  }
-
-  // In a real implementation, we would open an editor like vim/nano
-  // For this example, we'll require the message to be provided via -m
-  throw new Error(
-    "Aborting commit due to empty commit message.\n" +
-      "Please use 'gitique commit -m \"your message\"' to provide a commit message.",
-  );
-}
-
-/**
  * Executes the git commit command with the parsed configuration.
  */
 export async function executeCommit(config: CommitConfig): Promise<void> {
@@ -153,8 +134,7 @@ export async function executeCommit(config: CommitConfig): Promise<void> {
       );
     }
 
-    // Get commit message
-    const commitMessage = getCommitMessage(config.message);
+    const commitMessage = config.message;
 
     // Create author signature; pass repo so local config is checked first.
     let authorSignature;

--- a/examples/gitique/src/commands/commit.ts
+++ b/examples/gitique/src/commands/commit.ts
@@ -130,7 +130,7 @@ export async function executeCommit(config: CommitConfig): Promise<void> {
     // Reject empty commits unless --allow-empty is set
     if (!config.allowEmpty && isIndexEmpty(repo)) {
       throw new Error(
-        "nothing to commit (create/copy files and use 'gitique add' to track)",
+        "nothing to commit (create/copy files and use 'gitique add' to track).",
       );
     }
 

--- a/examples/gitique/src/commands/commit.ts
+++ b/examples/gitique/src/commands/commit.ts
@@ -144,7 +144,7 @@ export async function executeCommit(config: CommitConfig): Promise<void> {
     // Create author signature; pass repo so local config is checked first.
     let authorSignature;
     if (config.author) {
-      const { name, email } = parseAuthor(config.author);
+      const { name, email } = parseAuthor(config.author.trim());
       authorSignature = createGitSignature(name, email, repo);
     } else {
       authorSignature = createGitSignature(undefined, undefined, repo);

--- a/examples/gitique/src/commands/diff.ts
+++ b/examples/gitique/src/commands/diff.ts
@@ -222,13 +222,11 @@ export async function executeDiff(config: DiffConfig): Promise<void> {
 
       case "numstat": {
         // Print numstat format (insertions deletions filename).
-        // Per-file counts are not available; 0 is used as a placeholder.
+        // es-git does not expose per-file insertion/deletion counts, so
+        // 0 is used as a placeholder to preserve the parseable format.
         for (const delta of diffResult.deltas) {
           console.log(`0\t0\t${delta.path}`);
         }
-        console.log(
-          `${diffResult.stats.insertions}\t${diffResult.stats.deletions}\t(total, approximate)`,
-        );
         break;
       }
 

--- a/examples/gitique/src/commands/diff.ts
+++ b/examples/gitique/src/commands/diff.ts
@@ -157,6 +157,53 @@ export const diffCommand = command("diff", diffOptionsParser, {
 export type DiffConfig = InferValue<typeof diffCommand>;
 
 /**
+ * Parses per-file insertion/deletion counts from unified diff text.
+ * Handles additions, deletions, and modifications including renamed files.
+ */
+function parseNumstat(
+  diffText: string,
+): Map<string, { ins: number; del: number }> {
+  const result = new Map<string, { ins: number; del: number }>();
+  let currentPath: string | null = null;
+  let pendingOldPath: string | null = null;
+  let ins = 0;
+  let del = 0;
+
+  const flush = () => {
+    if (currentPath !== null) {
+      result.set(currentPath, { ins, del });
+      currentPath = null;
+      ins = 0;
+      del = 0;
+    }
+  };
+
+  for (const line of diffText.split("\n")) {
+    if (line.startsWith("--- a/")) {
+      flush();
+      pendingOldPath = line.slice(6);
+    } else if (line.startsWith("--- /dev/null")) {
+      flush();
+      pendingOldPath = null; // New file — path comes from +++ line
+    } else if (line.startsWith("+++ b/")) {
+      currentPath = line.slice(6);
+      pendingOldPath = null;
+    } else if (line.startsWith("+++ /dev/null")) {
+      // Deletion — use the old path captured from --- line
+      currentPath = pendingOldPath;
+      pendingOldPath = null;
+    } else if (line.startsWith("+") && !line.startsWith("+++")) {
+      if (currentPath !== null) ins++;
+    } else if (line.startsWith("-") && !line.startsWith("---")) {
+      if (currentPath !== null) del++;
+    }
+  }
+  flush();
+
+  return result;
+}
+
+/**
  * Determines the output mode based on display options.
  */
 type OutputMode = "patch" | "stat" | "numstat" | "name-only" | "name-status";
@@ -221,11 +268,11 @@ export async function executeDiff(config: DiffConfig): Promise<void> {
       }
 
       case "numstat": {
-        // Print numstat format (insertions deletions filename).
-        // es-git does not expose per-file insertion/deletion counts, so
-        // 0 is used as a placeholder to preserve the parseable format.
+        // Parse per-file counts from the diff text.
+        const fileStats = parseNumstat(diffResult.text);
         for (const delta of diffResult.deltas) {
-          console.log(`0\t0\t${delta.path}`);
+          const stats = fileStats.get(delta.path) ?? { ins: 0, del: 0 };
+          console.log(`${stats.ins}\t${stats.del}\t${delta.path}`);
         }
         break;
       }

--- a/examples/gitique/src/commands/diff.ts
+++ b/examples/gitique/src/commands/diff.ts
@@ -206,11 +206,22 @@ function parseNumstat(
     } else if (line.startsWith("@@")) {
       // Hunk header — from here on, +/- lines are content, not file headers.
       inHunk = true;
-    } else if (
-      !inHunk &&
-      (line.startsWith("Binary files ") || line.startsWith("GIT binary patch"))
-    ) {
+    } else if (!inHunk && line.startsWith("Binary files ")) {
       // Binary patch — no textual hunk lines; mark as binary so we emit "-".
+      isBinary = true;
+      // Some diff generators omit the --- / +++ headers for binary files,
+      // leaving currentPath null.  Extract the path from the "Binary files"
+      // line directly so we still record the entry.
+      if (currentPath === null) {
+        const m = line.match(
+          /^Binary files (?:a\/(.+)|\/dev\/null) and (?:b\/(.+)|\/dev\/null) differ$/,
+        );
+        if (m) {
+          currentPath = m[2] ?? m[1] ?? null;
+        }
+      }
+    } else if (!inHunk && line.startsWith("GIT binary patch")) {
+      // git-format binary patch — path already captured from --- / +++ lines.
       isBinary = true;
     } else if (!inHunk && line.startsWith("--- a/")) {
       pendingOldPath = line.slice(6);

--- a/examples/gitique/src/commands/diff.ts
+++ b/examples/gitique/src/commands/diff.ts
@@ -206,14 +206,15 @@ export async function executeDiff(config: DiffConfig): Promise<void> {
       }
 
       case "stat": {
-        // Print stat-style summary for each file
+        // Print stat-style summary for each file.
+        // Per-file insertion/deletion counts are not available from es-git,
+        // so only file names are shown; totals are approximate.
         for (const delta of diffResult.deltas) {
-          // Note: We don't have per-file stats, so just show file names with status
           console.log(` ${delta.path}`);
         }
         console.log("");
         console.log(
-          formatDiffStats(
+          "(approximate) " + formatDiffStats(
             diffResult.stats.filesChanged,
             diffResult.stats.insertions,
             diffResult.stats.deletions,
@@ -223,14 +224,14 @@ export async function executeDiff(config: DiffConfig): Promise<void> {
       }
 
       case "numstat": {
-        // Print numstat format (insertions deletions filename)
-        // Note: We don't have per-file stats, showing totals
-        console.log(
-          `${diffResult.stats.insertions}\t${diffResult.stats.deletions}\ttotal`,
-        );
+        // Print numstat format (insertions deletions filename).
+        // Per-file counts are not available; 0 is used as a placeholder.
         for (const delta of diffResult.deltas) {
-          console.log(`-\t-\t${delta.path}`);
+          console.log(`0\t0\t${delta.path}`);
         }
+        console.log(
+          `${diffResult.stats.insertions}\t${diffResult.stats.deletions}\t(total, approximate)`,
+        );
         break;
       }
 

--- a/examples/gitique/src/commands/diff.ts
+++ b/examples/gitique/src/commands/diff.ts
@@ -185,6 +185,8 @@ export async function executeDiff(config: DiffConfig): Promise<void> {
       cached: config.cached,
       commit,
       paths: config.paths.length > 0 ? [...config.paths] : undefined,
+      unified: config.unified,
+      algorithm: config.algorithm,
     });
 
     const outputMode = getOutputMode(config);

--- a/examples/gitique/src/commands/diff.ts
+++ b/examples/gitique/src/commands/diff.ts
@@ -174,20 +174,26 @@ export type DiffConfig = InferValue<typeof diffCommand>;
  */
 function parseNumstat(
   diffText: string,
-): Map<string, { ins: number; del: number }> {
-  const result = new Map<string, { ins: number; del: number }>();
+): Map<string, { ins: number | null; del: number | null }> {
+  const result = new Map<string, { ins: number | null; del: number | null }>();
   let currentPath: string | null = null;
   let pendingOldPath: string | null = null;
   let inHunk = false;
+  let isBinary = false;
   let ins = 0;
   let del = 0;
 
   const flush = () => {
     if (currentPath !== null) {
-      result.set(currentPath, { ins, del });
+      // Binary files have no hunk lines; represent them as null (git uses "-").
+      result.set(currentPath, {
+        ins: isBinary ? null : ins,
+        del: isBinary ? null : del,
+      });
       currentPath = null;
       ins = 0;
       del = 0;
+      isBinary = false;
     }
   };
 
@@ -200,6 +206,12 @@ function parseNumstat(
     } else if (line.startsWith("@@")) {
       // Hunk header — from here on, +/- lines are content, not file headers.
       inHunk = true;
+    } else if (
+      !inHunk &&
+      (line.startsWith("Binary files ") || line.startsWith("GIT binary patch"))
+    ) {
+      // Binary patch — no textual hunk lines; mark as binary so we emit "-".
+      isBinary = true;
     } else if (!inHunk && line.startsWith("--- a/")) {
       pendingOldPath = line.slice(6);
     } else if (!inHunk && line.startsWith("--- /dev/null")) {
@@ -291,11 +303,14 @@ export async function executeDiff(config: DiffConfig): Promise<void> {
         const fileStats = parseNumstat(diffResult.text);
         for (const delta of diffResult.deltas) {
           const stats = fileStats.get(delta.path) ?? { ins: 0, del: 0 };
+          // Binary files have null counts; git numstat uses "-" for these.
+          const insCol = stats.ins === null ? "-" : String(stats.ins);
+          const delCol = stats.del === null ? "-" : String(stats.del);
           // For renames/copies, git numstat uses "{old => new}" path notation.
           const displayPath = delta.oldPath
             ? `${delta.oldPath} => ${delta.path}`
             : delta.path;
-          console.log(`${stats.ins}\t${stats.del}\t${displayPath}`);
+          console.log(`${insCol}\t${delCol}\t${displayPath}`);
         }
         break;
       }

--- a/examples/gitique/src/commands/diff.ts
+++ b/examples/gitique/src/commands/diff.ts
@@ -5,6 +5,7 @@ import { argument, command, constant, option } from "@optique/core/primitives";
 import { choice, integer, string } from "@optique/core/valueparser";
 import {
   commandLine,
+  lineBreak,
   message,
   metavar,
   optionName,
@@ -134,11 +135,19 @@ export const diffCommand = command("diff", diffOptionsParser, {
     message`Show changes between commits, commit and working tree, etc. Use ${
       optionName("--cached")
     } to view staged changes.`,
-  footer: message`Examples:
-  ${commandLine("gitique diff")}                    Show unstaged changes
-  ${commandLine("gitique diff --cached")}           Show staged changes
-  ${commandLine("gitique diff HEAD~1")}             Compare with previous commit
-  ${commandLine("gitique diff --stat")}             Show change statistics
+  footer: message`Examples:${lineBreak()}
+  ${
+    commandLine("gitique diff")
+  }                    Show unstaged changes${lineBreak()}
+  ${
+    commandLine("gitique diff --cached")
+  }           Show staged changes${lineBreak()}
+  ${
+    commandLine("gitique diff HEAD~1")
+  }             Compare with previous commit${lineBreak()}
+  ${
+    commandLine("gitique diff --stat")
+  }             Show change statistics${lineBreak()}
   ${
     commandLine("gitique diff --name-only")
   }        Show only changed file names`,

--- a/examples/gitique/src/commands/diff.ts
+++ b/examples/gitique/src/commands/diff.ts
@@ -291,7 +291,11 @@ export async function executeDiff(config: DiffConfig): Promise<void> {
         const fileStats = parseNumstat(diffResult.text);
         for (const delta of diffResult.deltas) {
           const stats = fileStats.get(delta.path) ?? { ins: 0, del: 0 };
-          console.log(`${stats.ins}\t${stats.del}\t${delta.path}`);
+          // For renames/copies, git numstat uses "{old => new}" path notation.
+          const displayPath = delta.oldPath
+            ? `${delta.oldPath} => ${delta.path}`
+            : delta.path;
+          console.log(`${stats.ins}\t${stats.del}\t${displayPath}`);
         }
         break;
       }

--- a/examples/gitique/src/commands/diff.ts
+++ b/examples/gitique/src/commands/diff.ts
@@ -117,11 +117,21 @@ const diffOptionsParser = map(
       ),
     }),
   ),
-  (result) => ({
-    ...result,
+  (result) => {
     // Treat --staged as alias for --cached
-    cached: result.cached || result.staged,
-  }),
+    const displayModes = [
+      result.stat,
+      result.numstat,
+      result.nameOnly,
+      result.nameStatus,
+    ].filter(Boolean).length;
+    if (displayModes > 1) {
+      throw new Error(
+        "Only one of --stat, --numstat, --name-only, --name-status may be used at a time.",
+      );
+    }
+    return { ...result, cached: result.cached || result.staged };
+  },
 );
 
 /**

--- a/examples/gitique/src/commands/diff.ts
+++ b/examples/gitique/src/commands/diff.ts
@@ -158,7 +158,9 @@ export type DiffConfig = InferValue<typeof diffCommand>;
 
 /**
  * Parses per-file insertion/deletion counts from unified diff text.
- * Handles additions, deletions, and modifications including renamed files.
+ * Uses a state machine to distinguish file-header lines from hunk content,
+ * so that content lines whose text starts with '+' or '-' are never
+ * mistaken for file headers.
  */
 function parseNumstat(
   diffText: string,
@@ -166,6 +168,7 @@ function parseNumstat(
   const result = new Map<string, { ins: number; del: number }>();
   let currentPath: string | null = null;
   let pendingOldPath: string | null = null;
+  let inHunk = false;
   let ins = 0;
   let del = 0;
 
@@ -179,27 +182,28 @@ function parseNumstat(
   };
 
   for (const line of diffText.split("\n")) {
-    if (line.startsWith("--- a/")) {
+    if (line.startsWith("diff --git ")) {
+      // Start of a new file patch — flush previous file and reset hunk state.
       flush();
+      inHunk = false;
+      pendingOldPath = null;
+    } else if (line.startsWith("@@")) {
+      // Hunk header — from here on, +/- lines are content, not file headers.
+      inHunk = true;
+    } else if (!inHunk && line.startsWith("--- a/")) {
       pendingOldPath = line.slice(6);
-    } else if (line.startsWith("--- /dev/null")) {
-      flush();
-      pendingOldPath = null; // New file — path comes from +++ line
-    } else if (line.startsWith("+++ b/")) {
+    } else if (!inHunk && line.startsWith("--- /dev/null")) {
+      pendingOldPath = null; // New file — path comes from the +++ line
+    } else if (!inHunk && line.startsWith("+++ b/")) {
       currentPath = line.slice(6);
       pendingOldPath = null;
-    } else if (line.startsWith("+++ /dev/null")) {
+    } else if (!inHunk && line.startsWith("+++ /dev/null")) {
       // Deletion — use the old path captured from --- line
       currentPath = pendingOldPath;
       pendingOldPath = null;
-    } else if (line.startsWith("+")) {
-      // Content insertion. File headers (+++ b/... and +++ /dev/null) were
-      // already matched by the earlier else-if branches; any remaining line
-      // starting with "+" is a hunk insertion, even if its content starts
-      // with "++" (which makes the full line start with "+++").
+    } else if (inHunk && line.startsWith("+")) {
       if (currentPath !== null) ins++;
-    } else if (line.startsWith("-")) {
-      // Content deletion — same reasoning as above.
+    } else if (inHunk && line.startsWith("-")) {
       if (currentPath !== null) del++;
     }
   }

--- a/examples/gitique/src/commands/diff.ts
+++ b/examples/gitique/src/commands/diff.ts
@@ -24,7 +24,7 @@ import {
  * Diff algorithm choices.
  * Demonstrates Optique's choice() value parser.
  */
-const algorithms = ["default", "minimal", "patience", "histogram"] as const;
+const algorithms = ["default", "minimal", "patience"] as const;
 
 /**
  * Display options for the diff command.
@@ -67,7 +67,7 @@ const contextOptions = group(
     algorithm: withDefault(
       option("--diff-algorithm", choice(algorithms, { metavar: "ALGORITHM" }), {
         description:
-          message`Choose a diff algorithm (default, minimal, patience, histogram)`,
+          message`Choose a diff algorithm (default, minimal, patience)`,
       }),
       "default" as const,
     ),

--- a/examples/gitique/src/commands/diff.ts
+++ b/examples/gitique/src/commands/diff.ts
@@ -192,9 +192,14 @@ function parseNumstat(
       // Deletion — use the old path captured from --- line
       currentPath = pendingOldPath;
       pendingOldPath = null;
-    } else if (line.startsWith("+") && !line.startsWith("+++")) {
+    } else if (line.startsWith("+")) {
+      // Content insertion. File headers (+++ b/... and +++ /dev/null) were
+      // already matched by the earlier else-if branches; any remaining line
+      // starting with "+" is a hunk insertion, even if its content starts
+      // with "++" (which makes the full line start with "+++").
       if (currentPath !== null) ins++;
-    } else if (line.startsWith("-") && !line.startsWith("---")) {
+    } else if (line.startsWith("-")) {
+      // Content deletion — same reasoning as above.
       if (currentPath !== null) del++;
     }
   }

--- a/examples/gitique/src/commands/diff.ts
+++ b/examples/gitique/src/commands/diff.ts
@@ -10,7 +10,7 @@ import {
   metavar,
   optionName,
 } from "@optique/core/message";
-import { path, printError } from "@optique/run";
+import { printError } from "@optique/run";
 import process from "node:process";
 import { getDiff, getRepository } from "../utils/git.ts";
 import {
@@ -105,17 +105,15 @@ const diffOptionsParser = map(
     displayOptions,
     contextOptions,
     filterOptions,
+    // Path filtering via positional arguments is not supported because
+    // Optique cannot disambiguate commit refs from file paths without a
+    // "--" separator.  All positionals are consumed as commit arguments.
     object({
       commits: multiple(
         argument(string({ metavar: "COMMIT" }), {
           description: message`Commits to compare (0, 1, or 2)`,
         }),
         { max: 2 },
-      ),
-      paths: multiple(
-        argument(path({ metavar: "PATH" }), {
-          description: message`Limit diff to these paths`,
-        }),
       ),
     }),
   ),
@@ -186,7 +184,6 @@ export async function executeDiff(config: DiffConfig): Promise<void> {
       cached: config.cached,
       commit,
       commit2,
-      paths: config.paths.length > 0 ? [...config.paths] : undefined,
       unified: config.unified,
       algorithm: config.algorithm,
     });

--- a/examples/gitique/src/commands/diff.ts
+++ b/examples/gitique/src/commands/diff.ts
@@ -180,10 +180,12 @@ export async function executeDiff(config: DiffConfig): Promise<void> {
 
     // Determine what to diff
     const commit = config.commits.length > 0 ? config.commits[0] : undefined;
+    const commit2 = config.commits.length > 1 ? config.commits[1] : undefined;
 
     const diffResult = getDiff(repo, {
       cached: config.cached,
       commit,
+      commit2,
       paths: config.paths.length > 0 ? [...config.paths] : undefined,
       unified: config.unified,
       algorithm: config.algorithm,

--- a/examples/gitique/src/commands/diff.ts
+++ b/examples/gitique/src/commands/diff.ts
@@ -191,7 +191,7 @@ function parseNumstat(
     }
   };
 
-  for (const line of diffText.split("\n")) {
+  for (const line of diffText.split(/\r?\n/)) {
     if (line.startsWith("diff --git ")) {
       // Start of a new file patch — flush previous file and reset hunk state.
       flush();

--- a/examples/gitique/src/commands/diff.ts
+++ b/examples/gitique/src/commands/diff.ts
@@ -174,8 +174,11 @@ export type DiffConfig = InferValue<typeof diffCommand>;
  */
 function parseNumstat(
   diffText: string,
-): Map<string, { ins: number | null; del: number | null }> {
-  const result = new Map<string, { ins: number | null; del: number | null }>();
+): Map<string, { readonly ins: number | null; readonly del: number | null }> {
+  const result = new Map<
+    string,
+    { readonly ins: number | null; readonly del: number | null }
+  >();
   let currentPath: string | null = null;
   let pendingOldPath: string | null = null;
   let inHunk = false;

--- a/examples/gitique/src/commands/log.ts
+++ b/examples/gitique/src/commands/log.ts
@@ -241,16 +241,20 @@ export async function executeLog(config: LogConfig): Promise<void> {
   try {
     const repo = await getRepository();
 
-    // Get commit history
-    const commits = getCommitHistory(repo, config.maxCount);
+    // Fetch all commits first, then filter, then limit.  Limiting before
+    // filtering would incorrectly exclude matching commits deeper in history.
+    const allCommits = getCommitHistory(repo);
 
-    if (commits.length === 0) {
+    if (allCommits.length === 0) {
       console.log("No commits found in the repository.");
       return;
     }
 
-    // Apply filters
-    const filteredCommits = filterCommits(commits, config);
+    // Apply filters, then honour --max-count
+    const filteredCommits = filterCommits(allCommits, config).slice(
+      0,
+      config.maxCount,
+    );
 
     if (filteredCommits.length === 0) {
       console.log("No commits match the specified criteria.");

--- a/examples/gitique/src/commands/log.ts
+++ b/examples/gitique/src/commands/log.ts
@@ -181,16 +181,16 @@ function filterCommits(
   if (config.since) {
     const sinceDate = parseDate(config.since);
     filtered = filtered.filter(({ commit }) => {
-      const commitDate = commit.time();
-      return commitDate >= sinceDate;
+      const authorDate = new Date(commit.author().timestamp * 1000);
+      return authorDate >= sinceDate;
     });
   }
 
   if (config.until) {
     const untilDate = parseDate(config.until);
     filtered = filtered.filter(({ commit }) => {
-      const commitDate = commit.time();
-      return commitDate <= untilDate;
+      const authorDate = new Date(commit.author().timestamp * 1000);
+      return authorDate <= untilDate;
     });
   }
 

--- a/examples/gitique/src/commands/log.ts
+++ b/examples/gitique/src/commands/log.ts
@@ -151,7 +151,15 @@ function parseDate(dateString: string): Date {
   // ISO date-only: treat as local midnight, not UTC midnight.
   if (/^\d{4}-\d{2}-\d{2}$/.test(dateString)) {
     const [year, month, day] = dateString.split("-").map(Number);
-    return new Date(year, month - 1, day);
+    const d = new Date(year, month - 1, day);
+    // new Date() normalises impossible dates (e.g. Feb 31 → Mar 2); reject them.
+    if (
+      d.getFullYear() !== year || d.getMonth() !== month - 1 ||
+      d.getDate() !== day
+    ) {
+      throw new Error(`Invalid date: "${dateString}"`);
+    }
+    return d;
   }
   const date = new Date(dateString);
   if (isNaN(date.getTime())) {

--- a/examples/gitique/src/commands/log.ts
+++ b/examples/gitique/src/commands/log.ts
@@ -3,7 +3,12 @@ import { map, optional, withDefault } from "@optique/core/modifiers";
 import type { InferValue } from "@optique/core/parser";
 import { command, constant, option } from "@optique/core/primitives";
 import { choice, integer, string } from "@optique/core/valueparser";
-import { commandLine, message, optionName } from "@optique/core/message";
+import {
+  commandLine,
+  lineBreak,
+  message,
+  optionName,
+} from "@optique/core/message";
 import { printError } from "@optique/run";
 import { getCommitHistory, getRepository } from "../utils/git.ts";
 import {
@@ -108,13 +113,19 @@ export const logCommand = command("log", logOptionsParser, {
     } for compact output or ${
       optionName("--format")
     } to customize the display.`,
-  footer: message`Examples:
-  ${commandLine("gitique log")}                     Show recent commits
+  footer: message`Examples:${lineBreak()}
+  ${
+    commandLine("gitique log")
+  }                     Show recent commits${lineBreak()}
   ${
     commandLine("gitique log --oneline -n 5")
-  }      Show 5 commits in one-line format
-  ${commandLine("gitique log --format=full")}       Show full commit details
-  ${commandLine("gitique log --author=john")}       Filter by author
+  }      Show 5 commits in one-line format${lineBreak()}
+  ${
+    commandLine("gitique log --format=full")
+  }       Show full commit details${lineBreak()}
+  ${
+    commandLine("gitique log --author=john")
+  }       Filter by author${lineBreak()}
   ${commandLine('gitique log --since="2024-01-01"')}  Show commits since date`,
 });
 

--- a/examples/gitique/src/commands/log.ts
+++ b/examples/gitique/src/commands/log.ts
@@ -143,8 +143,16 @@ export type LogConfig = InferValue<typeof logCommand>;
  * Parses a date string into a Date object.
  * Accepts any format understood by `new Date(string)`, such as ISO 8601
  * dates.  Relative phrases like "2 days ago" are not supported.
+ *
+ * Bare `YYYY-MM-DD` strings are treated as local-time midnight to avoid
+ * UTC-offset surprises (e.g. "2024-01-01" meaning 2023-12-31 for UTC-8).
  */
 function parseDate(dateString: string): Date {
+  // ISO date-only: treat as local midnight, not UTC midnight.
+  if (/^\d{4}-\d{2}-\d{2}$/.test(dateString)) {
+    const [year, month, day] = dateString.split("-").map(Number);
+    return new Date(year, month - 1, day);
+  }
   const date = new Date(dateString);
   if (isNaN(date.getTime())) {
     throw new Error(`Invalid date format: "${dateString}"`);

--- a/examples/gitique/src/commands/log.ts
+++ b/examples/gitique/src/commands/log.ts
@@ -31,11 +31,10 @@ const formatChoices = ["oneline", "short", "medium", "full"] as const;
 const displayOptions = group(
   "Display Options",
   object({
-    format: withDefault(
+    format: optional(
       option("--format", choice(formatChoices, { metavar: "FORMAT" }), {
         description: message`Output format: oneline, short, medium, or full`,
       }),
-      "medium" as const,
     ),
     oneline: option("--oneline", {
       description: message`Shorthand for ${optionName("--format")}=oneline`,
@@ -95,11 +94,17 @@ const logOptionsParser = map(
     displayOptions,
     filterOptions,
   ),
-  (result) => ({
-    ...result,
-    // Handle --oneline shorthand by overriding format
-    format: result.oneline ? ("oneline" as const) : result.format,
-  }),
+  (result) => {
+    if (result.oneline && result.format !== undefined) {
+      throw new Error("Cannot use --oneline together with --format.");
+    }
+    return {
+      ...result,
+      format: result.oneline
+        ? ("oneline" as const)
+        : (result.format ?? ("medium" as const)),
+    };
+  },
 );
 
 /**

--- a/examples/gitique/src/commands/log.ts
+++ b/examples/gitique/src/commands/log.ts
@@ -219,13 +219,16 @@ function formatCommitShort(oid: string, commit: Commit): string {
 function formatCommitFull(oid: string, commit: Commit): string {
   const author = commit.author();
   const committer = commit.committer();
-  const commitTime = commit.time();
+  // Use author timestamp for the Date line; use committer timestamp for Commit.
+  const authorDate = new Date(author.timestamp * 1000);
+  const committerDate = new Date(committer.timestamp * 1000);
 
   const lines = [
     `commit ${oid}`,
     `Author: ${author.name} <${author.email}>`,
+    `AuthorDate: ${authorDate.toISOString()}`,
     `Commit: ${committer.name} <${committer.email}>`,
-    `Date:   ${commitTime.toDateString()}`,
+    `CommitDate: ${committerDate.toISOString()}`,
     "",
     ...commit.message().split("\n").map((line: string) => `    ${line}`),
     "",

--- a/examples/gitique/src/commands/log.ts
+++ b/examples/gitique/src/commands/log.ts
@@ -125,10 +125,10 @@ export type LogConfig = InferValue<typeof logCommand>;
 
 /**
  * Parses a date string into a Date object.
- * Supports various formats like "2024-01-01", "2 days ago", etc.
+ * Accepts any format understood by `new Date(string)`, such as ISO 8601
+ * dates.  Relative phrases like "2 days ago" are not supported.
  */
 function parseDate(dateString: string): Date {
-  // Simple implementation - in a real scenario, you'd want more robust date parsing
   const date = new Date(dateString);
   if (isNaN(date.getTime())) {
     throw new Error(`Invalid date format: "${dateString}"`);

--- a/examples/gitique/src/commands/log.ts
+++ b/examples/gitique/src/commands/log.ts
@@ -260,9 +260,18 @@ export async function executeLog(config: LogConfig): Promise<void> {
   try {
     const repo = await getRepository();
 
-    // Fetch all commits first, then filter, then limit.  Limiting before
-    // filtering would incorrectly exclude matching commits deeper in history.
-    const allCommits = getCommitHistory(repo);
+    // When no commit filters are active we can cap the fetch upfront,
+    // avoiding a full-history walk just to take the first N entries.
+    // When filters are set we must fetch everything first because
+    // matching commits may be scattered anywhere in history.
+    const hasFilters = config.since !== undefined ||
+      config.until !== undefined ||
+      config.author !== undefined ||
+      config.grep !== undefined;
+    const allCommits = getCommitHistory(
+      repo,
+      hasFilters ? undefined : config.maxCount,
+    );
 
     if (allCommits.length === 0) {
       console.log("No commits found in the repository.");

--- a/examples/gitique/src/commands/reset.ts
+++ b/examples/gitique/src/commands/reset.ts
@@ -175,7 +175,7 @@ function resetFiles(
   repo: Repository,
   files: readonly string[],
   quiet: boolean,
-): void {
+): boolean {
   if (!quiet) {
     console.log(`Resetting ${files.length} file(s) to HEAD...`);
   }
@@ -203,8 +203,9 @@ function resetFiles(
 
   if (hadError) {
     process.exitCode = 1;
-    return;
+    return false;
   }
+  return true;
 }
 
 /**
@@ -282,8 +283,8 @@ export async function executeReset(config: ResetConfig): Promise<void> {
     const repo = await getRepository();
 
     if (config.files.length > 0) {
-      // Reset specific files
-      resetFiles(repo, config.files, config.quiet);
+      // Reset specific files; bail out without the success banner on failure
+      if (!resetFiles(repo, config.files, config.quiet)) return;
     } else {
       // Reset to commit
       const targetCommit = config.commit ?? "HEAD";

--- a/examples/gitique/src/commands/reset.ts
+++ b/examples/gitique/src/commands/reset.ts
@@ -186,7 +186,7 @@ function resetFiles(
     try {
       unstageFile(repo, file);
       if (!quiet) {
-        console.log(`Reset '${file}' to HEAD.`);
+        console.log(`Unstaged '${file}'.`);
       }
     } catch (error) {
       hadError = true;

--- a/examples/gitique/src/commands/reset.ts
+++ b/examples/gitique/src/commands/reset.ts
@@ -9,6 +9,7 @@ import {
   message,
   optionName,
 } from "@optique/core/message";
+import process from "node:process";
 import { printError } from "@optique/run";
 import {
   getRepository,
@@ -201,7 +202,8 @@ function resetFiles(
   }
 
   if (hadError) {
-    throw new Error("One or more files could not be reset.");
+    process.exitCode = 1;
+    return;
   }
 }
 

--- a/examples/gitique/src/commands/reset.ts
+++ b/examples/gitique/src/commands/reset.ts
@@ -178,7 +178,7 @@ function resetFiles(
   quiet: boolean,
 ): boolean {
   if (!quiet) {
-    console.log(`Resetting ${files.length} file(s) to HEAD...`);
+    console.log(`Unstaging ${files.length} file(s)...`);
   }
 
   let hadError = false;

--- a/examples/gitique/src/commands/reset.ts
+++ b/examples/gitique/src/commands/reset.ts
@@ -1,5 +1,5 @@
 import { group, merge, object } from "@optique/core/constructs";
-import { map, multiple, optional, withDefault } from "@optique/core/modifiers";
+import { map, multiple, optional } from "@optique/core/modifiers";
 import type { InferValue } from "@optique/core/parser";
 import { argument, command, constant, option } from "@optique/core/primitives";
 import { choice, string } from "@optique/core/valueparser";
@@ -37,12 +37,11 @@ const resetModes = ["soft", "mixed", "hard"] as const;
 const modeOptions = group(
   "Reset Mode",
   object({
-    mode: withDefault(
+    mode: optional(
       option("--mode", choice(resetModes, { metavar: "MODE" }), {
         description:
           message`Reset mode: ${"soft"} (keep changes staged), ${"mixed"} (unstage changes), ${"hard"} (discard all)`,
       }),
-      "mixed" as const,
     ),
     soft: option("--soft", {
       description: message`Shorthand for ${commandLine("--mode=soft")}`,
@@ -97,15 +96,21 @@ const resetOptionsParser = map(
       ),
     }),
   ),
-  (result) => ({
-    ...result,
-    // Handle shorthand flags by overriding mode
-    mode: result.soft
-      ? ("soft" as const)
-      : result.hard
-      ? ("hard" as const)
-      : result.mode,
-  }),
+  (result) => {
+    if ((result.soft || result.hard) && result.mode !== undefined) {
+      throw new Error(
+        "Cannot use --soft or --hard together with --mode.",
+      );
+    }
+    return {
+      ...result,
+      mode: result.soft
+        ? ("soft" as const)
+        : result.hard
+        ? ("hard" as const)
+        : (result.mode ?? ("mixed" as const)),
+    };
+  },
 );
 
 /**

--- a/examples/gitique/src/commands/reset.ts
+++ b/examples/gitique/src/commands/reset.ts
@@ -10,7 +10,12 @@ import {
   optionName,
 } from "@optique/core/message";
 import { printError } from "@optique/run";
-import { getRepository, resetIndex } from "../utils/git.ts";
+import {
+  getRepository,
+  moveHead,
+  resetIndex,
+  resolveCommitOid,
+} from "../utils/git.ts";
 import type { Repository } from "es-git";
 import {
   formatError,
@@ -190,20 +195,24 @@ function resetFiles(
 /**
  * Resets the repository to a specific commit with the given mode.
  */
-async function resetToCommit(
+function resetToCommit(
   repo: Repository,
   commit: string,
   mode: "soft" | "mixed" | "hard",
   quiet: boolean,
-): Promise<void> {
+): void {
   if (!quiet) {
     console.log(`Performing ${mode} reset to ${commit}...`);
   }
 
   try {
+    // Resolve the spec and move HEAD (and the branch pointer) to the target
+    const targetOid = resolveCommitOid(repo, commit);
+    moveHead(repo, targetOid);
+
     switch (mode) {
       case "soft":
-        // Only move HEAD, keep index and working directory
+        // HEAD moved; index and working directory unchanged
         if (!quiet) {
           console.log(
             formatWarning(
@@ -214,8 +223,8 @@ async function resetToCommit(
         break;
 
       case "mixed":
-        // Move HEAD and reset index, keep working directory
-        await resetIndex(repo);
+        // HEAD moved; reset index, keep working directory
+        resetIndex(repo);
         if (!quiet) {
           console.log(
             formatSuccess(
@@ -226,8 +235,9 @@ async function resetToCommit(
         break;
 
       case "hard":
-        // Move HEAD, reset index, and reset working directory
-        await resetIndex(repo);
+        // HEAD moved; reset both index and working directory
+        resetIndex(repo);
+        repo.checkoutHead({ force: true });
         if (!quiet) {
           console.log(
             formatWarning(
@@ -271,7 +281,7 @@ export async function executeReset(config: ResetConfig): Promise<void> {
         );
       }
 
-      await resetToCommit(repo, targetCommit, config.mode, config.quiet);
+      resetToCommit(repo, targetCommit, config.mode, config.quiet);
     }
 
     if (!config.quiet) {

--- a/examples/gitique/src/commands/reset.ts
+++ b/examples/gitique/src/commands/reset.ts
@@ -71,7 +71,7 @@ const outputOptions = group(
  * Demonstrates:
  * - group() for organizing options in help text
  * - merge() for combining multiple option groups
- * - withDefault() for default values
+ * - optional() for optional values
  * - choice() for enumerated values
  * - map() for transforming parser results
  */
@@ -172,7 +172,7 @@ function validateResetConfig(config: ResetConfig): void {
  */
 function resetFiles(
   repo: Repository,
-  files: string[],
+  files: readonly string[],
   quiet: boolean,
 ): void {
   if (!quiet) {
@@ -281,7 +281,7 @@ export async function executeReset(config: ResetConfig): Promise<void> {
 
     if (config.files.length > 0) {
       // Reset specific files
-      resetFiles(repo, [...config.files], config.quiet);
+      resetFiles(repo, config.files, config.quiet);
     } else {
       // Reset to commit
       const targetCommit = config.commit ?? "HEAD";

--- a/examples/gitique/src/commands/reset.ts
+++ b/examples/gitique/src/commands/reset.ts
@@ -87,10 +87,12 @@ const resetOptionsParser = map(
           description: message`Commit to reset to (defaults to HEAD)`,
         }),
       ),
+      // Use an explicit --file option instead of a positional argument to
+      // avoid ambiguity between commit refs and file paths, which Optique
+      // cannot disambiguate via "--" for positional parsers.
       files: multiple(
-        argument(string({ metavar: "FILE" }), {
-          description:
-            message`Files to reset (when used without commit, resets these files to HEAD)`,
+        option("-f", "--file", string({ metavar: "FILE" }), {
+          description: message`Unstage specific files (can be repeated)`,
         }),
       ),
     }),
@@ -128,7 +130,7 @@ export const resetCommand = command("reset", resetOptionsParser, {
   ${
     commandLine("gitique reset --hard")
   }             Hard reset (DANGER: loses changes)${lineBreak()}
-  ${commandLine("gitique reset -- file.ts")}         Unstage specific file`,
+  ${commandLine("gitique reset --file file.ts")}      Unstage a specific file`,
 });
 
 /**

--- a/examples/gitique/src/commands/reset.ts
+++ b/examples/gitique/src/commands/reset.ts
@@ -12,6 +12,7 @@ import {
 import process from "node:process";
 import { printError } from "@optique/run";
 import {
+  checkoutHead,
   getRepository,
   moveHead,
   resetIndex,
@@ -253,7 +254,7 @@ function resetToCommit(
       case "hard":
         // HEAD moved; reset both index and working directory
         resetIndex(repo);
-        repo.checkoutHead({ force: true });
+        checkoutHead(repo, { force: true });
         if (!quiet) {
           console.log(
             formatWarning(

--- a/examples/gitique/src/commands/reset.ts
+++ b/examples/gitique/src/commands/reset.ts
@@ -179,6 +179,7 @@ function resetFiles(
     console.log(`Resetting ${files.length} file(s) to HEAD...`);
   }
 
+  let hadError = false;
   for (const file of files) {
     try {
       unstageFile(repo, file);
@@ -186,6 +187,7 @@ function resetFiles(
         console.log(`Reset '${file}' to HEAD.`);
       }
     } catch (error) {
+      hadError = true;
       printError(
         message`${
           formatError(
@@ -196,6 +198,10 @@ function resetFiles(
         }`,
       );
     }
+  }
+
+  if (hadError) {
+    throw new Error("One or more files could not be reset.");
   }
 }
 

--- a/examples/gitique/src/commands/reset.ts
+++ b/examples/gitique/src/commands/reset.ts
@@ -15,6 +15,7 @@ import {
   moveHead,
   resetIndex,
   resolveCommitOid,
+  unstageFile,
 } from "../utils/git.ts";
 import type { Repository } from "es-git";
 import {
@@ -163,7 +164,7 @@ function validateResetConfig(config: ResetConfig): void {
  * Resets specific files to HEAD state.
  */
 function resetFiles(
-  _repo: Repository,
+  repo: Repository,
   files: string[],
   quiet: boolean,
 ): void {
@@ -173,8 +174,7 @@ function resetFiles(
 
   for (const file of files) {
     try {
-      // In a real implementation, this would reset the specific file
-      // For now, we'll just show what would happen
+      unstageFile(repo, file);
       if (!quiet) {
         console.log(`Reset '${file}' to HEAD.`);
       }

--- a/examples/gitique/src/commands/reset.ts
+++ b/examples/gitique/src/commands/reset.ts
@@ -107,7 +107,9 @@ export const resetCommand = command("reset", resetOptionsParser, {
   brief: message`Reset current HEAD`,
   description: message`Reset current HEAD to the specified state. Use ${
     optionName("--soft")
-  } to keep changes staged, ${optionName("--mixed")} to unstage, or ${
+  } to keep changes staged, omit a mode flag (or use ${
+    optionName("--mode=mixed")
+  }) for the default mixed reset, or ${
     optionName("--hard")
   } to discard all changes (dangerous).`,
   footer: message`Examples:${lineBreak()}

--- a/examples/gitique/src/commands/status.ts
+++ b/examples/gitique/src/commands/status.ts
@@ -194,67 +194,61 @@ export async function executeStatus(config: StatusConfig): Promise<void> {
     const repo = await getRepository();
     const statuses = getStatus(repo);
 
+    // Determine branch state once for use in both -b header and long body.
+    let resolvedBranchName: string | null = null;
+    let isUnbornBranch = false;
+    if (!repo.headDetached()) {
+      try {
+        resolvedBranchName = repo.head().name().replace("refs/heads/", "");
+      } catch {
+        // HEAD can't be resolved (unborn branch) — read from .git/HEAD
+        resolvedBranchName = readHeadBranchName(repo.path());
+        isUnbornBranch = true;
+      }
+    }
+
     // Show branch information if requested
     if (config.branch) {
       if (config.format === "porcelain") {
-        // Machine-readable porcelain v1 branch line
+        // Machine-readable porcelain v1 branch line.
+        // git uses "## No commits yet on <branch>" for unborn branches.
         if (repo.headDetached()) {
           console.log("## HEAD (no branch)");
+        } else if (isUnbornBranch && resolvedBranchName) {
+          console.log(`## No commits yet on ${resolvedBranchName}`);
+        } else if (resolvedBranchName) {
+          console.log(`## ${resolvedBranchName}`);
         } else {
-          let branchName: string | null = null;
-          try {
-            branchName = repo.head().name().replace("refs/heads/", "");
-          } catch {
-            // HEAD can't be resolved (unborn branch) — read from .git/HEAD
-            branchName = readHeadBranchName(repo.path());
-          }
-          if (branchName) {
-            console.log(`## ${branchName}`);
-          } else {
-            console.log("## HEAD (no branch)");
-          }
+          console.log("## HEAD (no branch)");
         }
       } else {
         if (repo.headDetached()) {
           console.log("Not currently on any branch.");
           console.log("");
+        } else if (resolvedBranchName) {
+          console.log(
+            `On branch ${colors.green}${resolvedBranchName}${colors.reset}`,
+          );
+          if (isUnbornBranch) {
+            console.log("");
+            console.log("No commits yet");
+          }
+          console.log("");
         } else {
-          let branchName: string | null = null;
-          try {
-            branchName = repo.head().name().replace("refs/heads/", "");
-          } catch {
-            // HEAD can't be resolved (unborn branch) — read from .git/HEAD
-            branchName = readHeadBranchName(repo.path());
-          }
-          if (branchName) {
-            console.log(
-              `On branch ${colors.green}${branchName}${colors.reset}`,
-            );
-            console.log("");
-          } else {
-            console.log("Not currently on any branch.");
-            console.log("");
-          }
+          console.log("Not currently on any branch.");
+          console.log("");
         }
       }
     }
 
     if (statuses.length === 0) {
       if (config.format === "long") {
-        // Distinguish a clean repo with commits from a brand-new unborn repo
-        let hasCommits = false;
-        try {
-          repo.head().peelToTree();
-          hasCommits = true;
-        } catch {
-          // Unborn branch — no commits yet
-        }
-        if (hasCommits) {
-          console.log("nothing to commit, working tree clean");
-        } else {
+        if (isUnbornBranch) {
           console.log(
             "No commits yet\n\nnothing to commit (create/copy files and use 'gitique add' to track)",
           );
+        } else {
+          console.log("nothing to commit, working tree clean");
         }
       }
       return;
@@ -267,6 +261,12 @@ export async function executeStatus(config: StatusConfig): Promise<void> {
     // Format output based on format option
     switch (config.format) {
       case "long": {
+        if (isUnbornBranch && !config.branch) {
+          // Show the unborn-branch header even without -b so users know
+          // they're looking at a pre-first-commit state.
+          console.log("No commits yet");
+          console.log("");
+        }
         if (staged.length > 0) {
           console.log("Changes to be committed:");
           console.log('  (use "gitique reset --file <file>..." to unstage)');

--- a/examples/gitique/src/commands/status.ts
+++ b/examples/gitique/src/commands/status.ts
@@ -1,5 +1,5 @@
 import { group, merge, object } from "@optique/core/constructs";
-import { map, withDefault } from "@optique/core/modifiers";
+import { map, optional } from "@optique/core/modifiers";
 import type { InferValue } from "@optique/core/parser";
 import { command, constant, option } from "@optique/core/primitives";
 import { choice } from "@optique/core/valueparser";
@@ -32,12 +32,11 @@ const outputFormats = ["long", "short", "porcelain"] as const;
 const displayOptions = group(
   "Display Options",
   object({
-    format: withDefault(
+    format: optional(
       option("--format", choice(outputFormats, { metavar: "FORMAT" }), {
         description:
           message`Output format: long (default), short, or porcelain`,
       }),
-      "long" as const,
     ),
     short: option("-s", "--short", {
       description: message`Shorthand for ${optionName("--format")}=short`,
@@ -67,15 +66,21 @@ const statusOptionsParser = map(
     object({ command: constant("status" as const) }),
     displayOptions,
   ),
-  (result) => ({
-    ...result,
-    // Handle shorthand flags by overriding format
-    format: result.short
-      ? ("short" as const)
-      : result.porcelain
-      ? ("porcelain" as const)
-      : result.format,
-  }),
+  (result) => {
+    if ((result.short || result.porcelain) && result.format !== undefined) {
+      throw new Error(
+        "Cannot use --short or --porcelain together with --format.",
+      );
+    }
+    return {
+      ...result,
+      format: result.short
+        ? ("short" as const)
+        : result.porcelain
+        ? ("porcelain" as const)
+        : (result.format ?? ("long" as const)),
+    };
+  },
 );
 
 /**

--- a/examples/gitique/src/commands/status.ts
+++ b/examples/gitique/src/commands/status.ts
@@ -12,15 +12,18 @@ import {
 import { printError } from "@optique/run";
 import { getRepository, getStatus } from "../utils/git.ts";
 import type { FileStatus } from "../utils/git.ts";
-import {
-  colors,
-  formatError,
-  formatStatusLong,
-  formatStatusPorcelain,
-  formatStatusShort,
-} from "../utils/formatters.ts";
+import { colors, formatError, formatStatusLong } from "../utils/formatters.ts";
 
 type FileStatusEntry = Pick<FileStatus, "path" | "status" | "oldPath">;
+
+const statusIndicatorMap: Record<string, string> = {
+  Added: "A",
+  Deleted: "D",
+  Modified: "M",
+  Renamed: "R",
+  Copied: "C",
+  Untracked: "?",
+};
 
 /**
  * Merges staged and unstaged state into a single short-format status line,
@@ -31,26 +34,17 @@ function formatStatusShortMerged(
   unstagedEntry: FileStatusEntry | undefined,
   path: string,
 ): string {
-  const stagedStatus = stagedEntry?.status ?? "";
-  const unstagedStatus = unstagedEntry?.status ?? "";
+  const stagedCol = stagedEntry
+    ? (statusIndicatorMap[stagedEntry.status] ?? "?")
+    : " ";
+  const unstagedCol = unstagedEntry
+    ? (statusIndicatorMap[unstagedEntry.status] ?? "?")
+    : " ";
   const oldPath = stagedEntry?.oldPath ?? unstagedEntry?.oldPath;
-  const staged = stagedEntry !== undefined;
-  return formatStatusShort(
-    path,
-    staged ? stagedStatus : unstagedStatus,
-    staged,
-    oldPath,
-  )
-    .replace(/^( ?)( ?)/, () => {
-      // Overwrite both columns with the correct indicators
-      const stagedIndicator = stagedEntry
-        ? (stagedEntry.status[0] ?? "?")
-        : " ";
-      const unstagedIndicator = unstagedEntry
-        ? (unstagedEntry.status[0] ?? "?")
-        : " ";
-      return `${stagedIndicator}${unstagedIndicator}`;
-    });
+  const displayPath = oldPath ? `${oldPath} -> ${path}` : path;
+  const stagedColor = stagedEntry ? colors.green : "";
+  const unstagedColor = unstagedEntry ? colors.red : "";
+  return `${stagedColor}${stagedCol}${colors.reset}${unstagedColor}${unstagedCol}${colors.reset} ${displayPath}`;
 }
 
 /**
@@ -61,25 +55,17 @@ function formatStatusPorcelainMerged(
   unstagedEntry: FileStatusEntry | undefined,
   path: string,
 ): string {
-  const stagedStatus = stagedEntry?.status ?? "";
-  const unstagedStatus = unstagedEntry?.status ?? "";
+  const stagedCol = stagedEntry
+    ? (statusIndicatorMap[stagedEntry.status] ?? "?")
+    : " ";
+  const unstagedCol = unstagedEntry
+    ? (statusIndicatorMap[unstagedEntry.status] ?? "?")
+    : " ";
   const oldPath = stagedEntry?.oldPath ?? unstagedEntry?.oldPath;
-  const staged = stagedEntry !== undefined;
-  return formatStatusPorcelain(
-    path,
-    staged ? stagedStatus : unstagedStatus,
-    staged,
-    oldPath,
-  )
-    .replace(/^( ?)( ?)/, () => {
-      const stagedIndicator = stagedEntry
-        ? (stagedEntry.status[0] ?? "?")
-        : " ";
-      const unstagedIndicator = unstagedEntry
-        ? (unstagedEntry.status[0] ?? "?")
-        : " ";
-      return `${stagedIndicator}${unstagedIndicator}`;
-    });
+  if (oldPath) {
+    return `${stagedCol}${unstagedCol} ${oldPath} -> ${path}`;
+  }
+  return `${stagedCol}${unstagedCol} ${path}`;
 }
 
 /**

--- a/examples/gitique/src/commands/status.ts
+++ b/examples/gitique/src/commands/status.ts
@@ -261,6 +261,12 @@ export async function executeStatus(config: StatusConfig): Promise<void> {
     const staged = statuses.filter((s) => s.staged);
     const unstaged = statuses.filter((s) => !s.staged);
 
+    // Pre-index staged/unstaged entries for O(1) lookups in the merge loops.
+    const stagedByPath = new Map(staged.map((entry) => [entry.path, entry]));
+    const unstagedByPath = new Map(
+      unstaged.map((entry) => [entry.path, entry]),
+    );
+
     // Format output based on format option
     switch (config.format) {
       case "long": {
@@ -315,8 +321,8 @@ export async function executeStatus(config: StatusConfig): Promise<void> {
         for (const file of statuses) {
           if (seenShort.has(file.path)) continue;
           seenShort.add(file.path);
-          const stagedEntry = staged.find((s) => s.path === file.path);
-          const unstagedEntry = unstaged.find((u) => u.path === file.path);
+          const stagedEntry = stagedByPath.get(file.path);
+          const unstagedEntry = unstagedByPath.get(file.path);
           console.log(
             formatStatusShortMerged(stagedEntry, unstagedEntry, file.path),
           );
@@ -329,8 +335,8 @@ export async function executeStatus(config: StatusConfig): Promise<void> {
         for (const file of statuses) {
           if (seenPorcelain.has(file.path)) continue;
           seenPorcelain.add(file.path);
-          const stagedEntry = staged.find((s) => s.path === file.path);
-          const unstagedEntry = unstaged.find((u) => u.path === file.path);
+          const stagedEntry = stagedByPath.get(file.path);
+          const unstagedEntry = unstagedByPath.get(file.path);
           console.log(
             formatStatusPorcelainMerged(stagedEntry, unstagedEntry, file.path),
           );

--- a/examples/gitique/src/commands/status.ts
+++ b/examples/gitique/src/commands/status.ts
@@ -237,13 +237,30 @@ export async function executeStatus(config: StatusConfig): Promise<void> {
           console.log("");
         }
 
-        if (unstaged.length > 0) {
+        const tracked = unstaged.filter((f) => f.status !== "Untracked");
+        const untracked = unstaged.filter((f) => f.status === "Untracked");
+
+        if (tracked.length > 0) {
           console.log("Changes not staged for commit:");
           console.log(
             '  (use "gitique add <file>..." to update what will be committed)',
           );
           console.log("");
-          for (const file of unstaged) {
+          for (const file of tracked) {
+            console.log(
+              formatStatusLong(file.path, file.status, false, file.oldPath),
+            );
+          }
+          console.log("");
+        }
+
+        if (untracked.length > 0) {
+          console.log("Untracked files:");
+          console.log(
+            '  (use "gitique add <file>..." to include in what will be committed)',
+          );
+          console.log("");
+          for (const file of untracked) {
             console.log(
               formatStatusLong(file.path, file.status, false, file.oldPath),
             );

--- a/examples/gitique/src/commands/status.ts
+++ b/examples/gitique/src/commands/status.ts
@@ -241,7 +241,21 @@ export async function executeStatus(config: StatusConfig): Promise<void> {
 
     if (statuses.length === 0) {
       if (config.format === "long") {
-        console.log("nothing to commit, working tree clean");
+        // Distinguish a clean repo with commits from a brand-new unborn repo
+        let hasCommits = false;
+        try {
+          repo.head().peelToTree();
+          hasCommits = true;
+        } catch {
+          // Unborn branch — no commits yet
+        }
+        if (hasCommits) {
+          console.log("nothing to commit, working tree clean");
+        } else {
+          console.log(
+            "No commits yet\n\nnothing to commit (create/copy files and use 'gitique add' to track)",
+          );
+        }
       }
       return;
     }

--- a/examples/gitique/src/commands/status.ts
+++ b/examples/gitique/src/commands/status.ts
@@ -34,15 +34,19 @@ function formatStatusShortMerged(
   unstagedEntry: FileStatusEntry | undefined,
   path: string,
 ): string {
-  const stagedCol = stagedEntry
-    ? (statusIndicatorMap[stagedEntry.status] ?? "?")
-    : " ";
+  // Untracked files use '??' in both columns (git status -s convention).
+  const isUntracked = !stagedEntry && unstagedEntry?.status === "Untracked";
+  const stagedCol = isUntracked
+    ? "?"
+    : (stagedEntry ? (statusIndicatorMap[stagedEntry.status] ?? "?") : " ");
   const unstagedCol = unstagedEntry
     ? (statusIndicatorMap[unstagedEntry.status] ?? "?")
     : " ";
   const oldPath = stagedEntry?.oldPath ?? unstagedEntry?.oldPath;
   const displayPath = oldPath ? `${oldPath} -> ${path}` : path;
-  const stagedColor = stagedEntry ? colors.green : "";
+  const stagedColor = isUntracked
+    ? colors.red
+    : (stagedEntry ? colors.green : "");
   const unstagedColor = unstagedEntry ? colors.red : "";
   return `${stagedColor}${stagedCol}${colors.reset}${unstagedColor}${unstagedCol}${colors.reset} ${displayPath}`;
 }
@@ -55,9 +59,11 @@ function formatStatusPorcelainMerged(
   unstagedEntry: FileStatusEntry | undefined,
   path: string,
 ): string {
-  const stagedCol = stagedEntry
-    ? (statusIndicatorMap[stagedEntry.status] ?? "?")
-    : " ";
+  // Untracked files use '??' in both columns (git status --porcelain convention).
+  const isUntracked = !stagedEntry && unstagedEntry?.status === "Untracked";
+  const stagedCol = isUntracked
+    ? "?"
+    : (stagedEntry ? (statusIndicatorMap[stagedEntry.status] ?? "?") : " ");
   const unstagedCol = unstagedEntry
     ? (statusIndicatorMap[unstagedEntry.status] ?? "?")
     : " ";

--- a/examples/gitique/src/commands/status.ts
+++ b/examples/gitique/src/commands/status.ts
@@ -205,7 +205,7 @@ export async function executeStatus(config: StatusConfig): Promise<void> {
       case "long": {
         if (staged.length > 0) {
           console.log("Changes to be committed:");
-          console.log('  (use "gitique reset HEAD <file>..." to unstage)');
+          console.log('  (use "gitique reset --file <file>..." to unstage)');
           console.log("");
           for (const file of staged) {
             console.log(

--- a/examples/gitique/src/commands/status.ts
+++ b/examples/gitique/src/commands/status.ts
@@ -9,12 +9,30 @@ import {
   message,
   optionName,
 } from "@optique/core/message";
+import { readFileSync } from "node:fs";
 import { printError } from "@optique/run";
 import { getRepository, getStatus } from "../utils/git.ts";
 import type { FileStatus } from "../utils/git.ts";
 import { colors, formatError, formatStatusLong } from "../utils/formatters.ts";
 
 type FileStatusEntry = Pick<FileStatus, "path" | "status" | "oldPath">;
+
+/**
+ * Reads the current branch name from the repository even when HEAD hasn't been
+ * resolved yet (i.e., an unborn branch where the branch ref doesn't exist).
+ * Returns the branch name string, or null if HEAD is detached or unreadable.
+ */
+function readHeadBranchName(gitDir: string): string | null {
+  try {
+    const headContent = readFileSync(gitDir + "HEAD", "utf-8").trim();
+    if (headContent.startsWith("ref: refs/heads/")) {
+      return headContent.slice("ref: refs/heads/".length);
+    }
+  } catch {
+    // Ignore read errors
+  }
+  return null;
+}
 
 const statusIndicatorMap: Record<string, string> = {
   Added: "A",
@@ -183,11 +201,16 @@ export async function executeStatus(config: StatusConfig): Promise<void> {
         if (repo.headDetached()) {
           console.log("## HEAD (no branch)");
         } else {
+          let branchName: string | null = null;
           try {
-            const head = repo.head();
-            const branchName = head.name().replace("refs/heads/", "");
-            console.log(`## ${branchName}`);
+            branchName = repo.head().name().replace("refs/heads/", "");
           } catch {
+            // HEAD can't be resolved (unborn branch) — read from .git/HEAD
+            branchName = readHeadBranchName(repo.path());
+          }
+          if (branchName) {
+            console.log(`## ${branchName}`);
+          } else {
             console.log("## HEAD (no branch)");
           }
         }
@@ -196,14 +219,19 @@ export async function executeStatus(config: StatusConfig): Promise<void> {
           console.log("Not currently on any branch.");
           console.log("");
         } else {
+          let branchName: string | null = null;
           try {
-            const head = repo.head();
-            const branchName = head.name().replace("refs/heads/", "");
+            branchName = repo.head().name().replace("refs/heads/", "");
+          } catch {
+            // HEAD can't be resolved (unborn branch) — read from .git/HEAD
+            branchName = readHeadBranchName(repo.path());
+          }
+          if (branchName) {
             console.log(
               `On branch ${colors.green}${branchName}${colors.reset}`,
             );
             console.log("");
-          } catch {
+          } else {
             console.log("Not currently on any branch.");
             console.log("");
           }

--- a/examples/gitique/src/commands/status.ts
+++ b/examples/gitique/src/commands/status.ts
@@ -10,6 +10,7 @@ import {
   optionName,
 } from "@optique/core/message";
 import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { printError } from "@optique/run";
 import { getRepository, getStatus } from "../utils/git.ts";
 import type { FileStatus } from "../utils/git.ts";
@@ -24,7 +25,7 @@ type FileStatusEntry = Pick<FileStatus, "path" | "status" | "oldPath">;
  */
 function readHeadBranchName(gitDir: string): string | null {
   try {
-    const headContent = readFileSync(gitDir + "HEAD", "utf-8").trim();
+    const headContent = readFileSync(resolve(gitDir, "HEAD"), "utf-8").trim();
     if (headContent.startsWith("ref: refs/heads/")) {
       return headContent.slice("ref: refs/heads/".length);
     }

--- a/examples/gitique/src/commands/status.ts
+++ b/examples/gitique/src/commands/status.ts
@@ -207,8 +207,9 @@ export async function executeStatus(config: StatusConfig): Promise<void> {
       }
     }
 
-    // Show branch information if requested
-    if (config.branch) {
+    // Show branch information: always in long format, only with -b in
+    // short/porcelain formats (where it changes the output structure).
+    if (config.branch || config.format === "long") {
       if (config.format === "porcelain" || config.format === "short") {
         // Machine-readable / short format: ## <branch> header line.
         // git uses "## No commits yet on <branch>" for unborn branches.

--- a/examples/gitique/src/commands/status.ts
+++ b/examples/gitique/src/commands/status.ts
@@ -3,7 +3,12 @@ import { map, withDefault } from "@optique/core/modifiers";
 import type { InferValue } from "@optique/core/parser";
 import { command, constant, option } from "@optique/core/primitives";
 import { choice } from "@optique/core/valueparser";
-import { commandLine, message, optionName } from "@optique/core/message";
+import {
+  commandLine,
+  lineBreak,
+  message,
+  optionName,
+} from "@optique/core/message";
 import { printError } from "@optique/run";
 import { getRepository, getStatus } from "../utils/git.ts";
 import {
@@ -84,10 +89,12 @@ export const statusCommand = command("status", statusOptionsParser, {
     } for compact output or ${
       optionName("--porcelain")
     } for machine-readable format.`,
-  footer: message`Examples:
-  ${commandLine("gitique status")}              Show full status
-  ${commandLine("gitique status -s")}           Show short format
-  ${commandLine("gitique status --porcelain")}  Machine-readable format
+  footer: message`Examples:${lineBreak()}
+  ${commandLine("gitique status")}              Show full status${lineBreak()}
+  ${commandLine("gitique status -s")}           Show short format${lineBreak()}
+  ${
+    commandLine("gitique status --porcelain")
+  }  Machine-readable format${lineBreak()}
   ${commandLine("gitique status -b")}           Show branch information`,
 });
 

--- a/examples/gitique/src/commands/status.ts
+++ b/examples/gitique/src/commands/status.ts
@@ -246,12 +246,7 @@ export async function executeStatus(config: StatusConfig): Promise<void> {
 
     if (statuses.length === 0) {
       if (config.format === "long") {
-        // Only print "No commits yet" prefix if -b hasn't already shown it
-        if (isUnbornBranch && !config.branch) {
-          console.log(
-            "No commits yet\n\nnothing to commit (create/copy files and use 'gitique add' to track)",
-          );
-        } else if (isUnbornBranch) {
+        if (isUnbornBranch) {
           console.log(
             "nothing to commit (create/copy files and use 'gitique add' to track)",
           );
@@ -269,12 +264,6 @@ export async function executeStatus(config: StatusConfig): Promise<void> {
     // Format output based on format option
     switch (config.format) {
       case "long": {
-        if (isUnbornBranch && !config.branch) {
-          // Show the unborn-branch header even without -b so users know
-          // they're looking at a pre-first-commit state.
-          console.log("No commits yet");
-          console.log("");
-        }
         if (staged.length > 0) {
           console.log("Changes to be committed:");
           console.log('  (use "gitique reset --file <file>..." to unstage)');

--- a/examples/gitique/src/commands/status.ts
+++ b/examples/gitique/src/commands/status.ts
@@ -169,22 +169,33 @@ export async function executeStatus(config: StatusConfig): Promise<void> {
     if (config.branch) {
       if (config.format === "porcelain") {
         // Machine-readable porcelain v1 branch line
-        try {
-          const head = repo.head();
-          const branchName = head.name().replace("refs/heads/", "");
-          console.log(`## ${branchName}`);
-        } catch {
+        if (repo.headDetached()) {
           console.log("## HEAD (no branch)");
+        } else {
+          try {
+            const head = repo.head();
+            const branchName = head.name().replace("refs/heads/", "");
+            console.log(`## ${branchName}`);
+          } catch {
+            console.log("## HEAD (no branch)");
+          }
         }
       } else {
-        try {
-          const head = repo.head();
-          const branchName = head.name().replace("refs/heads/", "");
-          console.log(`On branch ${colors.green}${branchName}${colors.reset}`);
-          console.log("");
-        } catch {
+        if (repo.headDetached()) {
           console.log("Not currently on any branch.");
           console.log("");
+        } else {
+          try {
+            const head = repo.head();
+            const branchName = head.name().replace("refs/heads/", "");
+            console.log(
+              `On branch ${colors.green}${branchName}${colors.reset}`,
+            );
+            console.log("");
+          } catch {
+            console.log("Not currently on any branch.");
+            console.log("");
+          }
         }
       }
     }

--- a/examples/gitique/src/commands/status.ts
+++ b/examples/gitique/src/commands/status.ts
@@ -11,6 +11,7 @@ import {
 } from "@optique/core/message";
 import { printError } from "@optique/run";
 import { getRepository, getStatus } from "../utils/git.ts";
+import type { FileStatus } from "../utils/git.ts";
 import {
   colors,
   formatError,
@@ -18,6 +19,68 @@ import {
   formatStatusPorcelain,
   formatStatusShort,
 } from "../utils/formatters.ts";
+
+type FileStatusEntry = Pick<FileStatus, "path" | "status" | "oldPath">;
+
+/**
+ * Merges staged and unstaged state into a single short-format status line,
+ * producing the XY two-column format used by `git status -s`.
+ */
+function formatStatusShortMerged(
+  stagedEntry: FileStatusEntry | undefined,
+  unstagedEntry: FileStatusEntry | undefined,
+  path: string,
+): string {
+  const stagedStatus = stagedEntry?.status ?? "";
+  const unstagedStatus = unstagedEntry?.status ?? "";
+  const oldPath = stagedEntry?.oldPath ?? unstagedEntry?.oldPath;
+  const staged = stagedEntry !== undefined;
+  return formatStatusShort(
+    path,
+    staged ? stagedStatus : unstagedStatus,
+    staged,
+    oldPath,
+  )
+    .replace(/^( ?)( ?)/, () => {
+      // Overwrite both columns with the correct indicators
+      const stagedIndicator = stagedEntry
+        ? (stagedEntry.status[0] ?? "?")
+        : " ";
+      const unstagedIndicator = unstagedEntry
+        ? (unstagedEntry.status[0] ?? "?")
+        : " ";
+      return `${stagedIndicator}${unstagedIndicator}`;
+    });
+}
+
+/**
+ * Merges staged and unstaged state into a single porcelain-format status line.
+ */
+function formatStatusPorcelainMerged(
+  stagedEntry: FileStatusEntry | undefined,
+  unstagedEntry: FileStatusEntry | undefined,
+  path: string,
+): string {
+  const stagedStatus = stagedEntry?.status ?? "";
+  const unstagedStatus = unstagedEntry?.status ?? "";
+  const oldPath = stagedEntry?.oldPath ?? unstagedEntry?.oldPath;
+  const staged = stagedEntry !== undefined;
+  return formatStatusPorcelain(
+    path,
+    staged ? stagedStatus : unstagedStatus,
+    staged,
+    oldPath,
+  )
+    .replace(/^( ?)( ?)/, () => {
+      const stagedIndicator = stagedEntry
+        ? (stagedEntry.status[0] ?? "?")
+        : " ";
+      const unstagedIndicator = unstagedEntry
+        ? (unstagedEntry.status[0] ?? "?")
+        : " ";
+      return `${stagedIndicator}${unstagedIndicator}`;
+    });
+}
 
 /**
  * Output format choices for the status command.
@@ -182,28 +245,30 @@ export async function executeStatus(config: StatusConfig): Promise<void> {
       }
 
       case "short": {
+        // Merge staged and unstaged entries for the same path into one line
+        // so a dual-state file shows "MM" instead of two separate lines.
+        const seenShort = new Set<string>();
         for (const file of statuses) {
+          if (seenShort.has(file.path)) continue;
+          seenShort.add(file.path);
+          const stagedEntry = staged.find((s) => s.path === file.path);
+          const unstagedEntry = unstaged.find((u) => u.path === file.path);
           console.log(
-            formatStatusShort(
-              file.path,
-              file.status,
-              file.staged,
-              file.oldPath,
-            ),
+            formatStatusShortMerged(stagedEntry, unstagedEntry, file.path),
           );
         }
         break;
       }
 
       case "porcelain": {
+        const seenPorcelain = new Set<string>();
         for (const file of statuses) {
+          if (seenPorcelain.has(file.path)) continue;
+          seenPorcelain.add(file.path);
+          const stagedEntry = staged.find((s) => s.path === file.path);
+          const unstagedEntry = unstaged.find((u) => u.path === file.path);
           console.log(
-            formatStatusPorcelain(
-              file.path,
-              file.status,
-              file.staged,
-              file.oldPath,
-            ),
+            formatStatusPorcelainMerged(stagedEntry, unstagedEntry, file.path),
           );
         }
         break;

--- a/examples/gitique/src/commands/status.ts
+++ b/examples/gitique/src/commands/status.ts
@@ -209,8 +209,8 @@ export async function executeStatus(config: StatusConfig): Promise<void> {
 
     // Show branch information if requested
     if (config.branch) {
-      if (config.format === "porcelain") {
-        // Machine-readable porcelain v1 branch line.
+      if (config.format === "porcelain" || config.format === "short") {
+        // Machine-readable / short format: ## <branch> header line.
         // git uses "## No commits yet on <branch>" for unborn branches.
         if (repo.headDetached()) {
           console.log("## HEAD (no branch)");
@@ -222,6 +222,7 @@ export async function executeStatus(config: StatusConfig): Promise<void> {
           console.log("## HEAD (no branch)");
         }
       } else {
+        // Long format: human-readable branch header.
         if (repo.headDetached()) {
           console.log("Not currently on any branch.");
           console.log("");
@@ -243,9 +244,14 @@ export async function executeStatus(config: StatusConfig): Promise<void> {
 
     if (statuses.length === 0) {
       if (config.format === "long") {
-        if (isUnbornBranch) {
+        // Only print "No commits yet" prefix if -b hasn't already shown it
+        if (isUnbornBranch && !config.branch) {
           console.log(
             "No commits yet\n\nnothing to commit (create/copy files and use 'gitique add' to track)",
+          );
+        } else if (isUnbornBranch) {
+          console.log(
+            "nothing to commit (create/copy files and use 'gitique add' to track)",
           );
         } else {
           console.log("nothing to commit, working tree clean");

--- a/examples/gitique/src/commands/status.ts
+++ b/examples/gitique/src/commands/status.ts
@@ -35,7 +35,7 @@ function readHeadBranchName(gitDir: string): string | null {
   return null;
 }
 
-const statusIndicatorMap: Record<string, string> = {
+const statusIndicatorMap: Record<FileStatus["status"], string> = {
   Added: "A",
   Deleted: "D",
   Modified: "M",

--- a/examples/gitique/src/commands/status.ts
+++ b/examples/gitique/src/commands/status.ts
@@ -129,6 +129,9 @@ const statusOptionsParser = map(
         "Cannot use --short or --porcelain together with --format.",
       );
     }
+    if (result.short && result.porcelain) {
+      throw new Error("Cannot use --short and --porcelain together.");
+    }
     return {
       ...result,
       format: result.short

--- a/examples/gitique/src/commands/status.ts
+++ b/examples/gitique/src/commands/status.ts
@@ -317,15 +317,30 @@ export async function executeStatus(config: StatusConfig): Promise<void> {
       case "short": {
         // Merge staged and unstaged entries for the same path into one line
         // so a dual-state file shows "MM" instead of two separate lines.
+        // Exception: a staged deletion + new untracked file at the same path
+        // must stay as two separate lines ("D  foo" + "?? foo"), matching git.
         const seenShort = new Set<string>();
         for (const file of statuses) {
           if (seenShort.has(file.path)) continue;
           seenShort.add(file.path);
           const stagedEntry = stagedByPath.get(file.path);
           const unstagedEntry = unstagedByPath.get(file.path);
-          console.log(
-            formatStatusShortMerged(stagedEntry, unstagedEntry, file.path),
-          );
+          if (
+            stagedEntry?.status === "Deleted" &&
+            unstagedEntry?.status === "Untracked"
+          ) {
+            // Emit two separate lines rather than a merged "D?" line
+            console.log(
+              formatStatusShortMerged(stagedEntry, undefined, file.path),
+            );
+            console.log(
+              formatStatusShortMerged(undefined, unstagedEntry, file.path),
+            );
+          } else {
+            console.log(
+              formatStatusShortMerged(stagedEntry, unstagedEntry, file.path),
+            );
+          }
         }
         break;
       }
@@ -337,9 +352,30 @@ export async function executeStatus(config: StatusConfig): Promise<void> {
           seenPorcelain.add(file.path);
           const stagedEntry = stagedByPath.get(file.path);
           const unstagedEntry = unstagedByPath.get(file.path);
-          console.log(
-            formatStatusPorcelainMerged(stagedEntry, unstagedEntry, file.path),
-          );
+          if (
+            stagedEntry?.status === "Deleted" &&
+            unstagedEntry?.status === "Untracked"
+          ) {
+            // Emit two separate lines rather than a merged "D?" line
+            console.log(
+              formatStatusPorcelainMerged(stagedEntry, undefined, file.path),
+            );
+            console.log(
+              formatStatusPorcelainMerged(
+                undefined,
+                unstagedEntry,
+                file.path,
+              ),
+            );
+          } else {
+            console.log(
+              formatStatusPorcelainMerged(
+                stagedEntry,
+                unstagedEntry,
+                file.path,
+              ),
+            );
+          }
         }
         break;
       }

--- a/examples/gitique/src/commands/status.ts
+++ b/examples/gitique/src/commands/status.ts
@@ -23,6 +23,8 @@ const statusIndicatorMap: Record<string, string> = {
   Renamed: "R",
   Copied: "C",
   Untracked: "?",
+  Typechange: "T",
+  Conflicted: "U",
 };
 
 /**

--- a/examples/gitique/src/commands/status.ts
+++ b/examples/gitique/src/commands/status.ts
@@ -113,14 +113,25 @@ export async function executeStatus(config: StatusConfig): Promise<void> {
 
     // Show branch information if requested
     if (config.branch) {
-      try {
-        const head = repo.head();
-        const branchName = head.name().replace("refs/heads/", "");
-        console.log(`On branch ${colors.green}${branchName}${colors.reset}`);
-        console.log("");
-      } catch {
-        console.log("Not currently on any branch.");
-        console.log("");
+      if (config.format === "porcelain") {
+        // Machine-readable porcelain v1 branch line
+        try {
+          const head = repo.head();
+          const branchName = head.name().replace("refs/heads/", "");
+          console.log(`## ${branchName}`);
+        } catch {
+          console.log("## HEAD (no branch)");
+        }
+      } else {
+        try {
+          const head = repo.head();
+          const branchName = head.name().replace("refs/heads/", "");
+          console.log(`On branch ${colors.green}${branchName}${colors.reset}`);
+          console.log("");
+        } catch {
+          console.log("Not currently on any branch.");
+          console.log("");
+        }
       }
     }
 

--- a/examples/gitique/src/utils/formatters.ts
+++ b/examples/gitique/src/utils/formatters.ts
@@ -36,12 +36,13 @@ export function formatCommitOneline(oid: string, commit: Commit): string {
 export function formatCommitDetailed(oid: string, commit: Commit): string {
   const author = commit.author();
   const message = commit.message();
-  const commitTime = commit.time();
+  // Use author timestamp (when the change was authored), not committer time.
+  const authorDate = new Date(author.timestamp * 1000);
 
   const lines = [
     `${colors.yellow}commit ${oid}${colors.reset}`,
     `Author: ${author.name} <${author.email}>`,
-    `Date:   ${commitTime.toDateString()}`,
+    `Date:   ${authorDate.toISOString()}`,
     "",
     ...message.split("\n").map((line: string) => `    ${line}`),
     "",

--- a/examples/gitique/src/utils/formatters.ts
+++ b/examples/gitique/src/utils/formatters.ts
@@ -159,46 +159,6 @@ export function formatStatusLong(
 }
 
 /**
- * Formats a file status line for status command output (short format)
- */
-export function formatStatusShort(
-  path: string,
-  status: string,
-  staged: boolean,
-  oldPath?: string,
-): string {
-  const indicator = statusIndicators[status] || "?";
-  const stagedCol = staged ? indicator : " ";
-  const unstagedCol = staged ? " " : indicator;
-  const stagedColor = staged ? colors.green : "";
-  const unstagedColor = staged ? "" : colors.red;
-
-  if (oldPath) {
-    return `${stagedColor}${stagedCol}${colors.reset}${unstagedColor}${unstagedCol}${colors.reset} ${oldPath} -> ${path}`;
-  }
-  return `${stagedColor}${stagedCol}${colors.reset}${unstagedColor}${unstagedCol}${colors.reset} ${path}`;
-}
-
-/**
- * Formats a file status line for status command output (porcelain format)
- */
-export function formatStatusPorcelain(
-  path: string,
-  status: string,
-  staged: boolean,
-  oldPath?: string,
-): string {
-  const indicator = statusIndicators[status] || "?";
-  const stagedCol = staged ? indicator : " ";
-  const unstagedCol = staged ? " " : indicator;
-
-  if (oldPath) {
-    return `${stagedCol}${unstagedCol} ${oldPath} -> ${path}`;
-  }
-  return `${stagedCol}${unstagedCol} ${path}`;
-}
-
-/**
  * Formats diff statistics summary
  */
 export function formatDiffStats(

--- a/examples/gitique/src/utils/formatters.ts
+++ b/examples/gitique/src/utils/formatters.ts
@@ -60,10 +60,14 @@ export function formatAddedFile(filePath: string): string {
 /**
  * Formats commit creation message
  */
-export function formatCommitCreated(oid: string, message: string): string {
+export function formatCommitCreated(
+  oid: string,
+  message: string,
+  branchName: string,
+): string {
   const shortOid = oid.substring(0, 7);
   const summary = message.split("\n")[0];
-  return `[main ${colors.yellow}${shortOid}${colors.reset}] ${summary}`;
+  return `[${branchName} ${colors.yellow}${shortOid}${colors.reset}] ${summary}`;
 }
 
 /**

--- a/examples/gitique/src/utils/formatters.ts
+++ b/examples/gitique/src/utils/formatters.ts
@@ -136,6 +136,8 @@ const statusIndicators: Record<string, string> = {
   Renamed: "R",
   Copied: "C",
   Untracked: "?",
+  Typechange: "T",
+  Conflicted: "U",
 };
 
 /**

--- a/examples/gitique/src/utils/git.ts
+++ b/examples/gitique/src/utils/git.ts
@@ -8,7 +8,7 @@ import {
   RevwalkSort,
   type Signature,
 } from "es-git";
-import { readFileSync, statSync } from "node:fs";
+import { lstatSync, readFileSync } from "node:fs";
 import { relative, resolve } from "node:path";
 import process from "node:process";
 
@@ -147,7 +147,7 @@ export function addFile(
   let isDirectory = filePath === ".";
   if (!isDirectory) {
     try {
-      isDirectory = statSync(absolutePath).isDirectory();
+      isDirectory = lstatSync(absolutePath).isDirectory();
     } catch {
       // Path doesn't exist — let addPath handle the error
     }
@@ -173,7 +173,7 @@ export function addFile(
     // so that --force on a completely unknown path still errors.
     const existsOnDisk = (() => {
       try {
-        statSync(absolutePath);
+        lstatSync(absolutePath);
         return true;
       } catch {
         return false;

--- a/examples/gitique/src/utils/git.ts
+++ b/examples/gitique/src/utils/git.ts
@@ -51,7 +51,7 @@ export function createGitSignature(
     if (repo) {
       configSources.push(() => {
         try {
-          const localConfig = openConfig(repo.path() + "config");
+          const localConfig = openConfig(resolve(repo.path(), "config"));
           if (!authorName) {
             try {
               authorName = localConfig.getString("user.name");
@@ -346,7 +346,8 @@ export function moveHead(repo: Repository, targetOid: string): void {
     } catch {
       // Unborn branch — read the symbolic target from .git/HEAD
       try {
-        const headContent = readFileSync(repo.path() + "HEAD", "utf-8").trim();
+        const headContent = readFileSync(resolve(repo.path(), "HEAD"), "utf-8")
+          .trim();
         if (headContent.startsWith("ref: refs/heads/")) {
           branchName = headContent.slice("ref: refs/heads/".length);
         }

--- a/examples/gitique/src/utils/git.ts
+++ b/examples/gitique/src/utils/git.ts
@@ -109,9 +109,11 @@ export function createGitSignature(
  * Converts a file path to be relative to the repository root.
  */
 function toRepoRelativePath(repo: Repository, filePath: string): string {
-  const repoRoot = repo.path().replace(/\.git\/?$/, "");
+  // Strip the trailing /.git/ or \.git\ (Windows) from the repo path.
+  const repoRoot = repo.path().replace(/[/\\]?\.git[/\\]?$/, "");
   const absolutePath = resolve(process.cwd(), filePath);
-  return relative(repoRoot, absolutePath);
+  // Normalize to forward slashes — libgit2/es-git expects POSIX separators.
+  return relative(repoRoot, absolutePath).replace(/\\/g, "/");
 }
 
 /**

--- a/examples/gitique/src/utils/git.ts
+++ b/examples/gitique/src/utils/git.ts
@@ -178,42 +178,53 @@ export function getStatus(repo: Repository): FileStatus[] {
     try {
       headTree = repo.head().peelToTree();
     } catch {
-      // No HEAD exists (empty repository)
+      // No HEAD exists (unborn repository)
     }
 
-    // Get all changes (staged + unstaged) using diffTreeToWorkdirWithIndex
-    // This compares HEAD tree to working directory with index
-    if (headTree) {
-      const diff = repo.diffTreeToWorkdirWithIndex(headTree);
-      for (const delta of diff.deltas()) {
-        const path = delta.newFile().path();
-        if (path === null) continue;
+    // Staged changes: compare HEAD tree (or empty) to the index
+    const index = repo.index();
+    const indexTreeOid = index.writeTree();
+    const indexTree = repo.getTree(indexTreeOid);
 
-        results.push({
-          path,
-          status: delta.status() as FileStatus["status"],
-          oldPath: delta.status() === "Renamed"
-            ? (delta.oldFile().path() ?? undefined)
-            : undefined,
-          staged: false, // We can't distinguish staged/unstaged with this method
-        });
-      }
-    } else {
-      // For empty repository, get unstaged changes only
-      const unstagedDiff = repo.diffIndexToWorkdir();
-      for (const delta of unstagedDiff.deltas()) {
-        const path = delta.newFile().path();
-        if (path === null) continue;
+    const stagedDiff = repo.diffTreeToTree(
+      headTree ?? undefined,
+      indexTree,
+    );
+    for (const delta of stagedDiff.deltas()) {
+      const path = delta.newFile().path();
+      if (path === null) continue;
 
-        results.push({
-          path,
-          status: delta.status() as FileStatus["status"],
-          oldPath: delta.status() === "Renamed"
-            ? (delta.oldFile().path() ?? undefined)
-            : undefined,
-          staged: false,
-        });
-      }
+      results.push({
+        path,
+        status: delta.status() as FileStatus["status"],
+        oldPath: delta.status() === "Renamed"
+          ? (delta.oldFile().path() ?? undefined)
+          : undefined,
+        staged: true,
+      });
+    }
+
+    // Unstaged changes: compare index to working directory
+    const unstagedDiff = repo.diffIndexToWorkdir();
+    for (const delta of unstagedDiff.deltas()) {
+      const path = delta.newFile().path();
+      if (path === null) continue;
+
+      // Skip if already reported as staged (avoid duplicates for files
+      // that have both staged and unstaged changes)
+      const alreadyStaged = results.some(
+        (r) => r.path === path && r.staged,
+      );
+      if (alreadyStaged) continue;
+
+      results.push({
+        path,
+        status: delta.status() as FileStatus["status"],
+        oldPath: delta.status() === "Renamed"
+          ? (delta.oldFile().path() ?? undefined)
+          : undefined,
+        staged: false,
+      });
     }
   } catch (error) {
     throw new Error(

--- a/examples/gitique/src/utils/git.ts
+++ b/examples/gitique/src/utils/git.ts
@@ -294,7 +294,14 @@ export function createCommit(
  */
 export function isIndexEmpty(repo: Repository): boolean {
   const index = repo.index();
-  const indexTreeOid = index.writeTree();
+  let indexTreeOid: string;
+  try {
+    indexTreeOid = index.writeTree();
+  } catch {
+    // Unmerged entries prevent writing the tree; treat the index as
+    // non-empty so the caller can surface a conflict-aware error.
+    return false;
+  }
   const indexTree = repo.getTree(indexTreeOid);
 
   let headTree;
@@ -689,7 +696,16 @@ export function getDiff(
         }
       }
       const index = repo.index();
-      const indexTreeOid = index.writeTree();
+      let indexTreeOid: string;
+      try {
+        indexTreeOid = index.writeTree();
+      } catch {
+        throw new Error(
+          "Cannot diff cached changes: the index contains unresolved " +
+            "merge conflicts. Resolve them before running " +
+            "'gitique diff --cached'.",
+        );
+      }
       const indexTree = repo.getTree(indexTreeOid);
       diff = repo.diffTreeToTree(baseTree, indexTree, esDiffOptions);
     } else if (options.commit && options.commit2) {

--- a/examples/gitique/src/utils/git.ts
+++ b/examples/gitique/src/utils/git.ts
@@ -485,6 +485,18 @@ export function resetIndex(repo: Repository): void {
 }
 
 /**
+ * Checks out HEAD, updating the working directory to match.
+ * Wraps es-git's repo.checkoutHead() to keep all es-git calls
+ * in the shared utility layer rather than in command handlers.
+ */
+export function checkoutHead(
+  repo: Repository,
+  options?: { force?: boolean },
+): void {
+  repo.checkoutHead(options);
+}
+
+/**
  * Represents a file's status in the working directory.
  */
 export interface FileStatus {

--- a/examples/gitique/src/utils/git.ts
+++ b/examples/gitique/src/utils/git.ts
@@ -1,6 +1,7 @@
 import {
   type Commit,
   createSignature,
+  openDefaultConfig,
   openRepository,
   type Repository,
   RevwalkSort,
@@ -22,26 +23,51 @@ interface CommitWithOid {
 export async function getRepository(): Promise<Repository> {
   try {
     return await openRepository(".");
-  } catch (_error) {
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
     throw new Error(
-      "Not a git repository (or any of the parent directories): .git",
+      `Not a git repository (or any of the parent directories): .git (${detail})`,
     );
   }
 }
 
 /**
  * Creates a signature for commits using Git configuration or provided values.
+ * Reads user.name and user.email from the default git config when not provided.
  */
 export function createGitSignature(
   name?: string,
   email?: string,
 ): Signature {
-  // In a real implementation, we would read from git config
-  // For this example, we'll use defaults or provided values
-  const authorName = name ?? "Gitique User";
-  const authorEmail = email ?? "gitique@example.com";
+  let authorName = name;
+  let authorEmail = email;
 
-  return createSignature(authorName, authorEmail);
+  if (!authorName || !authorEmail) {
+    try {
+      const config = openDefaultConfig();
+      if (!authorName) {
+        try {
+          authorName = config.getString("user.name");
+        } catch {
+          // Key not set in any config file
+        }
+      }
+      if (!authorEmail) {
+        try {
+          authorEmail = config.getString("user.email");
+        } catch {
+          // Key not set in any config file
+        }
+      }
+    } catch {
+      // Config files unavailable — fall through to defaults
+    }
+  }
+
+  return createSignature(
+    authorName ?? "Gitique User",
+    authorEmail ?? "gitique@example.com",
+  );
 }
 
 /**
@@ -452,6 +478,13 @@ export function getDiff(
   repo: Repository,
   options: DiffOptions = {},
 ): DiffResult {
+  if (options.cached && options.commit2) {
+    throw new Error(
+      "--cached compares the index to a base tree; " +
+        "specifying two commits is not supported with --cached.",
+    );
+  }
+
   try {
     let diff;
 

--- a/examples/gitique/src/utils/git.ts
+++ b/examples/gitique/src/utils/git.ts
@@ -233,6 +233,42 @@ export function getCommitHistory(
 }
 
 /**
+ * Unstages a single file by reverting the index entry to match HEAD.
+ * For tracked files, the HEAD version is restored in the index (the
+ * working tree is not touched).  For files that are new in the index
+ * (not in HEAD), the entry is removed from the index entirely.
+ */
+export function unstageFile(repo: Repository, filePath: string): void {
+  const index = repo.index();
+
+  // Check whether the file exists in HEAD
+  let inHead = false;
+  try {
+    const headTree = repo.head().peelToTree();
+    inHead = headTree.getPath(filePath) !== null;
+  } catch {
+    // Unborn repository — nothing in HEAD
+  }
+
+  if (inHead) {
+    // Re-stage from the working tree (addPath refreshes from disk),
+    // then let the caller know the index was updated.  This is an
+    // approximation: it re-adds the current on-disk version instead
+    // of the HEAD blob, but it demonstrates the unstage pattern.
+    index.removeAll([filePath]);
+    try {
+      index.addPath(filePath);
+    } catch {
+      // File may have been deleted in the working tree — leave removed
+    }
+  } else {
+    // File is new in the index (not tracked in HEAD) — just remove it
+    index.removeAll([filePath]);
+  }
+  index.write();
+}
+
+/**
  * Resets the index to match HEAD (unstages all changes).
  */
 export function resetIndex(repo: Repository): void {

--- a/examples/gitique/src/utils/git.ts
+++ b/examples/gitique/src/utils/git.ts
@@ -93,7 +93,13 @@ export function addFile(
     index.addAll([repoRelativePath], { force: true });
   } else {
     const repoRelativePath = toRepoRelativePath(repo, filePath);
-    index.addPath(repoRelativePath);
+    try {
+      index.addPath(repoRelativePath);
+    } catch {
+      // addPath requires the file to exist in the working tree.
+      // If it doesn't exist, try updateAll to stage a tracked deletion.
+      index.updateAll([repoRelativePath]);
+    }
   }
   index.write();
 }
@@ -260,19 +266,21 @@ export function unstageFile(repo: Repository, filePath: string): void {
     // Unborn repository — nothing in HEAD
   }
 
+  // Remove the staged version from the index.  Without a readTree API in
+  // es-git, we cannot restore the exact HEAD blob; removing the entry and
+  // re-reading from disk is the closest approximation available.
+  // - For a new file (not in HEAD): removal correctly unstages it.
+  // - For a modified tracked file: removal leaves the file untracked in
+  //   the index view, which is an imperfect approximation.
+  index.removeAll([repoRelativePath]);
   if (inHead) {
-    // Re-stage from the working tree (addPath refreshes from disk).
-    // This is an approximation: it restores the on-disk version rather
-    // than the HEAD blob, demonstrating the unstage interaction pattern.
-    index.removeAll([repoRelativePath]);
+    // Re-read from disk so the file stays tracked rather than appearing
+    // as a staged deletion; this is an approximation of HEAD restoration.
     try {
       index.addPath(repoRelativePath);
     } catch {
-      // File deleted in the working tree — leave it removed from index
+      // File was deleted from the working tree — leave the staged deletion
     }
-  } else {
-    // File is new in the index (not tracked in HEAD) — just remove it
-    index.removeAll([repoRelativePath]);
   }
   index.write();
 }

--- a/examples/gitique/src/utils/git.ts
+++ b/examples/gitique/src/utils/git.ts
@@ -3,6 +3,7 @@ import {
   createSignature,
   openRepository,
   type Repository,
+  RevwalkSort,
   type Signature,
 } from "es-git";
 import { statSync } from "node:fs";
@@ -242,7 +243,7 @@ export function getCommitHistory(
   const commits: CommitWithOid[] = [];
 
   try {
-    const revwalk = repo.revwalk().pushHead();
+    const revwalk = repo.revwalk().setSorting(RevwalkSort.Time).pushHead();
 
     let count = 0;
     for (const oid of revwalk) {
@@ -361,6 +362,7 @@ export function getStatus(repo: Repository): FileStatus[] {
       headTree ?? undefined,
       indexTree,
     );
+    stagedDiff.findSimilar();
     for (const delta of stagedDiff.deltas()) {
       // Deleted deltas have no newFile path; use oldFile path instead.
       const status = delta.status() as FileStatus["status"];
@@ -387,6 +389,7 @@ export function getStatus(repo: Repository): FileStatus[] {
     const unstagedDiff = repo.diffIndexToWorkdir(undefined, {
       includeUntracked: true,
     });
+    unstagedDiff.findSimilar();
     for (const delta of unstagedDiff.deltas()) {
       // Deleted deltas have no newFile path; use oldFile path instead.
       const status = delta.status() as FileStatus["status"];
@@ -509,6 +512,9 @@ export function getDiff(
       // Unstaged changes: index vs workdir
       diff = repo.diffIndexToWorkdir(undefined, esDiffOptions);
     }
+
+    // Enable rename and copy detection.
+    diff.findSimilar();
 
     const stats = diff.stats();
     const deltas: DiffResult["deltas"] = [];

--- a/examples/gitique/src/utils/git.ts
+++ b/examples/gitique/src/utils/git.ts
@@ -104,12 +104,14 @@ export function createGitSignature(
       !authorName && "user.name",
       !authorEmail && "user.email",
     ].filter(Boolean).join(" and ");
+    const commands = [
+      !authorName && `  git config --global user.name "Your Name"`,
+      !authorEmail && `  git config --global user.email "you@example.com"`,
+    ].filter(Boolean).join("\n");
     throw new Error(
       `Please tell me who you are.\n\n` +
         `Run\n\n` +
-        `  git config --global ${
-          !authorName ? "user.name" : "user.email"
-        } "Your ${!authorName ? "Name" : "Email"}"\n\n` +
+        `${commands}\n\n` +
         `to set your account's default identity.\n\n` +
         `Cannot read ${missing} from git config.`,
     );

--- a/examples/gitique/src/utils/git.ts
+++ b/examples/gitique/src/utils/git.ts
@@ -392,28 +392,22 @@ export function getCommitHistory(
 ): CommitWithOid[] {
   const commits: CommitWithOid[] = [];
 
+  // Check whether HEAD resolves; unborn repositories have no commits at
+  // all, so return an empty list rather than letting pushHead() throw an
+  // opaque internal error that we would have to recognise by string.
   try {
-    const revwalk = repo.revwalk().setSorting(RevwalkSort.Time).pushHead();
+    repo.head();
+  } catch {
+    return commits;
+  }
 
-    let count = 0;
-    for (const oid of revwalk) {
-      if (maxCount && count >= maxCount) break;
-
-      const commit = repo.getCommit(oid);
-      commits.push({ oid, commit });
-      count++;
-    }
-  } catch (error) {
-    // An unborn repository has no HEAD — treat it as empty history.
-    // Rethrow any other unexpected error.
-    const msg = error instanceof Error ? error.message : String(error);
-    if (
-      !msg.includes("reference") &&
-      !msg.includes("HEAD") &&
-      !msg.includes("unborn")
-    ) {
-      throw error;
-    }
+  const revwalk = repo.revwalk().setSorting(RevwalkSort.Time).pushHead();
+  let count = 0;
+  for (const oid of revwalk) {
+    if (maxCount && count >= maxCount) break;
+    const commit = repo.getCommit(oid);
+    commits.push({ oid, commit });
+    count++;
   }
 
   return commits;

--- a/examples/gitique/src/utils/git.ts
+++ b/examples/gitique/src/utils/git.ts
@@ -99,10 +99,23 @@ export function createGitSignature(
     }
   }
 
-  return createSignature(
-    authorName ?? "Gitique User",
-    authorEmail ?? "gitique@example.com",
-  );
+  if (!authorName || !authorEmail) {
+    const missing = [
+      !authorName && "user.name",
+      !authorEmail && "user.email",
+    ].filter(Boolean).join(" and ");
+    throw new Error(
+      `Please tell me who you are.\n\n` +
+        `Run\n\n` +
+        `  git config --global ${
+          !authorName ? "user.name" : "user.email"
+        } "Your ${!authorName ? "Name" : "Email"}"\n\n` +
+        `to set your account's default identity.\n\n` +
+        `Cannot read ${missing} from git config.`,
+    );
+  }
+
+  return createSignature(authorName, authorEmail);
 }
 
 /**
@@ -323,8 +336,17 @@ export function getCommitHistory(
       commits.push({ oid, commit });
       count++;
     }
-  } catch (_error) {
-    // No commits yet or other error - this is normal for empty repositories
+  } catch (error) {
+    // An unborn repository has no HEAD — treat it as empty history.
+    // Rethrow any other unexpected error.
+    const msg = error instanceof Error ? error.message : String(error);
+    if (
+      !msg.includes("reference") &&
+      !msg.includes("HEAD") &&
+      !msg.includes("unborn")
+    ) {
+      throw error;
+    }
   }
 
   return commits;
@@ -450,7 +472,7 @@ export function getStatus(repo: Repository): FileStatus[] {
       results.push({
         path,
         status,
-        oldPath: status === "Renamed"
+        oldPath: (status === "Renamed" || status === "Copied")
           ? (delta.oldFile().path() ?? undefined)
           : undefined,
         staged: true,
@@ -477,7 +499,7 @@ export function getStatus(repo: Repository): FileStatus[] {
       results.push({
         path,
         status,
-        oldPath: status === "Renamed"
+        oldPath: (status === "Renamed" || status === "Copied")
           ? (delta.oldFile().path() ?? undefined)
           : undefined,
         staged: false,
@@ -503,7 +525,7 @@ export interface DiffOptions {
   commit2?: string;
   paths?: string[];
   unified?: number;
-  algorithm?: "default" | "minimal" | "patience" | "histogram";
+  algorithm?: "default" | "minimal" | "patience";
 }
 
 /**
@@ -555,7 +577,7 @@ export function getDiff(
     } else if (options.algorithm === "minimal") {
       esDiffOptions.minimal = true;
     }
-    // "histogram" and "default" use default es-git behaviour
+    // "default" uses default es-git behaviour
     if (options.paths && options.paths.length > 0) {
       esDiffOptions.pathspecs = options.paths;
     }
@@ -621,7 +643,7 @@ export function getDiff(
 
       deltas.push({
         path,
-        oldPath: status === "Renamed"
+        oldPath: (status === "Renamed" || status === "Copied")
           ? (delta.oldFile().path() ?? undefined)
           : undefined,
         status,

--- a/examples/gitique/src/utils/git.ts
+++ b/examples/gitique/src/utils/git.ts
@@ -613,7 +613,6 @@ export interface DiffOptions {
   cached?: boolean;
   commit?: string;
   commit2?: string;
-  paths?: string[];
   unified?: number;
   algorithm?: "default" | "minimal" | "patience";
 }
@@ -668,9 +667,6 @@ export function getDiff(
       esDiffOptions.minimal = true;
     }
     // "default" uses default es-git behaviour
-    if (options.paths && options.paths.length > 0) {
-      esDiffOptions.pathspecs = options.paths;
-    }
 
     if (options.cached) {
       // Staged changes only: compare a base tree to the index tree.

--- a/examples/gitique/src/utils/git.ts
+++ b/examples/gitique/src/utils/git.ts
@@ -281,7 +281,13 @@ export function getDiff(
     if (options.cached) {
       // Staged changes only: compare HEAD tree to index tree.
       // Using diffTreeToWorkdirWithIndex would blend in unstaged changes.
-      const headTree = repo.head().peelToTree();
+      // When on an unborn branch (no HEAD yet) treat as empty old tree.
+      let headTree;
+      try {
+        headTree = repo.head().peelToTree();
+      } catch {
+        // No HEAD yet (unborn repository) — diff against empty tree
+      }
       const index = repo.index();
       const indexTreeOid = index.writeTree();
       const indexTree = repo.getTree(indexTreeOid);

--- a/examples/gitique/src/utils/git.ts
+++ b/examples/gitique/src/utils/git.ts
@@ -656,7 +656,6 @@ export function getDiff(
       contextLines?: number;
       patience?: boolean;
       minimal?: boolean;
-      pathspecs?: string[];
     } = {};
     if (options.unified !== undefined) {
       esDiffOptions.contextLines = options.unified;

--- a/examples/gitique/src/utils/git.ts
+++ b/examples/gitique/src/utils/git.ts
@@ -95,10 +95,23 @@ export function addFile(
     const repoRelativePath = toRepoRelativePath(repo, filePath);
     try {
       index.addPath(repoRelativePath);
-    } catch {
+    } catch (err) {
       // addPath requires the file to exist in the working tree.
-      // If it doesn't exist, try updateAll to stage a tracked deletion.
-      index.updateAll([repoRelativePath]);
+      // For tracked files deleted from the worktree, fall back to
+      // updateAll to stage the deletion.  For completely unknown paths
+      // (not in HEAD and not on disk), rethrow the original error.
+      let trackedInHead = false;
+      try {
+        const headTree = repo.head().peelToTree();
+        trackedInHead = headTree.getPath(repoRelativePath) !== null;
+      } catch {
+        // Unborn repository — nothing in HEAD
+      }
+      if (trackedInHead) {
+        index.updateAll([repoRelativePath]);
+      } else {
+        throw err;
+      }
     }
   }
   index.write();

--- a/examples/gitique/src/utils/git.ts
+++ b/examples/gitique/src/utils/git.ts
@@ -248,6 +248,7 @@ export function getStatus(repo: Repository): FileStatus[] {
 export interface DiffOptions {
   cached?: boolean;
   commit?: string;
+  commit2?: string;
   paths?: string[];
   unified?: number;
   algorithm?: "default" | "minimal" | "patience" | "histogram";
@@ -285,6 +286,7 @@ export function getDiff(
       contextLines?: number;
       patience?: boolean;
       minimal?: boolean;
+      pathspecs?: string[];
     } = {};
     if (options.unified !== undefined) {
       esDiffOptions.contextLines = options.unified;
@@ -295,6 +297,9 @@ export function getDiff(
       esDiffOptions.minimal = true;
     }
     // "histogram" and "default" use default es-git behaviour
+    if (options.paths && options.paths.length > 0) {
+      esDiffOptions.pathspecs = options.paths;
+    }
 
     if (options.cached) {
       // Staged changes only: compare HEAD tree to index tree.
@@ -310,6 +315,11 @@ export function getDiff(
       const indexTreeOid = index.writeTree();
       const indexTree = repo.getTree(indexTreeOid);
       diff = repo.diffTreeToTree(headTree, indexTree, esDiffOptions);
+    } else if (options.commit && options.commit2) {
+      // Compare two specific commits
+      const tree1 = repo.getCommit(options.commit).tree();
+      const tree2 = repo.getCommit(options.commit2).tree();
+      diff = repo.diffTreeToTree(tree1, tree2, esDiffOptions);
     } else if (options.commit) {
       // Compare with specific commit
       const commitObj = repo.getCommit(options.commit);

--- a/examples/gitique/src/utils/git.ts
+++ b/examples/gitique/src/utils/git.ts
@@ -169,6 +169,30 @@ export function addFile(
     // Also call updateAll first so that a tracked file that was deleted
     // from the worktree has its deletion staged even under --force.
     const repoRelativePath = toRepoRelativePath(repo, filePath);
+    // Validate that the path exists on disk or is already tracked in HEAD
+    // so that --force on a completely unknown path still errors.
+    const existsOnDisk = (() => {
+      try {
+        statSync(absolutePath);
+        return true;
+      } catch {
+        return false;
+      }
+    })();
+    if (!existsOnDisk) {
+      let trackedInHead = false;
+      try {
+        const headTree = repo.head().peelToTree();
+        trackedInHead = headTree.getPath(repoRelativePath) !== null;
+      } catch {
+        // Unborn repository
+      }
+      if (!trackedInHead) {
+        throw new Error(
+          `pathspec '${filePath}' did not match any files`,
+        );
+      }
+    }
     index.updateAll([repoRelativePath]);
     index.addAll([repoRelativePath], { force: true });
   } else {
@@ -373,6 +397,13 @@ export function unstageFile(repo: Repository, filePath: string): void {
     inHead = headTree.getPath(repoRelativePath) !== null;
   } catch {
     // Unborn repository — nothing in HEAD
+  }
+
+  // Verify the path is known to at least one of HEAD or the index before
+  // proceeding; an entirely unknown path should be an error, not a no-op.
+  const inIndex = index.getByPath(repoRelativePath) !== null;
+  if (!inHead && !inIndex) {
+    throw new Error(`pathspec '${filePath}' did not match any files`);
   }
 
   // Remove the staged version from the index.  Without a readTree API in

--- a/examples/gitique/src/utils/git.ts
+++ b/examples/gitique/src/utils/git.ts
@@ -27,7 +27,7 @@ export async function getRepository(): Promise<Repository> {
   } catch (error) {
     const detail = error instanceof Error ? error.message : String(error);
     throw new Error(
-      `Not a git repository (or any of the parent directories): .git (${detail})`,
+      `Not a git repository (or any of the parent directories): .git (${detail}).`,
     );
   }
 }
@@ -192,7 +192,7 @@ export function addFile(
       const inIndex = index.getByPath(repoRelativePath) !== null;
       if (!trackedInHead && !inIndex) {
         throw new Error(
-          `pathspec '${filePath}' did not match any files`,
+          `pathspec '${filePath}' did not match any files.`,
         );
       }
     }
@@ -319,7 +319,7 @@ export function isIndexEmpty(repo: Repository): boolean {
 export function resolveCommitOid(repo: Repository, spec: string): string {
   const oid = repo.revparseSingle(spec);
   const obj = repo.findObject(oid);
-  if (!obj) throw new Error(`Failed to find object for '${spec}'`);
+  if (!obj) throw new Error(`Failed to find object for '${spec}'.`);
   return obj.peelToCommit().id();
 }
 
@@ -423,7 +423,7 @@ export function unstageFile(repo: Repository, filePath: string): void {
   // proceeding; an entirely unknown path should be an error, not a no-op.
   const inIndex = index.getByPath(repoRelativePath) !== null;
   if (!inHead && !inIndex) {
-    throw new Error(`pathspec '${filePath}' did not match any files`);
+    throw new Error(`pathspec '${filePath}' did not match any files.`);
   }
 
   // Remove the staged version from the index.  Without a readTree API in

--- a/examples/gitique/src/utils/git.ts
+++ b/examples/gitique/src/utils/git.ts
@@ -204,8 +204,13 @@ export function getStatus(repo: Repository): FileStatus[] {
       });
     }
 
-    // Unstaged changes: compare index to working directory
-    const unstagedDiff = repo.diffIndexToWorkdir();
+    // Unstaged changes: compare index to working directory.
+    // includeUntracked: true ensures untracked files are shown,
+    // which is required both in normal repos and in unborn repos
+    // where no HEAD exists yet.
+    const unstagedDiff = repo.diffIndexToWorkdir(undefined, {
+      includeUntracked: true,
+    });
     for (const delta of unstagedDiff.deltas()) {
       const path = delta.newFile().path();
       if (path === null) continue;

--- a/examples/gitique/src/utils/git.ts
+++ b/examples/gitique/src/utils/git.ts
@@ -5,6 +5,7 @@ import {
   type Repository,
   type Signature,
 } from "es-git";
+import { statSync } from "node:fs";
 import { relative, resolve } from "node:path";
 import process from "node:process";
 
@@ -59,8 +60,28 @@ export function addFile(
   filePath: string,
 ): void {
   const index = repo.index();
-  const repoRelativePath = toRepoRelativePath(repo, filePath);
-  index.addPath(repoRelativePath);
+  const absolutePath = resolve(process.cwd(), filePath);
+
+  // When the path is "." or an existing directory, use addAll with a
+  // glob pattern so libgit2 can enumerate the contents recursively.
+  let isDirectory = filePath === ".";
+  if (!isDirectory) {
+    try {
+      isDirectory = statSync(absolutePath).isDirectory();
+    } catch {
+      // Path doesn't exist — let addPath handle the error
+    }
+  }
+
+  if (isDirectory) {
+    const pattern = filePath === "."
+      ? "*"
+      : toRepoRelativePath(repo, filePath) + "/**";
+    index.addAll([pattern]);
+  } else {
+    const repoRelativePath = toRepoRelativePath(repo, filePath);
+    index.addPath(repoRelativePath);
+  }
   index.write();
 }
 

--- a/examples/gitique/src/utils/git.ts
+++ b/examples/gitique/src/utils/git.ts
@@ -8,7 +8,7 @@ import {
   RevwalkSort,
   type Signature,
 } from "es-git";
-import { statSync } from "node:fs";
+import { readFileSync, statSync } from "node:fs";
 import { relative, resolve } from "node:path";
 import process from "node:process";
 
@@ -187,7 +187,10 @@ export function addFile(
       } catch {
         // Unborn repository
       }
-      if (!trackedInHead) {
+      // Also allow a file that is staged but not yet committed (in index but
+      // not in HEAD) — staging its deletion is valid even under --force.
+      const inIndex = index.getByPath(repoRelativePath) !== null;
+      if (!trackedInHead && !inIndex) {
         throw new Error(
           `pathspec '${filePath}' did not match any files`,
         );
@@ -211,7 +214,10 @@ export function addFile(
       } catch {
         // Unborn repository — nothing in HEAD
       }
-      if (trackedInHead) {
+      // Also handle a staged-but-not-committed file deleted from disk:
+      // it's not in HEAD but IS in the index, and staging the deletion is valid.
+      const inIndex = index.getByPath(repoRelativePath) !== null;
+      if (trackedInHead || inIndex) {
         index.updateAll([repoRelativePath]);
       } else {
         throw err;
@@ -331,13 +337,26 @@ export function moveHead(repo: Repository, targetOid: string): void {
   // points to a branch.  repo.head() resolves the ref so symbolicTarget()
   // is always null there — use headDetached() to distinguish the two cases.
   if (!repo.headDetached()) {
+    // Try to resolve the branch name from the resolved ref first; fall back
+    // to reading .git/HEAD directly for unborn branches where repo.head()
+    // throws because the branch ref doesn't exist yet.
+    let branchName: string | null = null;
     try {
-      const head = repo.head();
-      const branchName = head.name().replace(/^refs\/heads\//, "");
+      branchName = repo.head().name().replace(/^refs\/heads\//, "");
+    } catch {
+      // Unborn branch — read the symbolic target from .git/HEAD
+      try {
+        const headContent = readFileSync(repo.path() + "HEAD", "utf-8").trim();
+        if (headContent.startsWith("ref: refs/heads/")) {
+          branchName = headContent.slice("ref: refs/heads/".length);
+        }
+      } catch {
+        // Unable to read HEAD
+      }
+    }
+    if (branchName) {
       repo.createBranch(branchName, commit, { force: true });
       return;
-    } catch {
-      // Fall through to detached-HEAD path (e.g., unborn branch)
     }
   }
   repo.setHeadDetached(commit);

--- a/examples/gitique/src/utils/git.ts
+++ b/examples/gitique/src/utils/git.ts
@@ -102,6 +102,16 @@ export function addAllFiles(repo: Repository, force?: boolean): void {
 }
 
 /**
+ * Stages only tracked (already-indexed) files, equivalent to `git add -u`.
+ * Untracked files are left unstaged, matching `git commit -a` semantics.
+ */
+export function stageTrackedFiles(repo: Repository): void {
+  const index = repo.index();
+  index.updateAll(["*"]);
+  index.write();
+}
+
+/**
  * Creates a commit with the current index state.
  */
 export function createCommit(

--- a/examples/gitique/src/utils/git.ts
+++ b/examples/gitique/src/utils/git.ts
@@ -412,10 +412,16 @@ export function getCommitHistory(
 }
 
 /**
- * Unstages a single file by reverting the index entry to match HEAD.
- * For tracked files, the HEAD version is restored in the index (the
- * working tree is not touched).  For files that are new in the index
- * (not in HEAD), the entry is removed from the index entirely.
+ * Best-effort approximation of unstaging a single file.
+ *
+ * The current index entry is removed.  If the path exists in HEAD the
+ * file is then re-added from the working tree so that it remains tracked
+ * rather than appearing as a staged deletion.  This does *not* truly
+ * restore the HEAD blob into the index — es-git does not expose an API
+ * to add index entries by OID — so a tracked file that was staged after
+ * modification may remain staged with the modified content.  Files not
+ * present in HEAD are removed from the index entirely (unstage an
+ * addition).
  */
 export function unstageFile(repo: Repository, filePath: string): void {
   const index = repo.index();

--- a/examples/gitique/src/utils/git.ts
+++ b/examples/gitique/src/utils/git.ts
@@ -137,6 +137,31 @@ export function createCommit(
 }
 
 /**
+ * Returns true when the index matches HEAD (nothing staged to commit).
+ * In an unborn repository the index is empty when it has no entries.
+ */
+export function isIndexEmpty(repo: Repository): boolean {
+  const index = repo.index();
+  const indexTreeOid = index.writeTree();
+  const indexTree = repo.getTree(indexTreeOid);
+
+  let headTree;
+  try {
+    headTree = repo.head().peelToTree();
+  } catch {
+    // Unborn repository — index is non-empty when the tree has any entries
+    return indexTree.isEmpty();
+  }
+
+  const diff = repo.diffTreeToTree(headTree, indexTree);
+  // Deltas is an iterable with no length property; check for any delta
+  for (const _ of diff.deltas()) {
+    return false;
+  }
+  return true;
+}
+
+/**
  * Gets the commit history starting from HEAD.
  */
 export function getCommitHistory(

--- a/examples/gitique/src/utils/git.ts
+++ b/examples/gitique/src/utils/git.ts
@@ -530,30 +530,41 @@ export function getStatus(repo: Repository): FileStatus[] {
       // No HEAD exists (unborn repository)
     }
 
-    // Staged changes: compare HEAD tree (or empty) to the index
+    // Staged changes: compare HEAD tree (or empty) to the index.
+    // index.writeTree() fails when the index contains unresolved merge
+    // conflicts (unmerged entries).  In that case we skip the staged diff
+    // entirely rather than crashing — the unstaged diff below will still
+    // show the conflicted files.
     const index = repo.index();
-    const indexTreeOid = index.writeTree();
-    const indexTree = repo.getTree(indexTreeOid);
+    let indexTreeOid: string | null = null;
+    try {
+      indexTreeOid = index.writeTree();
+    } catch {
+      // Unmerged entries prevent writing the tree; skip staged diff
+    }
 
-    const stagedDiff = repo.diffTreeToTree(
-      headTree ?? undefined,
-      indexTree,
-    );
-    stagedDiff.findSimilar();
-    for (const delta of stagedDiff.deltas()) {
-      // Deleted deltas have no newFile path; use oldFile path instead.
-      const status = delta.status() as FileStatus["status"];
-      const path = delta.newFile().path() ?? delta.oldFile().path();
-      if (path === null) continue;
+    if (indexTreeOid !== null) {
+      const indexTree = repo.getTree(indexTreeOid);
+      const stagedDiff = repo.diffTreeToTree(
+        headTree ?? undefined,
+        indexTree,
+      );
+      stagedDiff.findSimilar();
+      for (const delta of stagedDiff.deltas()) {
+        // Deleted deltas have no newFile path; use oldFile path instead.
+        const status = delta.status() as FileStatus["status"];
+        const path = delta.newFile().path() ?? delta.oldFile().path();
+        if (path === null) continue;
 
-      results.push({
-        path,
-        status,
-        oldPath: (status === "Renamed" || status === "Copied")
-          ? (delta.oldFile().path() ?? undefined)
-          : undefined,
-        staged: true,
-      });
+        results.push({
+          path,
+          status,
+          oldPath: (status === "Renamed" || status === "Copied")
+            ? (delta.oldFile().path() ?? undefined)
+            : undefined,
+          staged: true,
+        });
+      }
     }
 
     // Unstaged changes: compare index to working directory.
@@ -669,7 +680,9 @@ export function getDiff(
         // Peel through annotated tags to get the actual commit tree.
         const baseOid = repo.revparseSingle(options.commit);
         const baseObj = repo.findObject(baseOid);
-        if (!baseObj) throw new Error(`Object not found: ${baseOid}`);
+        if (!baseObj) {
+          throw new Error(`Object not found for '${options.commit}'.`);
+        }
         baseTree = baseObj.peelToCommit().tree();
       } else {
         try {
@@ -689,8 +702,8 @@ export function getDiff(
       const oid2 = repo.revparseSingle(options.commit2);
       const obj1 = repo.findObject(oid1);
       const obj2 = repo.findObject(oid2);
-      if (!obj1) throw new Error(`Object not found: ${oid1}`);
-      if (!obj2) throw new Error(`Object not found: ${oid2}`);
+      if (!obj1) throw new Error(`Object not found for '${options.commit}'.`);
+      if (!obj2) throw new Error(`Object not found for '${options.commit2}'.`);
       const tree1 = obj1.peelToCommit().tree();
       const tree2 = obj2.peelToCommit().tree();
       diff = repo.diffTreeToTree(tree1, tree2, esDiffOptions);
@@ -698,7 +711,7 @@ export function getDiff(
       // Compare with specific commit; peel through annotated tags.
       const oid = repo.revparseSingle(options.commit);
       const obj = repo.findObject(oid);
-      if (!obj) throw new Error(`Object not found: ${oid}`);
+      if (!obj) throw new Error(`Object not found for '${options.commit}'.`);
       const commitTree = obj.peelToCommit().tree();
       diff = repo.diffTreeToWorkdirWithIndex(commitTree, esDiffOptions);
     } else {

--- a/examples/gitique/src/utils/git.ts
+++ b/examples/gitique/src/utils/git.ts
@@ -362,13 +362,15 @@ export function getStatus(repo: Repository): FileStatus[] {
       indexTree,
     );
     for (const delta of stagedDiff.deltas()) {
-      const path = delta.newFile().path();
+      // Deleted deltas have no newFile path; use oldFile path instead.
+      const status = delta.status() as FileStatus["status"];
+      const path = delta.newFile().path() ?? delta.oldFile().path();
       if (path === null) continue;
 
       results.push({
         path,
-        status: delta.status() as FileStatus["status"],
-        oldPath: delta.status() === "Renamed"
+        status,
+        oldPath: status === "Renamed"
           ? (delta.oldFile().path() ?? undefined)
           : undefined,
         staged: true,
@@ -386,13 +388,15 @@ export function getStatus(repo: Repository): FileStatus[] {
       includeUntracked: true,
     });
     for (const delta of unstagedDiff.deltas()) {
-      const path = delta.newFile().path();
+      // Deleted deltas have no newFile path; use oldFile path instead.
+      const status = delta.status() as FileStatus["status"];
+      const path = delta.newFile().path() ?? delta.oldFile().path();
       if (path === null) continue;
 
       results.push({
         path,
-        status: delta.status() as FileStatus["status"],
-        oldPath: delta.status() === "Renamed"
+        status,
+        oldPath: status === "Renamed"
           ? (delta.oldFile().path() ?? undefined)
           : undefined,
         staged: false,
@@ -510,15 +514,17 @@ export function getDiff(
     const deltas: DiffResult["deltas"] = [];
 
     for (const delta of diff.deltas()) {
-      const path = delta.newFile().path();
+      // Deleted deltas have no newFile path; use oldFile path instead.
+      const status = delta.status();
+      const path = delta.newFile().path() ?? delta.oldFile().path();
       if (path === null) continue;
 
       deltas.push({
         path,
-        oldPath: delta.status() === "Renamed"
+        oldPath: status === "Renamed"
           ? (delta.oldFile().path() ?? undefined)
           : undefined,
-        status: delta.status(),
+        status,
       });
     }
 

--- a/examples/gitique/src/utils/git.ts
+++ b/examples/gitique/src/utils/git.ts
@@ -249,6 +249,8 @@ export interface DiffOptions {
   cached?: boolean;
   commit?: string;
   paths?: string[];
+  unified?: number;
+  algorithm?: "default" | "minimal" | "patience" | "histogram";
 }
 
 /**
@@ -278,6 +280,22 @@ export function getDiff(
   try {
     let diff;
 
+    // Build es-git diff options from our options
+    const esDiffOptions: {
+      contextLines?: number;
+      patience?: boolean;
+      minimal?: boolean;
+    } = {};
+    if (options.unified !== undefined) {
+      esDiffOptions.contextLines = options.unified;
+    }
+    if (options.algorithm === "patience") {
+      esDiffOptions.patience = true;
+    } else if (options.algorithm === "minimal") {
+      esDiffOptions.minimal = true;
+    }
+    // "histogram" and "default" use default es-git behaviour
+
     if (options.cached) {
       // Staged changes only: compare HEAD tree to index tree.
       // Using diffTreeToWorkdirWithIndex would blend in unstaged changes.
@@ -291,15 +309,15 @@ export function getDiff(
       const index = repo.index();
       const indexTreeOid = index.writeTree();
       const indexTree = repo.getTree(indexTreeOid);
-      diff = repo.diffTreeToTree(headTree, indexTree);
+      diff = repo.diffTreeToTree(headTree, indexTree, esDiffOptions);
     } else if (options.commit) {
       // Compare with specific commit
       const commitObj = repo.getCommit(options.commit);
       const commitTree = commitObj.tree();
-      diff = repo.diffTreeToWorkdirWithIndex(commitTree);
+      diff = repo.diffTreeToWorkdirWithIndex(commitTree, esDiffOptions);
     } else {
       // Unstaged changes: index vs workdir
-      diff = repo.diffIndexToWorkdir();
+      diff = repo.diffIndexToWorkdir(undefined, esDiffOptions);
     }
 
     const stats = diff.stats();

--- a/examples/gitique/src/utils/git.ts
+++ b/examples/gitique/src/utils/git.ts
@@ -392,12 +392,10 @@ export function getCommitHistory(
 ): CommitWithOid[] {
   const commits: CommitWithOid[] = [];
 
-  // Check whether HEAD resolves; unborn repositories have no commits at
-  // all, so return an empty list rather than letting pushHead() throw an
-  // opaque internal error that we would have to recognise by string.
-  try {
-    repo.head();
-  } catch {
+  // Unborn repositories have no commits; return early rather than letting
+  // pushHead() throw.  Use isEmpty() so that real errors (corrupt refs,
+  // permission problems) still propagate instead of being silently swallowed.
+  if (repo.isEmpty()) {
     return commits;
   }
 
@@ -460,14 +458,19 @@ export function unstageFile(repo: Repository, filePath: string): void {
 }
 
 /**
- * Resets the index to match HEAD (unstages all changes).
+ * Best-effort approximation of unstaging all changes.
  *
  * Note: es-git does not expose `git_index_read_tree`, so we cannot
- * restore index entries from an arbitrary commit tree.  As an
- * approximation, reload the on-disk index (which reflects the last
- * commit) and then synchronize tracked entries with the working
- * tree.  This correctly unstages modifications but may leave deleted
- * tracked files as staged removals until the next hard reset.
+ * repopulate the index from the HEAD tree as `git reset --mixed` would.
+ * Instead, this reloads the current on-disk index (the persisted staging
+ * area, which already includes any staged changes written by prior
+ * `index.write()` calls) and then refreshes tracked entries from the
+ * working tree.
+ *
+ * This drops only unsaved in-memory index mutations; it does not guarantee
+ * that the resulting index matches HEAD or that all previously staged
+ * changes are removed.  A correct implementation would require an upstream
+ * es-git binding for `git_index_read_tree`.
  */
 export function resetIndex(repo: Repository): void {
   try {

--- a/examples/gitique/src/utils/git.ts
+++ b/examples/gitique/src/utils/git.ts
@@ -77,9 +77,12 @@ export function addFile(
   }
 
   if (isDirectory) {
-    const pattern = filePath === "."
-      ? "*"
-      : toRepoRelativePath(repo, filePath) + "/**";
+    // Convert "." to the repo-relative path of the current directory so that
+    // `gitique add .` from a subdirectory stages only that subtree, not the
+    // whole repository.
+    const repoRelDir = toRepoRelativePath(repo, filePath);
+    // An empty string means the cwd is the repo root — use "*" to match all
+    const pattern = repoRelDir === "" ? "*" : repoRelDir + "/**";
     index.addAll([pattern], force ? { force: true } : undefined);
   } else if (force) {
     // addPath has no force option; route through addAll instead
@@ -188,21 +191,20 @@ export function resolveCommitOid(repo: Repository, spec: string): string {
 export function moveHead(repo: Repository, targetOid: string): void {
   const commit = repo.getCommit(targetOid);
 
-  try {
-    const head = repo.head();
-    const symbolicTarget = head.symbolicTarget();
-    if (symbolicTarget) {
-      // Attached HEAD — move the branch tip to the target commit
-      const branchName = symbolicTarget.replace(/^refs\/heads\//, "");
+  // repo.headDetached() returns true for detached HEAD and false when HEAD
+  // points to a branch.  repo.head() resolves the ref so symbolicTarget()
+  // is always null there — use headDetached() to distinguish the two cases.
+  if (!repo.headDetached()) {
+    try {
+      const head = repo.head();
+      const branchName = head.name().replace(/^refs\/heads\//, "");
       repo.createBranch(branchName, commit, { force: true });
-    } else {
-      // Detached HEAD
-      repo.setHeadDetached(commit);
+      return;
+    } catch {
+      // Fall through to detached-HEAD path (e.g., unborn branch)
     }
-  } catch {
-    // Unborn branch — set detached HEAD as fallback
-    repo.setHeadDetached(commit);
   }
+  repo.setHeadDetached(commit);
 }
 
 /**
@@ -240,30 +242,31 @@ export function getCommitHistory(
  */
 export function unstageFile(repo: Repository, filePath: string): void {
   const index = repo.index();
+  // All index operations require repo-root-relative paths
+  const repoRelativePath = toRepoRelativePath(repo, filePath);
 
   // Check whether the file exists in HEAD
   let inHead = false;
   try {
     const headTree = repo.head().peelToTree();
-    inHead = headTree.getPath(filePath) !== null;
+    inHead = headTree.getPath(repoRelativePath) !== null;
   } catch {
     // Unborn repository — nothing in HEAD
   }
 
   if (inHead) {
-    // Re-stage from the working tree (addPath refreshes from disk),
-    // then let the caller know the index was updated.  This is an
-    // approximation: it re-adds the current on-disk version instead
-    // of the HEAD blob, but it demonstrates the unstage pattern.
-    index.removeAll([filePath]);
+    // Re-stage from the working tree (addPath refreshes from disk).
+    // This is an approximation: it restores the on-disk version rather
+    // than the HEAD blob, demonstrating the unstage interaction pattern.
+    index.removeAll([repoRelativePath]);
     try {
-      index.addPath(filePath);
+      index.addPath(repoRelativePath);
     } catch {
-      // File may have been deleted in the working tree — leave removed
+      // File deleted in the working tree — leave it removed from index
     }
   } else {
     // File is new in the index (not tracked in HEAD) — just remove it
-    index.removeAll([filePath]);
+    index.removeAll([repoRelativePath]);
   }
   index.write();
 }
@@ -341,19 +344,15 @@ export function getStatus(repo: Repository): FileStatus[] {
     // includeUntracked: true ensures untracked files are shown,
     // which is required both in normal repos and in unborn repos
     // where no HEAD exists yet.
+    // A file that has both staged and unstaged changes is intentionally
+    // reported twice (once per state) so callers can show dual-state
+    // output like "MM" or "AM".
     const unstagedDiff = repo.diffIndexToWorkdir(undefined, {
       includeUntracked: true,
     });
     for (const delta of unstagedDiff.deltas()) {
       const path = delta.newFile().path();
       if (path === null) continue;
-
-      // Skip if already reported as staged (avoid duplicates for files
-      // that have both staged and unstaged changes)
-      const alreadyStaged = results.some(
-        (r) => r.path === path && r.staged,
-      );
-      if (alreadyStaged) continue;
 
       results.push({
         path,
@@ -449,13 +448,17 @@ export function getDiff(
       const indexTree = repo.getTree(indexTreeOid);
       diff = repo.diffTreeToTree(headTree, indexTree, esDiffOptions);
     } else if (options.commit && options.commit2) {
-      // Compare two specific commits
-      const tree1 = repo.getCommit(options.commit).tree();
-      const tree2 = repo.getCommit(options.commit2).tree();
+      // Compare two specific commits; resolve revspecs first so names like
+      // HEAD, HEAD~1, and branch names work (getCommit expects raw OIDs).
+      const oid1 = repo.revparseSingle(options.commit);
+      const oid2 = repo.revparseSingle(options.commit2);
+      const tree1 = repo.getCommit(oid1).tree();
+      const tree2 = repo.getCommit(oid2).tree();
       diff = repo.diffTreeToTree(tree1, tree2, esDiffOptions);
     } else if (options.commit) {
-      // Compare with specific commit
-      const commitObj = repo.getCommit(options.commit);
+      // Compare with specific commit; resolve revspec first
+      const oid = repo.revparseSingle(options.commit);
+      const commitObj = repo.getCommit(oid);
       const commitTree = commitObj.tree();
       diff = repo.diffTreeToWorkdirWithIndex(commitTree, esDiffOptions);
     } else {

--- a/examples/gitique/src/utils/git.ts
+++ b/examples/gitique/src/utils/git.ts
@@ -35,7 +35,9 @@ export async function getRepository(): Promise<Repository> {
 /**
  * Creates a signature for commits using Git configuration or provided values.
  * When name/email are not provided, reads user.name and user.email from
- * the repo-local config first, then from the default (global/XDG/system) config.
+ * the default (global/XDG/system) config.  If `repo` is provided, the
+ * repo-local config is consulted first and takes precedence over the
+ * default config.
  */
 export function createGitSignature(
   name?: string,

--- a/examples/gitique/src/utils/git.ts
+++ b/examples/gitique/src/utils/git.ts
@@ -83,6 +83,9 @@ export function addFile(
     const repoRelDir = toRepoRelativePath(repo, filePath);
     // An empty string means the cwd is the repo root — use "*" to match all
     const pattern = repoRelDir === "" ? "*" : repoRelDir + "/**";
+    // updateAll first to stage deletions of tracked files, then addAll for
+    // new and modified files.
+    index.updateAll([pattern]);
     index.addAll([pattern], force ? { force: true } : undefined);
   } else if (force) {
     // addPath has no force option; route through addAll instead
@@ -100,6 +103,9 @@ export function addFile(
  */
 export function addAllFiles(repo: Repository, force?: boolean): void {
   const index = repo.index();
+  // updateAll stages removals of tracked files (paths deleted from workdir)
+  index.updateAll(["*"]);
+  // addAll stages new and modified files; force bypasses gitignore
   index.addAll(["*"], force ? { force: true } : undefined);
   index.write();
 }
@@ -273,14 +279,22 @@ export function unstageFile(repo: Repository, filePath: string): void {
 
 /**
  * Resets the index to match HEAD (unstages all changes).
+ *
+ * Note: es-git does not expose `git_index_read_tree`, so we cannot
+ * restore index entries from an arbitrary commit tree.  As an
+ * approximation, reload the on-disk index (which reflects the last
+ * commit) and then synchronize tracked entries with the working
+ * tree.  This correctly unstages modifications but may leave deleted
+ * tracked files as staged removals until the next hard reset.
  */
 export function resetIndex(repo: Repository): void {
   try {
     const index = repo.index();
-
-    // Remove all files from index using removeAll with wildcard
-    // This effectively clears the index
-    index.removeAll(["*"]);
+    // Reload the index from disk to drop in-memory staged changes
+    index.read(true);
+    // Re-synchronize tracked entries with the working tree so that
+    // existing modifications in the workdir are reflected correctly
+    index.updateAll(["*"]);
     index.write();
   } catch (error) {
     throw new Error(
@@ -434,19 +448,24 @@ export function getDiff(
     }
 
     if (options.cached) {
-      // Staged changes only: compare HEAD tree to index tree.
-      // Using diffTreeToWorkdirWithIndex would blend in unstaged changes.
-      // When on an unborn branch (no HEAD yet) treat as empty old tree.
-      let headTree;
+      // Staged changes only: compare a base tree to the index tree.
+      // The base is options.commit when provided (e.g. diff --cached HEAD~1),
+      // otherwise HEAD.  Unborn repos fall back to an empty tree.
+      let baseTree;
       try {
-        headTree = repo.head().peelToTree();
+        if (options.commit) {
+          const baseOid = repo.revparseSingle(options.commit);
+          baseTree = repo.getCommit(baseOid).tree();
+        } else {
+          baseTree = repo.head().peelToTree();
+        }
       } catch {
         // No HEAD yet (unborn repository) — diff against empty tree
       }
       const index = repo.index();
       const indexTreeOid = index.writeTree();
       const indexTree = repo.getTree(indexTreeOid);
-      diff = repo.diffTreeToTree(headTree, indexTree, esDiffOptions);
+      diff = repo.diffTreeToTree(baseTree, indexTree, esDiffOptions);
     } else if (options.commit && options.commit2) {
       // Compare two specific commits; resolve revspecs first so names like
       // HEAD, HEAD~1, and branch names work (getCommit expects raw OIDs).

--- a/examples/gitique/src/utils/git.ts
+++ b/examples/gitique/src/utils/git.ts
@@ -165,8 +165,11 @@ export function addFile(
     index.updateAll([pattern]);
     index.addAll([pattern], force ? { force: true } : undefined);
   } else if (force) {
-    // addPath has no force option; route through addAll instead
+    // addPath has no force option; route through addAll instead.
+    // Also call updateAll first so that a tracked file that was deleted
+    // from the worktree has its deletion staged even under --force.
     const repoRelativePath = toRepoRelativePath(repo, filePath);
+    index.updateAll([repoRelativePath]);
     index.addAll([repoRelativePath], { force: true });
   } else {
     const repoRelativePath = toRepoRelativePath(repo, filePath);

--- a/examples/gitique/src/utils/git.ts
+++ b/examples/gitique/src/utils/git.ts
@@ -227,12 +227,17 @@ export function isIndexEmpty(repo: Repository): boolean {
 }
 
 /**
- * Resolves a commit-ish spec (e.g. "HEAD", "HEAD~1", an OID) to a full OID.
+ * Resolves a commit-ish spec (e.g. "HEAD", "HEAD~1", an OID, a tag name) to
+ * the OID of the underlying commit.  Peels through annotated tags so that
+ * tag references can be used wherever commit OIDs are expected.
  *
- * @throws If the spec cannot be resolved.
+ * @throws If the spec cannot be resolved or does not point to a commit.
  */
 export function resolveCommitOid(repo: Repository, spec: string): string {
-  return repo.revparseSingle(spec);
+  const oid = repo.revparseSingle(spec);
+  const obj = repo.findObject(oid);
+  if (!obj) throw new Error(`Failed to find object for '${spec}'`);
+  return obj.peelToCommit().id();
 }
 
 /**
@@ -241,7 +246,9 @@ export function resolveCommitOid(repo: Repository, spec: string): string {
  * createBranch; otherwise (detached HEAD) setHeadDetached is used.
  */
 export function moveHead(repo: Repository, targetOid: string): void {
-  const commit = repo.getCommit(targetOid);
+  const obj = repo.findObject(targetOid);
+  if (!obj) throw new Error(`Failed to find object: ${targetOid}`);
+  const commit = obj.peelToCommit();
 
   // repo.headDetached() returns true for detached HEAD and false when HEAD
   // points to a branch.  repo.head() resolves the ref so symbolicTarget()
@@ -358,7 +365,15 @@ export function resetIndex(repo: Repository): void {
  */
 export interface FileStatus {
   path: string;
-  status: "Added" | "Deleted" | "Modified" | "Renamed" | "Copied" | "Untracked";
+  status:
+    | "Added"
+    | "Deleted"
+    | "Modified"
+    | "Renamed"
+    | "Copied"
+    | "Untracked"
+    | "Typechange"
+    | "Conflicted";
   oldPath?: string;
   staged: boolean;
 }
@@ -514,9 +529,12 @@ export function getDiff(
       // otherwise HEAD.  Unborn repos fall back to an empty tree.
       let baseTree;
       if (options.commit) {
-        // Explicit commit argument — let revspec errors propagate to the caller
+        // Explicit commit argument — let revspec errors propagate to the caller.
+        // Peel through annotated tags to get the actual commit tree.
         const baseOid = repo.revparseSingle(options.commit);
-        baseTree = repo.getCommit(baseOid).tree();
+        const baseObj = repo.findObject(baseOid);
+        if (!baseObj) throw new Error(`Object not found: ${baseOid}`);
+        baseTree = baseObj.peelToCommit().tree();
       } else {
         try {
           baseTree = repo.head().peelToTree();
@@ -529,18 +547,23 @@ export function getDiff(
       const indexTree = repo.getTree(indexTreeOid);
       diff = repo.diffTreeToTree(baseTree, indexTree, esDiffOptions);
     } else if (options.commit && options.commit2) {
-      // Compare two specific commits; resolve revspecs first so names like
-      // HEAD, HEAD~1, and branch names work (getCommit expects raw OIDs).
+      // Compare two specific commits; peel through annotated tags so that
+      // tag refs like 'v1.0' work alongside branch names and OIDs.
       const oid1 = repo.revparseSingle(options.commit);
       const oid2 = repo.revparseSingle(options.commit2);
-      const tree1 = repo.getCommit(oid1).tree();
-      const tree2 = repo.getCommit(oid2).tree();
+      const obj1 = repo.findObject(oid1);
+      const obj2 = repo.findObject(oid2);
+      if (!obj1) throw new Error(`Object not found: ${oid1}`);
+      if (!obj2) throw new Error(`Object not found: ${oid2}`);
+      const tree1 = obj1.peelToCommit().tree();
+      const tree2 = obj2.peelToCommit().tree();
       diff = repo.diffTreeToTree(tree1, tree2, esDiffOptions);
     } else if (options.commit) {
-      // Compare with specific commit; resolve revspec first
+      // Compare with specific commit; peel through annotated tags.
       const oid = repo.revparseSingle(options.commit);
-      const commitObj = repo.getCommit(oid);
-      const commitTree = commitObj.tree();
+      const obj = repo.findObject(oid);
+      if (!obj) throw new Error(`Object not found: ${oid}`);
+      const commitTree = obj.peelToCommit().tree();
       diff = repo.diffTreeToWorkdirWithIndex(commitTree, esDiffOptions);
     } else {
       // Unstaged changes: index vs workdir

--- a/examples/gitique/src/utils/git.ts
+++ b/examples/gitique/src/utils/git.ts
@@ -480,15 +480,16 @@ export function getDiff(
       // The base is options.commit when provided (e.g. diff --cached HEAD~1),
       // otherwise HEAD.  Unborn repos fall back to an empty tree.
       let baseTree;
-      try {
-        if (options.commit) {
-          const baseOid = repo.revparseSingle(options.commit);
-          baseTree = repo.getCommit(baseOid).tree();
-        } else {
+      if (options.commit) {
+        // Explicit commit argument — let revspec errors propagate to the caller
+        const baseOid = repo.revparseSingle(options.commit);
+        baseTree = repo.getCommit(baseOid).tree();
+      } else {
+        try {
           baseTree = repo.head().peelToTree();
+        } catch {
+          // No HEAD yet (unborn repository) — diff against empty tree
         }
-      } catch {
-        // No HEAD yet (unborn repository) — diff against empty tree
       }
       const index = repo.index();
       const indexTreeOid = index.writeTree();

--- a/examples/gitique/src/utils/git.ts
+++ b/examples/gitique/src/utils/git.ts
@@ -279,10 +279,13 @@ export function getDiff(
     let diff;
 
     if (options.cached) {
-      // Staged changes: compare HEAD tree to workdir with index
-      // This shows what would be committed
+      // Staged changes only: compare HEAD tree to index tree.
+      // Using diffTreeToWorkdirWithIndex would blend in unstaged changes.
       const headTree = repo.head().peelToTree();
-      diff = repo.diffTreeToWorkdirWithIndex(headTree);
+      const index = repo.index();
+      const indexTreeOid = index.writeTree();
+      const indexTree = repo.getTree(indexTreeOid);
+      diff = repo.diffTreeToTree(headTree, indexTree);
     } else if (options.commit) {
       // Compare with specific commit
       const commitObj = repo.getCommit(options.commit);

--- a/examples/gitique/src/utils/git.ts
+++ b/examples/gitique/src/utils/git.ts
@@ -172,6 +172,40 @@ export function isIndexEmpty(repo: Repository): boolean {
 }
 
 /**
+ * Resolves a commit-ish spec (e.g. "HEAD", "HEAD~1", an OID) to a full OID.
+ *
+ * @throws If the spec cannot be resolved.
+ */
+export function resolveCommitOid(repo: Repository, spec: string): string {
+  return repo.revparseSingle(spec);
+}
+
+/**
+ * Moves HEAD (and the current branch pointer) to the given commit OID.
+ * When HEAD is a symbolic reference the branch pointer is updated via
+ * createBranch; otherwise (detached HEAD) setHeadDetached is used.
+ */
+export function moveHead(repo: Repository, targetOid: string): void {
+  const commit = repo.getCommit(targetOid);
+
+  try {
+    const head = repo.head();
+    const symbolicTarget = head.symbolicTarget();
+    if (symbolicTarget) {
+      // Attached HEAD — move the branch tip to the target commit
+      const branchName = symbolicTarget.replace(/^refs\/heads\//, "");
+      repo.createBranch(branchName, commit, { force: true });
+    } else {
+      // Detached HEAD
+      repo.setHeadDetached(commit);
+    }
+  } catch {
+    // Unborn branch — set detached HEAD as fallback
+    repo.setHeadDetached(commit);
+  }
+}
+
+/**
  * Gets the commit history starting from HEAD.
  */
 export function getCommitHistory(

--- a/examples/gitique/src/utils/git.ts
+++ b/examples/gitique/src/utils/git.ts
@@ -1,6 +1,7 @@
 import {
   type Commit,
   createSignature,
+  openConfig,
   openDefaultConfig,
   openRepository,
   type Repository,
@@ -33,34 +34,68 @@ export async function getRepository(): Promise<Repository> {
 
 /**
  * Creates a signature for commits using Git configuration or provided values.
- * Reads user.name and user.email from the default git config when not provided.
+ * When name/email are not provided, reads user.name and user.email from
+ * the repo-local config first, then from the default (global/XDG/system) config.
  */
 export function createGitSignature(
   name?: string,
   email?: string,
+  repo?: Repository,
 ): Signature {
   let authorName = name;
   let authorEmail = email;
 
   if (!authorName || !authorEmail) {
-    try {
-      const config = openDefaultConfig();
-      if (!authorName) {
+    // Try local repo config first, then the default cascade.
+    const configSources: Array<() => void> = [];
+    if (repo) {
+      configSources.push(() => {
         try {
-          authorName = config.getString("user.name");
+          const localConfig = openConfig(repo.path() + "config");
+          if (!authorName) {
+            try {
+              authorName = localConfig.getString("user.name");
+            } catch {
+              // Key not set in local config
+            }
+          }
+          if (!authorEmail) {
+            try {
+              authorEmail = localConfig.getString("user.email");
+            } catch {
+              // Key not set in local config
+            }
+          }
         } catch {
-          // Key not set in any config file
+          // Local config file unavailable
         }
-      }
-      if (!authorEmail) {
-        try {
-          authorEmail = config.getString("user.email");
-        } catch {
-          // Key not set in any config file
+      });
+    }
+    configSources.push(() => {
+      try {
+        const defaultConfig = openDefaultConfig();
+        if (!authorName) {
+          try {
+            authorName = defaultConfig.getString("user.name");
+          } catch {
+            // Key not set in global config
+          }
         }
+        if (!authorEmail) {
+          try {
+            authorEmail = defaultConfig.getString("user.email");
+          } catch {
+            // Key not set in global config
+          }
+        }
+      } catch {
+        // Default config unavailable
       }
-    } catch {
-      // Config files unavailable — fall through to defaults
+    });
+
+    for (const tryConfig of configSources) {
+      tryConfig();
+      if (authorName && authorEmail) break;
     }
   }
 

--- a/examples/gitique/src/utils/git.ts
+++ b/examples/gitique/src/utils/git.ts
@@ -327,8 +327,13 @@ export function resolveCommitOid(repo: Repository, spec: string): string {
 
 /**
  * Moves HEAD (and the current branch pointer) to the given commit OID.
- * When HEAD is a symbolic reference the branch pointer is updated via
- * createBranch; otherwise (detached HEAD) setHeadDetached is used.
+ * When HEAD is a symbolic reference the branch pointer is updated;
+ * otherwise (detached HEAD) setHeadDetached is used.
+ *
+ * libgit2 (and thus es-git) rejects createBranch(..., { force: true })
+ * when the branch is currently checked out.  The workaround is to
+ * temporarily detach HEAD so that the branch reference is no longer
+ * "in use", update the branch, then re-attach HEAD.
  */
 export function moveHead(repo: Repository, targetOid: string): void {
   const obj = repo.findObject(targetOid);
@@ -358,7 +363,11 @@ export function moveHead(repo: Repository, targetOid: string): void {
       }
     }
     if (branchName) {
+      // Detach HEAD first to lift the "branch is checked out" restriction,
+      // then update the branch reference, then re-attach HEAD.
+      repo.setHeadDetached(commit);
       repo.createBranch(branchName, commit, { force: true });
+      repo.setHead(`refs/heads/${branchName}`);
       return;
     }
   }

--- a/examples/gitique/src/utils/git.ts
+++ b/examples/gitique/src/utils/git.ts
@@ -58,12 +58,15 @@ function toRepoRelativePath(repo: Repository, filePath: string): string {
 export function addFile(
   repo: Repository,
   filePath: string,
+  force?: boolean,
 ): void {
   const index = repo.index();
   const absolutePath = resolve(process.cwd(), filePath);
 
   // When the path is "." or an existing directory, use addAll with a
   // glob pattern so libgit2 can enumerate the contents recursively.
+  // For individual files with --force, also use addAll because addPath
+  // has no force option.
   let isDirectory = filePath === ".";
   if (!isDirectory) {
     try {
@@ -77,7 +80,11 @@ export function addFile(
     const pattern = filePath === "."
       ? "*"
       : toRepoRelativePath(repo, filePath) + "/**";
-    index.addAll([pattern]);
+    index.addAll([pattern], force ? { force: true } : undefined);
+  } else if (force) {
+    // addPath has no force option; route through addAll instead
+    const repoRelativePath = toRepoRelativePath(repo, filePath);
+    index.addAll([repoRelativePath], { force: true });
   } else {
     const repoRelativePath = toRepoRelativePath(repo, filePath);
     index.addPath(repoRelativePath);
@@ -88,9 +95,9 @@ export function addFile(
 /**
  * Adds all files to the Git index (equivalent to `git add .`).
  */
-export function addAllFiles(repo: Repository): void {
+export function addAllFiles(repo: Repository, force?: boolean): void {
   const index = repo.index();
-  index.addAll(["*"]);
+  index.addAll(["*"], force ? { force: true } : undefined);
   index.write();
 }
 


### PR DESCRIPTION
This PR fixes all 23 issues labeled `bug` against the *examples/gitique* directory, plus additional correctness issues found during iterative code review.

**Documentation fixes.** The README walkthrough had incorrect import paths — `command`, `constant`, and `option` belonged in *@optique/core/primitives*, `object` in *@optique/core/constructs*, and `string` in *@optique/core/valueparser*, while `multiple`, `argument`, and `optional` were not imported at all. The log example comment claimed to "show all commits" when the command defaults to the last 10. A shell completion example incorrectly suggested `--author` provides suggestions. The `parseDate()` JSDoc claimed support for relative phrases like "2 days ago", which it never had. The *reset* command description mentioned `--mixed` as an explicit flag when no such flag exists — mixed is the default mode.

**Parser correctness.** The `log`, `status`, and `reset` commands used `withDefault()` for the `--format`/`--mode` option, which meant shorthand flags (`--oneline`, `--short`, `--porcelain`, `--soft`, `--hard`) silently won regardless of flag order. Each has been changed to `optional()` with explicit conflict detection: passing `--oneline` together with `--format`, `--short` together with `--porcelain`, or `--soft` together with `--mode` now throws a clear error. The `diff` command likewise validates that at most one of `--stat`, `--numstat`, `--name-only`, and `--name-status` is active at a time. The `commit` command's `-m`/`--message` option is now required at the parser level, eliminating the stub `getCommitMessage()` that threw anyway.

**Status output.** `getStatus()` previously always set `staged: false` on every entry. It now runs two diffs — HEAD-tree-to-index for staged changes and index-to-workdir for unstaged — and marks each entry accordingly. Rename and copy detection (`findSimilar()`) runs on both diffs. Deleted deltas (whose `newFile().path()` is null) now correctly fall back to `oldFile().path()`. The `Typechange` and `Conflicted` status types are recognised throughout. Long-format output now separates untracked files into their own "Untracked files:" section with the correct hint text, and always shows the branch header line without requiring `-b`. Short-format and porcelain `-b` output use `## <branch>` as git does. Unborn branches are identified by reading *.git/HEAD* directly when `repo.head()` cannot resolve, and are reported with "No commits yet" prefixes rather than being silently treated as ordinary branches.

**Diff output.** `getDiff()` with `--cached` was calling `diffTreeToWorkdirWithIndex` which blends staged and unstaged changes; it now writes the index to a tree and calls `diffTreeToTree(headTree, indexTree)` so only staged changes are shown. Passing two commit arguments now uses `diffTreeToTree(tree1, tree2)` rather than ignoring the second commit. The `--unified` and `--diff-algorithm` options are wired through to es-git's `contextLines`, `patience`, and `minimal` diff options. `histogram` was removed from the algorithm choices because es-git does not expose it. The `--numstat` output now parses actual per-file insertion/deletion counts from unified diff text using a state machine that correctly ignores content lines inside hunks, and shows `oldPath => path` for renamed and copied files. `oldPath` is now preserved for `Copied` deltas as well as `Renamed`.

**`git add` semantics.** `addFile()` previously failed when given `"."` or a directory path. It now detects directory paths using `lstatSync()` (not `statSync()`, so symlinks to directories are staged as symlinks) and routes them through `updateAll` + `addAll` with the appropriate glob pattern. The `--force` flag is passed to `addAll` when set. Staged-but-not-yet-committed files that were subsequently deleted from disk can now be re-staged (the deletion is staged) because the path check consults the index in addition to HEAD and the filesystem. Completely unknown paths still produce an error. `addAllFiles()` now calls `updateAll` before `addAll` so deletions of tracked files are staged when `gitique add -A` is used.

**`git commit` semantics.** The `--allow-empty` guard now compares the index tree to the HEAD tree (or checks `indexTree.isEmpty()` on an unborn branch) before deciding whether the commit would be empty. The `-a`/`--all` flag uses `stageTrackedFiles()` which calls `index.updateAll()` rather than `index.addAll()`, matching git's behaviour of staging only tracked modified/deleted files without pulling in untracked content. The commit output shows the real branch name (read from *.git/HEAD* when `repo.head()` cannot yet resolve) and uses the commit's actual author timestamp rather than `new Date()`. Blank or whitespace-only commit messages are rejected. The `--author` option now rejects empty name or email after regex matching, preventing mixed explicit/config-derived identity. `createGitSignature()` throws a descriptive error when `user.name` or `user.email` cannot be resolved from any config source, instead of silently creating commits as "Gitique User".

**`git reset` semantics.** `resetToCommit()` now actually moves the HEAD/branch pointer by resolving the target spec through `revparseSingle` and `peelToCommit`, then calling `createBranch` (or `setHeadDetached` for detached HEAD). The branch name is read from *.git/HEAD* directly when `repo.head()` throws on an unborn branch so that resetting on a not-yet-born branch creates the branch ref rather than detaching HEAD. The `--file` option now calls `unstageFile()` which removes the path from the index and, if the file was tracked in HEAD or the working tree, re-reads it from disk. Unknown paths that are absent from both HEAD and the index produce an error rather than a silent no-op. The positional path argument that conflicted with the commit argument was replaced by a named `-f`/`--file` option.

**`git log` output.** The revwalk is now sorted by `RevwalkSort.Time` so commits appear newest-first. Filtering is applied to the full history before the `--max-count` slice, so limiting and filtering work correctly together. All commit formatters now use `author.timestamp` (the author date) rather than `commit.time()` (the committer time), and render full ISO-8601 strings instead of `toDateString()` so time-of-day information is not lost. `parseDate()` treats bare `YYYY-MM-DD` strings as local-time midnight and validates that the resulting date matches the input, so impossible values like `2024-02-31` are rejected. The `getCommitHistory()` catch block now only suppresses unborn/HEAD-not-found errors and rethrows unexpected revwalk errors.

**Help text.** All command footers replaced bare template literal newlines between examples with `lineBreak()` calls, which Optique renders as proper line breaks rather than soft-wrapping them.

All changes pass `deno task check` (type checking, linting, format check, and publish dry-run).