### PR TITLE
Add property-based tests for core Optique packages

### DIFF
--- a/.agents/skills/javascript-testing-expert/SKILL.md
+++ b/.agents/skills/javascript-testing-expert/SKILL.md
@@ -1,0 +1,402 @@
+---
+name: javascript-testing-expert
+description: Expert-level JavaScript testing skill focused on writing high-quality tests that find bugs, serve as documentation, and prevent regressions. Advocates for property-based testing with fast-check and protects against indeterministic code in tests. Does not cover black-box e2e testing.
+---
+
+> **⚠️ Scope:** Testing functions and components, not black-box e2e.
+
+**🏅 Main objectives:** use tests as a way to...
+
+1. uncover hard to detect bugs
+2. document how to use the code
+3. avoid regressions
+4. challenge the code
+
+**🔧 Recommended tooling:** `vitest`, `fast-check`, `@fast-check/vitest`, `@testing-library/*`, `@vitest/browser-playwright`, `msw` installed as devDependencies.  
+**✅ Do** try to install missing and relevant tooling, only recommend for `@fast-check/vitest` and browser testing.  
+**✅ Do** highly recommend user to install missing and relevant tooling.  
+**✅ Do** adapt yourself to missing tools.
+
+## File and code layout
+
+**✅ Do** mimic the existing test structure of the project when adding new tests
+
+**✅ Do** use one test file per code file
+
+**👍 Prefer** using `.spec.ts` extension (e.g., `fileName.ts` → `fileName.spec.ts`) and colocated with the source file if no existing test structure is present
+
+**✅ Do** put `it` within `describe`, when using `it`
+
+**👍 Prefer** `it` over `test`
+
+**✅ Do** name the `describe` with the name of the function being tested
+
+**✅ Do** use a dedicated `describe` for each function being tested
+
+**✅ Do** start naming `it` with "should" and considers that the name should be clear, as consise as possible and could be read as a sentence implicitly prefixed by "it"
+
+**✅ Do** start with simple and documenting tests
+
+**✅ Do** continue with advanced tests looking for edge-cases
+
+**❌ Don't** delimitate explicitely simple from advanced tests, just but them in the right order
+
+**✅ Do** put helper functions specific to the file after all the `describe`s just below a comment `// Helpers` stating the beginning of the helpers tailored for this file
+
+## Core guidelines
+
+**✅ Do** follow the AAA pattern and make it visible in the test
+
+```ts
+it('should...', () => {
+  // Arrange
+  code;
+
+  // Act
+  code;
+
+  // Assert
+  code;
+});
+```
+
+**✅ Do** keep tests focused, try to assert on one precise aspect
+
+**✅ Do** keep tests simple
+
+**👎 Avoid** complex logic in tests or its helpers
+
+**❌ Don't** test internal details
+
+**👍 Prefer** stubs over mocks, the first one provides an alternate implementation, the second one helps to assert on calls being done or not  
+Why? Often, asserting the number of calls is not something critical for the user of the function but purely an internal detail
+
+**❌ Don't** rely on network call, stub it with `msw`
+
+**✅ Do** reset globals and mocks in `beforeEach` if any `it` plays with mocks or spies or alter globals  
+Alternatively, when using vitest you could check if flags `mockReset`, `unstubEnvs` and `unstubGlobals` have been enabled in the configuration, in such case resetting globals is done by default
+
+**👍 Prefer** realistic data for documentation-like tests  
+Eg.: use real names if you have to build instances of users
+
+**❌ Don't** overuse snapshot tests; only snapshot things when the "what is expected to be seen in the snapshot" is clear  
+Why? Snapshots tests tend to capture too many details in the snapshot, making them hard to update given future reader is lost on what was the real thing being tested
+
+**👍 Prefer** snapshots when shape and structure are important (component hierarchy, attributes, non-regression on output structure)
+
+**👍 Prefer** screenshots when final render is important (visual styling, layout)
+
+**✅ Do** warn developer when the code under tests requires too many parameters and/or too many mocks/stubs to be forged (more than 10)  
+Why? Code being hardly testable is often a code smell pinpointing an API having to be changed. Code is harder to evolve, harder to reason about and often handling too many responsibilities. Recommend the single-responsibility principle (SRP)
+
+**✅ Do** try to make tests shorter and faster to read by factorizing recurrent logics into helper functions
+
+**✅ Do** group shared logics under a function having a clear and explicit name, follow SRP for these helpers  
+Eg.: avoid functions with lots of optional parameters, doing several things
+
+**❌ Don't** write a big `prepare` function re-used by all tests in their act part, but make the name clearer and eventually split it into multiple functions
+
+**✅ Do** make sure your test breaks if you drop the thing supposed to make it pass  
+Eg.: When your test says "should do X when Y" makes sure that if you don't have Y it fails before keeping it.
+
+**👎 Avoid** writing tests with entities specifying hardcoded values on unused fields
+
+Example of test content
+
+```ts
+const user: User = {
+  name: 'Paul', // unused
+  birthday: '2010-02-03',
+};
+const age = computeAge(user);
+//...
+```
+
+**👍 Prefer** leveraging `@fast-check/vitest`, if installed
+
+```ts
+import { describe } from 'vitest';
+import { it, fc } from '@fast-check/vitest';
+
+describe('computeAge', () => {
+  it('should compute a positive age', ({ g }) => {
+    // Arrange
+    const user: User = {
+      name: g(fc.string), // unused
+      birthday: '2010-02-03',
+    };
+
+    // Act
+    const age = computeAge(user);
+
+    // Assert
+    expect(age).toBeGreaterThan(0);
+  });
+});
+```
+
+**👍 Prefer** leveraging `fast-check`, if installed but not `@fast-check/vitest`
+
+**👎 Avoid** writing tests depending on unstable values  
+Eg.: in the example above `computeAge` depends on the current date  
+Remark: same for locales and plenty other platform dependent values
+
+**👍 Prefer** stubbing today using `vi.setSystemTime`
+
+**👍 Prefer** controlling today using `@fast-check/vitest`  
+Why? Contrary to `vi.setSystemTime` alone you check the code against one new today at each run, but if it happens to fail one day you will be reported with the exact date causing the problem
+
+```ts
+// Arrange
+vi.setSystemTime(g(fc.date, { min: new Date('2010-02-04'), noInvalidDate: true }));
+const user: User = {
+  name: g(fc.string), // unused
+  birthday: '2010-02-03',
+};
+```
+
+**👎 Avoid** writing tests depending on random values or entities
+
+**👍 Prefer** controlling randomly generated values by relying on `@fast-check/vitest` if installed, or `fast-check` otherwise
+
+**✅ Do** use property based tests for any test with a notion of always or never  
+Eg.: name being "should always do x when y" or "should never do x when y"  
+Remark: consider these tests as advanced and put them after the documentation tests and not with them
+
+**👍 Prefer** using property based testing for edge case detection instead of writing all cases one by one
+
+**❌ Don't** try to test 100% of the algorithm cases using property-based testing
+Why? Property-based testing and example-based testing are complementary. Property-based tests are excellent for uncovering edge cases and validating general properties, while example-based tests provide clear documentation and cover specific important scenarios. Use both approaches together for comprehensive test coverage.
+
+```ts
+// for all a, b, c strings
+// b is a substring of a + b + c
+it.prop([fc.string(), fc.string(), fc.string()])('should detect the substring', (a, b, c) => {
+  // Arrange
+  const text = a + b + c;
+  const pattern = b;
+
+  // Act
+  const result = isSubstring(text, pattern);
+
+  // Assert
+  expect(result).toBe(true);
+});
+```
+
+**✅ Do** extract complex logic from components into dedicated and testable functions
+
+**❌ Don't** test trivial component logic that has zero complexity
+
+**👍 Prefer** testing the DOM structure and user interactions when using testing-library
+
+**👍 Prefer** testing the visual display and user interactions when using browser testing
+
+**👍 Prefer** querying by accessible attributes and user-visible text by relying on `getByRole`, `getByLabelText`, `getByText` over `getByTestId` whenever possible for testing-library and browser testing
+
+**✅ Do** ensure non visual regression of Design System components and more generally visual components by leveraging screenshot tests in browser when available  
+**✅ Do** fallback to snapshot tests capturing the DOM structure if screenshot tests cannot be ran
+
+## Guidelines for properties
+
+All this section considers that we are in the context of property based tests!
+
+**⚠️ Important:** When using `g` from `@fast-check/vitest`, pass the arbitrary **function** (e.g., `fc.string`, `fc.date`) along with its arguments as separate parameters to `g`, not the result of calling it.  
+Correct: `g(fc.string)`, `g(fc.date, { min: new Date('2010-01-01') })`  
+Incorrect: `g(fc.string())`, `g(fc.date({ min: new Date('2010-01-01') }))`
+
+**❌ Don't** generate inputs directly  
+The risk being that you may end up rewriting the code being tested in the test
+
+**✅ Do** construct values to build some inputs where you know the expected outcome
+
+**❌ Don't** expect the returned value in details, in many cases you won't have enough details to be able to assert the full value
+
+**✅ Do** expect some aspects and characteristics of the returned value
+
+**❌ NEVER** specify any `maxLength` on an arbitrary if it is a not a requirement of the algorithm  
+**👍 Prefer** specifying a `size: '-1'` if you feel that the algorithm will take very long on large inputs (by default fast-check generates up to 10 items, so only use `size` when clearly required)  
+Eg.: No `fc.string({maxLength: 5})` or `fc.array(arb, {maxLength: 8})` except being a string requirement
+
+**❌ NEVER** specify any constraint on an arbitrary if it is not a requirement of the arbitrary, use defaults as much as possible  
+Eg.: if the algorithm should accept any integer just ask an integer without specifying any min and max
+
+**👎 Avoid** overusing `.filter` and `fc.pre`  
+Why? They slow down the generation of values by dropping some generated ones
+
+**👍 Prefer** using options provided by arbitraries to directly generate valid values  
+Eg.: use `fc.string({ minLength: 2 })` instead of `fc.string().filter(s => s.length >= 2)`  
+Eg.: use `fc.integer({ min: 1 })` instead of `fc.integer().filter(n => n >= 1)`, or use `fc.nat()` instead of `fc.integer().filter(n => n >= 0)`
+
+**👍 Prefer** using `map` over `filter` when a `map` trick can avoid filtering  
+Eg.: use `fc.nat().map(n => n * 2)` for even numbers  
+Eg.: use `fc.tuple(fc.string(), fc.string()).map(([start, end]) => start + 'A' + end)` for strings always having an 'A' character
+
+**👍 Prefer** bigint type over number type for integer computations used within predicates when there is a risk of overflow (eg.: when running pow, multiply.. on generated values)
+
+Some classical properties:
+
+1. Characteristics independent of the inputs. _Eg.: for any floating point number d, Math.floor(d) is an integer. for any integer n, Math.abs(n) ≥ 0_
+2. Characteristics derived from the inputs. _Eg.: for any a and b integers, the average of a and b is between a and b. for any n, the product of all numbers in the prime factor decomposition of n equals n. for any array of data, sorted(data) and data contains the same elements. for any n1, n2 integers such that n1 != n2, romanString(n1) != romanString(n2). for any floating point number d, Math.floor(d) is an integer such as d-1 ≤ Math.floor(d) ≤ d_
+3. Restricted set of inputs with useful characteristics. _Eg.: for any array data with no duplicates, the result of removing duplicates from data is data itself. for any a, b and c strings, the concatenation of a, b and c always contains b. for any prime number p, its decomposition into prime factors is itself_
+4. Characteristics on combination of functions. _Eg.: zipping then unzipping a file should result in the original file. lcm(a,b) times gcd(a,b) must be equal to a times b_
+5. Comparison with a simpler implementation. _Eg.: c is contained inside sorted array data for binary search is equivalent to c is contained inside data for linear search_
+
+## Guidelines for race conditions
+
+**✅ Do** write tests checking for race conditions and playing with resolution order — _automatically handled by `fast-check`_ — when an algorithm accepts asynchronous functions as input
+
+**✅ Do** leverage `fast-check` and its `fc.scheduler()` arbitrary to test asynchronous code depending on asynchronous functions
+
+Turn:
+
+```ts
+it('should resolve in call order', async () => {
+  // Arrange
+  const seenAnswers = [];
+  const call = vi.fn().mockImplementation((v) => Promise.resolve(v));
+
+  // Act
+  const queued = queue(call);
+  await Promise.all([queued(1).then((v) => seenAnswers.push(v)), queued(2).then((v) => seenAnswers.push(v))]);
+
+  // Assert
+  expect(seenAnswers).toEqual([1, 2]);
+});
+```
+
+Into:
+
+```ts
+it('should resolve in call order', async () => {
+  await fc.assert(
+    fc.asyncProperty(fc.scheduler(), async (s) => {
+      // Arrange
+      const seenAnswers = [];
+      const call = vi.fn().mockImplementation((v) => Promise.resolve(v));
+
+      // Act
+      const queued = queue(s.scheduleFunction(call));
+      await s.waitFor(
+        Promise.all([queued(1).then((v) => seenAnswers.push(v)), queued(2).then((v) => seenAnswers.push(v))]),
+      );
+
+      // Assert
+      expect(seenAnswers).toEqual([1, 2]);
+    }),
+  );
+});
+```
+
+## Recommendation for faker users
+
+If using `faker` to fake data, we recommend wiring any fake data generation within `fast-check` by leveraging this code snippet:
+
+```ts
+// Source: https://fast-check.dev/blog/2024/07/18/integrating-faker-with-fast-check/
+import { Faker, Randomizer, base } from '@faker-js/faker';
+import fc from 'fast-check';
+
+class FakerBuilder<TValue> extends fc.Arbitrary<TValue> {
+  constructor(private readonly generator: (faker: Faker) => TValue) {
+    super();
+  }
+  generate(mrng: fc.Random, biasFactor: number | undefined): fc.Value<TValue> {
+    const randomizer: Randomizer = {
+      next: (): number => mrng.nextDouble(),
+      seed: () => {}, // no-op, no support for updates of the seed, could even throw
+    };
+    const customFaker = new Faker({ locale: base, randomizer });
+    return new fc.Value(this.generator(customFaker), undefined);
+  }
+  canShrinkWithoutContext(value: unknown): value is TValue {
+    return false;
+  }
+  shrink(value: TValue, context: unknown): fc.Stream<fc.Value<TValue>> {
+    return fc.Stream.nil();
+  }
+}
+
+function fakerToArb<TValue>(generator: (faker: Faker) => TValue): fc.Arbitrary<TValue> {
+  return new FakerBuilder(generator);
+}
+```
+
+Example of usage
+
+```ts
+fc.assert(
+  fc.property(
+    fakerToArb((faker) => faker.person.firstName),
+    fakerToArb((faker) => faker.person.lastName),
+    (firstName, lastName) => {
+      // code
+    },
+  ),
+);
+```
+
+## Equivalence `fast-check` and `@fast-check/vitest`
+
+Example 1.
+
+```ts
+// with @fast-check/vitest
+import { it, fc } from '@fast-check/vitest';
+it('...', ({ g }) => {
+  //...
+});
+
+// with fast-check
+import { it } from 'vitest';
+import fc from 'fast-check';
+it('...', () => {
+  fc.assert(
+    fc.property(fc.gen(), (g) => {
+      //...
+    }),
+  );
+});
+```
+
+Example 2.
+
+```ts
+// with @fast-check/vitest
+import { it, fc } from '@fast-check/vitest';
+it.prop([...arbitraries])('...', (...values) => {
+  //...
+});
+
+// with fast-check
+import { it } from 'vitest';
+import fc from 'fast-check';
+it('...', () => {
+  fc.assert(
+    fc.property(...arbitraries, (...values) => {
+      //...
+    }),
+  );
+});
+```
+
+Example 3. If the predicate of `it` or `it.prop` is asynchronous, when using only `fast-check` the property has to be instantiated via `asyncProperty` and `assert` has to be awaited.
+
+```ts
+// with @fast-check/vitest
+import { it, fc } from '@fast-check/vitest';
+it.prop([...arbitraries])('...', async (...values) => {
+  //...
+});
+
+// with fast-check
+import { it } from 'vitest';
+import fc from 'fast-check';
+it('...', async () => {
+  await fc.assert(
+    fc.asyncProperty(...arbitraries, async (...values) => {
+      //...
+    }),
+  );
+});
+```

