### PR TITLE
Add negatable Boolean flag primitive

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,20 @@ Version 1.1.0
 
 To be released.
 
+### @optique/core
+
+ -  Added `negatableFlag()` for paired Boolean options such as `--color` and
+    `--no-color`.  The parser returns `true` for positive flags and `false`
+    for negative flags, fails when neither side is provided, and composes with
+    `optional()` and `withDefault()` for explicit override and runtime-default
+    use cases.  It supports aliases, help text, shell suggestions, hidden
+    visibility, duplicate/conflict diagnostics, and custom error messages.
+    Documentation and the negatable Boolean options pattern example now show
+    the new primitive.  [[#801], [#802]]
+
+[#801]: https://github.com/dahlia/optique/issues/801
+[#802]: https://github.com/dahlia/optique/pull/802
+
 
 Version 1.0.2
 -------------

--- a/docs/concepts/primitives.md
+++ b/docs/concepts/primitives.md
@@ -341,6 +341,129 @@ The `flag()` parser has the same priority (10) as `option()` to ensure
 consistent option handling.
 
 
+`negatableFlag()` parser
+------------------------
+
+*This API is available since Optique 1.1.0.*
+
+The `negatableFlag()` parser creates a required Boolean choice between a
+positive flag and a negative flag. It returns `true` when the positive flag is
+provided and `false` when the negative flag is provided. If neither flag is
+present, parsing fails unless you wrap it with `optional()` or `withDefault()`.
+
+This is useful for settings whose default can vary at runtime, but where users
+still need an explicit command-line override in either direction:
+
+~~~~ typescript twoslash
+import { withDefault } from "@optique/core/modifiers";
+import { message } from "@optique/core/message";
+import { negatableFlag } from "@optique/core/primitives";
+declare function detectColorSupport(): boolean;
+// ---cut-before---
+const color = withDefault(
+  negatableFlag({
+    positive: "--color",
+    negative: "--no-color",
+  }, {
+    description: message`Force-enable or force-disable colored output.`,
+  }),
+  () => detectColorSupport(),
+  { message: message`auto` },
+);
+~~~~
+
+When used without a wrapper, one of the two flags is required:
+
+~~~~ typescript twoslash
+import { parse } from "@optique/core/parser";
+import { negatableFlag } from "@optique/core/primitives";
+
+const parser = negatableFlag({
+  positive: "--color",
+  negative: "--no-color",
+});
+
+parse(parser, ["--color"]);    // => { success: true, value: true }
+parse(parser, ["--no-color"]); // => { success: true, value: false }
+parse(parser, []);             // => { success: false, ... }
+~~~~
+
+### Aliases and help output
+
+Each side can have aliases. In help output, Optique renders the positive and
+negative names in one entry because they control the same Boolean value:
+
+~~~~ typescript twoslash
+import { message } from "@optique/core/message";
+import { negatableFlag } from "@optique/core/primitives";
+// ---cut-before---
+const color = negatableFlag({
+  positive: ["-c", "--color"],
+  negative: "--no-color",
+}, {
+  description: message`Control colored output.`,
+});
+~~~~
+
+The same option name cannot appear twice, or appear on both sides. Repeating
+the same side on the command line is treated as a duplicate, while using both
+the positive and negative flags is treated as a conflict.
+
+### Optional and defaulted negatable flags
+
+Wrap `negatableFlag()` with `optional()` when absence should mean “no explicit
+override”:
+
+~~~~ typescript twoslash
+import { optional } from "@optique/core/modifiers";
+import { negatableFlag } from "@optique/core/primitives";
+
+const colorOverride = optional(negatableFlag({
+  positive: "--color",
+  negative: "--no-color",
+}));
+~~~~
+
+Use `withDefault()` when you always want a concrete Boolean. The default value
+can be computed lazily, which makes runtime-dependent defaults explicit:
+
+~~~~ typescript twoslash
+import { withDefault } from "@optique/core/modifiers";
+import { negatableFlag } from "@optique/core/primitives";
+declare function shouldUseColor(): boolean;
+// ---cut-before---
+const color = withDefault(
+  negatableFlag({
+    positive: "--color",
+    negative: "--no-color",
+  }),
+  () => shouldUseColor(),
+);
+~~~~
+
+### Custom errors
+
+`negatableFlag()` accepts custom error messages for missing flags, duplicate
+uses, conflicts, unexpected joined values, and no-match suggestions:
+
+~~~~ typescript twoslash
+import { message, text } from "@optique/core/message";
+import { negatableFlag } from "@optique/core/primitives";
+// ---cut-before---
+const color = negatableFlag({
+  positive: "--color",
+  negative: "--no-color",
+}, {
+  errors: {
+    missing: (positive, negative) =>
+      message`Pass ${text(positive[0])} or ${text(negative[0])}.`,
+    conflict: (previous, next) =>
+      message`${text(previous)} and ${text(next)} cannot be used together.`,
+  },
+});
+~~~~
+
+
 `argument()` parser
 -------------------
 
@@ -678,7 +801,7 @@ The `passThrough()` parser has the *lowest priority* (−10) among all parsers
 to ensure explicit parsers always match first:
 
  -  *Priority 15*: `command()` parsers
- -  *Priority 10*: `option()` and `flag()` parsers
+ -  *Priority 10*: `option()`, `flag()`, and `negatableFlag()` parsers
  -  *Priority 5*: `argument()` parsers
  -  *Priority 0*: `constant()` and `fail()` parsers
  -  *Priority −10*: `passThrough()` parsers
@@ -723,7 +846,7 @@ applied when multiple parsers are available. This ensures that more specific
 parsers (like commands) are tried before more general ones (like arguments):
 
  -  *Priority 15*: `command()` parsers
- -  *Priority 10*: `option()` and `flag()` parsers
+ -  *Priority 10*: `option()`, `flag()`, and `negatableFlag()` parsers
  -  *Priority 5*: `argument()` parsers
  -  *Priority 0*: `constant()` and `fail()` parsers
  -  *Priority −10*: `passThrough()` parsers
@@ -868,8 +991,8 @@ const parser = object({
 Hidden parsers
 --------------
 
-All primitive parsers—`option()`, `flag()`, `argument()`, `command()`,
-and `passThrough()`—support a `hidden` option:
+All primitive parsers—`option()`, `flag()`, `negatableFlag()`, `argument()`,
+`command()`, and `passThrough()`—support a `hidden` option:
 
  -  `true`: hide from usage, help entries, shell completions, and
     “Did you mean?” suggestions

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -887,29 +887,52 @@ for both code clarity and user experience independently.
 
 ### Negatable Boolean options
 
-Linux CLI tools commonly support `--no-` prefix options that negate default
-behavior. This pattern allows users to explicitly disable features that are
-enabled by default.
+Linux CLI tools commonly support positive and negative option pairs such as
+`--color` and `--no-color`. Use
+[`negatableFlag()`](./concepts/primitives.md#negatableflag-parser) when users
+should be able to override a Boolean setting in either direction.
 
 ~~~~ typescript twoslash
 import { object } from "@optique/core/constructs";
-import { map } from "@optique/core/modifiers";
-import { option } from "@optique/core/primitives";
+import { withDefault } from "@optique/core/modifiers";
+import { negatableFlag, option } from "@optique/core/primitives";
 import { message } from "@optique/core/message";
 import { print, run } from "@optique/run";
+declare function detectColorSupport(): boolean;
 // ---cut-before---
 const configParser = object({
-  // Code fence is enabled by default, --no-code-fence disables it
-  codeFence: map(option("--no-code-fence"), (o) => !o),
+  codeFence: withDefault(
+    negatableFlag({
+      positive: "--code-fence",
+      negative: "--no-code-fence",
+    }, {
+      description: message`Enable or disable Markdown code fences.`,
+    }),
+    true,
+  ),
 
-  // Line numbers are disabled by default, --line-numbers enables it
   lineNumbers: option("--line-numbers"),
 
-  // Colors are enabled by default, --no-colors disables them
-  colors: map(option("--no-colors"), (o) => !o),
+  colors: withDefault(
+    negatableFlag({
+      positive: "--colors",
+      negative: "--no-colors",
+    }, {
+      description: message`Enable or disable colored output.`,
+    }),
+    () => detectColorSupport(),
+    { message: message`auto` },
+  ),
 
-  // Syntax highlighting is enabled by default, --no-syntax disables it
-  syntax: map(option("--no-syntax"), (o) => !o),
+  syntax: withDefault(
+    negatableFlag({
+      positive: "--syntax",
+      negative: "--no-syntax",
+    }, {
+      description: message`Enable or disable syntax highlighting.`,
+    }),
+    true,
+  ),
 });
 
 const result = run(configParser);
@@ -925,37 +948,46 @@ const result = run(configParser);
 console.debug(result);
 ~~~~
 
-This pattern leverages the fact that
-[`option()`](./concepts/primitives.md#option-parser) without a value parser
-creates a Boolean flag that produces `false` when absent and `true` when
-present. The [`map()`](./concepts/modifiers.md#map-parser) combinator inverts
-this behavior:
+`negatableFlag()` returns `true` for the positive flag and `false` for the
+negative flag. By itself it requires one of the two flags, so the example wraps
+each parser with [`withDefault()`](./concepts/modifiers.md#withdefault-parser)
+to keep the defaults explicit.
+
+When `--code-fence` is provided
+:   `negatableFlag()` produces `true`
+
+When neither flag is provided
+:   `withDefault()` uses the default value `true`
 
 When `--no-code-fence` is provided
-:   `option()` produces `true` → `map()` inverts to `false`
+:   `negatableFlag()` produces `false`
 
-When `--no-code-fence` is not provided
-:   `option()` produces `false` → `map()` inverts to `true`
+If a CLI only supports a negative form, keep the simpler `option()` and `map()`
+pattern:
 
-This creates the expected Linux CLI behavior where features are enabled by
-default and can be explicitly disabled with `--no-` prefixed options.
+~~~~ typescript twoslash
+import { map } from "@optique/core/modifiers";
+import { option } from "@optique/core/primitives";
+
+const codeFence = map(option("--no-code-fence"), (provided) => !provided);
+~~~~
 
 ### Usage examples
 
 ~~~~ bash
-# All defaults: codeFence=true, lineNumbers=false, colors=true, syntax=true
+# All defaults: codeFence=true, lineNumbers=false, colors=auto, syntax=true
 myapp
 
-# Disable colors and syntax, enable line numbers
+# Disable colors and syntax, enable line numbers explicitly
 myapp --no-colors --no-syntax --line-numbers
 
-# Disable code fence only
-myapp --no-code-fence
+# Enable colors explicitly when auto-detection would disable them
+myapp --colors
 ~~~~
 
 This pattern is particularly useful for configuration-heavy tools where users
-need fine-grained control over default behaviors, following the Unix tradition
-of sensible defaults with explicit override capabilities.
+need fine-grained control over defaults that may come from configuration files,
+environment variables, or runtime detection.
 
 ### Conditional defaults based on input consumption
 

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -953,6 +953,9 @@ negative flag. By itself it requires one of the two flags, so the example wraps
 each parser with [`withDefault()`](./concepts/modifiers.md#withdefault-parser)
 to keep the defaults explicit.
 
+The `message` option on `withDefault()` only changes the displayed default
+label; `detectColorSupport()` still returns the Boolean fallback value.
+
 When `--code-fence` is provided
 :   `negatableFlag()` produces `true`
 
@@ -975,7 +978,8 @@ const codeFence = map(option("--no-code-fence"), (provided) => !provided);
 ### Usage examples
 
 ~~~~ bash
-# All defaults: codeFence=true, lineNumbers=false, colors=auto, syntax=true
+# All defaults: codeFence=true, lineNumbers=false,
+# colors follow auto-detection, syntax=true
 myapp
 
 # Disable colors and syntax, enable line numbers explicitly

--- a/examples/patterns/negatable-boolean-options.ts
+++ b/examples/patterns/negatable-boolean-options.ts
@@ -1,25 +1,54 @@
-// This example demonstrates how to implement --no- prefix boolean options
-// commonly found in Linux CLI tools, where --no-option negates a default
-// behavior.
+// This example demonstrates how to implement positive and negative Boolean
+// option pairs commonly found in Linux CLI tools, such as --color and
+// --no-color.
 import { object } from "@optique/core/constructs";
-import { map } from "@optique/core/modifiers";
-import { option } from "@optique/core/primitives";
-import { run } from "@optique/run";
+import { message } from "@optique/core/message";
+import { withDefault } from "@optique/core/modifiers";
+import { negatableFlag, option } from "@optique/core/primitives";
+import { print, run } from "@optique/run";
+
+function detectColorSupport(): boolean {
+  return true;
+}
 
 const configParser = object({
-  // Code fence is enabled by default, --no-code-fence disables it
-  codeFence: map(option("--no-code-fence"), (o) => !o),
+  codeFence: withDefault(
+    negatableFlag({
+      positive: "--code-fence",
+      negative: "--no-code-fence",
+    }, {
+      description: message`Enable or disable Markdown code fences.`,
+    }),
+    true,
+  ),
 
-  // Line numbers are disabled by default, --line-numbers enables it
   lineNumbers: option("--line-numbers"),
 
-  // Colors are enabled by default, --no-colors disables them
-  colors: map(option("--no-colors"), (o) => !o),
+  colors: withDefault(
+    negatableFlag({
+      positive: "--colors",
+      negative: "--no-colors",
+    }, {
+      description: message`Enable or disable colored output.`,
+    }),
+    () => detectColorSupport(),
+    { message: message`auto` },
+  ),
 
-  // Syntax highlighting is enabled by default, --no-syntax disables it
-  syntax: map(option("--no-syntax"), (o) => !o),
+  syntax: withDefault(
+    negatableFlag({
+      positive: "--syntax",
+      negative: "--no-syntax",
+    }, {
+      description: message`Enable or disable syntax highlighting.`,
+    }),
+    true,
+  ),
 });
 
 const result = run(configParser);
 
-console.log(result);
+print(message`Code fences: ${String(result.codeFence)}.`);
+print(message`Line numbers: ${String(result.lineNumbers)}.`);
+print(message`Colors: ${String(result.colors)}.`);
+print(message`Syntax highlighting: ${String(result.syntax)}.`);

--- a/packages/core/src/primitives.test.ts
+++ b/packages/core/src/primitives.test.ts
@@ -1682,7 +1682,7 @@ describe("negatableFlag()", () => {
 
     assert.ok(result.success);
     if (result.success) {
-      assert.equal(result.value, true);
+      assert.ok(result.value);
     }
   });
 
@@ -1696,7 +1696,7 @@ describe("negatableFlag()", () => {
 
     assert.ok(result.success);
     if (result.success) {
-      assert.equal(result.value, false);
+      assert.ok(!result.value);
     }
   });
 
@@ -1757,7 +1757,7 @@ describe("negatableFlag()", () => {
 
     assert.ok(result.success);
     if (result.success) {
-      assert.equal(result.value, true);
+      assert.ok(result.value);
     }
   });
 
@@ -1772,11 +1772,11 @@ describe("negatableFlag()", () => {
 
     assert.ok(positive.success);
     if (positive.success) {
-      assert.equal(positive.value, true);
+      assert.ok(positive.value);
     }
     assert.ok(negative.success);
     if (negative.success) {
-      assert.equal(negative.value, false);
+      assert.ok(!negative.value);
     }
   });
 
@@ -2022,18 +2022,18 @@ describe("negatableFlag()", () => {
 
     assert.ok(positive.success);
     if (positive.success) {
-      assert.equal(positive.next.state?.success, true);
+      assert.ok(positive.next.state?.success);
       if (positive.next.state?.success) {
-        assert.equal(positive.next.state.value, true);
+        assert.ok(positive.next.state.value);
       }
       assert.deepEqual(positive.next.buffer, ["-v"]);
       assert.deepEqual(positive.consumed, ["-c"]);
     }
     assert.ok(negative.success);
     if (negative.success) {
-      assert.equal(negative.next.state?.success, true);
+      assert.ok(negative.next.state?.success);
       if (negative.next.state?.success) {
-        assert.equal(negative.next.state.value, false);
+        assert.ok(!negative.next.state.value);
       }
       assert.deepEqual(negative.next.buffer, ["-v"]);
       assert.deepEqual(negative.consumed, ["-C"]);
@@ -2055,7 +2055,7 @@ describe("negatableFlag()", () => {
 
     assert.ok(result.success);
     if (result.success) {
-      assert.equal(result.next.optionsTerminated, true);
+      assert.ok(result.next.optionsTerminated);
       assert.deepEqual(result.next.buffer, ["--color"]);
       assert.deepEqual(result.consumed, ["--"]);
     }
@@ -2253,14 +2253,14 @@ describe("negatableFlag()", () => {
             const result = parseSync(parser, [name]);
             assert.ok(result.success);
             if (result.success) {
-              assert.equal(result.value, true);
+              assert.ok(result.value);
             }
           }
           for (const name of negativeNames) {
             const result = parseSync(parser, [name]);
             assert.ok(result.success);
             if (result.success) {
-              assert.equal(result.value, false);
+              assert.ok(!result.value);
             }
           }
         },

--- a/packages/core/src/primitives.test.ts
+++ b/packages/core/src/primitives.test.ts
@@ -2022,8 +2022,8 @@ describe("negatableFlag()", () => {
 
     assert.ok(positive.success);
     if (positive.success) {
-      assert.ok(positive.next.state?.success);
-      if (positive.next.state?.success) {
+      assert.ok(positive.next.state != null);
+      if (positive.next.state != null) {
         assert.ok(positive.next.state.value);
       }
       assert.deepEqual(positive.next.buffer, ["-v"]);
@@ -2031,8 +2031,8 @@ describe("negatableFlag()", () => {
     }
     assert.ok(negative.success);
     if (negative.success) {
-      assert.ok(negative.next.state?.success);
-      if (negative.next.state?.success) {
+      assert.ok(negative.next.state != null);
+      if (negative.next.state != null) {
         assert.ok(!negative.next.state.value);
       }
       assert.deepEqual(negative.next.buffer, ["-v"]);
@@ -2098,13 +2098,13 @@ describe("negatableFlag()", () => {
     });
     const duplicate = parser.parse({
       buffer: ["--color"],
-      state: { success: true, value: true, token: "--color" },
+      state: { value: true, token: "--color" },
       optionsTerminated: false,
       usage: parser.usage,
     });
     const conflict = parser.parse({
       buffer: ["--no-color"],
-      state: { success: true, value: true, token: "--color" },
+      state: { value: true, token: "--color" },
       optionsTerminated: false,
       usage: parser.usage,
     });

--- a/packages/core/src/primitives.test.ts
+++ b/packages/core/src/primitives.test.ts
@@ -1982,17 +1982,23 @@ describe("negatableFlag()", () => {
 
   it("should reject values joined to positive and negative flags", () => {
     const parser = negatableFlag({
-      positive: "--color",
+      positive: ["--color", "+color"],
       negative: "/color",
     });
 
     const positive = parseSync(parser, ["--color=true"]);
+    const plusPositive = parseSync(parser, ["+color=true"]);
     const negative = parseSync(parser, ["/color:false"]);
 
     assert.ok(!positive.success);
     if (!positive.success) {
       assertErrorIncludes(positive.error, "does not accept a value");
       assertErrorIncludes(positive.error, "true");
+    }
+    assert.ok(!plusPositive.success);
+    if (!plusPositive.success) {
+      assertErrorIncludes(plusPositive.error, "does not accept a value");
+      assertErrorIncludes(plusPositive.error, "true");
     }
     assert.ok(!negative.success);
     if (!negative.success) {

--- a/packages/core/src/primitives.test.ts
+++ b/packages/core/src/primitives.test.ts
@@ -7968,6 +7968,76 @@ describe("validateValue on primitives (#414)", () => {
     });
   });
 
+  describe("negatableFlag()", () => {
+    it("accepts boolean fallback values", () => {
+      const parser = negatableFlag({
+        positive: "--color",
+        negative: "--no-color",
+      });
+
+      assert.ok(typeof parser.validateValue === "function");
+      assert.ok(!Object.keys(parser).includes("validateValue"));
+
+      const trueResult = parser.validateValue!(true);
+      assert.ok(
+        trueResult && typeof trueResult === "object" &&
+          "success" in trueResult,
+      );
+      assert.ok(trueResult.success);
+      if (trueResult.success) {
+        assert.ok(trueResult.value);
+      }
+
+      const falseResult = parser.validateValue!(false);
+      assert.ok(
+        falseResult && typeof falseResult === "object" &&
+          "success" in falseResult,
+      );
+      assert.ok(falseResult.success);
+      if (falseResult.success) {
+        assert.ok(!falseResult.value);
+      }
+    });
+
+    it("rejects non-boolean fallback values", () => {
+      const parser = negatableFlag({
+        positive: "--color",
+        negative: "--no-color",
+      });
+
+      assert.ok(typeof parser.validateValue === "function");
+
+      const stringResult = parser.validateValue!("yes" as never);
+      assert.ok(
+        stringResult && typeof stringResult === "object" &&
+          "success" in stringResult,
+      );
+      assert.ok(!stringResult.success);
+      if (!stringResult.success) {
+        const formatted = formatMessage(stringResult.error);
+        assert.ok(
+          formatted.includes("--color"),
+          `expected error to mention the positive option, got: ${formatted}`,
+        );
+        assert.ok(
+          formatted.includes("--no-color"),
+          `expected error to mention the negative option, got: ${formatted}`,
+        );
+        assert.ok(
+          formatted.toLowerCase().includes("boolean"),
+          `expected error to mention "boolean", got: ${formatted}`,
+        );
+      }
+
+      const nullResult = parser.validateValue!(null as never);
+      assert.ok(
+        nullResult && typeof nullResult === "object" &&
+          "success" in nullResult,
+      );
+      assert.ok(!nullResult.success);
+    });
+  });
+
   describe("argument()", () => {
     it("accepts values passing the inner pattern", () => {
       const parser = argument(string({ pattern: /^[A-Z]+$/ }));

--- a/packages/core/src/primitives.test.ts
+++ b/packages/core/src/primitives.test.ts
@@ -2228,6 +2228,28 @@ describe("negatableFlag()", () => {
     ]);
   });
 
+  it("should suggest plus-prefixed positive and negative names", () => {
+    const parser = negatableFlag({
+      positive: "+color",
+      negative: "+no-color",
+    });
+
+    const suggestions = Array.from(parser.suggest(
+      {
+        buffer: [],
+        state: parser.initialState,
+        optionsTerminated: false,
+        usage: parser.usage,
+      },
+      "+",
+    ));
+
+    assert.deepEqual(suggestions, [
+      { kind: "literal", text: "+color" },
+      { kind: "literal", text: "+no-color" },
+    ]);
+  });
+
   it("should always parse generated positive and negative names by polarity", () => {
     fc.assert(
       fc.property(

--- a/packages/core/src/primitives.test.ts
+++ b/packages/core/src/primitives.test.ts
@@ -21,6 +21,7 @@ import {
   constant,
   fail,
   flag,
+  negatableFlag,
   option,
   passThrough,
 } from "@optique/core/primitives";
@@ -1665,6 +1666,195 @@ describe("flag", () => {
         names: ["-f", "--force"],
       }]);
     });
+  });
+});
+
+describe("negatableFlag()", () => {
+  it("should parse the positive flag as true", () => {
+    const parser = negatableFlag({
+      positive: "--color",
+      negative: "--no-color",
+    });
+
+    const result = parseSync(parser, ["--color"]);
+
+    assert.ok(result.success);
+    if (result.success) {
+      assert.equal(result.value, true);
+    }
+  });
+
+  it("should parse the negative flag as false", () => {
+    const parser = negatableFlag({
+      positive: "--color",
+      negative: "--no-color",
+    });
+
+    const result = parseSync(parser, ["--no-color"]);
+
+    assert.ok(result.success);
+    if (result.success) {
+      assert.equal(result.value, false);
+    }
+  });
+
+  it("should fail when neither flag is provided", () => {
+    const parser = negatableFlag({
+      positive: "--color",
+      negative: "--no-color",
+    });
+
+    const result = parseSync(parser, []);
+
+    assert.ok(!result.success);
+    if (!result.success) {
+      assertErrorIncludes(result.error, "Expected an option");
+    }
+  });
+
+  it("should report all names when completed without a flag", () => {
+    const parser = negatableFlag({
+      positive: "--color",
+      negative: "--no-color",
+    });
+
+    const result = parser.complete(undefined);
+
+    assert.ok(!result.success);
+    if (!result.success) {
+      assertErrorIncludes(result.error, "Required flag");
+      assertErrorIncludes(result.error, "--color");
+      assertErrorIncludes(result.error, "--no-color");
+    }
+  });
+
+  it("should return undefined when wrapped in optional", () => {
+    const parser = optional(negatableFlag({
+      positive: "--color",
+      negative: "--no-color",
+    }));
+
+    const result = parseSync(parser, []);
+
+    assert.ok(result.success);
+    if (result.success) {
+      assert.equal(result.value, undefined);
+    }
+  });
+
+  it("should use a default when wrapped in withDefault", () => {
+    const parser = withDefault(
+      negatableFlag({
+        positive: "--color",
+        negative: "--no-color",
+      }),
+      () => true,
+    );
+
+    const result = parseSync(parser, []);
+
+    assert.ok(result.success);
+    if (result.success) {
+      assert.equal(result.value, true);
+    }
+  });
+
+  it("should support positive and negative aliases", () => {
+    const parser = negatableFlag({
+      positive: ["-c", "--color"],
+      negative: ["-C", "--no-color"],
+    });
+
+    const positive = parseSync(parser, ["-c"]);
+    const negative = parseSync(parser, ["-C"]);
+
+    assert.ok(positive.success);
+    if (positive.success) {
+      assert.equal(positive.value, true);
+    }
+    assert.ok(negative.success);
+    if (negative.success) {
+      assert.equal(negative.value, false);
+    }
+  });
+
+  it("should expose all names in one documentation entry", () => {
+    const parser = negatableFlag({
+      positive: ["--color"],
+      negative: ["--no-color"],
+    }, {
+      description: message`Control colored output.`,
+    });
+
+    const fragments = parser.getDocFragments(
+      { kind: "unavailable" },
+      undefined,
+    );
+
+    assert.equal(fragments.fragments.length, 1);
+    assert.equal(fragments.fragments[0].type, "entry");
+    if (fragments.fragments[0].type === "entry") {
+      assert.equal(fragments.fragments[0].term.type, "option");
+      if (fragments.fragments[0].term.type === "option") {
+        assert.deepEqual(fragments.fragments[0].term.names, [
+          "--color",
+          "--no-color",
+        ]);
+      }
+      assert.ok(fragments.fragments[0].description);
+      assert.equal(
+        formatMessage(fragments.fragments[0].description),
+        "Control colored output.",
+      );
+    }
+  });
+
+  it("should suggest matching positive and negative names", () => {
+    const parser = negatableFlag({
+      positive: ["-c", "--color"],
+      negative: ["-C", "--no-color"],
+    });
+
+    const suggestions = Array.from(parser.suggest(
+      {
+        buffer: [],
+        state: parser.initialState,
+        optionsTerminated: false,
+        usage: parser.usage,
+      },
+      "--",
+    ));
+
+    assert.deepEqual(suggestions, [
+      { kind: "literal", text: "--color" },
+      { kind: "literal", text: "--no-color" },
+    ]);
+  });
+
+  it("should respect hidden options in docs and suggestions", () => {
+    const parser = negatableFlag({
+      positive: "--color",
+      negative: "--no-color",
+    }, {
+      hidden: true,
+    });
+
+    const fragments = parser.getDocFragments(
+      { kind: "unavailable" },
+      undefined,
+    );
+    const suggestions = Array.from(parser.suggest(
+      {
+        buffer: [],
+        state: parser.initialState,
+        optionsTerminated: false,
+        usage: parser.usage,
+      },
+      "--",
+    ));
+
+    assert.deepEqual(fragments.fragments, []);
+    assert.deepEqual(suggestions, []);
   });
 });
 

--- a/packages/core/src/primitives.test.ts
+++ b/packages/core/src/primitives.test.ts
@@ -14,6 +14,7 @@ import {
   message,
   text,
 } from "@optique/core/message";
+import { formatDocPage } from "@optique/core/doc";
 import { map, multiple, optional, withDefault } from "@optique/core/modifiers";
 import {
   argument,
@@ -52,6 +53,7 @@ import {
   type Suggestion,
 } from "@optique/core/parser";
 import type { Usage } from "@optique/core/usage";
+import * as fc from "fast-check";
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
@@ -1855,6 +1857,450 @@ describe("negatableFlag()", () => {
 
     assert.deepEqual(fragments.fragments, []);
     assert.deepEqual(suggestions, []);
+  });
+
+  it("should render positive and negative flags on one help line", () => {
+    const parser = negatableFlag({
+      positive: "--color",
+      negative: "--no-color",
+    }, {
+      description: message`Control colored output.`,
+    });
+    const fragments = parser.getDocFragments(
+      { kind: "unavailable" },
+      undefined,
+    );
+
+    const output = formatDocPage("myapp", {
+      sections: [{
+        entries: fragments.fragments.filter((f) => f.type === "entry"),
+      }],
+    });
+
+    assert.match(output, /--color, --no-color\s+Control colored output\./);
+  });
+
+  it("should reject duplicate positive names", () => {
+    assert.throws(
+      () =>
+        negatableFlag({
+          positive: ["--color", "--color"],
+          negative: "--no-color",
+        }),
+      {
+        name: "TypeError",
+        message: 'Positive flag has a duplicate name: "--color".',
+      },
+    );
+  });
+
+  it("should reject duplicate negative names", () => {
+    assert.throws(
+      () =>
+        negatableFlag({
+          positive: "--color",
+          negative: ["--no-color", "--no-color"],
+        }),
+      {
+        name: "TypeError",
+        message: 'Negative flag has a duplicate name: "--no-color".',
+      },
+    );
+  });
+
+  it("should reject names shared by positive and negative sets", () => {
+    assert.throws(
+      () =>
+        negatableFlag({
+          positive: ["--color", "--colour"],
+          negative: ["--no-color", "--colour"],
+        }),
+      {
+        name: "TypeError",
+        message:
+          'Negatable flag name is both positive and negative: "--colour".',
+      },
+    );
+  });
+
+  it("should reject empty positive and negative name lists", () => {
+    assert.throws(
+      () =>
+        negatableFlag({
+          // @ts-expect-error Testing runtime validation for non-TypeScript callers.
+          positive: [],
+          negative: "--no-color",
+        }),
+      {
+        name: "TypeError",
+        message: "Expected at least one positive flag name.",
+      },
+    );
+    assert.throws(
+      () =>
+        negatableFlag({
+          positive: "--color",
+          // @ts-expect-error Testing runtime validation for non-TypeScript callers.
+          negative: [],
+        }),
+      {
+        name: "TypeError",
+        message: "Expected at least one negative flag name.",
+      },
+    );
+  });
+
+  it("should fail duplicate same-polarity flags", () => {
+    const parser = negatableFlag({
+      positive: ["-c", "--color"],
+      negative: "--no-color",
+    });
+
+    const result = parseSync(parser, ["-c", "--color"]);
+
+    assert.ok(!result.success);
+    if (!result.success) {
+      assertErrorIncludes(result.error, "cannot be used multiple times");
+    }
+  });
+
+  it("should fail conflicting positive and negative flags", () => {
+    const parser = negatableFlag({
+      positive: "--color",
+      negative: "--no-color",
+    });
+
+    const result = parseSync(parser, ["--color", "--no-color"]);
+
+    assert.ok(!result.success);
+    if (!result.success) {
+      assertErrorIncludes(result.error, "--color");
+      assertErrorIncludes(result.error, "--no-color");
+      assertErrorIncludes(result.error, "cannot be used together");
+    }
+  });
+
+  it("should reject values joined to positive and negative flags", () => {
+    const parser = negatableFlag({
+      positive: "--color",
+      negative: "/color",
+    });
+
+    const positive = parseSync(parser, ["--color=true"]);
+    const negative = parseSync(parser, ["/color:false"]);
+
+    assert.ok(!positive.success);
+    if (!positive.success) {
+      assertErrorIncludes(positive.error, "does not accept a value");
+      assertErrorIncludes(positive.error, "true");
+    }
+    assert.ok(!negative.success);
+    if (!negative.success) {
+      assertErrorIncludes(negative.error, "does not accept a value");
+      assertErrorIncludes(negative.error, "false");
+    }
+  });
+
+  it("should consume bundled short positive and negative flags", () => {
+    const parser = negatableFlag({
+      positive: "-c",
+      negative: "-C",
+    });
+
+    const positive = parser.parse({
+      buffer: ["-cv"],
+      state: parser.initialState,
+      optionsTerminated: false,
+      usage: parser.usage,
+    });
+    const negative = parser.parse({
+      buffer: ["-Cv"],
+      state: parser.initialState,
+      optionsTerminated: false,
+      usage: parser.usage,
+    });
+
+    assert.ok(positive.success);
+    if (positive.success) {
+      assert.equal(positive.next.state?.success, true);
+      if (positive.next.state?.success) {
+        assert.equal(positive.next.state.value, true);
+      }
+      assert.deepEqual(positive.next.buffer, ["-v"]);
+      assert.deepEqual(positive.consumed, ["-c"]);
+    }
+    assert.ok(negative.success);
+    if (negative.success) {
+      assert.equal(negative.next.state?.success, true);
+      if (negative.next.state?.success) {
+        assert.equal(negative.next.state.value, false);
+      }
+      assert.deepEqual(negative.next.buffer, ["-v"]);
+      assert.deepEqual(negative.consumed, ["-C"]);
+    }
+  });
+
+  it("should handle the options terminator", () => {
+    const parser = negatableFlag({
+      positive: "--color",
+      negative: "--no-color",
+    });
+
+    const result = parser.parse({
+      buffer: ["--", "--color"],
+      state: parser.initialState,
+      optionsTerminated: false,
+      usage: parser.usage,
+    });
+
+    assert.ok(result.success);
+    if (result.success) {
+      assert.equal(result.next.optionsTerminated, true);
+      assert.deepEqual(result.next.buffer, ["--color"]);
+      assert.deepEqual(result.consumed, ["--"]);
+    }
+  });
+
+  it("should customize every error branch", () => {
+    const parser = negatableFlag({
+      positive: "--color",
+      negative: "--no-color",
+    }, {
+      errors: {
+        missing: (positiveNames, negativeNames) =>
+          message`missing ${text(positiveNames.join(","))} ${
+            text(negativeNames.join(","))
+          }`,
+        optionsTerminated: message`terminated`,
+        endOfInput: message`empty`,
+        duplicate: (token) => message`duplicate ${text(token)}`,
+        conflict: (previous, token) =>
+          message`conflict ${text(previous)} ${text(token)}`,
+        unexpectedValue: (name, value) =>
+          message`unexpected ${text(name)} ${text(value)}`,
+        noMatch: (invalid, suggestions) =>
+          message`nomatch ${text(invalid)} ${text(suggestions.join(","))}`,
+      },
+    });
+
+    const missing = parser.complete(undefined);
+    const terminated = parser.parse({
+      buffer: ["--color"],
+      state: parser.initialState,
+      optionsTerminated: true,
+      usage: parser.usage,
+    });
+    const empty = parser.parse({
+      buffer: [],
+      state: parser.initialState,
+      optionsTerminated: false,
+      usage: parser.usage,
+    });
+    const duplicate = parser.parse({
+      buffer: ["--color"],
+      state: { success: true, value: true, token: "--color" },
+      optionsTerminated: false,
+      usage: parser.usage,
+    });
+    const conflict = parser.parse({
+      buffer: ["--no-color"],
+      state: { success: true, value: true, token: "--color" },
+      optionsTerminated: false,
+      usage: parser.usage,
+    });
+    const unexpected = parser.parse({
+      buffer: ["--color=true"],
+      state: parser.initialState,
+      optionsTerminated: false,
+      usage: parser.usage,
+    });
+    const noMatch = parser.parse({
+      buffer: ["--colr"],
+      state: parser.initialState,
+      optionsTerminated: false,
+      usage: parser.usage,
+    });
+
+    assert.ok(!missing.success);
+    if (!missing.success) {
+      assert.equal(formatMessage(missing.error), "missing --color --no-color");
+    }
+    assert.ok(!terminated.success);
+    if (!terminated.success) {
+      assert.equal(formatMessage(terminated.error), "terminated");
+    }
+    assert.ok(!empty.success);
+    if (!empty.success) {
+      assert.equal(formatMessage(empty.error), "empty");
+    }
+    assert.ok(!duplicate.success);
+    if (!duplicate.success) {
+      assert.equal(formatMessage(duplicate.error), "duplicate --color");
+    }
+    assert.ok(!conflict.success);
+    if (!conflict.success) {
+      assert.equal(
+        formatMessage(conflict.error),
+        "conflict --color --no-color",
+      );
+    }
+    assert.ok(!unexpected.success);
+    if (!unexpected.success) {
+      assert.equal(formatMessage(unexpected.error), "unexpected --color true");
+    }
+    assert.ok(!noMatch.success);
+    if (!noMatch.success) {
+      assert.equal(formatMessage(noMatch.error), "nomatch --colr --color");
+    }
+  });
+
+  it('should keep docs and suggestions for hidden: "usage"', () => {
+    const parser = negatableFlag({
+      positive: "--color",
+      negative: "--no-color",
+    }, {
+      hidden: "usage",
+    });
+
+    const fragments = parser.getDocFragments(
+      { kind: "unavailable" },
+      undefined,
+    );
+    const suggestions = Array.from(parser.suggest(
+      {
+        buffer: [],
+        state: parser.initialState,
+        optionsTerminated: false,
+        usage: parser.usage,
+      },
+      "--",
+    ));
+
+    assert.equal(fragments.fragments.length, 1);
+    assert.equal(suggestions.length, 2);
+  });
+
+  it('should hide docs but keep suggestions for hidden: "help"', () => {
+    const parser = negatableFlag({
+      positive: "--color",
+      negative: "--no-color",
+    }, {
+      hidden: "help",
+    });
+
+    const fragments = parser.getDocFragments(
+      { kind: "unavailable" },
+      undefined,
+    );
+    const suggestions = Array.from(parser.suggest(
+      {
+        buffer: [],
+        state: parser.initialState,
+        optionsTerminated: false,
+        usage: parser.usage,
+      },
+      "--",
+    ));
+
+    assert.deepEqual(fragments.fragments, []);
+    assert.equal(suggestions.length, 2);
+  });
+
+  it("should only suggest short options for a bare dash prefix", () => {
+    const parser = negatableFlag({
+      positive: ["-c", "--color"],
+      negative: ["-C", "--no-color"],
+    });
+
+    const suggestions = Array.from(parser.suggest(
+      {
+        buffer: [],
+        state: parser.initialState,
+        optionsTerminated: false,
+        usage: parser.usage,
+      },
+      "-",
+    ));
+
+    assert.deepEqual(suggestions, [
+      { kind: "literal", text: "-c" },
+      { kind: "literal", text: "-C" },
+    ]);
+  });
+
+  it("should always parse generated positive and negative names by polarity", () => {
+    fc.assert(
+      fc.property(
+        fc.uniqueArray(fc.stringMatching(/^[a-z][a-z0-9]{0,6}$/), {
+          minLength: 4,
+          maxLength: 4,
+        }),
+        ([positive, positiveAlias, negative, negativeAlias]) => {
+          const positiveNames = [
+            `--${positive}`,
+            `--${positiveAlias}`,
+          ] as const;
+          const negativeNames = [
+            `--${negative}`,
+            `--${negativeAlias}`,
+          ] as const;
+          const parser = negatableFlag({
+            positive: positiveNames,
+            negative: negativeNames,
+          });
+
+          for (const name of positiveNames) {
+            const result = parseSync(parser, [name]);
+            assert.ok(result.success);
+            if (result.success) {
+              assert.equal(result.value, true);
+            }
+          }
+          for (const name of negativeNames) {
+            const result = parseSync(parser, [name]);
+            assert.ok(result.success);
+            if (result.success) {
+              assert.equal(result.value, false);
+            }
+          }
+        },
+      ),
+    );
+  });
+
+  it("should always classify repeated generated flags", () => {
+    fc.assert(
+      fc.property(
+        fc.uniqueArray(fc.stringMatching(/^[a-z][a-z0-9]{0,6}$/), {
+          minLength: 2,
+          maxLength: 2,
+        }),
+        fc.boolean(),
+        ([positive, negative], repeatSamePolarity) => {
+          const positiveName = `--${positive}` as const;
+          const negativeName = `--${negative}` as const;
+          const parser = negatableFlag({
+            positive: positiveName,
+            negative: negativeName,
+          });
+          const input = repeatSamePolarity
+            ? [positiveName, positiveName]
+            : [positiveName, negativeName];
+
+          const result = parseSync(parser, input);
+
+          assert.ok(!result.success);
+          if (!result.success) {
+            const formatted = formatMessage(result.error);
+            if (repeatSamePolarity) {
+              assert.ok(formatted.includes("multiple times"));
+            } else {
+              assert.ok(formatted.includes("used together"));
+            }
+          }
+        },
+      ),
+    );
   });
 });
 

--- a/packages/core/src/primitives.ts
+++ b/packages/core/src/primitives.ts
@@ -2166,14 +2166,15 @@ export function negatableFlag(
         );
       }
 
-      const prefixes = optionNames
-        .filter((name) =>
-          name.startsWith("--") ||
-          name.startsWith("/") ||
-          (name.startsWith("-") && name.length > 2)
-        )
-        .map((name) => name.startsWith("/") ? `${name}:` : `${name}=`);
-      for (const prefix of prefixes) {
+      for (const name of optionNames) {
+        if (
+          !name.startsWith("--") &&
+          !name.startsWith("/") &&
+          !(name.startsWith("-") && name.length > 2)
+        ) {
+          continue;
+        }
+        const prefix = name.startsWith("/") ? `${name}:` : `${name}=`;
         if (context.buffer[0].startsWith(prefix)) {
           const value = context.buffer[0].slice(prefix.length);
           return {
@@ -2188,8 +2189,8 @@ export function negatableFlag(
         }
       }
 
-      const shortOptions = optionNames.filter((name) => name.match(/^-[^-]$/));
-      for (const shortOption of shortOptions) {
+      for (const shortOption of optionNames) {
+        if (!shortOption.match(/^-[^-]$/)) continue;
         if (!context.buffer[0].startsWith(shortOption)) continue;
         return parseMatchedNegatableFlag(
           context,
@@ -2294,6 +2295,23 @@ export function negatableFlag(
       return `negatableFlag({ ${args.join(", ")} })`;
     },
   };
+  Object.defineProperty(result, "validateValue", {
+    value(v: boolean): ValueParserResult<boolean> {
+      if (typeof v !== "boolean") {
+        const actualType = v === null ? "null" : typeof v;
+        return {
+          success: false,
+          error: message`${
+            eOptionNames(optionNames)
+          }: Expected a boolean value, but received ${actualType}.`,
+        };
+      }
+      return { success: true, value: v };
+    },
+    configurable: true,
+    enumerable: false,
+    writable: false,
+  });
   Object.defineProperty(result, "placeholder", {
     value: false,
     configurable: true,

--- a/packages/core/src/primitives.ts
+++ b/packages/core/src/primitives.ts
@@ -2095,6 +2095,8 @@ function parseMatchedNegatableFlag(
  * @param options Optional metadata and error customization.
  * @returns A {@link Parser} that produces `true` for positive names and
  *          `false` for negative names.
+ * @throws {TypeError} If any option name is invalid, duplicated within one
+ *         side, or shared by the positive and negative sides.
  * @since 1.1.0
  */
 export function negatableFlag(

--- a/packages/core/src/primitives.ts
+++ b/packages/core/src/primitives.ts
@@ -2170,6 +2170,7 @@ export function negatableFlag(
         if (
           !name.startsWith("--") &&
           !name.startsWith("/") &&
+          !name.startsWith("+") &&
           !(name.startsWith("-") && name.length > 2)
         ) {
           continue;

--- a/packages/core/src/primitives.ts
+++ b/packages/core/src/primitives.ts
@@ -2268,7 +2268,7 @@ export function negatableFlag(
       const suggestions: Suggestion[] = [];
       if (
         prefix.startsWith("--") || prefix.startsWith("-") ||
-        prefix.startsWith("/")
+        prefix.startsWith("/") || prefix.startsWith("+")
       ) {
         for (const optionName of optionNames) {
           if (optionName.startsWith(prefix)) {

--- a/packages/core/src/primitives.ts
+++ b/packages/core/src/primitives.ts
@@ -1863,6 +1863,457 @@ export function flag(
 }
 
 /**
+ * A non-empty list of option names, or a single option name.
+ * @since 1.1.0
+ */
+export type NegatableFlagNameList =
+  | OptionName
+  | readonly [OptionName, ...readonly OptionName[]];
+
+/**
+ * Option names for the {@link negatableFlag} parser.
+ * @since 1.1.0
+ */
+export interface NegatableFlagNames {
+  /**
+   * Option names that produce `true`.
+   */
+  readonly positive: NegatableFlagNameList;
+
+  /**
+   * Option names that produce `false`.
+   */
+  readonly negative: NegatableFlagNameList;
+}
+
+/**
+ * Options for the {@link negatableFlag} parser.
+ * @since 1.1.0
+ */
+export interface NegatableFlagOptions {
+  /**
+   * The description of the flag pair, which can be used for help messages.
+   */
+  readonly description?: Message;
+
+  /**
+   * Controls flag visibility:
+   *
+   * - `true`: hide from usage, docs, and suggestions
+   * - `"usage"`: hide from usage only
+   * - `"doc"`: hide from docs only
+   * - `"help"`: hide from usage and docs, keep suggestions
+   */
+  readonly hidden?: HiddenVisibility;
+
+  /**
+   * Error message customization options.
+   */
+  readonly errors?: NegatableFlagErrorOptions;
+}
+
+/**
+ * Options for customizing error messages in the {@link negatableFlag} parser.
+ * @since 1.1.0
+ */
+export interface NegatableFlagErrorOptions {
+  /**
+   * Custom error message when neither flag is provided.
+   * Can be a static message or a function that receives the positive and
+   * negative option names.
+   */
+  missing?:
+    | Message
+    | ((
+      positiveNames: readonly string[],
+      negativeNames: readonly string[],
+    ) => Message);
+
+  /**
+   * Custom error message when options are terminated (after --).
+   */
+  optionsTerminated?: Message;
+
+  /**
+   * Custom error message when input is empty but a flag is expected.
+   */
+  endOfInput?: Message;
+
+  /**
+   * Custom error message when the same polarity is used multiple times.
+   */
+  duplicate?: Message | ((token: string) => Message);
+
+  /**
+   * Custom error message when both positive and negative flags are used.
+   */
+  conflict?:
+    | Message
+    | ((previousToken: string, token: string) => Message);
+
+  /**
+   * Custom error message when a flag receives an unexpected value.
+   */
+  unexpectedValue?:
+    | Message
+    | ((optionName: string, value: string) => Message);
+
+  /**
+   * Custom error message when no matching flag is found.
+   */
+  noMatch?:
+    | Message
+    | ((invalidOption: string, suggestions: readonly string[]) => Message);
+}
+
+/**
+ * State stored by the {@link negatableFlag} parser.
+ * @since 1.1.0
+ */
+export type NegatableFlagState =
+  | {
+    readonly success: true;
+    readonly value: boolean;
+    readonly token: string;
+  }
+  | {
+    readonly success: false;
+    readonly error: Message;
+  };
+
+function normalizeNegatableFlagNameList(
+  names: NegatableFlagNameList,
+): readonly OptionName[] {
+  return typeof names === "string" ? [names] : names;
+}
+
+function validateNoDuplicateOptionNames(
+  names: readonly OptionName[],
+  label: string,
+): void {
+  const seen = new Set<string>();
+  for (const name of names) {
+    if (seen.has(name)) {
+      throw new TypeError(`${label} has a duplicate name: "${name}".`);
+    }
+    seen.add(name);
+  }
+}
+
+function validateNoNegatableFlagNameCollision(
+  positiveNames: readonly OptionName[],
+  negativeNames: readonly OptionName[],
+): void {
+  const positiveSet = new Set<string>(positiveNames);
+  for (const name of negativeNames) {
+    if (positiveSet.has(name)) {
+      throw new TypeError(
+        `Negatable flag name is both positive and negative: "${name}".`,
+      );
+    }
+  }
+}
+
+function formatNegatableFlagDuplicateError(
+  options: NegatableFlagOptions,
+  token: string,
+): Message {
+  return options.errors?.duplicate
+    ? (typeof options.errors.duplicate === "function"
+      ? options.errors.duplicate(token)
+      : options.errors.duplicate)
+    : message`${eOptionName(token)} cannot be used multiple times.`;
+}
+
+function formatNegatableFlagConflictError(
+  options: NegatableFlagOptions,
+  previousToken: string,
+  token: string,
+): Message {
+  return options.errors?.conflict
+    ? (typeof options.errors.conflict === "function"
+      ? options.errors.conflict(previousToken, token)
+      : options.errors.conflict)
+    : message`${eOptionName(previousToken)} and ${
+      eOptionName(token)
+    } cannot be used together.`;
+}
+
+function formatNegatableFlagUnexpectedValueError(
+  options: NegatableFlagOptions,
+  optionName: string,
+  value: string,
+): Message {
+  return options.errors?.unexpectedValue
+    ? (typeof options.errors.unexpectedValue === "function"
+      ? options.errors.unexpectedValue(optionName, value)
+      : options.errors.unexpectedValue)
+    : message`Flag ${
+      eOptionName(optionName)
+    } does not accept a value, but got: ${value}.`;
+}
+
+function parseMatchedNegatableFlag(
+  context: ParserContext<NegatableFlagState | undefined>,
+  token: string,
+  value: boolean,
+  consumed: readonly string[],
+  consumedOnFailure: number,
+  buffer: readonly string[],
+  options: NegatableFlagOptions,
+): ParserResult<NegatableFlagState> {
+  if (context.state?.success) {
+    return {
+      success: false,
+      consumed: consumedOnFailure,
+      error: context.state.value === value
+        ? formatNegatableFlagDuplicateError(options, token)
+        : formatNegatableFlagConflictError(options, context.state.token, token),
+    };
+  }
+  return {
+    success: true,
+    next: {
+      ...context,
+      state: { success: true, value, token },
+      buffer,
+    },
+    consumed,
+  };
+}
+
+/**
+ * Creates a parser for a pair of command-line flags that explicitly enable or
+ * disable a Boolean value.
+ *
+ * The positive names produce `true`; the negative names produce `false`.
+ * Unlike {@link option}, this parser fails when neither side is present,
+ * matching {@link flag} semantics. Wrap it in {@link optional} for a
+ * tri-state override or {@link withDefault} for a concrete fallback.
+ *
+ * @param names The positive and negative option names to parse.
+ * @param options Optional metadata and error customization.
+ * @returns A {@link Parser} that produces `true` for positive names and
+ *          `false` for negative names.
+ * @since 1.1.0
+ */
+export function negatableFlag(
+  names: NegatableFlagNames,
+  options: NegatableFlagOptions = {},
+): Parser<"sync", boolean, NegatableFlagState | undefined> {
+  const positiveNames = normalizeNegatableFlagNameList(names.positive);
+  const negativeNames = normalizeNegatableFlagNameList(names.negative);
+  validateOptionNames(positiveNames, "Positive flag");
+  validateOptionNames(negativeNames, "Negative flag");
+  validateNoDuplicateOptionNames(positiveNames, "Positive flag");
+  validateNoDuplicateOptionNames(negativeNames, "Negative flag");
+  validateNoNegatableFlagNameCollision(positiveNames, negativeNames);
+
+  const optionNames = [...positiveNames, ...negativeNames];
+  const valueByName = new Map<string, boolean>();
+  for (const name of positiveNames) valueByName.set(name, true);
+  for (const name of negativeNames) valueByName.set(name, false);
+
+  const result: Parser<"sync", boolean, NegatableFlagState | undefined> = {
+    $valueType: [],
+    $stateType: [],
+    mode: "sync",
+    priority: 10,
+    usage: [{
+      type: "option",
+      names: optionNames,
+      ...(options.hidden != null && { hidden: options.hidden }),
+    }],
+    leadingNames: new Set<string>(optionNames),
+    acceptingAnyToken: false,
+    initialState: undefined,
+    parse(context) {
+      if (context.optionsTerminated) {
+        return {
+          success: false,
+          consumed: 0,
+          error: options.errors?.optionsTerminated ??
+            message`No more options can be parsed.`,
+        };
+      } else if (context.buffer.length < 1) {
+        return {
+          success: false,
+          consumed: 0,
+          error: options.errors?.endOfInput ??
+            message`Expected an option, but got end of input.`,
+        };
+      }
+
+      if (context.buffer[0] === "--") {
+        return {
+          success: true,
+          next: {
+            ...context,
+            buffer: context.buffer.slice(1),
+            state: context.state,
+            optionsTerminated: true,
+          },
+          consumed: context.buffer.slice(0, 1),
+        };
+      }
+
+      const directValue = valueByName.get(context.buffer[0]);
+      if (directValue != null) {
+        return parseMatchedNegatableFlag(
+          context,
+          context.buffer[0],
+          directValue,
+          context.buffer.slice(0, 1),
+          1,
+          context.buffer.slice(1),
+          options,
+        );
+      }
+
+      const prefixes = optionNames
+        .filter((name) =>
+          name.startsWith("--") ||
+          name.startsWith("/") ||
+          (name.startsWith("-") && name.length > 2)
+        )
+        .map((name) => name.startsWith("/") ? `${name}:` : `${name}=`);
+      for (const prefix of prefixes) {
+        if (context.buffer[0].startsWith(prefix)) {
+          const value = context.buffer[0].slice(prefix.length);
+          return {
+            success: false,
+            consumed: 1,
+            error: formatNegatableFlagUnexpectedValueError(
+              options,
+              prefix.slice(0, -1),
+              value,
+            ),
+          };
+        }
+      }
+
+      const shortOptions = optionNames.filter((name) => name.match(/^-[^-]$/));
+      for (const shortOption of shortOptions) {
+        if (!context.buffer[0].startsWith(shortOption)) continue;
+        return parseMatchedNegatableFlag(
+          context,
+          shortOption,
+          valueByName.get(shortOption)!,
+          [context.buffer[0].slice(0, 2)],
+          1,
+          [`-${context.buffer[0].slice(2)}`, ...context.buffer.slice(1)],
+          options,
+        );
+      }
+
+      const invalidOption = context.buffer[0];
+      if (options.errors?.noMatch) {
+        const candidates = new Set<string>();
+        for (const name of extractOptionNames(context.usage)) {
+          candidates.add(name);
+        }
+        const suggestions = findSimilar(
+          invalidOption,
+          candidates,
+          DEFAULT_FIND_SIMILAR_OPTIONS,
+        );
+        return {
+          success: false,
+          consumed: 0,
+          error: typeof options.errors.noMatch === "function"
+            ? options.errors.noMatch(invalidOption, suggestions)
+            : options.errors.noMatch,
+        };
+      }
+
+      const baseError = message`No matched option for ${
+        eOptionName(invalidOption)
+      }.`;
+      return {
+        success: false,
+        consumed: 0,
+        error: createErrorWithSuggestions(
+          baseError,
+          invalidOption,
+          context.usage,
+          "option",
+        ),
+      };
+    },
+    complete(state, _exec?: ExecutionContext) {
+      if (state == null) {
+        return {
+          success: false,
+          error: options.errors?.missing
+            ? (typeof options.errors.missing === "function"
+              ? options.errors.missing(positiveNames, negativeNames)
+              : options.errors.missing)
+            : message`Required flag ${eOptionNames(optionNames)} is missing.`,
+        };
+      }
+      if (state.success) {
+        return { success: true, value: state.value };
+      }
+      return {
+        success: false,
+        error: message`${eOptionNames(optionNames)}: ${state.error}`,
+      };
+    },
+    suggest(_context, prefix) {
+      if (isSuggestionHidden(options.hidden)) {
+        return [];
+      }
+      const suggestions: Suggestion[] = [];
+      if (
+        prefix.startsWith("--") || prefix.startsWith("-") ||
+        prefix.startsWith("/")
+      ) {
+        for (const optionName of optionNames) {
+          if (optionName.startsWith(prefix)) {
+            if (prefix === "-" && optionName.length !== 2) {
+              continue;
+            }
+            suggestions.push({ kind: "literal", text: optionName });
+          }
+        }
+      }
+      return suggestions;
+    },
+    getDocFragments(
+      _state: DocState<NegatableFlagState | undefined>,
+      _defaultValue?,
+    ) {
+      if (isDocHidden(options.hidden)) {
+        return { fragments: [], description: options.description };
+      }
+      const fragments: readonly DocFragment[] = [{
+        type: "entry",
+        term: {
+          type: "option",
+          names: optionNames,
+        },
+        description: options.description,
+      }];
+      return { fragments, description: options.description };
+    },
+    [Symbol.for("Deno.customInspect")]() {
+      const args = [
+        `positive: ${JSON.stringify(positiveNames)}`,
+        `negative: ${JSON.stringify(negativeNames)}`,
+      ];
+      return `negatableFlag({ ${args.join(", ")} })`;
+    },
+  };
+  Object.defineProperty(result, "placeholder", {
+    value: false,
+    configurable: true,
+    enumerable: false,
+    writable: false,
+  });
+  return result;
+}
+
+/**
  * Options for the {@link argument} parser.
  */
 export interface ArgumentOptions {

--- a/packages/core/src/primitives.ts
+++ b/packages/core/src/primitives.ts
@@ -1922,7 +1922,7 @@ export interface NegatableFlagErrorOptions {
    * Can be a static message or a function that receives the positive and
    * negative option names.
    */
-  missing?:
+  readonly missing?:
     | Message
     | ((
       positiveNames: readonly string[],
@@ -1932,36 +1932,36 @@ export interface NegatableFlagErrorOptions {
   /**
    * Custom error message when options are terminated (after --).
    */
-  optionsTerminated?: Message;
+  readonly optionsTerminated?: Message;
 
   /**
    * Custom error message when input is empty but a flag is expected.
    */
-  endOfInput?: Message;
+  readonly endOfInput?: Message;
 
   /**
    * Custom error message when the same polarity is used multiple times.
    */
-  duplicate?: Message | ((token: string) => Message);
+  readonly duplicate?: Message | ((token: string) => Message);
 
   /**
    * Custom error message when both positive and negative flags are used.
    */
-  conflict?:
+  readonly conflict?:
     | Message
     | ((previousToken: string, token: string) => Message);
 
   /**
    * Custom error message when a flag receives an unexpected value.
    */
-  unexpectedValue?:
+  readonly unexpectedValue?:
     | Message
     | ((optionName: string, value: string) => Message);
 
   /**
    * Custom error message when no matching flag is found.
    */
-  noMatch?:
+  readonly noMatch?:
     | Message
     | ((invalidOption: string, suggestions: readonly string[]) => Message);
 }

--- a/packages/core/src/primitives.ts
+++ b/packages/core/src/primitives.ts
@@ -1970,16 +1970,10 @@ export interface NegatableFlagErrorOptions {
  * State stored by the {@link negatableFlag} parser.
  * @since 1.1.0
  */
-export type NegatableFlagState =
-  | {
-    readonly success: true;
-    readonly value: boolean;
-    readonly token: string;
-  }
-  | {
-    readonly success: false;
-    readonly error: Message;
-  };
+export interface NegatableFlagState {
+  readonly value: boolean;
+  readonly token: string;
+}
 
 function normalizeNegatableFlagNameList(
   names: NegatableFlagNameList,
@@ -2062,7 +2056,7 @@ function parseMatchedNegatableFlag(
   buffer: readonly string[],
   options: NegatableFlagOptions,
 ): ParserResult<NegatableFlagState> {
-  if (context.state?.success) {
+  if (context.state != null) {
     return {
       success: false,
       consumed: consumedOnFailure,
@@ -2075,7 +2069,7 @@ function parseMatchedNegatableFlag(
     success: true,
     next: {
       ...context,
-      state: { success: true, value, token },
+      state: { value, token },
       buffer,
     },
     consumed,
@@ -2253,13 +2247,7 @@ export function negatableFlag(
             : message`Required flag ${eOptionNames(optionNames)} is missing.`,
         };
       }
-      if (state.success) {
-        return { success: true, value: state.value };
-      }
-      return {
-        success: false,
-        error: message`${eOptionNames(optionNames)}: ${state.error}`,
-      };
+      return { success: true, value: state.value };
     },
     suggest(_context, prefix) {
       if (isSuggestionHidden(options.hidden)) {

--- a/packages/core/src/public-api.test.ts
+++ b/packages/core/src/public-api.test.ts
@@ -128,6 +128,7 @@ test("parser module hides constructs and parser-internal helpers", () => {
 test("root module keeps user-facing APIs but not internal machinery", () => {
   assert.equal(typeof root.object, "function");
   assert.equal(typeof root.option, "function");
+  assert.equal(typeof root.negatableFlag, "function");
   assert.equal(typeof root.parse, "function");
   assert.equal(typeof root.dependency, "function");
   assert.ok(!Object.hasOwn(root, "annotationKey"));


### PR DESCRIPTION
This adds `negatableFlag()` to *@optique/core* for paired Boolean flags such as `--color` and `--no-color`.

The new primitive returns `true` for positive names and `false` for negative names. When neither side is provided, it fails like `flag()`, so callers can choose their own absence behavior with `optional()` or `withDefault()`. This keeps runtime defaults explicit while still letting users override a setting in either direction.

The implementation in *packages/core/src/primitives.ts* supports aliases on both sides, one-line help entries, shell suggestions, hidden visibility modes, duplicate and conflict diagnostics, joined-value rejection, and custom error messages. Tests in *packages/core/src/primitives.test.ts* cover the main parser behavior, edge cases, and fast-check properties. *packages/core/src/public-api.test.ts* verifies the root export.

The documentation in *docs/concepts/primitives.md* and *docs/cookbook.md* describes the new API and shows how to combine it with `optional()` and `withDefault()`. The runnable pattern example in *examples/patterns/negatable-boolean-options.ts* now uses `negatableFlag()`, and *CHANGES.md* records the change.

Closes #801.