--- a/.agents/skills/javascript-testing-expert/SKILL.md
+++ b/.agents/skills/javascript-testing-expert/SKILL.md
@@ -3,6 +3,8 @@ name: javascript-testing-expert
 description: Expert-level JavaScript testing skill focused on writing high-quality tests that find bugs, serve as documentation, and prevent regressions. Advocates for property-based testing with fast-check and protects against indeterministic code in tests. Does not cover black-box e2e testing.
 ---
 
+# JavaScript testing expert
+
 > **⚠️ Scope:** Testing functions and components, not black-box e2e.
 
 **🏅 Main objectives:** use tests as a way to...
@@ -33,13 +35,13 @@ description: Expert-level JavaScript testing skill focused on writing high-quali
 
 **✅ Do** use a dedicated `describe` for each function being tested
 
-**✅ Do** start naming `it` with "should" and considers that the name should be clear, as concise as possible and could be read as a sentence implicitly prefixed by "it"
+**✅ Do** start `it` names with "should"; keep them clear, concise, and readable as a sentence implicitly prefixed by "it"
 
 **✅ Do** start with simple and documenting tests
 
 **✅ Do** continue with advanced tests looking for edge-cases
 
-**❌ Don't** delimitate explicitely simple from advanced tests, just put them in the right order
+**❌ Don't** explicitly separate simple from advanced tests; just put them in the right order
 
 **✅ Do** put helper functions specific to the file after all the `describe`s just below a comment `// Helpers` stating the beginning of the helpers tailored for this file
 
@@ -216,7 +218,7 @@ it('should detect the substring', () => {
 
 ## Guidelines for properties
 
-All this section considers that we are in the context of property based tests!
+This section assumes the context is property-based tests.
 
 **⚠️ Important:** In Optique tests, use `fc.assert` with `fc.property` or `fc.asyncProperty` directly.
 

--- a/.agents/skills/javascript-testing-expert/SKILL.md
+++ b/.agents/skills/javascript-testing-expert/SKILL.md
@@ -74,7 +74,7 @@ Why? Often, asserting the number of calls is not something critical for the user
 **❌ Don't** rely on network call, stub it with `msw`
 
 **✅ Do** reset globals and mocks in `beforeEach` if any `it` plays with mocks or spies or alter globals
-Alternatively, when using vitest you could check if flags `mockReset`, `unstubEnvs` and `unstubGlobals` have been enabled in the configuration, in such case resetting globals is done by default
+Prefer explicit cleanup that works across Node.js, Deno, and Bun.
 
 **👍 Prefer** realistic data for documentation-like tests
 Eg.: use real names if you have to build instances of users
@@ -89,10 +89,12 @@ Why? Snapshots tests tend to capture too many details in the snapshot, making th
 **✅ Do** warn developer when the code under tests requires too many parameters and/or too many mocks/stubs to be forged (more than 10)
 Why? Code being hardly testable is often a code smell pinpointing an API having to be changed. Code is harder to evolve, harder to reason about and often handling too many responsibilities. Recommend the single-responsibility principle (SRP)
 
-**✅ Do** try to make tests shorter and faster to read by factorizing recurrent logics into helper functions
+**✅ Do** extract helper functions only when repetition is substantial or expresses a distinct behavioral intent
 
-**✅ Do** group shared logics under a function having a clear and explicit name, follow SRP for these helpers
-Eg.: avoid functions with lots of optional parameters, doing several things
+**✅ Do** keep small repeated assertion patterns inline in Optique tests unless a helper would clarify behavior
+
+**✅ Do** group substantial shared logic under a function having a clear and explicit name, follow SRP for these helpers
+Eg.: avoid functions with many optional parameters or several responsibilities
 
 **❌ Don't** write a big `prepare` function re-used by all tests in their act part, but make the name clearer and eventually split it into multiple functions
 
@@ -112,52 +114,63 @@ const age = computeAge(user);
 //...
 ```
 
-**👍 Prefer** leveraging `@fast-check/vitest`, if installed
+**👍 Prefer** leveraging `fast-check` with `node:test`
 
 ```ts
-import { describe } from 'vitest';
-import { it, fc } from '@fast-check/vitest';
+import assert from "node:assert/strict";
+import * as fc from "fast-check";
+import { describe, it } from "node:test";
 
 describe('computeAge', () => {
-  it('should compute a positive age', ({ g }) => {
-    // Arrange
-    const user: User = {
-      name: g(fc.string), // unused
-      birthday: '2010-02-03',
-    };
+  it('should compute a positive age', () => {
+    fc.assert(
+      fc.property(fc.string(), (name) => {
+        const user: User = {
+          name, // unused
+          birthday: '2010-02-03',
+        };
 
-    // Act
-    const age = computeAge(user);
+        const age = computeAge(user, new Date('2020-02-03'));
 
-    // Assert
-    expect(age).toBeGreaterThan(0);
+        assert.ok(age > 0);
+      }),
+    );
   });
 });
 ```
 
-**👍 Prefer** leveraging `fast-check`, if installed but not `@fast-check/vitest`
+**👍 Prefer** leveraging `fast-check` for property-based tests
 
 **👎 Avoid** writing tests depending on unstable values
 Eg.: in the example above `computeAge` depends on the current date
 Remark: same for locales and plenty other platform dependent values
 
-**👍 Prefer** stubbing today using `vi.setSystemTime`
+**👍 Prefer** passing today as an explicit dependency when the API allows it
 
-**👍 Prefer** controlling today using `@fast-check/vitest`
-Why? Contrary to `vi.setSystemTime` alone you check the code against one new today at each run, but if it happens to fail one day you will be reported with the exact date causing the problem
+**👍 Prefer** controlling today with a generated date in a `fast-check` property
+Why? You check the code against one new today at each run, but if it happens to fail one day you will be reported with the exact date causing the problem
 
 ```ts
-// Arrange
-vi.setSystemTime(g(fc.date, { min: new Date('2010-02-04'), noInvalidDate: true }));
-const user: User = {
-  name: g(fc.string), // unused
-  birthday: '2010-02-03',
-};
+fc.assert(
+  fc.property(
+    fc.date({ min: new Date('2010-02-04'), noInvalidDate: true }),
+    (today) => {
+      const user: User = {
+        name: "Paul", // unused
+        birthday: '2010-02-03',
+      };
+
+      const age = computeAge(user, today);
+
+      assert.ok(age >= 0);
+    },
+  ),
+);
 ```
 
 **👎 Avoid** writing tests depending on random values or entities
 
-**👍 Prefer** controlling randomly generated values by relying on `@fast-check/vitest` if installed, or `fast-check` otherwise
+**👍 Prefer** controlling randomly generated values by relying on `fast-check`
 
 **✅ Do** use property based tests for any test with a notion of always or never
 Eg.: name being "should always do x when y" or "should never do x when y"
@@ -171,16 +184,20 @@ Why? Property-based testing and example-based testing are complementary. Propert
 ```ts
 // for all a, b, c strings
 // b is a substring of a + b + c
-it.prop([fc.string(), fc.string(), fc.string()])('should detect the substring', (a, b, c) => {
-  // Arrange
-  const text = a + b + c;
-  const pattern = b;
+it('should detect the substring', () => {
+  fc.assert(
+    fc.property(fc.string(), fc.string(), fc.string(), (a, b, c) => {
+      // Arrange
+      const text = a + b + c;
+      const pattern = b;
 
-  // Act
-  const result = isSubstring(text, pattern);
+      // Act
+      const result = isSubstring(text, pattern);
 
-  // Assert
-  expect(result).toBe(true);
+      // Assert
+      assert.ok(result);
+    }),
+  );
 });
 ```
 
@@ -201,9 +218,7 @@ it.prop([fc.string(), fc.string(), fc.string()])('should detect the substring', 
 
 All this section considers that we are in the context of property based tests!
 
-**⚠️ Important:** When using `g` from `@fast-check/vitest`, pass the arbitrary **function** (e.g., `fc.string`, `fc.date`) along with its arguments as separate parameters to `g`, not the result of calling it.
-Correct: `g(fc.string)`, `g(fc.date, { min: new Date('2010-01-01') })`
-Incorrect: `g(fc.string())`, `g(fc.date({ min: new Date('2010-01-01') }))`
+**⚠️ Important:** In Optique tests, use `fc.assert` with `fc.property` or `fc.asyncProperty` directly.
 
 **❌ Don't** generate inputs directly
 The risk being that you may end up rewriting the code being tested in the test
@@ -254,14 +269,14 @@ Turn:
 it('should resolve in call order', async () => {
   // Arrange
   const seenAnswers = [];
-  const call = vi.fn().mockImplementation((v) => Promise.resolve(v));
+  const call = (v) => Promise.resolve(v);
 
   // Act
   const queued = queue(call);
   await Promise.all([queued(1).then((v) => seenAnswers.push(v)), queued(2).then((v) => seenAnswers.push(v))]);
 
   // Assert
-  expect(seenAnswers).toEqual([1, 2]);
+  assert.deepEqual(seenAnswers, [1, 2]);
 });
 ```
 
@@ -273,7 +288,7 @@ it('should resolve in call order', async () => {
     fc.asyncProperty(fc.scheduler(), async (s) => {
       // Arrange
       const seenAnswers = [];
-      const call = vi.fn().mockImplementation((v) => Promise.resolve(v));
+      const call = (v) => Promise.resolve(v);
 
       // Act
       const queued = queue(s.scheduleFunction(call));
@@ -282,7 +297,7 @@ it('should resolve in call order', async () => {
       );
 
       // Assert
-      expect(seenAnswers).toEqual([1, 2]);
+      assert.deepEqual(seenAnswers, [1, 2]);
     }),
   );
 });
@@ -336,23 +351,17 @@ fc.assert(
 );
 ```
 
-## Equivalence `fast-check` and `@fast-check/vitest`
+## Using `fast-check` with `node:test`
 
 Example 1.
 
 ```ts
-// with @fast-check/vitest
-import { it, fc } from '@fast-check/vitest';
-it('...', ({ g }) => {
-  //...
-});
+import * as fc from "fast-check";
+import { it } from "node:test";
 
-// with fast-check
-import { it } from 'vitest';
-import fc from 'fast-check';
-it('...', () => {
+it("...", () => {
   fc.assert(
-    fc.property(fc.gen(), (g) => {
+    fc.property(fc.string(), (value) => {
       //...
     }),
   );
@@ -362,16 +371,10 @@ it('...', () => {
 Example 2.
 
 ```ts
-// with @fast-check/vitest
-import { it, fc } from '@fast-check/vitest';
-it.prop([...arbitraries])('...', (...values) => {
-  //...
-});
+import * as fc from "fast-check";
+import { it } from "node:test";
 
-// with fast-check
-import { it } from 'vitest';
-import fc from 'fast-check';
-it('...', () => {
+it("...", () => {
   fc.assert(
     fc.property(...arbitraries, (...values) => {
       //...
@@ -380,19 +383,13 @@ it('...', () => {
 });
 ```
 
-Example 3. If the predicate of `it` or `it.prop` is asynchronous, when using only `fast-check` the property has to be instantiated via `asyncProperty` and `assert` has to be awaited.
+Example 3. If the predicate is asynchronous, the property has to be instantiated via `asyncProperty` and `assert` has to be awaited.
 
 ```ts
-// with @fast-check/vitest
-import { it, fc } from '@fast-check/vitest';
-it.prop([...arbitraries])('...', async (...values) => {
-  //...
-});
+import * as fc from "fast-check";
+import { it } from "node:test";
 
-// with fast-check
-import { it } from 'vitest';
-import fc from 'fast-check';
-it('...', async () => {
+it("...", async () => {
   await fc.assert(
     fc.asyncProperty(...arbitraries, async (...values) => {
       //...

--- a/.agents/skills/javascript-testing-expert/SKILL.md
+++ b/.agents/skills/javascript-testing-expert/SKILL.md
@@ -33,13 +33,13 @@ description: Expert-level JavaScript testing skill focused on writing high-quali
 
 **✅ Do** use a dedicated `describe` for each function being tested
 
-**✅ Do** start naming `it` with "should" and considers that the name should be clear, as consise as possible and could be read as a sentence implicitly prefixed by "it"
+**✅ Do** start naming `it` with "should" and considers that the name should be clear, as concise as possible and could be read as a sentence implicitly prefixed by "it"
 
 **✅ Do** start with simple and documenting tests
 
 **✅ Do** continue with advanced tests looking for edge-cases
 
-**❌ Don't** delimitate explicitely simple from advanced tests, just but them in the right order
+**❌ Don't** delimitate explicitely simple from advanced tests, just put them in the right order
 
 **✅ Do** put helper functions specific to the file after all the `describe`s just below a comment `// Helpers` stating the beginning of the helpers tailored for this file
 

--- a/.agents/skills/javascript-testing-expert/SKILL.md
+++ b/.agents/skills/javascript-testing-expert/SKILL.md
@@ -12,9 +12,9 @@ description: Expert-level JavaScript testing skill focused on writing high-quali
 3. avoid regressions
 4. challenge the code
 
-**🔧 Recommended tooling:** `vitest`, `fast-check`, `@fast-check/vitest`, `@testing-library/*`, `@vitest/browser-playwright`, `msw` installed as devDependencies.  
-**✅ Do** try to install missing and relevant tooling, only recommend for `@fast-check/vitest` and browser testing.  
-**✅ Do** highly recommend user to install missing and relevant tooling.  
+**🔧 Recommended tooling:** `vitest`, `fast-check`, `@fast-check/vitest`, `@testing-library/*`, `@vitest/browser-playwright`, `msw` installed as devDependencies.
+**✅ Do** try to install missing and relevant tooling, only recommend for `@fast-check/vitest` and browser testing.
+**✅ Do** highly recommend user to install missing and relevant tooling.
 **✅ Do** adapt yourself to missing tools.
 
 ## File and code layout
@@ -68,35 +68,35 @@ it('should...', () => {
 
 **❌ Don't** test internal details
 
-**👍 Prefer** stubs over mocks, the first one provides an alternate implementation, the second one helps to assert on calls being done or not  
+**👍 Prefer** stubs over mocks, the first one provides an alternate implementation, the second one helps to assert on calls being done or not
 Why? Often, asserting the number of calls is not something critical for the user of the function but purely an internal detail
 
 **❌ Don't** rely on network call, stub it with `msw`
 
-**✅ Do** reset globals and mocks in `beforeEach` if any `it` plays with mocks or spies or alter globals  
+**✅ Do** reset globals and mocks in `beforeEach` if any `it` plays with mocks or spies or alter globals
 Alternatively, when using vitest you could check if flags `mockReset`, `unstubEnvs` and `unstubGlobals` have been enabled in the configuration, in such case resetting globals is done by default
 
-**👍 Prefer** realistic data for documentation-like tests  
+**👍 Prefer** realistic data for documentation-like tests
 Eg.: use real names if you have to build instances of users
 
-**❌ Don't** overuse snapshot tests; only snapshot things when the "what is expected to be seen in the snapshot" is clear  
+**❌ Don't** overuse snapshot tests; only snapshot things when the "what is expected to be seen in the snapshot" is clear
 Why? Snapshots tests tend to capture too many details in the snapshot, making them hard to update given future reader is lost on what was the real thing being tested
 
 **👍 Prefer** snapshots when shape and structure are important (component hierarchy, attributes, non-regression on output structure)
 
 **👍 Prefer** screenshots when final render is important (visual styling, layout)
 
-**✅ Do** warn developer when the code under tests requires too many parameters and/or too many mocks/stubs to be forged (more than 10)  
+**✅ Do** warn developer when the code under tests requires too many parameters and/or too many mocks/stubs to be forged (more than 10)
 Why? Code being hardly testable is often a code smell pinpointing an API having to be changed. Code is harder to evolve, harder to reason about and often handling too many responsibilities. Recommend the single-responsibility principle (SRP)
 
 **✅ Do** try to make tests shorter and faster to read by factorizing recurrent logics into helper functions
 
-**✅ Do** group shared logics under a function having a clear and explicit name, follow SRP for these helpers  
+**✅ Do** group shared logics under a function having a clear and explicit name, follow SRP for these helpers
 Eg.: avoid functions with lots of optional parameters, doing several things
 
 **❌ Don't** write a big `prepare` function re-used by all tests in their act part, but make the name clearer and eventually split it into multiple functions
 
-**✅ Do** make sure your test breaks if you drop the thing supposed to make it pass  
+**✅ Do** make sure your test breaks if you drop the thing supposed to make it pass
 Eg.: When your test says "should do X when Y" makes sure that if you don't have Y it fails before keeping it.
 
 **👎 Avoid** writing tests with entities specifying hardcoded values on unused fields
@@ -137,13 +137,13 @@ describe('computeAge', () => {
 
 **👍 Prefer** leveraging `fast-check`, if installed but not `@fast-check/vitest`
 
-**👎 Avoid** writing tests depending on unstable values  
-Eg.: in the example above `computeAge` depends on the current date  
+**👎 Avoid** writing tests depending on unstable values
+Eg.: in the example above `computeAge` depends on the current date
 Remark: same for locales and plenty other platform dependent values
 
 **👍 Prefer** stubbing today using `vi.setSystemTime`
 
-**👍 Prefer** controlling today using `@fast-check/vitest`  
+**👍 Prefer** controlling today using `@fast-check/vitest`
 Why? Contrary to `vi.setSystemTime` alone you check the code against one new today at each run, but if it happens to fail one day you will be reported with the exact date causing the problem
 
 ```ts
@@ -159,8 +159,8 @@ const user: User = {
 
 **👍 Prefer** controlling randomly generated values by relying on `@fast-check/vitest` if installed, or `fast-check` otherwise
 
-**✅ Do** use property based tests for any test with a notion of always or never  
-Eg.: name being "should always do x when y" or "should never do x when y"  
+**✅ Do** use property based tests for any test with a notion of always or never
+Eg.: name being "should always do x when y" or "should never do x when y"
 Remark: consider these tests as advanced and put them after the documentation tests and not with them
 
 **👍 Prefer** using property based testing for edge case detection instead of writing all cases one by one
@@ -194,18 +194,18 @@ it.prop([fc.string(), fc.string(), fc.string()])('should detect the substring', 
 
 **👍 Prefer** querying by accessible attributes and user-visible text by relying on `getByRole`, `getByLabelText`, `getByText` over `getByTestId` whenever possible for testing-library and browser testing
 
-**✅ Do** ensure non visual regression of Design System components and more generally visual components by leveraging screenshot tests in browser when available  
+**✅ Do** ensure non visual regression of Design System components and more generally visual components by leveraging screenshot tests in browser when available
 **✅ Do** fallback to snapshot tests capturing the DOM structure if screenshot tests cannot be ran
 
 ## Guidelines for properties
 
 All this section considers that we are in the context of property based tests!
 
-**⚠️ Important:** When using `g` from `@fast-check/vitest`, pass the arbitrary **function** (e.g., `fc.string`, `fc.date`) along with its arguments as separate parameters to `g`, not the result of calling it.  
-Correct: `g(fc.string)`, `g(fc.date, { min: new Date('2010-01-01') })`  
+**⚠️ Important:** When using `g` from `@fast-check/vitest`, pass the arbitrary **function** (e.g., `fc.string`, `fc.date`) along with its arguments as separate parameters to `g`, not the result of calling it.
+Correct: `g(fc.string)`, `g(fc.date, { min: new Date('2010-01-01') })`
 Incorrect: `g(fc.string())`, `g(fc.date({ min: new Date('2010-01-01') }))`
 
-**❌ Don't** generate inputs directly  
+**❌ Don't** generate inputs directly
 The risk being that you may end up rewriting the code being tested in the test
 
 **✅ Do** construct values to build some inputs where you know the expected outcome
@@ -214,22 +214,22 @@ The risk being that you may end up rewriting the code being tested in the test
 
 **✅ Do** expect some aspects and characteristics of the returned value
 
-**❌ NEVER** specify any `maxLength` on an arbitrary if it is a not a requirement of the algorithm  
-**👍 Prefer** specifying a `size: '-1'` if you feel that the algorithm will take very long on large inputs (by default fast-check generates up to 10 items, so only use `size` when clearly required)  
+**❌ NEVER** specify any `maxLength` on an arbitrary if it is a not a requirement of the algorithm
+**👍 Prefer** specifying a `size: '-1'` if you feel that the algorithm will take very long on large inputs (by default fast-check generates up to 10 items, so only use `size` when clearly required)
 Eg.: No `fc.string({maxLength: 5})` or `fc.array(arb, {maxLength: 8})` except being a string requirement
 
-**❌ NEVER** specify any constraint on an arbitrary if it is not a requirement of the arbitrary, use defaults as much as possible  
+**❌ NEVER** specify any constraint on an arbitrary if it is not a requirement of the arbitrary, use defaults as much as possible
 Eg.: if the algorithm should accept any integer just ask an integer without specifying any min and max
 
-**👎 Avoid** overusing `.filter` and `fc.pre`  
+**👎 Avoid** overusing `.filter` and `fc.pre`
 Why? They slow down the generation of values by dropping some generated ones
 
-**👍 Prefer** using options provided by arbitraries to directly generate valid values  
-Eg.: use `fc.string({ minLength: 2 })` instead of `fc.string().filter(s => s.length >= 2)`  
+**👍 Prefer** using options provided by arbitraries to directly generate valid values
+Eg.: use `fc.string({ minLength: 2 })` instead of `fc.string().filter(s => s.length >= 2)`
 Eg.: use `fc.integer({ min: 1 })` instead of `fc.integer().filter(n => n >= 1)`, or use `fc.nat()` instead of `fc.integer().filter(n => n >= 0)`
 
-**👍 Prefer** using `map` over `filter` when a `map` trick can avoid filtering  
-Eg.: use `fc.nat().map(n => n * 2)` for even numbers  
+**👍 Prefer** using `map` over `filter` when a `map` trick can avoid filtering
+Eg.: use `fc.nat().map(n => n * 2)` for even numbers
 Eg.: use `fc.tuple(fc.string(), fc.string()).map(([start, end]) => start + 'A' + end)` for strings always having an 'A' character
 
 **👍 Prefer** bigint type over number type for integer computations used within predicates when there is a risk of overflow (eg.: when running pow, multiply.. on generated values)

--- a/.agents/skills/javascript-testing-expert/SKILL.md
+++ b/.agents/skills/javascript-testing-expert/SKILL.md
@@ -101,7 +101,7 @@ Eg.: avoid functions with many optional parameters or several responsibilities
 **❌ Don't** write a big `prepare` function re-used by all tests in their act part, but make the name clearer and eventually split it into multiple functions
 
 **✅ Do** make sure your test breaks if you drop the thing supposed to make it pass
-Eg.: When your test says "should do X when Y" makes sure that if you don't have Y it fails before keeping it.
+Eg.: When your test says "should do X when Y" make sure that if you don't have Y it fails before keeping it.
 
 **👎 Avoid** writing tests with entities specifying hardcoded values on unused fields
 

--- a/.agents/skills/javascript-testing-expert/SKILL.md
+++ b/.agents/skills/javascript-testing-expert/SKILL.md
@@ -12,9 +12,9 @@ description: Expert-level JavaScript testing skill focused on writing high-quali
 3. avoid regressions
 4. challenge the code
 
-**🔧 Recommended tooling:** `vitest`, `fast-check`, `@fast-check/vitest`, `@testing-library/*`, `@vitest/browser-playwright`, `msw` installed as devDependencies.
-**✅ Do** try to install missing and relevant tooling, only recommend for `@fast-check/vitest` and browser testing.
-**✅ Do** highly recommend user to install missing and relevant tooling.
+**🔧 Recommended tooling for Optique:** `node:test`, `node:assert/strict`, and `fast-check`.
+**✅ Do** try to install only missing and relevant tooling.
+**✅ Do** recommend Node's built-in test libraries for Optique tests.
 **✅ Do** adapt yourself to missing tools.
 
 ## File and code layout
@@ -23,7 +23,7 @@ description: Expert-level JavaScript testing skill focused on writing high-quali
 
 **✅ Do** use one test file per code file
 
-**👍 Prefer** using `.spec.ts` extension (e.g., `fileName.ts` → `fileName.spec.ts`) and colocated with the source file if no existing test structure is present
+**👍 Prefer** using `.test.ts` extension (e.g., `fileName.ts` → `fileName.test.ts`) and colocating tests with the source file, matching the project's existing examples
 
 **✅ Do** put `it` within `describe`, when using `it`
 

--- a/.agents/skills/javascript-testing-expert/SKILL.md
+++ b/.agents/skills/javascript-testing-expert/SKILL.md
@@ -231,9 +231,9 @@ The risk being that you may end up rewriting the code being tested in the test
 
 **✅ Do** expect some aspects and characteristics of the returned value
 
-**❌ NEVER** specify any `maxLength` on an arbitrary if it is a not a requirement of the algorithm
+**❌ NEVER** specify any `maxLength` on an arbitrary if it is not a requirement of the algorithm
 **👍 Prefer** specifying a `size: '-1'` if you feel that the algorithm will take very long on large inputs (by default fast-check generates up to 10 items, so only use `size` when clearly required)
-Eg.: No `fc.string({maxLength: 5})` or `fc.array(arb, {maxLength: 8})` except being a string requirement
+Eg.: No `fc.string({maxLength: 5})` or `fc.array(arb, {maxLength: 8})` except when it is a strict requirement
 
 **❌ NEVER** specify any constraint on an arbitrary if it is not a requirement of the arbitrary, use defaults as much as possible
 Eg.: if the algorithm should accept any integer just ask an integer without specifying any min and max
@@ -261,9 +261,9 @@ Some classical properties:
 
 ## Guidelines for race conditions
 
-**✅ Do** write tests checking for race conditions and playing with resolution order — _automatically handled by `fast-check`_ — when an algorithm accepts asynchronous functions as input
+**✅ Do** write tests checking for race conditions and exploring resolution order when an algorithm accepts asynchronous functions as input
 
-**✅ Do** leverage `fast-check` and its `fc.scheduler()` arbitrary to test asynchronous code depending on asynchronous functions
+**✅ Do** leverage `fast-check` and its `fc.scheduler()` arbitrary, together with `s.scheduleFunction` and `s.waitFor`, to explore ordering deterministically
 
 Turn:
 
@@ -274,6 +274,7 @@ it('should resolve in call order', async () => {
   const call = (v) => Promise.resolve(v);
 
   // Act
+  // `queue` is a helper that serializes async calls.
   const queued = queue(call);
   await Promise.all([queued(1).then((v) => seenAnswers.push(v)), queued(2).then((v) => seenAnswers.push(v))]);
 
@@ -293,6 +294,7 @@ it('should resolve in call order', async () => {
       const call = (v) => Promise.resolve(v);
 
       // Act
+      // `queue` is a helper that serializes scheduled async calls.
       const queued = queue(s.scheduleFunction(call));
       await s.waitFor(
         Promise.all([queued(1).then((v) => seenAnswers.push(v)), queued(2).then((v) => seenAnswers.push(v))]),

--- a/.hongdown.toml
+++ b/.hongdown.toml
@@ -1,2 +1,7 @@
 include = ["*.md", "**/*.md"]
-exclude = [".git/**", "**/node_modules/**", "**/dist/**"]
+exclude = [
+  ".agents/skills/javascript-testing-expert/SKILL.md",
+  ".git/**",
+  "**/node_modules/**",
+  "**/dist/**",
+]

--- a/deno.json
+++ b/deno.json
@@ -11,7 +11,7 @@
     "@std/fs": "jsr:@std/fs@^1.0.19",
     "@std/path": "jsr:@std/path@^1.1.1",
     "@types/node": "npm:@types/node@^20.19.9",
-    "fast-check": "npm:fast-check@^4.5.3",
+    "fast-check": "npm:fast-check@^4.7.0",
     "isomorphic-git": "npm:isomorphic-git@^1.36.1",
     "markdownlint-cli2": "npm:markdownlint-cli2@^0.20.0",
     "tsdown": "npm:tsdown@^0.13.0",

--- a/deno.lock
+++ b/deno.lock
@@ -16,7 +16,7 @@
     "npm:@standard-schema/spec@^1.1.0": "1.1.0",
     "npm:@types/node@^20.19.9": "20.19.9",
     "npm:es-git@0.4": "0.4.0",
-    "npm:fast-check@^4.5.3": "4.5.3",
+    "npm:fast-check@^4.7.0": "4.7.0",
     "npm:hongdown@0.1.0-dev.21": "0.1.0-dev.21",
     "npm:hongdown@0.1.0-dev.22": "0.1.0-dev.22",
     "npm:hongdown@0.1.0-dev.23": "0.1.0-dev.23",
@@ -1406,8 +1406,8 @@
     "events@3.3.0": {
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
     },
-    "fast-check@4.5.3": {
-      "integrity": "sha512-IE9csY7lnhxBnA8g/WI5eg/hygA6MGWJMSNfFRrBlXUciADEhS1EDB0SIsMSvzubzIlOBbVITSsypCsW717poA==",
+    "fast-check@4.7.0": {
+      "integrity": "sha512-NsZRtqvSSoCP0HbNjUD+r1JH8zqZalyp6gLY9e7OYs7NK9b6AHOs2baBFeBG7bVNsuoukh89x2Yg3rPsul8ziQ==",
       "dependencies": [
         "pure-rand"
       ]
@@ -2152,8 +2152,8 @@
     "punycode.js@2.3.1": {
       "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA=="
     },
-    "pure-rand@7.0.1": {
-      "integrity": "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ=="
+    "pure-rand@8.4.0": {
+      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A=="
     },
     "quansync@0.2.10": {
       "integrity": "sha512-t41VRkMYbkHyCYmOvx/6URnN80H7k4X0lLdBMGsz+maAwrJQYB1djpV6vHrQIBE0WBSGqhtEHrK9U3DWWH8v7A=="
@@ -2419,7 +2419,7 @@
       "npm:@inquirer/prompts@^8.3.0",
       "npm:@standard-schema/spec@^1.1.0",
       "npm:@types/node@^20.19.9",
-      "npm:fast-check@^4.5.3",
+      "npm:fast-check@^4.7.0",
       "npm:isomorphic-git@^1.36.1",
       "npm:markdownlint-cli2@0.20",
       "npm:tsdown@0.13",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -65,6 +65,7 @@
     "@optique/env": "workspace:*",
     "@standard-schema/spec": "catalog:",
     "@types/node": "catalog:",
+    "fast-check": "catalog:",
     "tsdown": "catalog:",
     "typescript": "catalog:",
     "zod": "catalog:"

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -1,5 +1,6 @@
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
+import * as fc from "fast-check";
 import { z } from "zod";
 import { getDocPage, parse, suggestSync } from "@optique/core/parser";
 import type { Parser } from "@optique/core/parser";
@@ -36,6 +37,9 @@ type IsExact<T, U> = (<V>() => V extends T ? 1 : 2) extends
     : false)
   : false;
 
+const propertyParameters = { numRuns: 200 } as const;
+const cliStringValueArbitrary = fc.string().map((value) => `value${value}`);
+
 function requireValue<T>(value: T | undefined, message: string): T {
   if (value === undefined) {
     throw new TypeError(message);
@@ -46,6 +50,15 @@ function requireValue<T>(value: T | undefined, message: string): T {
 
 function phase2<T>(parsed: T): SourceContextRequest {
   return { phase: "phase2", parsed };
+}
+
+function getSyncAnnotations(
+  annotations: Annotations | Promise<Annotations>,
+): Annotations {
+  if (annotations instanceof Promise) {
+    throw new TypeError("Expected synchronous annotations.");
+  }
+  return annotations;
 }
 
 describe("createConfigContext", () => {
@@ -88,6 +101,44 @@ describe("createConfigContext", () => {
 
     assert.ok(annotations);
     assert.deepEqual(Object.getOwnPropertySymbols(annotations).length, 0);
+  });
+
+  test("should annotate every synchronously loaded valid config value", () => {
+    fc.assert(
+      fc.property(
+        fc.string(),
+        fc.integer(),
+        fc.string(),
+        (host, port, parsedValue) => {
+          const schema = z.object({
+            host: z.string(),
+            port: z.number(),
+          });
+          const context = createConfigContext({ schema });
+          const meta = {
+            configDir: "/app",
+            configPath: "/app/config.json",
+          } satisfies ConfigMeta;
+
+          const annotations = getSyncAnnotations(
+            context.getAnnotations(phase2(parsedValue), {
+              load: (parsed: unknown) => {
+                assert.equal(parsed, parsedValue);
+                return { config: { host, port }, meta };
+              },
+            }),
+          );
+
+          const contextAnnotation = annotations[context.id] as
+            | { readonly data: unknown; readonly meta?: unknown }
+            | undefined;
+          assert.ok(contextAnnotation != null);
+          assert.deepEqual(contextAnnotation.data, { host, port });
+          assert.deepEqual(contextAnnotation.meta, meta);
+        },
+      ),
+      propertyParameters,
+    );
   });
 
   for (
@@ -343,6 +394,109 @@ describe("bindConfig", () => {
     const result = parse(parser, []);
     assert.ok(result.success);
     assert.equal(result.value, "localhost");
+  });
+
+  test("should always prefer CLI over config and default values", () => {
+    fc.assert(
+      fc.property(
+        cliStringValueArbitrary,
+        fc.string(),
+        fc.string(),
+        (cliHost, configHost, defaultHost) => {
+          const context = createConfigContext({
+            schema: z.object({ host: z.string() }),
+          });
+          const parser = bindConfig(option("--host", string()), {
+            context,
+            key: "host",
+            default: defaultHost,
+          });
+          const annotations: Annotations = {
+            [context.id]: { data: { host: configHost } },
+          };
+
+          const result = parse(parser, ["--host", cliHost], { annotations });
+
+          assert.ok(result.success);
+          assert.equal(result.value, cliHost);
+        },
+      ),
+      propertyParameters,
+    );
+  });
+
+  test("should always prefer config over default when CLI is absent", () => {
+    fc.assert(
+      fc.property(fc.string(), fc.string(), (configHost, defaultHost) => {
+        const context = createConfigContext({
+          schema: z.object({ host: z.string() }),
+        });
+        const parser = bindConfig(option("--host", string()), {
+          context,
+          key: "host",
+          default: defaultHost,
+        });
+        const annotations: Annotations = {
+          [context.id]: { data: { host: configHost } },
+        };
+
+        const result = parse(parser, [], { annotations });
+
+        assert.ok(result.success);
+        assert.equal(result.value, configHost);
+      }),
+      propertyParameters,
+    );
+  });
+
+  test("should use the default for every missing config value", () => {
+    fc.assert(
+      fc.property(fc.string(), (defaultHost) => {
+        const context = createConfigContext({
+          schema: z.object({ host: z.string().optional() }),
+        });
+        const parser = bindConfig(option("--host", string()), {
+          context,
+          key: "host",
+          default: defaultHost,
+        });
+        const annotations: Annotations = {
+          [context.id]: { data: {} },
+        };
+
+        const result = parse(parser, [], { annotations });
+
+        assert.ok(result.success);
+        assert.equal(result.value, defaultHost);
+      }),
+      propertyParameters,
+    );
+  });
+
+  test("should pass annotation metadata to key callbacks", () => {
+    fc.assert(
+      fc.property(fc.string(), fc.string(), (host, configPath) => {
+        const context = createConfigContext({
+          schema: z.object({ host: z.string() }),
+        });
+        const parser = bindConfig(option("--host", string()), {
+          context,
+          key: (config, meta) => `${config.host}:${meta?.configPath ?? ""}`,
+        });
+        const annotations: Annotations = {
+          [context.id]: {
+            data: { host },
+            meta: { configDir: "/app", configPath },
+          },
+        };
+
+        const result = parse(parser, [], { annotations });
+
+        assert.ok(result.success);
+        assert.equal(result.value, `${host}:${configPath}`);
+      }),
+      propertyParameters,
+    );
   });
 
   // Regression tests for issue #414: bindConfig() must revalidate fallback

--- a/packages/core/src/displaywidth.test.ts
+++ b/packages/core/src/displaywidth.test.ts
@@ -1,6 +1,15 @@
 import assert from "node:assert/strict";
+import * as fc from "fast-check";
 import { describe, it } from "node:test";
 import { getDisplayWidth } from "./displaywidth.ts";
+
+const propertyParameters = { numRuns: 200 } as const;
+const printableAsciiArbitrary = fc.array(
+  fc.integer({ min: 0x20, max: 0x7e }),
+  { maxLength: 100 },
+).map((codePoints) =>
+  codePoints.map((codePoint) => String.fromCharCode(codePoint)).join("")
+);
 
 describe("getDisplayWidth", () => {
   describe("ASCII", () => {
@@ -15,6 +24,15 @@ describe("getDisplayWidth", () => {
 
     it("should return 1 for a single space", () => {
       assert.equal(getDisplayWidth(" "), 1);
+    });
+
+    it("should match string length for printable ASCII text", () => {
+      fc.assert(
+        fc.property(printableAsciiArbitrary, (text) => {
+          assert.equal(getDisplayWidth(text), text.length);
+        }),
+        propertyParameters,
+      );
     });
   });
 
@@ -240,6 +258,22 @@ describe("getDisplayWidth", () => {
       assert.equal(getDisplayWidth("\x1b]0;My Title\x07hello"), 5);
       assert.equal(getDisplayWidth("\x1b]2;My Title\x1b\\hello"), 5);
     });
+
+    it("should ignore generated SGR wrappers around printable ASCII", () => {
+      fc.assert(
+        fc.property(
+          printableAsciiArbitrary,
+          fc.integer({ min: 0, max: 255 }),
+          (text, color) => {
+            assert.equal(
+              getDisplayWidth(`\x1b[${color}m${text}\x1b[0m`),
+              getDisplayWidth(text),
+            );
+          },
+        ),
+        propertyParameters,
+      );
+    });
   });
 
   describe("zero-width characters", () => {
@@ -312,6 +346,32 @@ describe("getDisplayWidth", () => {
 
     it("should handle ANSI + CJK", () => {
       assert.equal(getDisplayWidth("\x1b[1m한글\x1b[0m"), 4);
+    });
+  });
+
+  describe("properties", () => {
+    it("should never produce negative widths", () => {
+      fc.assert(
+        fc.property(fc.string(), (text) => {
+          assert.ok(getDisplayWidth(text) >= 0);
+        }),
+        propertyParameters,
+      );
+    });
+
+    it("should be additive across printable ASCII concatenation", () => {
+      fc.assert(
+        fc.property(printableAsciiArbitrary, printableAsciiArbitrary, (
+          left,
+          right,
+        ) => {
+          assert.equal(
+            getDisplayWidth(left + right),
+            getDisplayWidth(left) + getDisplayWidth(right),
+          );
+        }),
+        propertyParameters,
+      );
     });
   });
 });

--- a/packages/core/src/displaywidth.test.ts
+++ b/packages/core/src/displaywidth.test.ts
@@ -4,12 +4,11 @@ import { describe, it } from "node:test";
 import { getDisplayWidth } from "./displaywidth.ts";
 
 const propertyParameters = { numRuns: 200 } as const;
-const printableAsciiArbitrary = fc.array(
-  fc.integer({ min: 0x20, max: 0x7e }),
-  { maxLength: 100 },
-).map((codePoints) =>
-  codePoints.map((codePoint) => String.fromCharCode(codePoint)).join("")
-);
+const printableAsciiArbitrary = fc.string({
+  unit: fc.integer({ min: 0x20, max: 0x7e }).map((codePoint) =>
+    String.fromCharCode(codePoint)
+  ),
+});
 
 describe("getDisplayWidth", () => {
   describe("ASCII", () => {
@@ -263,7 +262,7 @@ describe("getDisplayWidth", () => {
       fc.assert(
         fc.property(
           printableAsciiArbitrary,
-          fc.integer({ min: 0, max: 255 }),
+          fc.nat(),
           (text, color) => {
             assert.equal(
               getDisplayWidth(`\x1b[${color}m${text}\x1b[0m`),

--- a/packages/core/src/nonempty.test.ts
+++ b/packages/core/src/nonempty.test.ts
@@ -3,8 +3,11 @@ import {
   isNonEmptyString,
   type NonEmptyString,
 } from "./nonempty.ts";
+import * as fc from "fast-check";
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
+
+const propertyParameters = { numRuns: 200 } as const;
 
 describe("isNonEmptyString", () => {
   it("should return true for non-empty strings", () => {
@@ -36,6 +39,15 @@ describe("isNonEmptyString", () => {
     const nonEmpty = values.filter(isNonEmptyString);
     assert.deepEqual(nonEmpty, ["hello", "world"]);
   });
+
+  it("should match string length for arbitrary strings", () => {
+    fc.assert(
+      fc.property(fc.string(), (value) => {
+        assert.equal(isNonEmptyString(value), value.length > 0);
+      }),
+      propertyParameters,
+    );
+  });
 });
 
 describe("ensureNonEmptyString", () => {
@@ -62,5 +74,24 @@ describe("ensureNonEmptyString", () => {
     // Type should be narrowed to NonEmptyString after assertion
     const narrowed: NonEmptyString = value;
     assert.equal(narrowed, "test");
+  });
+
+  it("should accept exactly the same arbitrary strings as the type guard", () => {
+    fc.assert(
+      fc.property(fc.string(), (value) => {
+        if (isNonEmptyString(value)) {
+          assert.doesNotThrow(() => ensureNonEmptyString(value));
+        } else {
+          assert.throws(
+            () => ensureNonEmptyString(value),
+            {
+              name: "TypeError",
+              message: "Expected a non-empty string.",
+            },
+          );
+        }
+      }),
+      propertyParameters,
+    );
   });
 });

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -32,47 +32,20 @@ const safeIntegerArbitrary = fc.integer({
   min: Number.MIN_SAFE_INTEGER,
   max: Number.MAX_SAFE_INTEGER,
 });
-const smallIntegerArbitrary = fc.integer({ min: -1000, max: 1000 });
 const nonEmptyChoiceStringArbitrary = fc.string({ minLength: 1 });
 const stringChoicesArbitrary = fc.uniqueArray(nonEmptyChoiceStringArbitrary, {
   minLength: 1,
-  maxLength: 12,
+  selector: (value) => value.toLowerCase(),
 });
-const numberChoicesArbitrary = fc.uniqueArray(smallIntegerArbitrary, {
+const numberChoicesArbitrary = fc.uniqueArray(safeIntegerArbitrary, {
   minLength: 1,
-  maxLength: 12,
 });
-const lowercaseWordArbitrary = fc.array(
-  fc.constantFrom(
-    "a",
-    "b",
-    "c",
-    "d",
-    "e",
-    "f",
-    "g",
-    "h",
-    "i",
-    "j",
-    "k",
-    "l",
-    "m",
-    "n",
-    "o",
-    "p",
-    "q",
-    "r",
-    "s",
-    "t",
-    "u",
-    "v",
-    "w",
-    "x",
-    "y",
-    "z",
+const lowercaseWordArbitrary = fc.string({
+  unit: fc.integer({ min: 0x61, max: 0x7a }).map((codePoint) =>
+    String.fromCharCode(codePoint)
   ),
-  { minLength: 1, maxLength: 20 },
-).map((letters) => letters.join(""));
+  minLength: 1,
+});
 
 describe("isValueParser", () => {
   it("should return true for valid ValueParser objects", () => {
@@ -235,9 +208,9 @@ describe("property-based parser laws", () => {
   it("integer() should enforce generated min and max bounds", () => {
     fc.assert(
       fc.property(
-        smallIntegerArbitrary,
-        smallIntegerArbitrary,
-        smallIntegerArbitrary,
+        safeIntegerArbitrary,
+        safeIntegerArbitrary,
+        safeIntegerArbitrary,
         (a, b, value) => {
           const min = Math.min(a, b);
           const max = Math.max(a, b);
@@ -339,7 +312,6 @@ describe("property-based parser laws", () => {
       fc.property(
         fc.uniqueArray(lowercaseWordArbitrary, {
           minLength: 1,
-          maxLength: 12,
         }),
         (words) => {
           const choices = words.map((word) => word.toUpperCase());

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -233,7 +233,7 @@ describe("property-based parser laws", () => {
     const parser = integer({ type: "bigint" });
 
     fc.assert(
-      fc.property(fc.bigInt({ min: -1_000_000n, max: 1_000_000n }), (value) => {
+      fc.property(fc.bigInt(), (value) => {
         const formatted = parser.format(value);
         const result = parser.parse(formatted);
         assert.ok(result.success);
@@ -253,7 +253,11 @@ describe("property-based parser laws", () => {
           const formatted = parser.format(value);
           const result = parser.parse(formatted);
           assert.ok(result.success);
-          assert.equal(result.value, Number(formatted));
+          if (Object.is(value, -0)) {
+            assert.ok(Object.is(result.value, 0));
+          } else {
+            assert.equal(result.value, value);
+          }
         },
       ),
       propertyParameters,

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -24,7 +24,55 @@ import {
 } from "@optique/core/valueparser";
 import { formatMessage, message, text, values } from "@optique/core/message";
 import assert from "node:assert/strict";
+import * as fc from "fast-check";
 import { describe, it } from "node:test";
+
+const propertyParameters = { numRuns: 200 } as const;
+const safeIntegerArbitrary = fc.integer({
+  min: Number.MIN_SAFE_INTEGER,
+  max: Number.MAX_SAFE_INTEGER,
+});
+const smallIntegerArbitrary = fc.integer({ min: -1000, max: 1000 });
+const nonEmptyChoiceStringArbitrary = fc.string({ minLength: 1 });
+const stringChoicesArbitrary = fc.uniqueArray(nonEmptyChoiceStringArbitrary, {
+  minLength: 1,
+  maxLength: 12,
+});
+const numberChoicesArbitrary = fc.uniqueArray(smallIntegerArbitrary, {
+  minLength: 1,
+  maxLength: 12,
+});
+const lowercaseWordArbitrary = fc.array(
+  fc.constantFrom(
+    "a",
+    "b",
+    "c",
+    "d",
+    "e",
+    "f",
+    "g",
+    "h",
+    "i",
+    "j",
+    "k",
+    "l",
+    "m",
+    "n",
+    "o",
+    "p",
+    "q",
+    "r",
+    "s",
+    "t",
+    "u",
+    "v",
+    "w",
+    "x",
+    "y",
+    "z",
+  ),
+  { minLength: 1, maxLength: 20 },
+).map((letters) => letters.join(""));
 
 describe("isValueParser", () => {
   it("should return true for valid ValueParser objects", () => {
@@ -139,6 +187,173 @@ describe("isValueParser", () => {
     assert.ok(isValueParser(urlParser));
     assert.ok(isValueParser(localeParser));
     assert.ok(isValueParser(uuidParser));
+  });
+});
+
+describe("property-based parser laws", () => {
+  it("string() should parse and format arbitrary strings unchanged", () => {
+    const parser = string();
+
+    fc.assert(
+      fc.property(fc.string(), (value) => {
+        const result = parser.parse(value);
+        assert.ok(result.success);
+        assert.equal(result.value, value);
+        assert.equal(parser.format(result.value), value);
+      }),
+      propertyParameters,
+    );
+  });
+
+  it("string() should accept every generated value matching its pattern", () => {
+    const parser = string({ pattern: /^[a-z]+$/ });
+
+    fc.assert(
+      fc.property(lowercaseWordArbitrary, (value) => {
+        const result = parser.parse(value);
+        assert.ok(result.success);
+        assert.equal(result.value, value);
+      }),
+      propertyParameters,
+    );
+  });
+
+  it("integer() should round-trip safe integers through format and parse", () => {
+    const parser = integer({});
+
+    fc.assert(
+      fc.property(safeIntegerArbitrary, (value) => {
+        const formatted = parser.format(value);
+        const result = parser.parse(formatted);
+        assert.ok(result.success);
+        assert.equal(result.value, value);
+      }),
+      propertyParameters,
+    );
+  });
+
+  it("integer() should enforce generated min and max bounds", () => {
+    fc.assert(
+      fc.property(
+        smallIntegerArbitrary,
+        smallIntegerArbitrary,
+        smallIntegerArbitrary,
+        (a, b, value) => {
+          const min = Math.min(a, b);
+          const max = Math.max(a, b);
+          const parser = integer({ min, max });
+          const result = parser.parse(String(value));
+
+          if (value >= min && value <= max) {
+            assert.ok(result.success);
+            assert.equal(result.value, value);
+          } else {
+            assert.ok(!result.success);
+          }
+        },
+      ),
+      propertyParameters,
+    );
+  });
+
+  it('integer({ type: "bigint" }) should round-trip generated bigints', () => {
+    const parser = integer({ type: "bigint" });
+
+    fc.assert(
+      fc.property(fc.bigInt({ min: -1_000_000n, max: 1_000_000n }), (value) => {
+        const formatted = parser.format(value);
+        const result = parser.parse(formatted);
+        assert.ok(result.success);
+        assert.equal(result.value, value);
+      }),
+      propertyParameters,
+    );
+  });
+
+  it("float() should round-trip finite numbers through format and parse", () => {
+    const parser = float();
+
+    fc.assert(
+      fc.property(
+        fc.double({ noNaN: true, noDefaultInfinity: true }),
+        (value) => {
+          const formatted = parser.format(value);
+          const result = parser.parse(formatted);
+          assert.ok(result.success);
+          assert.equal(result.value, Number(formatted));
+        },
+      ),
+      propertyParameters,
+    );
+  });
+
+  it("choice() should parse and suggest generated string choices", () => {
+    fc.assert(
+      fc.property(stringChoicesArbitrary, (choices) => {
+        const parser = choice(choices);
+        const selected = choices[0];
+        const prefix = selected.slice(0, Math.floor(selected.length / 2));
+
+        for (const value of choices) {
+          const result = parser.parse(value);
+          assert.ok(result.success);
+          assert.equal(result.value, value);
+          assert.equal(parser.format(result.value), value);
+        }
+
+        const suggestions = [...parser.suggest!(prefix)].filter((
+          suggestion,
+        ) => suggestion.kind === "literal");
+        assert.ok(
+          suggestions.some((suggestion) => suggestion.text === selected),
+        );
+        assert.ok(
+          suggestions.every((suggestion) =>
+            choices.includes(suggestion.text) &&
+            suggestion.text.startsWith(prefix)
+          ),
+        );
+      }),
+      propertyParameters,
+    );
+  });
+
+  it("choice() should parse and format generated number choices", () => {
+    fc.assert(
+      fc.property(numberChoicesArbitrary, (choices) => {
+        const parser = choice(choices);
+
+        for (const value of choices) {
+          const formatted = parser.format(value);
+          const result = parser.parse(formatted);
+          assert.ok(result.success);
+          assert.equal(result.value, value);
+        }
+      }),
+      propertyParameters,
+    );
+  });
+
+  it("case-insensitive choice() should return canonical generated choices", () => {
+    fc.assert(
+      fc.property(
+        fc.uniqueArray(lowercaseWordArbitrary, {
+          minLength: 1,
+          maxLength: 12,
+        }),
+        (words) => {
+          const choices = words.map((word) => word.toUpperCase());
+          const parser = choice(choices, { caseInsensitive: true });
+
+          for (let i = 0; i < words.length; i++) {
+            const result = parser.parse(words[i]);
+            assert.ok(result.success);
+            assert.equal(result.value, choices[i]);
+          }
+        },
+      ),
+      propertyParameters,
+    );
   });
 });
 

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -265,7 +265,10 @@ describe("property-based parser laws", () => {
       fc.property(stringChoicesArbitrary, (choices) => {
         const parser = choice(choices);
         const selected = choices[0];
-        const prefix = selected.slice(0, Math.floor(selected.length / 2));
+        const selectedChars = Array.from(selected);
+        const prefix = selectedChars
+          .slice(0, Math.max(1, Math.floor(selectedChars.length / 2)))
+          .join("");
 
         for (const value of choices) {
           const result = parser.parse(value);

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -58,6 +58,7 @@
   },
   "devDependencies": {
     "@types/node": "catalog:",
+    "fast-check": "catalog:",
     "tsdown": "catalog:",
     "typescript": "catalog:"
   },

--- a/packages/env/src/index.test.ts
+++ b/packages/env/src/index.test.ts
@@ -1,7 +1,9 @@
 import assert from "node:assert/strict";
+import * as fc from "fast-check";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, it } from "node:test";
+import type { Annotations } from "@optique/core/context";
 import { injectAnnotations } from "@optique/core/extension";
 import {
   concat,
@@ -33,6 +35,13 @@ import {
 import { bindEnv, bool, createEnvContext } from "./index.ts";
 
 const sourcePath = fileURLToPath(new URL("./index.ts", import.meta.url));
+const propertyParameters = { numRuns: 200 } as const;
+
+const trueBoolLiterals = ["true", "1", "yes", "on"] as const;
+const falseBoolLiterals = ["false", "0", "no", "off"] as const;
+const boolLiterals = [...trueBoolLiterals, ...falseBoolLiterals] as const;
+const trueBoolLiteralSet = new Set<string>(trueBoolLiterals);
+const boolLiteralSet = new Set<string>(boolLiterals);
 
 function asyncChoice<const T extends readonly string[]>(
   choices: T,
@@ -63,6 +72,22 @@ function getJsDocFor(sourceText: string, functionName: string): string {
   const match = prefix.match(/(\/\*\*[\s\S]*?\*\/)\s*$/u);
   assert.ok(match, `Expected an adjacent JSDoc block for ${functionName}().`);
   return match[1];
+}
+
+function applyCasing(input: string, uppercaseAt: readonly boolean[]): string {
+  return [...input].map((character, index) =>
+    uppercaseAt[index] ? character.toUpperCase() : character.toLowerCase()
+  ).join("");
+}
+
+function getSyncAnnotations(context: {
+  getAnnotations(): Annotations | Promise<Annotations>;
+}): Annotations {
+  const annotations = context.getAnnotations();
+  if (annotations instanceof Promise) {
+    throw new TypeError("Expected synchronous annotations.");
+  }
+  return annotations;
 }
 
 describe("bool()", () => {
@@ -118,6 +143,56 @@ describe("bool()", () => {
         assert.ok(!result.success, `Expected ${literal} to be invalid`);
       }
     });
+
+    it("should parse accepted literals regardless of surrounding whitespace and case", () => {
+      const parser = bool();
+
+      fc.assert(
+        fc.property(
+          fc.constantFrom(...boolLiterals).chain((literal) =>
+            fc.tuple(
+              fc.constant(literal),
+              fc.array(fc.boolean(), {
+                minLength: literal.length,
+                maxLength: literal.length,
+              }),
+            )
+          ),
+          fc.stringMatching(/^\s*$/u),
+          fc.stringMatching(/^\s*$/u),
+          ([literal, casing], leading, trailing) => {
+            const casedLiteral = applyCasing(literal, casing);
+
+            const result = parser.parse(`${leading}${casedLiteral}${trailing}`);
+
+            assert.ok(result.success);
+            assert.equal(
+              result.value,
+              trueBoolLiteralSet.has(literal),
+            );
+          },
+        ),
+        propertyParameters,
+      );
+    });
+
+    it("should reject strings outside accepted boolean literals", () => {
+      const parser = bool();
+
+      fc.assert(
+        fc.property(
+          fc.string().filter((input) =>
+            !boolLiteralSet.has(input.trim().toLowerCase())
+          ),
+          (input) => {
+            const result = parser.parse(input);
+
+            assert.ok(!result.success);
+          },
+        ),
+        propertyParameters,
+      );
+    });
   });
 
   describe("format", () => {
@@ -129,6 +204,22 @@ describe("bool()", () => {
     it("formats false as false", () => {
       const parser = bool();
       assert.equal(parser.format(false), "false");
+    });
+
+    it("should format values as parseable canonical literals", () => {
+      const parser = bool();
+
+      fc.assert(
+        fc.property(fc.boolean(), (value) => {
+          const formatted = parser.format(value);
+
+          const result = parser.parse(formatted);
+
+          assert.ok(result.success);
+          assert.equal(result.value, value);
+        }),
+        propertyParameters,
+      );
     });
   });
 
@@ -187,6 +278,34 @@ describe("bool()", () => {
     it("returns empty array for unmatched prefix", () => {
       const parser = bool();
       assert.deepEqual([...parser.suggest?.("xyz") ?? []], []);
+    });
+
+    it("should only suggest accepted literals matching the prefix", () => {
+      const parser = bool();
+
+      fc.assert(
+        fc.property(
+          fc.constantFrom(...boolLiterals).chain((literal) =>
+            fc.integer({ min: 0, max: literal.length }).map((length) =>
+              literal.slice(0, length)
+            )
+          ),
+          fc.boolean(),
+          (prefix, uppercase) => {
+            const query = uppercase ? prefix.toUpperCase() : prefix;
+
+            const suggestions = [...parser.suggest?.(query) ?? []];
+
+            assert.deepEqual(
+              suggestions,
+              boolLiterals
+                .filter((literal) => literal.startsWith(prefix))
+                .map((literal) => ({ kind: "literal", text: literal })),
+            );
+          },
+        ),
+        propertyParameters,
+      );
     });
 
     it("rejects an empty metavar", () => {
@@ -515,6 +634,83 @@ describe("bindEnv()", () => {
     const result = parse(parser, []);
     assert.ok(result.success);
     assert.equal(result.value, 3000);
+  });
+
+  it("should always prefer CLI over env and default values", () => {
+    fc.assert(
+      fc.property(
+        fc.integer(),
+        fc.integer(),
+        fc.integer(),
+        (cliValue, envValue, defaultValue) => {
+          const context = createEnvContext({
+            source: (key) => key === "PORT" ? String(envValue) : undefined,
+          });
+          const parser = bindEnv(option("--port", integer()), {
+            context,
+            key: "PORT",
+            parser: integer(),
+            default: defaultValue,
+          });
+
+          const result = parse(parser, ["--port", String(cliValue)], {
+            annotations: getSyncAnnotations(context),
+          });
+
+          assert.ok(result.success);
+          assert.equal(result.value, cliValue);
+        },
+      ),
+      propertyParameters,
+    );
+  });
+
+  it("should always prefer env over default when CLI is absent", () => {
+    fc.assert(
+      fc.property(fc.integer(), fc.integer(), (envValue, defaultValue) => {
+        const context = createEnvContext({
+          source: (key) => key === "PORT" ? String(envValue) : undefined,
+        });
+        const parser = bindEnv(option("--port", integer()), {
+          context,
+          key: "PORT",
+          parser: integer(),
+          default: defaultValue,
+        });
+
+        const result = parse(parser, [], {
+          annotations: getSyncAnnotations(context),
+        });
+
+        assert.ok(result.success);
+        assert.equal(result.value, envValue);
+      }),
+      propertyParameters,
+    );
+  });
+
+  it("should use the default for every missing env value", () => {
+    fc.assert(
+      fc.property(fc.integer(), (defaultValue) => {
+        const context = createEnvContext({
+          source: () => undefined,
+        });
+        const parser = bindEnv(option("--port", integer()), {
+          context,
+          key: "PORT",
+          parser: integer(),
+          default: defaultValue,
+        });
+
+        const result = parse(parser, [], {
+          annotations: getSyncAnnotations(context),
+        });
+
+        assert.ok(result.success);
+        assert.equal(result.value, defaultValue);
+      }),
+      propertyParameters,
+    );
   });
 
   it("fails when CLI, env, and default are all missing", () => {

--- a/packages/inquirer/package.json
+++ b/packages/inquirer/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@optique/env": "workspace:*",
     "@types/node": "catalog:",
+    "fast-check": "catalog:",
     "tsdown": "catalog:",
     "typescript": "catalog:"
   },

--- a/packages/inquirer/src/index.test.ts
+++ b/packages/inquirer/src/index.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import * as fc from "fast-check";
 import { describe, it } from "node:test";
 import { type Annotations, getAnnotations } from "@optique/core/annotations";
 import { injectAnnotations } from "@optique/core/extension";
@@ -31,6 +32,8 @@ const promptFunctionsOverrideSymbol = Symbol.for(
   "@optique/inquirer/prompt-functions",
 );
 const annotationKey = Symbol.for("@optique/core/parser/annotation");
+const propertyParameters = { numRuns: 120 } as const;
+const cliStringValueArbitrary = fc.string().map((value) => `value${value}`);
 
 let promptFunctionsOverrideQueue = Promise.resolve();
 
@@ -173,6 +176,33 @@ describe("prompt()", () => {
       assert.ok(result.success);
       assert.deepEqual(result.value, ["a", "c"]);
     });
+
+    it("should always prefer CLI string values over prompted values", async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          cliStringValueArbitrary,
+          fc.string(),
+          async (cliValue, promptValue) => {
+            let promptCalled = false;
+            const parser = prompt(option("--name", string()), {
+              type: "input",
+              message: "Enter name:",
+              prompter: () => {
+                promptCalled = true;
+                return Promise.resolve(promptValue);
+              },
+            });
+
+            const result = await parseAsync(parser, ["--name", cliValue]);
+
+            assert.ok(result.success);
+            assert.equal(result.value, cliValue);
+            assert.ok(!promptCalled);
+          },
+        ),
+        propertyParameters,
+      );
+    });
   });
 
   describe("prompt fallback", () => {
@@ -290,6 +320,42 @@ describe("prompt()", () => {
       const result = await parseAsync(parser, []);
       assert.ok(result.success);
       assert.deepEqual(result.value, ["a", "c"]);
+    });
+
+    it("should use every prompted input value when CLI is absent", async () => {
+      await fc.assert(
+        fc.asyncProperty(fc.string(), async (promptValue) => {
+          const parser = prompt(option("--name", string()), {
+            type: "input",
+            message: "Enter name:",
+            prompter: () => Promise.resolve(promptValue),
+          });
+
+          const result = await parseAsync(parser, []);
+
+          assert.ok(result.success);
+          assert.equal(result.value, promptValue);
+        }),
+        propertyParameters,
+      );
+    });
+
+    it("should use every prompted confirm value when CLI is absent", async () => {
+      await fc.assert(
+        fc.asyncProperty(fc.boolean(), async (promptValue) => {
+          const parser = prompt(flag("--verbose"), {
+            type: "confirm",
+            message: "Verbose?",
+            prompter: () => Promise.resolve(promptValue),
+          });
+
+          const result = await parseAsync(parser, []);
+
+          assert.ok(result.success);
+          assert.equal(result.value, promptValue);
+        }),
+        propertyParameters,
+      );
     });
   });
 

--- a/packages/run/package.json
+++ b/packages/run/package.json
@@ -74,6 +74,7 @@
   },
   "devDependencies": {
     "@types/node": "catalog:",
+    "fast-check": "catalog:",
     "tsdown": "catalog:",
     "typescript": "catalog:"
   },

--- a/packages/run/src/run.test.ts
+++ b/packages/run/src/run.test.ts
@@ -21,6 +21,7 @@ import type { DocSection } from "@optique/core/doc";
 import type { RunOptions } from "@optique/run/run";
 import { run, runAsync, runSync } from "@optique/run/run";
 import assert from "node:assert/strict";
+import * as fc from "fast-check";
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import process from "node:process";
@@ -29,6 +30,8 @@ import { bindConfig, createConfigContext } from "../../config/src/index.ts";
 import { bindEnv, createEnvContext } from "../../env/src/index.ts";
 
 const TEST_DIR = join(import.meta.dirname ?? ".", "test-configs");
+const propertyParameters = { numRuns: 200 } as const;
+const cliArgumentArbitrary = fc.string().map((value) => `arg${value}`);
 
 function isPhase1ContextRequest(request: unknown): boolean {
   return request === undefined ||
@@ -166,6 +169,24 @@ describe("run", () => {
       assert.deepEqual(result, { name: "Alice" });
     });
 
+    it("should parse every explicit argument without reading process.argv", () => {
+      fc.assert(
+        fc.property(cliArgumentArbitrary, (name) => {
+          const parser = object({
+            name: argument(string()),
+          });
+
+          const result = run(parser, {
+            args: [name],
+            programName: "test",
+          });
+
+          assert.deepEqual(result, { name });
+        }),
+        propertyParameters,
+      );
+    });
+
     it("should not crash or() with annotated initial state in runSync()", () => {
       const { parser, context } = createIssue183RunFixture();
       const result = runSync(parser, {
@@ -246,6 +267,37 @@ describe("run", () => {
         count: 42,
         name: "Alice",
       });
+    });
+
+    it("should preserve option and argument values for generated inputs", () => {
+      fc.assert(
+        fc.property(
+          fc.boolean(),
+          fc.integer(),
+          cliArgumentArbitrary,
+          (verbose, count, name) => {
+            const parser = object({
+              verbose: option("--verbose"),
+              count: option("--count", integer()),
+              name: argument(string()),
+            });
+            const args = [
+              ...(verbose ? ["--verbose"] : []),
+              "--count",
+              String(count),
+              name,
+            ];
+
+            const result = run(parser, {
+              args,
+              programName: "test",
+            });
+
+            assert.deepEqual(result, { verbose, count, name });
+          },
+        ),
+        propertyParameters,
+      );
     });
 
     it("should parse commands", () => {

--- a/packages/run/src/valueparser.test.ts
+++ b/packages/run/src/valueparser.test.ts
@@ -8,9 +8,13 @@ import { describe, it } from "node:test";
 import { basename, join } from "node:path";
 
 const propertyParameters = { numRuns: 200 } as const;
-const nonEmptyPathArbitrary = fc.string().filter((input) =>
-  input.trim() !== ""
-);
+const nonWhitespacePathCharArbitrary = fc.integer({ min: 0x21, max: 0x7e })
+  .map((codePoint) => String.fromCharCode(codePoint));
+const nonBlankPathArbitrary = fc.tuple(
+  fc.string(),
+  nonWhitespacePathCharArbitrary,
+  fc.string(),
+).map((parts) => parts.join(""));
 const extensionArbitrary = fc
   .stringMatching(/^[a-z][a-z0-9]*$/u)
   .map((extension) => `.${extension}`);
@@ -49,7 +53,7 @@ describe("path", () => {
       const parser = path();
 
       fc.assert(
-        fc.property(nonEmptyPathArbitrary, (input) => {
+        fc.property(nonBlankPathArbitrary, (input) => {
           const result = parser.parse(input);
 
           assert.ok(result.success);

--- a/packages/run/src/valueparser.test.ts
+++ b/packages/run/src/valueparser.test.ts
@@ -2,9 +2,18 @@ import { formatMessage, message, values } from "@optique/core/message";
 import type { NonEmptyString } from "@optique/core/valueparser";
 import { path } from "@optique/run/valueparser";
 import assert from "node:assert/strict";
+import * as fc from "fast-check";
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { describe, it } from "node:test";
-import { join } from "node:path";
+import { basename, join } from "node:path";
+
+const propertyParameters = { numRuns: 200 } as const;
+const nonEmptyPathArbitrary = fc.string().filter((input) =>
+  input.trim() !== ""
+);
+const extensionArbitrary = fc
+  .stringMatching(/^[a-z][a-z0-9]*$/u)
+  .map((extension) => `.${extension}`);
 
 function createTempDir() {
   const tempDir = `/tmp/optique-test-${Date.now()}-${
@@ -36,6 +45,20 @@ describe("path", () => {
       }
     });
 
+    it("should parse every non-empty path without existence checks", () => {
+      const parser = path();
+
+      fc.assert(
+        fc.property(nonEmptyPathArbitrary, (input) => {
+          const result = parser.parse(input);
+
+          assert.ok(result.success);
+          assert.equal(result.value, input);
+        }),
+        propertyParameters,
+      );
+    });
+
     it("should use default metavar PATH", () => {
       const parser = path();
       assert.equal(parser.metavar, "PATH");
@@ -49,6 +72,19 @@ describe("path", () => {
     it("should format path values correctly", () => {
       const parser = path();
       assert.equal(parser.format("/some/path/file.txt"), "/some/path/file.txt");
+    });
+
+    it("should format every path as itself", () => {
+      const parser = path();
+
+      fc.assert(
+        fc.property(fc.string(), (input) => {
+          const formatted = parser.format(input);
+
+          assert.equal(formatted, input);
+        }),
+        propertyParameters,
+      );
     });
   });
 
@@ -75,6 +111,19 @@ describe("path", () => {
       const parser = path();
       const result = parser.parse("\t\n");
       assert.ok(!result.success);
+    });
+
+    it("should reject every whitespace-only path", () => {
+      const parser = path();
+
+      fc.assert(
+        fc.property(fc.stringMatching(/^\s*$/u), (input) => {
+          const result = parser.parse(input);
+
+          assert.ok(!result.success);
+        }),
+        propertyParameters,
+      );
     });
 
     it("should reject empty string with allowCreate", () => {
@@ -465,6 +514,25 @@ describe("path", () => {
 
       const ymlResult = parser.parse("config.yml");
       assert.equal(ymlResult.success, true);
+    });
+
+    it("should accept paths ending with any configured extension", () => {
+      fc.assert(
+        fc.property(
+          fc.string(),
+          extensionArbitrary,
+          (stem, extension) => {
+            const parser = path({ extensions: [extension] });
+            const input = `${stem}${extension}`;
+
+            const result = parser.parse(input);
+
+            assert.ok(result.success);
+            assert.equal(result.value, input);
+          },
+        ),
+        propertyParameters,
+      );
     });
 
     it("should fail when file has unaccepted extension", () => {
@@ -1136,6 +1204,33 @@ describe("path", () => {
         type: "text",
         text: "File or directory",
       }]);
+    });
+
+    it("should describe every file suggestion from parser options", () => {
+      fc.assert(
+        fc.property(
+          fc.string(),
+          fc.constantFrom("file", "directory", "either" as const),
+          fc.array(extensionArbitrary),
+          (prefix, type, extensions) => {
+            const parser = path({ type, extensions });
+
+            const suggestions = Array.from(parser.suggest!(prefix));
+
+            assert.equal(suggestions.length, 1);
+            const suggestion = suggestions[0];
+            assert.ok(suggestion.kind === "file");
+            assert.equal(suggestion.pattern, prefix);
+            assert.equal(suggestion.type, type === "either" ? "any" : type);
+            assert.deepEqual(suggestion.extensions, extensions);
+            assert.equal(
+              suggestion.includeHidden,
+              basename(prefix).startsWith(".") && basename(prefix) !== "..",
+            );
+          },
+        ),
+        propertyParameters,
+      );
     });
 
     it("should handle empty prefix gracefully", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,8 +22,8 @@ catalogs:
       specifier: ^20.19.9
       version: 20.19.9
     fast-check:
-      specifier: ^4.5.3
-      version: 4.5.3
+      specifier: ^4.7.0
+      version: 4.7.0
     isomorphic-git:
       specifier: ^1.36.1
       version: 1.36.1
@@ -155,6 +155,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.9
+      fast-check:
+        specifier: 'catalog:'
+        version: 4.7.0
       tsdown:
         specifier: 'catalog:'
         version: 0.13.0(typescript@5.8.3)
@@ -172,7 +175,7 @@ importers:
         version: 20.19.9
       fast-check:
         specifier: 'catalog:'
-        version: 4.5.3
+        version: 4.7.0
       tsdown:
         specifier: 'catalog:'
         version: 0.13.0(typescript@5.8.3)
@@ -189,6 +192,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.9
+      fast-check:
+        specifier: 'catalog:'
+        version: 4.7.0
       tsdown:
         specifier: 'catalog:'
         version: 0.13.0(typescript@5.8.3)
@@ -233,6 +239,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.9
+      fast-check:
+        specifier: 'catalog:'
+        version: 4.7.0
       tsdown:
         specifier: 'catalog:'
         version: 0.13.0(typescript@5.8.3)
@@ -293,6 +302,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.9
+      fast-check:
+        specifier: 'catalog:'
+        version: 4.7.0
       tsdown:
         specifier: 'catalog:'
         version: 0.13.0(typescript@5.8.3)
@@ -1641,8 +1653,8 @@ packages:
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
-  fast-check@4.5.3:
-    resolution: {integrity: sha512-IE9csY7lnhxBnA8g/WI5eg/hygA6MGWJMSNfFRrBlXUciADEhS1EDB0SIsMSvzubzIlOBbVITSsypCsW717poA==}
+  fast-check@4.7.0:
+    resolution: {integrity: sha512-NsZRtqvSSoCP0HbNjUD+r1JH8zqZalyp6gLY9e7OYs7NK9b6AHOs2baBFeBG7bVNsuoukh89x2Yg3rPsul8ziQ==}
     engines: {node: '>=12.17.0'}
 
   fast-string-truncated-width@3.0.3:
@@ -2082,8 +2094,8 @@ packages:
     resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
     engines: {node: '>=6'}
 
-  pure-rand@7.0.1:
-    resolution: {integrity: sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==}
+  pure-rand@8.4.0:
+    resolution: {integrity: sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==}
 
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
@@ -3514,9 +3526,9 @@ snapshots:
 
   extend@3.0.2: {}
 
-  fast-check@4.5.3:
+  fast-check@4.7.0:
     dependencies:
-      pure-rand: 7.0.1
+      pure-rand: 8.4.0
 
   fast-string-truncated-width@3.0.3: {}
 
@@ -4096,7 +4108,7 @@ snapshots:
 
   punycode.js@2.3.1: {}
 
-  pure-rand@7.0.1: {}
+  pure-rand@8.4.0: {}
 
   quansync@0.2.11: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,7 +9,7 @@ catalog:
   "@logtape/logtape": ^2.0.4
   "@standard-schema/spec": ^1.1.0
   "@types/node": ^20.19.9
-  fast-check: ^4.5.3
+  fast-check: ^4.7.0
   isomorphic-git: ^1.36.1
   tsdown: ^0.13.0
   tsx: ^4.21.0

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -5,7 +5,7 @@
       "source": "dubzzz/fast-check",
       "sourceType": "github",
       "skillPath": "skills/javascript-testing-expert/SKILL.md",
-      "computedHash": "a01dcd9b4e74a629253b340e9a15e3ee647af1c785f32637e7006d9a26d43150"
+      "computedHash": "dc434138e179e1aa1cfc7599541b033ec4fd7fb5686aa17a2f84c40c2e6c74ac"
     }
   }
 }

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -5,7 +5,7 @@
       "source": "dubzzz/fast-check",
       "sourceType": "github",
       "skillPath": "skills/javascript-testing-expert/SKILL.md",
-      "computedHash": "dc434138e179e1aa1cfc7599541b033ec4fd7fb5686aa17a2f84c40c2e6c74ac"
+      "computedHash": "283ab6afbc474024b955bf2aa3333805fbbbc3b8c91e3074e9fd271b470bbcfb"
     }
   }
 }

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "skills": {
+    "javascript-testing-expert": {
+      "source": "dubzzz/fast-check",
+      "sourceType": "github",
+      "skillPath": "skills/javascript-testing-expert/SKILL.md",
+      "computedHash": "a01dcd9b4e74a629253b340e9a15e3ee647af1c785f32637e7006d9a26d43150"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

This PR introduces property-based testing with fast-check across the core Optique packages, focusing on *@optique/core*, *@optique/run*, *@optique/config*, *@optique/inquirer*, and *@optique/env*.

It updates fast-check to 4.7.0 in *deno.json* and *pnpm-workspace.yaml*, adds package-level dev dependencies where needed, and expands generated-input coverage in *packages/env/src/index.test.ts*, *packages/config/src/index.test.ts*, *packages/run/src/run.test.ts*, *packages/run/src/valueparser.test.ts*, *packages/inquirer/src/index.test.ts*, *packages/core/src/displaywidth.test.ts*, *packages/core/src/nonempty.test.ts*, and *packages/core/src/valueparser.test.ts*.

## What changed

- Added property tests for env/config fallback priority: CLI values, context values, and defaults now get checked across generated inputs.
- Added property tests for prompt fallback behavior in *@optique/inquirer*, including CLI priority and generated prompt values.
- Added property tests for *@optique/run* argument handling and path value parser behavior.
- Added property tests for *@optique/core* value parsers, including string, integer, bigint, float, and choice parser laws.
- Added property tests for core text utilities such as non-empty string guards and terminal display width invariants.
- Normalized the installed *javascript-testing-expert* skill file so branch-wide whitespace checks stay clean.

## Testing

Every commit was reviewed before committing and passed `mise run test`.

Final checks also passed:

- `git diff --check dahlia/main..HEAD`
- `mise run test`

No product bug was found while adding these tests, so *CHANGES.md* was not updated.
