### PR TITLE
Improve test coverage from 84% to 91.7%

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -37,6 +37,8 @@
     "npm:tsdown@0.13": "0.13.0_typescript@5.8.3_rolldown@1.0.0-beta.29",
     "npm:tsx@^4.21.0": "4.21.0",
     "npm:typescript@^5.8.3": "5.8.3",
+    "npm:valibot@*": "1.4.0_typescript@5.8.3",
+    "npm:valibot@1.4.0": "1.4.0_typescript@5.8.3",
     "npm:zod@*": "3.25.76",
     "npm:zod@3.25.76": "3.25.76",
     "npm:zod@4": "4.1.12",
@@ -1397,7 +1399,6 @@
         "@esbuild/win32-ia32@0.27.2",
         "@esbuild/win32-x64@0.27.2"
       ],
-      "scripts": true,
       "bin": true
     },
     "event-target-shim@5.0.1": {
@@ -1466,8 +1467,7 @@
     },
     "fsevents@2.3.3": {
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "os": ["darwin"],
-      "scripts": true
+      "os": ["darwin"]
     },
     "function-bind@1.1.2": {
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
@@ -2386,6 +2386,15 @@
     },
     "unicorn-magic@0.3.0": {
       "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA=="
+    },
+    "valibot@1.4.0_typescript@5.8.3": {
+      "integrity": "sha512-iC/x7fVcSyOwlm/VSt7RlHnzNGLGvR9GnxdifUeWoCJo0q4ZZvrVkIHC6faTlkxG47I2Y4UrFquPuVHCrOnrLg==",
+      "dependencies": [
+        "typescript"
+      ],
+      "optionalPeers": [
+        "typescript"
+      ]
     },
     "which-typed-array@1.1.19": {
       "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",

--- a/mise.toml
+++ b/mise.toml
@@ -47,3 +47,11 @@ depends = ["check", "test:*"]
 [tasks.build]
 description = "Build all packages for npm publishing"
 run = "pnpm run --filter '!{docs}' -r build"
+
+[tasks.coverage]
+description = "Measure test coverage"
+run = """
+deno test --allow-read --allow-write --allow-run --allow-env --allow-net --allow-sys --allow-ffi --env-file=.env.test --coverage=coverage/raw
+deno coverage coverage/raw --lcov --include="packages/" > coverage/lcov.info
+deno coverage coverage/raw --include="packages/"
+"""

--- a/packages/core/src/annotation-state.test.ts
+++ b/packages/core/src/annotation-state.test.ts
@@ -754,4 +754,111 @@ describe("annotation-state", () => {
       assert.strictEqual(normalized.self, cyclic);
     },
   );
+
+  it(
+    "normalizeNestedDelegatedAnnotationState() preserves non-plain objects (Date, RegExp) as-is at the top level",
+    () => {
+      // Date and RegExp are non-plain objects whose prototype is not
+      // Object.prototype/null — they are neither Array nor Map nor Set.
+      // normalizeNestedDelegatedAnnotationState() should return them
+      // unchanged rather than treating them as structured plain objects.
+      const date = new Date(2024, 0, 1);
+      const re = /hello/g;
+
+      assert.strictEqual(normalizeNestedDelegatedAnnotationState(date), date);
+      assert.strictEqual(normalizeNestedDelegatedAnnotationState(re), re);
+    },
+  );
+
+  it(
+    "getWrappedChildState() falls back to annotation-view proxy when inheritance is disabled",
+    () => {
+      // When parser does NOT have inheritParentAnnotationsKey set (no
+      // defineInheritedAnnotationParser() call), getWrappedChildState() must
+      // still propagate annotations — but only via withAnnotationView(), not
+      // via injectAnnotations().  This is the branch where
+      // shouldInheritAnnotations is false and childState is an object.
+      const marker = Symbol.for(
+        "@test/getWrappedChildState-no-inherit-object",
+      );
+      const annotations = { [marker]: true } satisfies Annotations;
+      const parentState = injectAnnotations(undefined, annotations);
+
+      // Plain parser that does NOT opt in to annotation inheritance.
+      const parser: Parser<"sync", unknown, unknown> = {
+        mode: "sync",
+        $valueType: [] as readonly unknown[],
+        $stateType: [] as readonly unknown[],
+        priority: 1,
+        usage: [],
+        leadingNames: new Set(),
+        acceptingAnyToken: false,
+        initialState: undefined,
+        parse(context) {
+          return {
+            success: false as const,
+            consumed: 0,
+            error: message`unused parse: ${String(context.state)}`,
+          };
+        },
+        complete() {
+          return { success: true as const, value: undefined };
+        },
+        suggest() {
+          return [];
+        },
+        getDocFragments() {
+          return { fragments: [] };
+        },
+      };
+      // Deliberately do NOT call defineInheritedAnnotationParser(parser).
+
+      const childState = { value: "seed" };
+      const wrapped = getWrappedChildState(parentState, childState, parser);
+
+      // wrapped must carry the parent annotations via annotation-view proxy
+      assert.ok(
+        getAnnotations(wrapped)?.[marker],
+        "annotations should be surfaced via the annotation-view proxy",
+      );
+      // The proxy must preserve the original object shape
+      assert.equal(
+        (wrapped as typeof childState).value,
+        "seed",
+        "wrapped child state should preserve original value",
+      );
+      // normalizeDelegatedAnnotationState must unwrap back to childState
+      assert.strictEqual(
+        normalizeDelegatedAnnotationState(wrapped),
+        childState,
+      );
+    },
+  );
+
+  it(
+    "getDelegatedAnnotationState() returns child unchanged when already a tracked carrier with same annotations",
+    () => {
+      // This exercises the short-circuit branch:
+      //   getAnnotations(childState) === annotations &&
+      //   (delegatedAnnotationCloneTargets.has(...) || annotationViewTargets.has(...))
+      const marker = Symbol.for(
+        "@test/getDelegatedAnnotationState-idempotent",
+      );
+      const annotations = { [marker]: true } satisfies Annotations;
+      const parentState = injectAnnotations(undefined, annotations);
+
+      // First delegation creates a tracked clone
+      const original = { value: "seed" };
+      const delegated = getDelegatedAnnotationState(parentState, original);
+
+      // Second delegation on the already-delegated object should be a no-op
+      const reDelegated = getDelegatedAnnotationState(parentState, delegated);
+
+      assert.strictEqual(
+        reDelegated,
+        delegated,
+        "re-delegating an already-tracked carrier with same annotations should return it unchanged",
+      );
+    },
+  );
 });

--- a/packages/core/src/constructs.test.ts
+++ b/packages/core/src/constructs.test.ts
@@ -1231,13 +1231,7 @@ describe("or() inside object() — zero-input complete path", () => {
     // fallback, so the async no-match/no-candidate path fires.
     assert.ok(!result.success);
     if (!result.success) {
-      // The error should come from the no-match path (argument/option not
-      // provided) — not from the inner parser's "no value" complete error.
-      const msg = formatMessage(result.error);
-      assert.ok(
-        !msg.includes("no value"),
-        `Expected no-match error, not inner parser error: ${msg}`,
-      );
+      assert.deepEqual(result.error, message`No matching option found.`);
     }
   });
 });

--- a/packages/core/src/constructs.test.ts
+++ b/packages/core/src/constructs.test.ts
@@ -1157,6 +1157,16 @@ describe("or() inside object() — zero-input complete path", () => {
 
     const result = parseSync(parser, []);
     assert.ok(!result.success);
+    if (!result.success) {
+      // Should produce a no-match error, not a value-related parse error.
+      const msg = formatMessage(result.error);
+      assert.ok(
+        msg.toLowerCase().includes("option") ||
+          msg.toLowerCase().includes("match") ||
+          msg.toLowerCase().includes("action"),
+        `Expected no-match error but got: ${msg}`,
+      );
+    }
   });
 
   it("async: completes a sync constant() branch when the async or() field was never parsed", async () => {
@@ -1224,6 +1234,8 @@ describe("or() inside object() — zero-input complete path", () => {
     });
 
     const result = await parseAsync(parser, []);
+    // Fails because the only branch is a named option with no zero-consumed
+    // fallback, so the async no-match/no-candidate path fires.
     assert.ok(!result.success);
   });
 });

--- a/packages/core/src/constructs.test.ts
+++ b/packages/core/src/constructs.test.ts
@@ -1237,6 +1237,15 @@ describe("or() inside object() — zero-input complete path", () => {
     // Fails because the only branch is a named option with no zero-consumed
     // fallback, so the async no-match/no-candidate path fires.
     assert.ok(!result.success);
+    if (!result.success) {
+      // The error should come from the no-match path (argument/option not
+      // provided) — not from the inner parser's "no value" complete error.
+      const msg = formatMessage(result.error);
+      assert.ok(
+        !msg.includes("no value"),
+        `Expected no-match error, not inner parser error: ${msg}`,
+      );
+    }
   });
 });
 

--- a/packages/core/src/constructs.test.ts
+++ b/packages/core/src/constructs.test.ts
@@ -1120,6 +1120,82 @@ describe("or", () => {
   });
 });
 
+describe("or() inside object() — zero-input complete path", () => {
+  it("completes a zero-consumed constant() branch when the field was never parsed", () => {
+    // When or() is nested inside object(), its complete() is called with
+    // state=undefined for fields that were never touched.  The zero-input
+    // candidate path (lines 1167-1180 in constructs.ts) fires when there is
+    // exactly one branch that succeeds with 0 consumed tokens.
+    const parser = object({
+      mode: or(constant("default"), option("--mode", string())),
+    });
+
+    const result = parseSync(parser, []);
+    assert.ok(result.success);
+    if (result.success) {
+      assert.equal(result.value.mode, "default");
+    }
+  });
+
+  it("selects non-constant branch when a consuming branch has already been matched", () => {
+    const parser = object({
+      mode: or(constant("default"), option("--mode", string())),
+    });
+
+    const result = parseSync(parser, ["--mode", "fast"]);
+    assert.ok(result.success);
+    if (result.success) {
+      assert.equal(result.value.mode, "fast");
+    }
+  });
+
+  it("returns no-match error when no zero-input candidate exists in undefined state", () => {
+    // or(option(...), option(...)) has no zero-consumed fallback.
+    const parser = object({
+      action: or(option("-a", string()), option("-b", string())),
+    });
+
+    const result = parseSync(parser, []);
+    assert.ok(!result.success);
+  });
+
+  it("async: completes a sync constant() branch when the async or() field was never parsed", async () => {
+    // The async or() zero-input complete path fires when or() contains
+    // an async parser, the state is undefined, and there is exactly one
+    // sync zero-consumed candidate.
+    const asyncOption: Parser<"async", string, string> = {
+      mode: "async",
+      $valueType: [] as readonly string[],
+      $stateType: [] as readonly string[],
+      priority: 0,
+      usage: [{ type: "argument", metavar: "FILE", hidden: false }],
+      leadingNames: new Set(["--file"]),
+      acceptingAnyToken: false,
+      initialState: "",
+      parse: () =>
+        Promise.resolve({
+          success: false as const,
+          consumed: 0,
+          error: message`no match`,
+        }),
+      complete: () =>
+        Promise.resolve({ success: false as const, error: message`no value` }),
+      suggest: async function* () {},
+      getDocFragments: () => ({ fragments: [] }),
+    };
+
+    const parser = object({
+      mode: or(constant("async-default"), asyncOption),
+    });
+
+    const result = await parseAsync(parser, []);
+    assert.ok(result.success);
+    if (result.success) {
+      assert.equal(result.value.mode, "async-default");
+    }
+  });
+});
+
 describe("or() - duplicate option handling", () => {
   it("should allow duplicate option names in different branches", () => {
     // or() allows duplicates because branches are mutually exclusive

--- a/packages/core/src/constructs.test.ts
+++ b/packages/core/src/constructs.test.ts
@@ -1158,14 +1158,7 @@ describe("or() inside object() — zero-input complete path", () => {
     const result = parseSync(parser, []);
     assert.ok(!result.success);
     if (!result.success) {
-      // Should produce a no-match error, not a value-related parse error.
-      const msg = formatMessage(result.error);
-      assert.ok(
-        msg.toLowerCase().includes("option") ||
-          msg.toLowerCase().includes("match") ||
-          msg.toLowerCase().includes("action"),
-        `Expected no-match error but got: ${msg}`,
-      );
+      assert.deepEqual(result.error, message`No matching option found.`);
     }
   });
 
@@ -1178,7 +1171,7 @@ describe("or() inside object() — zero-input complete path", () => {
       $valueType: [] as readonly string[],
       $stateType: [] as readonly string[],
       priority: 0,
-      usage: [{ type: "argument", metavar: "FILE", hidden: false }],
+      usage: [{ type: "option", names: ["--file"], metavar: "FILE" }],
       leadingNames: new Set(["--file"]),
       acceptingAnyToken: false,
       initialState: "",
@@ -1213,7 +1206,7 @@ describe("or() inside object() — zero-input complete path", () => {
       $valueType: [] as readonly string[],
       $stateType: [] as readonly string[],
       priority: 0,
-      usage: [{ type: "argument", metavar: "FILE", hidden: false }],
+      usage: [{ type: "option", names: ["--file"], metavar: "FILE" }],
       leadingNames: new Set(["--file"]),
       acceptingAnyToken: false,
       initialState: "",

--- a/packages/core/src/constructs.test.ts
+++ b/packages/core/src/constructs.test.ts
@@ -1194,6 +1194,38 @@ describe("or() inside object() — zero-input complete path", () => {
       assert.equal(result.value.mode, "async-default");
     }
   });
+
+  it("async: returns no-match error when async or() has no zero-input candidate", async () => {
+    // When or() is async and has no zero-consumed fallback branch, the
+    // no-match error path (lines 1214-1218 in constructs.ts) fires.
+    const asyncOption: Parser<"async", string, string> = {
+      mode: "async",
+      $valueType: [] as readonly string[],
+      $stateType: [] as readonly string[],
+      priority: 0,
+      usage: [{ type: "argument", metavar: "FILE", hidden: false }],
+      leadingNames: new Set(["--file"]),
+      acceptingAnyToken: false,
+      initialState: "",
+      parse: () =>
+        Promise.resolve({
+          success: false as const,
+          consumed: 0,
+          error: message`no match`,
+        }),
+      complete: () =>
+        Promise.resolve({ success: false as const, error: message`no value` }),
+      suggest: async function* () {},
+      getDocFragments: () => ({ fragments: [] }),
+    };
+
+    const parser = object({
+      action: or(asyncOption),
+    });
+
+    const result = await parseAsync(parser, []);
+    assert.ok(!result.success);
+  });
 });
 
 describe("or() - duplicate option handling", () => {

--- a/packages/core/src/dependency-runtime.test.ts
+++ b/packages/core/src/dependency-runtime.test.ts
@@ -1353,3 +1353,298 @@ describe("buildRuntimeNodesFromArray", () => {
     assert.deepStrictEqual(nodes[0].path, ["parent", 0]);
   });
 });
+
+// =============================================================================
+// Additional branch coverage
+// =============================================================================
+
+describe("collectExplicitSourceValues — undefined return from extractSourceValue", () => {
+  test("skips registration when extractSourceValue returns undefined", () => {
+    // This exercises registerExplicitSourceValue() with result == null.
+    // The extractor returns undefined because the state doesn't contain
+    // a source result yet (unpopulated / initial state).
+    const runtime = createDependencyRuntimeContext();
+    const sourceId = Symbol("env");
+    const nodes: RuntimeNode[] = [{
+      path: ["env"],
+      parser: {
+        dependencyMetadata: {
+          source: {
+            kind: "source",
+            sourceId,
+            // Always returns undefined — state is unpopulated
+            extractSourceValue: (_state: unknown) => undefined,
+            preservesSourceValue: true,
+          },
+        },
+      },
+      state: { some: "initial-state" },
+    }];
+
+    collectExplicitSourceValues(nodes, runtime);
+
+    // Nothing registered, nothing failed
+    assert.ok(!runtime.hasSource(sourceId));
+    assert.ok(!runtime.isSourceFailed(sourceId));
+  });
+});
+
+describe("replayDerivedParser — additional branches", () => {
+  test("returns undefined when partial dependencies", () => {
+    // Two deps, only one registered → resolution.kind === "partial"
+    const runtime = createDependencyRuntimeContext();
+    const id1 = Symbol("a");
+    const id2 = Symbol("b");
+    runtime.registerSource(id1, "present", "cli");
+    // id2 is missing with no defaults
+
+    const metadata: ParserDependencyMetadata = {
+      derived: {
+        kind: "derived",
+        dependencyIds: [id1, id2],
+        replayParse: (_raw: string, deps: readonly unknown[]) => ({
+          success: true as const,
+          value: deps,
+        }),
+      },
+    };
+
+    const result = replayDerivedParser(
+      { path: ["x"], parser: { dependencyMetadata: metadata }, state: {} },
+      "input",
+      runtime,
+    );
+    assert.equal(result, undefined);
+  });
+
+  test("returns undefined when getDefaultDependencyValues thunk throws", () => {
+    // The node has no snapshotted defaults and the thunk throws —
+    // replayDerivedParser must return undefined rather than propagating.
+    const runtime = createDependencyRuntimeContext();
+    const sourceId = Symbol("env");
+    // Source is NOT registered so defaults are needed
+
+    const metadata: ParserDependencyMetadata = {
+      derived: {
+        kind: "derived",
+        dependencyIds: [sourceId],
+        getDefaultDependencyValues: () => {
+          throw new Error("thunk blew up");
+        },
+        replayParse: (_raw: string, deps: readonly unknown[]) => ({
+          success: true as const,
+          value: `parsed-${deps[0]}`,
+        }),
+      },
+    };
+
+    // No defaultDependencyValues on the node → thunk is called
+    const result = replayDerivedParser(
+      { path: ["level"], parser: { dependencyMetadata: metadata }, state: {} },
+      "warn",
+      runtime,
+    );
+    assert.equal(result, undefined);
+  });
+
+  test("returns undefined for node with no derived metadata", () => {
+    const runtime = createDependencyRuntimeContext();
+    const result = replayDerivedParser(
+      {
+        path: ["x"],
+        parser: { dependencyMetadata: undefined },
+        state: {},
+      },
+      "input",
+      runtime,
+    );
+    assert.equal(result, undefined);
+  });
+});
+
+describe("replayDerivedParserAsync — additional branches", () => {
+  test("returns undefined when dependencies are missing", async () => {
+    const runtime = createDependencyRuntimeContext();
+    const sourceId = Symbol("env");
+    // No source registered, no defaults
+
+    const metadata: ParserDependencyMetadata = {
+      derived: {
+        kind: "derived",
+        dependencyIds: [sourceId],
+        replayParse: (_raw: string, deps: readonly unknown[]) =>
+          Promise.resolve({
+            success: true as const,
+            value: `async-${deps[0]}`,
+          }),
+      },
+    };
+
+    const result = await replayDerivedParserAsync(
+      { path: ["level"], parser: { dependencyMetadata: metadata }, state: {} },
+      "warn",
+      runtime,
+    );
+    assert.equal(result, undefined);
+  });
+
+  test("returns undefined when partial dependencies", async () => {
+    const runtime = createDependencyRuntimeContext();
+    const id1 = Symbol("a");
+    const id2 = Symbol("b");
+    runtime.registerSource(id1, "present", "cli");
+    // id2 missing → partial
+
+    const metadata: ParserDependencyMetadata = {
+      derived: {
+        kind: "derived",
+        dependencyIds: [id1, id2],
+        replayParse: () =>
+          Promise.resolve({ success: true as const, value: 1 }),
+      },
+    };
+
+    const result = await replayDerivedParserAsync(
+      { path: ["x"], parser: { dependencyMetadata: metadata }, state: {} },
+      "input",
+      runtime,
+    );
+    assert.equal(result, undefined);
+  });
+
+  test("returns undefined when getDefaultDependencyValues thunk throws", async () => {
+    const runtime = createDependencyRuntimeContext();
+    const sourceId = Symbol("env");
+
+    const metadata: ParserDependencyMetadata = {
+      derived: {
+        kind: "derived",
+        dependencyIds: [sourceId],
+        getDefaultDependencyValues: () => {
+          throw new Error("async thunk blew up");
+        },
+        replayParse: () =>
+          Promise.resolve({ success: true as const, value: 0 }),
+      },
+    };
+
+    const result = await replayDerivedParserAsync(
+      { path: ["level"], parser: { dependencyMetadata: metadata }, state: {} },
+      "warn",
+      runtime,
+    );
+    assert.equal(result, undefined);
+  });
+
+  test("uses snapshotted defaults instead of thunk", async () => {
+    const runtime = createDependencyRuntimeContext();
+    const sourceId = Symbol("env");
+    let thunkCalls = 0;
+
+    const metadata: ParserDependencyMetadata = {
+      derived: {
+        kind: "derived",
+        dependencyIds: [sourceId],
+        getDefaultDependencyValues: () => {
+          thunkCalls++;
+          return ["thunk-dev"];
+        },
+        replayParse: (_raw: string, deps: readonly unknown[]) =>
+          Promise.resolve({
+            success: true as const,
+            value: `async-${deps[0]}`,
+          }),
+      },
+    };
+
+    const result = await replayDerivedParserAsync(
+      {
+        path: ["level"],
+        parser: { dependencyMetadata: metadata },
+        state: {},
+        defaultDependencyValues: ["snapshotted-dev"],
+      },
+      "warn",
+      runtime,
+    );
+
+    assert.equal(thunkCalls, 0);
+    assert.ok(result !== undefined);
+    assert.ok(result.success);
+    if (result.success) {
+      assert.equal(result.value, "async-snapshotted-dev");
+    }
+  });
+
+  test("returns undefined for node with no derived metadata", async () => {
+    const runtime = createDependencyRuntimeContext();
+    const result = await replayDerivedParserAsync(
+      {
+        path: ["x"],
+        parser: { dependencyMetadata: undefined },
+        state: {},
+      },
+      "input",
+      runtime,
+    );
+    assert.equal(result, undefined);
+  });
+});
+
+describe("fillMissingSourceDefaults — failure result", () => {
+  test("propagates failure when getMissingSourceValue returns { success: false }", () => {
+    const runtime = createDependencyRuntimeContext();
+    const sourceId = Symbol("env");
+    const errorMsg = message`env is required`;
+    const nodes: RuntimeNode[] = [{
+      path: ["env"],
+      parser: {
+        dependencyMetadata: {
+          source: {
+            kind: "source",
+            sourceId,
+            extractSourceValue: bareExtract,
+            preservesSourceValue: true,
+            getMissingSourceValue: () => ({
+              success: false as const,
+              error: errorMsg,
+            }),
+          },
+        },
+      },
+      state: undefined,
+    }];
+
+    const failures = fillMissingSourceDefaults(nodes, runtime);
+
+    assert.equal(failures.length, 1);
+    assert.equal(failures[0].sourceId, sourceId);
+    assert.ok(!failures[0].error.success);
+    // Source should not be registered
+    assert.ok(!runtime.hasSource(sourceId));
+  });
+});
+
+describe("DependencyRuntimeContext — FailedAwareRegistry clone with FailedAwareRegistry inner", () => {
+  test("clone() rebinds failed sources when inner clone is itself a FailedAwareRegistry", () => {
+    // Create a runtime, mark a source as failed, then clone the registry.
+    // When the inner registry also wraps a FailedAwareRegistry (because the
+    // original registry was already a FailedAwareRegistry), clone() must use
+    // rebindFailedSources rather than wrapping again.
+    const sourceId = Symbol("env");
+    const runtime = createDependencyRuntimeContext();
+    runtime.registerSource(sourceId, "prod", "cli");
+    runtime.markSourceFailed(sourceId);
+
+    // Clone the underlying registry (which is a FailedAwareRegistry)
+    // and wrap it in a new context — this exercises the
+    // `innerClone instanceof FailedAwareRegistry` branch in clone().
+    const clonedRegistry = runtime.registry.clone();
+    const cloned = createDependencyRuntimeContext(clonedRegistry);
+
+    // The clone must carry the failed-source state from the original
+    assert.ok(cloned.isSourceFailed(sourceId));
+    assert.ok(!cloned.hasSource(sourceId));
+    assert.equal(cloned.getSource(sourceId), undefined);
+  });
+});

--- a/packages/core/src/dependency-runtime.test.ts
+++ b/packages/core/src/dependency-runtime.test.ts
@@ -1631,24 +1631,27 @@ describe("fillMissingSourceDefaults — failure result", () => {
 
 describe("DependencyRuntimeContext — FailedAwareRegistry clone with FailedAwareRegistry inner", () => {
   test("clone() rebinds failed sources when inner clone is itself a FailedAwareRegistry", () => {
-    // Create a runtime, mark a source as failed, then clone the registry.
-    // When the inner registry also wraps a FailedAwareRegistry (because the
-    // original registry was already a FailedAwareRegistry), clone() must use
-    // rebindFailedSources rather than wrapping again.
-    const sourceId = Symbol("env");
+    // markSourceFailed() wraps the current registry in a new
+    // FailedAwareRegistry each time it is called.  After two calls with
+    // different IDs, the outer FailedAwareRegistry has another
+    // FailedAwareRegistry as its inner.  Cloning the outer one triggers
+    // the `innerClone instanceof FailedAwareRegistry` branch which calls
+    // rebindFailedSources() instead of wrapping again.
+    const sourceA = Symbol("envA");
+    const sourceB = Symbol("envB");
     const runtime = createDependencyRuntimeContext();
-    runtime.registerSource(sourceId, "prod", "cli");
-    runtime.markSourceFailed(sourceId);
+    runtime.registerSource(sourceA, "prod", "cli");
+    runtime.markSourceFailed(sourceA);
+    // Second markSourceFailed wraps the FailedAwareRegistry from above,
+    // so clone().inner will itself be a FailedAwareRegistry.
+    runtime.markSourceFailed(sourceB);
 
-    // Clone the underlying registry (which is a FailedAwareRegistry)
-    // and wrap it in a new context — this exercises the
-    // `innerClone instanceof FailedAwareRegistry` branch in clone().
     const clonedRegistry = runtime.registry.clone();
     const cloned = createDependencyRuntimeContext(clonedRegistry);
 
-    // The clone must carry the failed-source state from the original
-    assert.ok(cloned.isSourceFailed(sourceId));
-    assert.ok(!cloned.hasSource(sourceId));
-    assert.equal(cloned.getSource(sourceId), undefined);
+    // Both failed sources must be propagated through the clone
+    assert.ok(cloned.isSourceFailed(sourceA));
+    assert.ok(cloned.isSourceFailed(sourceB));
+    assert.ok(!cloned.hasSource(sourceA));
   });
 });

--- a/packages/core/src/dependency-runtime.test.ts
+++ b/packages/core/src/dependency-runtime.test.ts
@@ -1619,7 +1619,11 @@ describe("fillMissingSourceDefaults — failure result", () => {
 
     assert.equal(failures.length, 1);
     assert.equal(failures[0].sourceId, sourceId);
+    // The failure result should carry the exact error message we provided.
     assert.ok(!failures[0].error.success);
+    if (!failures[0].error.success) {
+      assert.deepEqual(failures[0].error.error, errorMsg);
+    }
     // Source should not be registered
     assert.ok(!runtime.hasSource(sourceId));
   });

--- a/packages/core/src/dependency-runtime.test.ts
+++ b/packages/core/src/dependency-runtime.test.ts
@@ -1629,21 +1629,15 @@ describe("fillMissingSourceDefaults — failure result", () => {
   });
 });
 
-describe("DependencyRuntimeContext — FailedAwareRegistry clone with FailedAwareRegistry inner", () => {
-  test("clone() rebinds failed sources when inner clone is itself a FailedAwareRegistry", () => {
-    // markSourceFailed() wraps the current registry in a new
-    // FailedAwareRegistry each time it is called.  After two calls with
-    // different IDs, the outer FailedAwareRegistry has another
-    // FailedAwareRegistry as its inner.  Cloning the outer one triggers
-    // the `innerClone instanceof FailedAwareRegistry` branch which calls
-    // rebindFailedSources() instead of wrapping again.
+describe("DependencyRuntimeContext — FailedAwareRegistry clone", () => {
+  test("clone() preserves all failed-source state across multiple failures", () => {
+    // Mark two distinct sources as failed and verify that both IDs are
+    // preserved when the registry is cloned and wrapped in a new context.
     const sourceA = Symbol("envA");
     const sourceB = Symbol("envB");
     const runtime = createDependencyRuntimeContext();
     runtime.registerSource(sourceA, "prod", "cli");
     runtime.markSourceFailed(sourceA);
-    // Second markSourceFailed wraps the FailedAwareRegistry from above,
-    // so clone().inner will itself be a FailedAwareRegistry.
     runtime.markSourceFailed(sourceB);
 
     const clonedRegistry = runtime.registry.clone();

--- a/packages/core/src/dependency.test.ts
+++ b/packages/core/src/dependency.test.ts
@@ -344,6 +344,55 @@ describe("derive()", () => {
     assert.equal(derived.format("test.txt"), "test.txt");
   });
 
+  test("placeholder returns undefined when factory throws", () => {
+    const modeParser = dependency(choice(["safe", "broken"] as const));
+
+    const derived = modeParser.derive<string>({
+      metavar: "VALUE",
+      mode: "sync",
+      factory: (value: "safe" | "broken") => {
+        if (value === "broken") {
+          throw new Error("derive sync factory exploded");
+        }
+        return string({ metavar: "VALUE" });
+      },
+      defaultValue: () => "broken" as const,
+    });
+
+    // When the factory throws, the placeholder getter catches it and returns
+    // undefined cast to the value type.
+    assert.equal(derived.placeholder, undefined);
+  });
+
+  test("parse() returns error result when factory throws", () => {
+    const modeParser = dependency(choice(["safe", "broken"] as const));
+
+    const derived = modeParser.derive<string>({
+      metavar: "VALUE",
+      mode: "sync",
+      factory: (value: "safe" | "broken") => {
+        if (value === "broken") {
+          throw new Error("derive sync factory exploded");
+        }
+        return string({ metavar: "VALUE" });
+      },
+      defaultValue: () => "broken" as const,
+    });
+
+    const result = derived.parse("anyInput");
+    assert.ok(!result.success);
+    if (!result.success) {
+      const errorText = result.error.map((part) =>
+        part.type === "text" ? part.text : ""
+      ).join("");
+      assert.ok(
+        errorText.includes("Derived parser error") ||
+          errorText.includes("factory exploded"),
+        `Unexpected error message: ${errorText}`,
+      );
+    }
+  });
+
   test("format() should not throw when factory throws on default value", () => {
     const modeParser = dependency(choice(["safe", "broken"] as const));
 
@@ -1432,6 +1481,53 @@ describe("derive() with async factory", () => {
       name: "TypeError",
       message: "Parser exploded.",
     });
+  });
+
+  test("async factory: placeholder returns undefined when factory throws", () => {
+    const modeParser = dependency(choice(["safe", "broken"] as const));
+
+    const derived = modeParser.derive({
+      metavar: "VALUE",
+      mode: "async",
+      factory: (value: "safe" | "broken") => {
+        if (value === "broken") {
+          throw new Error("derive async factory exploded");
+        }
+        return asyncChoice(["a", "b"]);
+      },
+      defaultValue: () => "broken" as const,
+    });
+
+    assert.equal(derived.placeholder, undefined);
+  });
+
+  test("async factory: parse() resolves to error when factory throws", async () => {
+    const modeParser = dependency(choice(["safe", "broken"] as const));
+
+    const derived = modeParser.derive({
+      metavar: "VALUE",
+      mode: "async",
+      factory: (value: "safe" | "broken") => {
+        if (value === "broken") {
+          throw new Error("derive async factory exploded");
+        }
+        return asyncChoice(["a", "b"]);
+      },
+      defaultValue: () => "broken" as const,
+    });
+
+    const result = await derived.parse("anyInput");
+    assert.ok(!result.success);
+    if (!result.success) {
+      const errorText = result.error.map((part) =>
+        part.type === "text" ? part.text : ""
+      ).join("");
+      assert.ok(
+        errorText.includes("Derived parser error") ||
+          errorText.includes("factory exploded"),
+        `Unexpected error message: ${errorText}`,
+      );
+    }
   });
 
   test("format() should not throw when factory throws on default value", () => {
@@ -4435,6 +4531,24 @@ describe("coverage-guided dependency parser tests", () => {
       await collectSuggestions(singleAsyncSourceSuggest("v", "boom")),
       [],
     );
+  });
+
+  test("suggestWithDependency returns empty when sync derived parser has no suggest method", () => {
+    // string() has no suggest() method, so suggestWithDependency should skip
+    const envParser = dependency(choice(["dev", "prod"] as const));
+    const derived = deriveFrom({
+      metavar: "VALUE",
+      mode: "sync",
+      dependencies: [envParser] as const,
+      factory: (_env: "dev" | "prod") => string({ metavar: "FILE" }) as never,
+      defaultValues: () => ["dev"] as const,
+    });
+    const suggestFn = derived[suggestWithDependency];
+    assert.ok(suggestFn != null);
+    const suggestions = [
+      ...(suggestFn("v", ["prod"] as const) as Iterable<Suggestion>),
+    ];
+    assert.deepEqual(suggestions, []);
   });
 
   test("suggestWithDependency should fall back to defaults for deriveFromAsync", async () => {

--- a/packages/core/src/dependency.test.ts
+++ b/packages/core/src/dependency.test.ts
@@ -382,13 +382,9 @@ describe("derive()", () => {
     const result = derived.parse("anyInput");
     assert.ok(!result.success);
     if (!result.success) {
-      const errorText = result.error.map((part) =>
-        part.type === "text" ? part.text : ""
-      ).join("");
-      assert.ok(
-        errorText.includes("Derived parser error") ||
-          errorText.includes("factory exploded"),
-        `Unexpected error message: ${errorText}`,
+      assert.deepEqual(
+        result.error,
+        message`Derived parser error: ${"derive sync factory exploded"}`,
       );
     }
   });
@@ -1519,13 +1515,9 @@ describe("derive() with async factory", () => {
     const result = await derived.parse("anyInput");
     assert.ok(!result.success);
     if (!result.success) {
-      const errorText = result.error.map((part) =>
-        part.type === "text" ? part.text : ""
-      ).join("");
-      assert.ok(
-        errorText.includes("Derived parser error") ||
-          errorText.includes("factory exploded"),
-        `Unexpected error message: ${errorText}`,
+      assert.deepEqual(
+        result.error,
+        message`Derived parser error: ${"derive async factory exploded"}`,
       );
     }
   });
@@ -4540,7 +4532,7 @@ describe("coverage-guided dependency parser tests", () => {
       metavar: "VALUE",
       mode: "sync",
       dependencies: [envParser] as const,
-      factory: (_env: "dev" | "prod") => string({ metavar: "FILE" }) as never,
+      factory: (_env: "dev" | "prod") => string({ metavar: "FILE" }),
       defaultValues: () => ["dev"] as const,
     });
     const suggestFn = derived[suggestWithDependency];

--- a/packages/core/src/displaywidth.test.ts
+++ b/packages/core/src/displaywidth.test.ts
@@ -373,4 +373,26 @@ describe("getDisplayWidth", () => {
       );
     });
   });
+
+  describe("rare Unicode double-width ranges", () => {
+    it("should count U+1F250 (🉐) as width 2", () => {
+      assert.equal(getDisplayWidth("\u{1F250}"), 2);
+    });
+
+    it("should count U+1F251 (🉑) as width 2", () => {
+      assert.equal(getDisplayWidth("\u{1F251}"), 2);
+    });
+
+    it("should count U+1F260 as width 2", () => {
+      assert.equal(getDisplayWidth("\u{1F260}"), 2);
+    });
+
+    it("should count CJK Extension B U+20000 (𠀀) as width 2", () => {
+      assert.equal(getDisplayWidth("\u{20000}"), 2);
+    });
+
+    it("should count rare CJK U+30000 (𰀀) as width 2 if in font", () => {
+      assert.equal(getDisplayWidth("\u{30000}"), 2);
+    });
+  });
 });

--- a/packages/core/src/doc.test.ts
+++ b/packages/core/src/doc.test.ts
@@ -2457,7 +2457,7 @@ describe("formatDocPage", () => {
         showChoices: { prefix: " (" },
       });
       assertLinesWithinMaxWidth(result, 60);
-      assert.ok(result.includes("(choices: a, b)"));
+      assert.ok(result.includes(" (choices: a, b)"));
     });
   });
 

--- a/packages/core/src/doc.test.ts
+++ b/packages/core/src/doc.test.ts
@@ -912,16 +912,16 @@ describe("formatDocPage", () => {
         entries: [{
           term: { type: "option", names: ["--port"] },
           description: [{ type: "text", text: "Port number" }],
-          default: valueSet(["3000"], { fallback: "", type: "unit" }),
+          default: message`3000`,
         }],
       }],
     };
     const result = formatDocPage("myapp", page, {
       showDefault: { suffix: "]" },
     });
-    // Uses the default prefix " [" since no prefix is specified
-    assert.ok(result.includes("["));
-    assert.ok(result.includes("]"));
+    // Uses the fallback prefix " [" since no prefix is specified;
+    // the plain-text default value "3000" should appear as "[3000]".
+    assert.ok(result.includes("[3000]"));
     assert.ok(result.includes("Port number"));
   });
 

--- a/packages/core/src/doc.test.ts
+++ b/packages/core/src/doc.test.ts
@@ -920,7 +920,7 @@ describe("formatDocPage", () => {
       showDefault: { suffix: "]" },
     });
     // Uses the fallback prefix " [" since no prefix is specified;
-    // the plain-text default value "3000" should appear as "[3000]".
+    // the plain-text default value "3000" should appear as " [3000]".
     assert.ok(result.includes(" [3000]"));
     assert.ok(result.includes("Port number"));
   });
@@ -2435,7 +2435,7 @@ describe("formatDocPage", () => {
         showDefault: { suffix: "]" },
       });
       assertLinesWithinMaxWidth(result, 40);
-      assert.ok(result.includes("[0]"));
+      assert.ok(result.includes(" [0]"));
     });
 
     it("uses fallback label 'choices: ' when showChoices has no label (maxWidth path)", () => {

--- a/packages/core/src/doc.test.ts
+++ b/packages/core/src/doc.test.ts
@@ -903,7 +903,7 @@ describe("formatDocPage", () => {
     const result = formatDocPage("myapp", page, {
       showChoices: {},
     });
-    assert.ok(result.includes("choices: json, yaml)"));
+    assert.ok(result.includes(" (choices: json, yaml)"));
   });
 
   it("should use default prefix when showDefault object has no prefix", () => {
@@ -921,7 +921,7 @@ describe("formatDocPage", () => {
     });
     // Uses the fallback prefix " [" since no prefix is specified;
     // the plain-text default value "3000" should appear as "[3000]".
-    assert.ok(result.includes("[3000]"));
+    assert.ok(result.includes(" [3000]"));
     assert.ok(result.includes("Port number"));
   });
 

--- a/packages/core/src/doc.test.ts
+++ b/packages/core/src/doc.test.ts
@@ -2450,8 +2450,8 @@ describe("formatDocPage", () => {
           }],
         }],
       };
-      // showChoices has prefix but no label → uses default "choices: " (8 chars).
-      // minDescWidth = prefix_width + label_width = 2 + 8 = 10
+      // showChoices has prefix but no label → uses default "choices: " (9 chars).
+      // minDescWidth = prefix_width + label_width = 2 + 9 = 11
       const result = formatDocPage("app", page, {
         maxWidth: 60,
         showChoices: { prefix: " (" },

--- a/packages/core/src/doc.test.ts
+++ b/packages/core/src/doc.test.ts
@@ -890,6 +890,41 @@ describe("formatDocPage", () => {
     assert.ok(result.includes("(choices: debug, info, warn)"));
   });
 
+  it("should use default label when showChoices object has no label", () => {
+    const page: DocPage = {
+      sections: [{
+        entries: [{
+          term: { type: "option", names: ["--format"] },
+          description: [{ type: "text", text: "Output format" }],
+          choices: valueSet(["json", "yaml"], { fallback: "", type: "unit" }),
+        }],
+      }],
+    };
+    const result = formatDocPage("myapp", page, {
+      showChoices: {},
+    });
+    assert.ok(result.includes("choices: json, yaml)"));
+  });
+
+  it("should use default prefix when showDefault object has no prefix", () => {
+    const page: DocPage = {
+      sections: [{
+        entries: [{
+          term: { type: "option", names: ["--port"] },
+          description: [{ type: "text", text: "Port number" }],
+          default: valueSet(["3000"], { fallback: "", type: "unit" }),
+        }],
+      }],
+    };
+    const result = formatDocPage("myapp", page, {
+      showDefault: { suffix: "]" },
+    });
+    // Uses the default prefix " [" since no prefix is specified
+    assert.ok(result.includes("["));
+    assert.ok(result.includes("]"));
+    assert.ok(result.includes("Port number"));
+  });
+
   it("should not show choices when entry has no choices field", () => {
     const page: DocPage = {
       sections: [{

--- a/packages/core/src/doc.test.ts
+++ b/packages/core/src/doc.test.ts
@@ -2415,6 +2415,50 @@ describe("formatDocPage", () => {
       });
       assertLinesWithinMaxWidth(result, 13);
     });
+
+    it("uses fallback prefix ' [' when showDefault has no prefix (maxWidth path)", () => {
+      // The ?? fallback for showDefault.prefix at line 631 is only reached
+      // when maxWidth is set and needsDescColumn is true.
+      const page: DocPage = {
+        sections: [{
+          entries: [{
+            term: { type: "argument", metavar: "X" },
+            description: [{ type: "text", text: "d" }],
+            default: [{ type: "text", text: "0" }],
+          }],
+        }],
+      };
+      // showDefault has suffix but no prefix → uses default " [" (2 chars).
+      // minDescWidth = 2, minimum = termIndent(2) + max(4, 2*2+1) = 2 + 5 = 7
+      const result = formatDocPage("app", page, {
+        maxWidth: 40,
+        showDefault: { suffix: "]" },
+      });
+      assertLinesWithinMaxWidth(result, 40);
+      assert.ok(result.includes("[0]"));
+    });
+
+    it("uses fallback label 'choices: ' when showChoices has no label (maxWidth path)", () => {
+      // The ?? fallback for showChoices.label at line 643 is only reached
+      // when maxWidth is set and needsDescColumn is true.
+      const page: DocPage = {
+        sections: [{
+          entries: [{
+            term: { type: "argument", metavar: "X" },
+            description: [{ type: "text", text: "d" }],
+            choices: valueSet(["a", "b"], { fallback: "", type: "unit" }),
+          }],
+        }],
+      };
+      // showChoices has prefix but no label → uses default "choices: " (8 chars).
+      // minDescWidth = prefix_width + label_width = 2 + 8 = 10
+      const result = formatDocPage("app", page, {
+        maxWidth: 60,
+        showChoices: { prefix: " (" },
+      });
+      assertLinesWithinMaxWidth(result, 60);
+      assert.ok(result.includes("(choices: a, b)"));
+    });
   });
 
   describe("Unicode display width", () => {

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -618,6 +618,21 @@ describe("integer", () => {
         assert.equal(typeof result.value, "bigint");
       }
     });
+
+    it("should use min as default placeholder when min > 0n", () => {
+      const parser = integer({ type: "bigint", min: 5n });
+      assert.equal(parser.placeholder, 5n);
+    });
+
+    it("should use max as default placeholder when max < 0n", () => {
+      const parser = integer({ type: "bigint", max: -3n });
+      assert.equal(parser.placeholder, -3n);
+    });
+
+    it("should use 0n as default placeholder when range includes 0", () => {
+      const parser = integer({ type: "bigint", min: -5n, max: 10n });
+      assert.equal(parser.placeholder, 0n);
+    });
   });
 
   describe("error messages", () => {
@@ -879,6 +894,18 @@ describe("integer", () => {
 
     it("should not throw when min equals max (bigint mode)", () => {
       assert.doesNotThrow(() => integer({ type: "bigint", min: 5n, max: 5n }));
+    });
+
+    it("should throw RangeError when fractional bounds leave no integer in range", () => {
+      // 1.5 <= 1.9 so the earlier min>max check passes, but Math.ceil(1.5)=2
+      // and Math.floor(1.9)=1, leaving no safe integer in [1.5, 1.9].
+      assert.throws(
+        () => integer({ min: 1.5, max: 1.9 }),
+        {
+          name: "RangeError",
+          message: /contains no safe integers/u,
+        },
+      );
     });
   });
 
@@ -1863,6 +1890,14 @@ describe("choice", () => {
       assert.throws(
         () => choice([] as number[]),
         TypeError,
+      );
+    });
+
+    it("should throw TypeError when any choice is NaN", () => {
+      // NaN in number choices is caught at construction time, not at parse time.
+      assert.throws(
+        () => choice([NaN]),
+        { name: "TypeError", message: "NaN is not allowed in number choices." },
       );
     });
 
@@ -2859,6 +2894,28 @@ describe("float", () => {
       if (result2.success) {
         assert.equal(result2.value, 0.123456789012345);
       }
+    });
+  });
+
+  describe("placeholder", () => {
+    it("should use min as default placeholder when min > 0", () => {
+      const parser = float({ min: 5 });
+      assert.equal(parser.placeholder, 5);
+    });
+
+    it("should use max as default placeholder when max < 0", () => {
+      const parser = float({ max: -3 });
+      assert.equal(parser.placeholder, -3);
+    });
+
+    it("should use 0 as default placeholder when range includes 0", () => {
+      const parser = float({ min: -5, max: 10 });
+      assert.equal(parser.placeholder, 0);
+    });
+
+    it("should use 0 as default placeholder when no bounds given", () => {
+      const parser = float({});
+      assert.equal(parser.placeholder, 0);
     });
   });
 

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -1797,6 +1797,13 @@ describe("choice", () => {
       assert.equal(parser.format(12), "12");
     });
 
+    it('should format -0 as "-0" not "0"', () => {
+      const parser = choice([0, -0, 1]);
+      assert.equal(parser.format(0), "0");
+      assert.equal(parser.format(-0), "-0");
+      assert.equal(parser.format(1), "1");
+    });
+
     it("should provide suggestions for number choices", () => {
       const parser = choice([8, 10, 12]);
 
@@ -2115,6 +2122,26 @@ describe("choice", () => {
 
       const result2 = parser.parse("2");
       assert.ok(result2.success);
+    });
+
+    it("should deduplicate repeated 0 and -0 in number choices", () => {
+      // Providing [0, -0, 0, -0, 1] should produce exactly [0, -0, 1]
+      // after deduplication. The second 0 and second -0 hit the `continue`
+      // branches for hasPositiveZero and hasNegativeZero respectively.
+      const parser = choice([0, -0, 0, -0, 1]);
+      assert.deepEqual(parser.choices, [0, -0, 1]);
+
+      const posResult = parser.parse("0");
+      assert.ok(posResult.success);
+      if (posResult.success) assert.ok(Object.is(posResult.value, 0));
+
+      const negResult = parser.parse("-0");
+      assert.ok(negResult.success);
+      if (negResult.success) assert.ok(Object.is(negResult.value, -0));
+
+      const oneResult = parser.parse("1");
+      assert.ok(oneResult.success);
+      if (oneResult.success) assert.equal(oneResult.value, 1);
     });
   });
 
@@ -6181,6 +6208,38 @@ describe("port", () => {
         TypeError,
       );
     });
+
+    it("should throw RangeError when disallowWellKnown range covers only well-known ports (number)", () => {
+      // When both min and max are below 1024 and disallowWellKnown is true,
+      // every port in the range would be rejected, so construction must fail.
+      assert.throws(
+        () => port({ min: 80, max: 443, disallowWellKnown: true }),
+        {
+          name: "RangeError",
+          message:
+            "disallowWellKnown is incompatible with the configured port range: " +
+            "all ports 80..443 are well-known.",
+        },
+      );
+    });
+
+    it("should throw RangeError when disallowWellKnown range covers only well-known ports (bigint)", () => {
+      assert.throws(
+        () =>
+          port({
+            type: "bigint",
+            min: 80n,
+            max: 443n,
+            disallowWellKnown: true,
+          }),
+        {
+          name: "RangeError",
+          message:
+            "disallowWellKnown is incompatible with the configured port range: " +
+            "all ports 80..443 are well-known.",
+        },
+      );
+    });
   });
 
   describe("type discriminant validation", () => {
@@ -7021,6 +7080,23 @@ describe("hostname()", () => {
 
       const result = parser.parse("*.localhost");
       assert.ok(result.success);
+    });
+
+    it("should use function callback for wildcard localhost error", () => {
+      const parser = hostname({
+        allowLocalhost: false,
+        allowWildcard: true,
+        errors: {
+          localhostNotAllowed: (input) => message`blocked: ${input}`,
+        },
+      });
+
+      const result = parser.parse("*.localhost");
+      assert.ok(!result.success);
+      assert.deepStrictEqual(result.error, [
+        { type: "text", text: "blocked: " },
+        { type: "value", value: "*.localhost" },
+      ]);
     });
   });
 

--- a/packages/env/src/index.test.ts
+++ b/packages/env/src/index.test.ts
@@ -469,6 +469,28 @@ describe("bindEnv()", () => {
         },
       );
     });
+
+    it("throws TypeError for any non-string key", () => {
+      const context = createEnvContext();
+
+      fc.assert(
+        fc.property(
+          fc.anything().filter((v) => typeof v !== "string"),
+          (invalidKey) => {
+            assert.throws(
+              () =>
+                bindEnv(option("--name", string()), {
+                  context,
+                  key: invalidKey as never,
+                  parser: string(),
+                }),
+              { name: "TypeError", message: /Expected key to be a string/ },
+            );
+          },
+        ),
+        propertyParameters,
+      );
+    });
   });
 
   describe("parser validation", () => {
@@ -549,28 +571,6 @@ describe("bindEnv()", () => {
           name: "TypeError",
           message: "Expected parser to be a ValueParser, but got: array.",
         },
-      );
-    });
-
-    it("throws TypeError for any non-string key", () => {
-      const context = createEnvContext();
-
-      fc.assert(
-        fc.property(
-          fc.anything().filter((v) => typeof v !== "string"),
-          (invalidKey) => {
-            assert.throws(
-              () =>
-                bindEnv(option("--name", string()), {
-                  context,
-                  key: invalidKey as never,
-                  parser: string(),
-                }),
-              { name: "TypeError", message: /Expected key to be a string/ },
-            );
-          },
-        ),
-        propertyParameters,
       );
     });
 

--- a/packages/env/src/index.test.ts
+++ b/packages/env/src/index.test.ts
@@ -551,6 +551,61 @@ describe("bindEnv()", () => {
         },
       );
     });
+
+    it("throws TypeError for any non-string key", () => {
+      const context = createEnvContext();
+
+      fc.assert(
+        fc.property(
+          fc.anything().filter((v) => typeof v !== "string"),
+          (invalidKey) => {
+            assert.throws(
+              () =>
+                bindEnv(option("--name", string()), {
+                  context,
+                  key: invalidKey as never,
+                  parser: string(),
+                }),
+              { name: "TypeError", message: /Expected key to be a string/ },
+            );
+          },
+        ),
+        propertyParameters,
+      );
+    });
+
+    it("throws TypeError for any non-ValueParser parser value", () => {
+      const context = createEnvContext();
+
+      fc.assert(
+        fc.property(
+          fc.oneof(
+            fc.integer(),
+            fc.float(),
+            fc.boolean(),
+            fc.string(),
+            fc.constant(null),
+            fc.constant([]),
+            fc.record({}),
+          ),
+          (invalidParser) => {
+            assert.throws(
+              () =>
+                bindEnv(option("--name", string()), {
+                  context,
+                  key: "NAME",
+                  parser: invalidParser as never,
+                }),
+              {
+                name: "TypeError",
+                message: /Expected parser to be a ValueParser/,
+              },
+            );
+          },
+        ),
+        propertyParameters,
+      );
+    });
   });
 
   it("uses CLI value when provided", () => {

--- a/packages/git/src/index.test.ts
+++ b/packages/git/src/index.test.ts
@@ -578,6 +578,30 @@ describe("git parsers", () => {
         },
       );
     });
+
+    it("should reject null remote", () => {
+      assert.throws(
+        () => gitRemoteBranch(null as never, { dir: "/tmp/dummy" }),
+        {
+          name: "TypeError",
+          message:
+            "Expected remote to be a non-empty string without whitespace " +
+            "or control characters, but got: null.",
+        },
+      );
+    });
+
+    it("should reject array remote", () => {
+      assert.throws(
+        () => gitRemoteBranch(["origin"] as never, { dir: "/tmp/dummy" }),
+        {
+          name: "TypeError",
+          message:
+            "Expected remote to be a non-empty string without whitespace " +
+            "or control characters, but got: array.",
+        },
+      );
+    });
   });
 
   describe("gitCommit()", () => {

--- a/packages/logtape/src/index.test.ts
+++ b/packages/logtape/src/index.test.ts
@@ -865,6 +865,31 @@ describe("createConsoleSink()", () => {
     );
   });
 
+  it("should throw TypeError for numeric stream option", () => {
+    // Non-string, non-object invalid stream uses String(value) for repr
+    // (line 233–234 in output.ts: `value === null || typeof value !== "object"`).
+    assert.throws(
+      () => createConsoleSink({ stream: 42 as never }),
+      {
+        name: "TypeError",
+        message: 'Invalid stream: expected "stdout" or "stderr", got 42.',
+      },
+    );
+  });
+
+  it("should throw TypeError for object stream option", () => {
+    // Non-null object stream uses JSON.stringify for repr
+    // (line 235–241 in output.ts: the else branch).
+    assert.throws(
+      () => createConsoleSink({ stream: { custom: true } as never }),
+      {
+        name: "TypeError",
+        message:
+          'Invalid stream: expected "stdout" or "stderr", got {"custom":true}.',
+      },
+    );
+  });
+
   it("should treat null stream as default stderr", () => {
     const sink = createConsoleSink({ stream: null });
     const originalError = console.error;

--- a/packages/logtape/src/index.test.ts
+++ b/packages/logtape/src/index.test.ts
@@ -890,6 +890,21 @@ describe("createConsoleSink()", () => {
     );
   });
 
+  it("should throw TypeError for cyclic object stream (JSON.stringify throws)", () => {
+    // When JSON.stringify throws (cyclic object), the catch block falls back
+    // to String(value) = "[object Object]" (lines 238–240 in output.ts).
+    const cyclic: { self?: unknown } = {};
+    cyclic.self = cyclic;
+    assert.throws(
+      () => createConsoleSink({ stream: cyclic as never }),
+      {
+        name: "TypeError",
+        message:
+          'Invalid stream: expected "stdout" or "stderr", got [object Object].',
+      },
+    );
+  });
+
   it("should treat null stream as default stderr", () => {
     const sink = createConsoleSink({ stream: null });
     const originalError = console.error;

--- a/packages/logtape/src/verbosity.ts
+++ b/packages/logtape/src/verbosity.ts
@@ -49,11 +49,6 @@ const VERBOSITY_LEVELS: readonly LogLevel[] = [
 ];
 
 /**
- * Index of "warning" in VERBOSITY_LEVELS (the default base level).
- */
-const WARNING_INDEX = 2;
-
-/**
  * Creates a parser for verbosity flags (`-v`, `-vv`, `-vvv`, etc.).
  *
  * This parser accumulates `-v` flags to determine the log level.
@@ -108,9 +103,8 @@ export function verbosity(
 
   validateLogLevel(baseLevel, "baseLevel");
 
-  // Find the index of the base level
-  const baseIndex = VERBOSITY_LEVELS.indexOf(baseLevel);
-  const effectiveBaseIndex = baseIndex >= 0 ? baseIndex : WARNING_INDEX;
+  // validateLogLevel() above guarantees baseLevel is in VERBOSITY_LEVELS
+  const effectiveBaseIndex = VERBOSITY_LEVELS.indexOf(baseLevel);
 
   const flagParser = flag(short, long, {
     description: options.description ??

--- a/packages/man/src/generator.test.ts
+++ b/packages/man/src/generator.test.ts
@@ -279,6 +279,20 @@ describe("generateManPageSync()", () => {
     );
   });
 
+  it("rejects null as parser", () => {
+    assert.throws(
+      () => generateManPageSync(null as never, { name: "x", section: 1 }),
+      { name: "TypeError", message: /not a valid.*Parser/ },
+    );
+  });
+
+  it("rejects a primitive (number) as parser", () => {
+    assert.throws(
+      () => generateManPageSync(42 as never, { name: "x", section: 1 }),
+      { name: "TypeError", message: /not a valid.*Parser/ },
+    );
+  });
+
   it("rejects a malformed parser-like object", () => {
     const fakeParser = {};
     assert.throws(

--- a/packages/man/src/generator.test.ts
+++ b/packages/man/src/generator.test.ts
@@ -350,6 +350,22 @@ describe("generateManPageSync()", () => {
     );
   });
 
+  it("rejects a Proxy that throws on property access", () => {
+    // isParser() and isProgram() each have a try/catch so that Proxies with
+    // throwing traps are treated as "not a parser" rather than propagating
+    // the exception.
+    const throwingProxy = new Proxy({}, {
+      has(_target, _prop) {
+        throw new Error("property access denied");
+      },
+    });
+    assert.throws(
+      () =>
+        generateManPageSync(throwingProxy as never, { name: "x", section: 1 }),
+      { name: "TypeError", message: /not a valid.*Parser/ },
+    );
+  });
+
   it("rejects empty name", () => {
     const parser = object({});
     assert.throws(

--- a/packages/man/src/man.test.ts
+++ b/packages/man/src/man.test.ts
@@ -346,6 +346,11 @@ describe("formatUsageTermAsRoff()", () => {
     assert.equal(formatUsageTermAsRoff(term), "[...]");
   });
 
+  it("formats ellipsis term", () => {
+    const term: UsageTerm = { type: "ellipsis" };
+    assert.equal(formatUsageTermAsRoff(term), "...");
+  });
+
   it("throws for unknown usage term type", () => {
     const invalid = { type: "unknown" } as unknown as UsageTerm;
     assert.throws(
@@ -2258,5 +2263,155 @@ describe("formatDocPageAsMan()", () => {
       !synopsis.includes("..."),
       "ancestor usageLine should not be applied on subcommand page",
     );
+  });
+});
+
+describe("doc-level usage term formatting (nested terms)", () => {
+  const minimalOptions: ManPageOptions = {
+    name: "test",
+    section: 1,
+  };
+
+  // formatDocUsageTermAsRoff is called for optional/multiple/exclusive terms
+  // in a doc entry, and recursively for their nested terms. The literal,
+  // passthrough, and ellipsis cases at lines 421-428 of man.ts are triggered
+  // via this recursive path.
+
+  it("formats literal term nested inside optional doc entry", () => {
+    const page: DocPage = {
+      sections: [
+        {
+          entries: [
+            {
+              term: {
+                type: "optional",
+                terms: [{ type: "literal", value: "example" }],
+              },
+              description: message`An example.`,
+            },
+          ],
+        },
+      ],
+    };
+    const result = formatDocPageAsMan(page, minimalOptions);
+    assert.ok(result.includes(".TP"));
+    assert.ok(result.includes("[example]"));
+  });
+
+  it("formats passthrough term nested inside optional doc entry", () => {
+    const page: DocPage = {
+      sections: [
+        {
+          entries: [
+            {
+              term: {
+                type: "optional",
+                terms: [{ type: "passthrough" }],
+              },
+              description: message`Pass through arguments.`,
+            },
+          ],
+        },
+      ],
+    };
+    const result = formatDocPageAsMan(page, minimalOptions);
+    assert.ok(result.includes("[...]"));
+  });
+
+  it("formats ellipsis term nested inside optional doc entry", () => {
+    const page: DocPage = {
+      sections: [
+        {
+          entries: [
+            {
+              term: {
+                type: "optional",
+                terms: [{ type: "ellipsis" }],
+              },
+              description: message`More items.`,
+            },
+          ],
+        },
+      ],
+    };
+    const result = formatDocPageAsMan(page, minimalOptions);
+    assert.ok(result.includes("[...]") || result.includes("..."));
+  });
+
+  it("throws for unknown term type in doc usage formatting", () => {
+    const page: DocPage = {
+      sections: [
+        {
+          entries: [
+            {
+              term: {
+                type: "optional",
+                terms: [{ type: "unknown_type" } as unknown as UsageTerm],
+              },
+              description: message`desc`,
+            },
+          ],
+        },
+      ],
+    };
+    assert.throws(
+      () => formatDocPageAsMan(page, minimalOptions),
+      /Unknown usage term type: unknown_type/,
+    );
+  });
+
+  it("returns empty string for optional with all-empty nested terms", () => {
+    // An optional whose inner terms all render to "" should produce ""
+    // (testing the if (inner === "") return "" branch)
+    const page: DocPage = {
+      sections: [
+        {
+          entries: [
+            {
+              term: {
+                type: "optional",
+                terms: [{
+                  type: "argument",
+                  metavar: "ARG",
+                  hidden: "doc",
+                }],
+              },
+              description: message`Hidden arg.`,
+            },
+          ],
+        },
+      ],
+    };
+    const result = formatDocPageAsMan(page, minimalOptions);
+    // The optional term renders as "" when all nested terms are doc-hidden
+    // and should not appear in the output
+    assert.ok(!result.includes("[") || result.includes(".TH"));
+  });
+
+  it("filters doc-hidden entries from doc sections", () => {
+    const page: DocPage = {
+      sections: [
+        {
+          title: "OPTIONS",
+          entries: [
+            {
+              term: { type: "option", names: ["--visible"] },
+              description: message`Visible option.`,
+            },
+            {
+              term: {
+                type: "option",
+                names: ["--hidden-opt"],
+                hidden: "doc",
+              },
+              description: message`Hidden option.`,
+            },
+          ],
+        },
+      ],
+    };
+    const result = formatDocPageAsMan(page, minimalOptions);
+    assert.ok(result.includes("visible"));
+    assert.ok(!result.includes("hidden-opt"));
   });
 });

--- a/packages/man/src/man.test.ts
+++ b/packages/man/src/man.test.ts
@@ -2335,7 +2335,9 @@ describe("doc-level usage term formatting (nested terms)", () => {
       ],
     };
     const result = formatDocPageAsMan(page, minimalOptions);
-    assert.ok(result.includes("[...]") || result.includes("..."));
+    // The ellipsis term nested inside optional should render as "[...]"
+    // (optional wraps with "[...]" and ellipsis renders as "...").
+    assert.ok(result.includes("[...]"));
   });
 
   it("throws for unknown term type in doc usage formatting", () => {
@@ -2384,8 +2386,10 @@ describe("doc-level usage term formatting (nested terms)", () => {
     };
     const result = formatDocPageAsMan(page, minimalOptions);
     // When all inner terms are doc-hidden, the optional renders to "",
-    // which causes the entire entry to be skipped — no "[" in the output.
+    // which causes the entire entry to be skipped — no "[" and no
+    // description text in the output.
     assert.ok(!result.includes("["));
+    assert.ok(!result.includes("Hidden arg."));
   });
 
   it("filters doc-hidden entries from doc sections", () => {
@@ -2435,9 +2439,10 @@ describe("doc-level usage term formatting (nested terms)", () => {
     };
     const result = formatDocPageAsMan(page, minimalOptions);
     // Both A and B are doc-hidden, so the entry is skipped entirely —
-    // neither roff-formatted metavar should appear.
+    // neither roff-formatted metavar nor the description should appear.
     assert.ok(!result.includes("\\fIA\\fR"));
     assert.ok(!result.includes("\\fIB\\fR"));
+    assert.ok(!result.includes("A choice."));
   });
 
   it("formats exclusive term with exactly one non-empty alternative", () => {
@@ -2481,7 +2486,8 @@ describe("doc-level usage term formatting (nested terms)", () => {
     };
     const result = formatDocPageAsMan(page, minimalOptions);
     // All inner terms are doc-hidden, so multiple renders to "" and the
-    // entry is skipped entirely — ARG should not appear in the output.
+    // entry is skipped entirely — neither ARG nor the description appear.
     assert.ok(!result.includes("ARG"));
+    assert.ok(!result.includes("A repeatable."));
   });
 });

--- a/packages/man/src/man.test.ts
+++ b/packages/man/src/man.test.ts
@@ -2383,9 +2383,9 @@ describe("doc-level usage term formatting (nested terms)", () => {
       ],
     };
     const result = formatDocPageAsMan(page, minimalOptions);
-    // The optional term renders as "" when all nested terms are doc-hidden
-    // and should not appear in the output
-    assert.ok(!result.includes("[") || result.includes(".TH"));
+    // When all inner terms are doc-hidden, the optional renders to "",
+    // which causes the entire entry to be skipped — no "[" in the output.
+    assert.ok(!result.includes("["));
   });
 
   it("filters doc-hidden entries from doc sections", () => {
@@ -2434,7 +2434,10 @@ describe("doc-level usage term formatting (nested terms)", () => {
       }],
     };
     const result = formatDocPageAsMan(page, minimalOptions);
-    assert.ok(typeof result === "string");
+    // Both A and B are doc-hidden, so the entry is skipped entirely —
+    // neither roff-formatted metavar should appear.
+    assert.ok(!result.includes("\\fIA\\fR"));
+    assert.ok(!result.includes("\\fIB\\fR"));
   });
 
   it("formats exclusive term with exactly one non-empty alternative", () => {
@@ -2455,8 +2458,10 @@ describe("doc-level usage term formatting (nested terms)", () => {
       }],
     };
     const result = formatDocPageAsMan(page, minimalOptions);
-    assert.ok(result.includes("FILE"));
-    assert.ok(!result.includes("(FILE |"));
+    // FILE is visible; it renders as \fIFILE\fR in roff.
+    assert.ok(result.includes("\\fIFILE\\fR"));
+    // Only one non-empty alternative, so it is not wrapped in parens.
+    assert.ok(!result.includes("(\\fIFILE\\fR"));
   });
 
   it("formats multiple term with all-hidden inner terms as empty string", () => {
@@ -2475,6 +2480,8 @@ describe("doc-level usage term formatting (nested terms)", () => {
       }],
     };
     const result = formatDocPageAsMan(page, minimalOptions);
-    assert.ok(typeof result === "string");
+    // All inner terms are doc-hidden, so multiple renders to "" and the
+    // entry is skipped entirely — ARG should not appear in the output.
+    assert.ok(!result.includes("ARG"));
   });
 });

--- a/packages/man/src/man.test.ts
+++ b/packages/man/src/man.test.ts
@@ -2414,4 +2414,67 @@ describe("doc-level usage term formatting (nested terms)", () => {
     assert.ok(result.includes("visible"));
     assert.ok(!result.includes("hidden-opt"));
   });
+
+  it("formats exclusive term with all-empty alternatives as empty string", () => {
+    // When all branches of an exclusive term produce empty strings (all
+    // terms inside each branch are doc-hidden), formatDocUsageAsRoff returns
+    // "" for the exclusive — line 400 in man.ts.
+    const page: DocPage = {
+      sections: [{
+        entries: [{
+          term: {
+            type: "exclusive",
+            terms: [
+              [{ type: "argument", metavar: "A", hidden: "doc" }],
+              [{ type: "argument", metavar: "B", hidden: "doc" }],
+            ],
+          },
+          description: message`A choice.`,
+        }],
+      }],
+    };
+    const result = formatDocPageAsMan(page, minimalOptions);
+    assert.ok(typeof result === "string");
+  });
+
+  it("formats exclusive term with exactly one non-empty alternative", () => {
+    // When only one alternative is non-empty, the result is unwrapped
+    // (no surrounding parens) — line 401 in man.ts.
+    const page: DocPage = {
+      sections: [{
+        entries: [{
+          term: {
+            type: "exclusive",
+            terms: [
+              [{ type: "argument", metavar: "FILE" }],
+              [{ type: "argument", metavar: "HIDDEN", hidden: "doc" }],
+            ],
+          },
+          description: message`A choice.`,
+        }],
+      }],
+    };
+    const result = formatDocPageAsMan(page, minimalOptions);
+    assert.ok(result.includes("FILE"));
+    assert.ok(!result.includes("(FILE |"));
+  });
+
+  it("formats multiple term with all-hidden inner terms as empty string", () => {
+    // When all inner terms of a multiple are doc-hidden,
+    // formatDocUsageAsRoff returns "" — line 389 in man.ts.
+    const page: DocPage = {
+      sections: [{
+        entries: [{
+          term: {
+            type: "multiple",
+            min: 0,
+            terms: [{ type: "argument", metavar: "ARG", hidden: "doc" }],
+          },
+          description: message`A repeatable.`,
+        }],
+      }],
+    };
+    const result = formatDocPageAsMan(page, minimalOptions);
+    assert.ok(typeof result === "string");
+  });
 });

--- a/packages/man/src/man.test.ts
+++ b/packages/man/src/man.test.ts
@@ -2350,7 +2350,7 @@ describe("doc-level usage term formatting (nested terms)", () => {
             {
               term: {
                 type: "optional",
-                terms: [{ type: "unknown_type" } as unknown as UsageTerm],
+                terms: [{ type: "unknown_type" } as never],
               },
               description: message`desc`,
             },
@@ -2418,7 +2418,7 @@ describe("doc-level usage term formatting (nested terms)", () => {
     };
     const result = formatDocPageAsMan(page, minimalOptions);
     assert.ok(result.includes("visible"));
-    assert.ok(!result.includes("hidden-opt"));
+    assert.ok(!result.includes("Hidden option."));
   });
 
   it("formats exclusive term with all-empty alternatives as empty string", () => {

--- a/packages/man/src/man.test.ts
+++ b/packages/man/src/man.test.ts
@@ -2315,7 +2315,8 @@ describe("doc-level usage term formatting (nested terms)", () => {
       ],
     };
     const result = formatDocPageAsMan(page, minimalOptions);
-    assert.ok(result.includes("[...]"));
+    // passthrough renders as "[...]", so optional(passthrough) is "[[...]]".
+    assert.ok(result.includes("[[...]]"));
   });
 
   it("formats ellipsis term nested inside optional doc entry", () => {
@@ -2335,9 +2336,10 @@ describe("doc-level usage term formatting (nested terms)", () => {
       ],
     };
     const result = formatDocPageAsMan(page, minimalOptions);
-    // The ellipsis term nested inside optional should render as "[...]"
-    // (optional wraps with "[...]" and ellipsis renders as "...").
+    // ellipsis renders as "...", so optional(ellipsis) → "[...]".
+    // Distinct from optional(passthrough) which would render as "[[...]]".
     assert.ok(result.includes("[...]"));
+    assert.ok(!result.includes("[[...]]"));
   });
 
   it("throws for unknown term type in doc usage formatting", () => {

--- a/packages/run/src/run.test.ts
+++ b/packages/run/src/run.test.ts
@@ -1370,6 +1370,39 @@ describe("runSync", () => {
       assert.ok(helpOutput.includes("myapp-sync"));
       assert.equal(exitCode, 0);
     });
+
+    it("should use explicit programName over program metadata name", () => {
+      // When programName is provided in options alongside a Program object,
+      // the explicit programName is used instead of program.metadata.name.
+      // This exercises the `options.programName == null ? ... : options`
+      // branch in run.ts (line 400).
+      const parser = option("--verbose");
+      const prog: Program<"sync", boolean> = {
+        parser,
+        metadata: { name: "metadata-name" },
+      };
+
+      let helpOutput = "";
+
+      try {
+        runSync(prog, {
+          args: ["--help"],
+          programName: "override-name",
+          help: "option",
+          stdout: (text) => {
+            helpOutput += `${text}\n`;
+          },
+          onExit: () => {
+            throw new Error("exit");
+          },
+        });
+      } catch {
+        // Expected exit
+      }
+
+      assert.ok(helpOutput.includes("override-name"));
+      assert.ok(!helpOutput.includes("metadata-name"));
+    });
   });
 });
 

--- a/packages/run/src/run.test.ts
+++ b/packages/run/src/run.test.ts
@@ -1384,21 +1384,21 @@ describe("runSync", () => {
 
       let helpOutput = "";
 
-      try {
-        runSync(prog, {
-          args: ["--help"],
-          programName: "override-name",
-          help: "option",
-          stdout: (text) => {
-            helpOutput += `${text}\n`;
-          },
-          onExit: () => {
-            throw new Error("exit");
-          },
-        });
-      } catch {
-        // Expected exit
-      }
+      assert.throws(
+        () =>
+          runSync(prog, {
+            args: ["--help"],
+            programName: "override-name",
+            help: "option",
+            stdout: (text) => {
+              helpOutput += `${text}\n`;
+            },
+            onExit: () => {
+              throw new Error("exit");
+            },
+          }),
+        /exit/,
+      );
 
       assert.ok(helpOutput.includes("override-name"));
       assert.ok(!helpOutput.includes("metadata-name"));

--- a/packages/run/src/valueparser.test.ts
+++ b/packages/run/src/valueparser.test.ts
@@ -1403,4 +1403,161 @@ describe("path", () => {
       assert.equal(parser.metavar, "FILE");
     });
   });
+
+  describe("property-based validation", () => {
+    // Arbitrary for "safe" non-boolean primitive values: values that are
+    // neither boolean nor undefined and whose String() conversion does not
+    // itself throw (which would produce an unrelated error).
+    const nonBooleanPrimitiveArbitrary = fc.oneof(
+      fc.string(),
+      fc.integer(),
+      fc.float().filter((v) => !Number.isNaN(v)),
+      fc.bigInt(),
+      fc.constant(null),
+    );
+
+    it("should throw TypeError for any non-allowed type value", () => {
+      // Use primitive-like values that JSON.stringify handles predictably.
+      // fc.anything() can produce Symbols which JSON.stringify silently
+      // converts to undefined, making the type check pass unexpectedly.
+      const invalidTypeArbitrary = fc.oneof(
+        fc.string().filter(
+          (v) => v !== "file" && v !== "directory" && v !== "either",
+        ),
+        fc.integer(),
+        fc.boolean(),
+        fc.constant(null),
+      );
+
+      fc.assert(
+        fc.property(
+          invalidTypeArbitrary,
+          (invalidType) => {
+            assert.throws(
+              // @ts-expect-error intentional runtime validation test
+              () => path({ type: invalidType }),
+              {
+                name: "TypeError",
+                message: /Expected "file", "directory", or "either"/,
+              },
+            );
+          },
+        ),
+        propertyParameters,
+      );
+    });
+
+    it("should throw TypeError for any extension that is not a dot-prefixed string", () => {
+      // Covers both non-string values and strings not starting with "."
+      const invalidExtArbitrary = fc.oneof(
+        fc.string().filter((v) => !v.startsWith(".")),
+        fc.integer(),
+        fc.boolean(),
+        fc.constant(null),
+      );
+
+      fc.assert(
+        fc.property(
+          invalidExtArbitrary,
+          (invalidExt) => {
+            assert.throws(
+              // @ts-expect-error intentional runtime validation test
+              () => path({ extensions: [invalidExt] }),
+              {
+                name: "TypeError",
+                message: /must start with a dot/,
+              },
+            );
+          },
+        ),
+        propertyParameters,
+      );
+    });
+
+    it("should throw TypeError for any non-boolean non-undefined allowCreate value", () => {
+      fc.assert(
+        fc.property(
+          nonBooleanPrimitiveArbitrary,
+          (invalidValue) => {
+            assert.throws(
+              // @ts-expect-error intentional runtime validation test
+              () => path({ allowCreate: invalidValue }),
+              {
+                name: "TypeError",
+                message: /Expected allowCreate to be a boolean/,
+              },
+            );
+          },
+        ),
+        propertyParameters,
+      );
+    });
+
+    it("should throw TypeError for any non-boolean non-undefined mustExist value", () => {
+      fc.assert(
+        fc.property(
+          nonBooleanPrimitiveArbitrary,
+          (invalidValue) => {
+            assert.throws(
+              // @ts-expect-error intentional runtime validation test
+              () => path({ mustExist: invalidValue }),
+              {
+                name: "TypeError",
+                message: /Expected mustExist to be a boolean/,
+              },
+            );
+          },
+        ),
+        propertyParameters,
+      );
+    });
+
+    it("should throw TypeError for any non-boolean non-undefined mustNotExist value", () => {
+      fc.assert(
+        fc.property(
+          nonBooleanPrimitiveArbitrary,
+          (invalidValue) => {
+            assert.throws(
+              // @ts-expect-error intentional runtime validation test
+              () => path({ mustNotExist: invalidValue }),
+              {
+                name: "TypeError",
+                message: /Expected mustNotExist to be a boolean/,
+              },
+            );
+          },
+        ),
+        propertyParameters,
+      );
+    });
+
+    it("should throw TypeError for any non-string non-undefined placeholder value", () => {
+      // placeholder only validates that the value is a string when provided —
+      // use a non-string-containing arbitrary to avoid false negatives.
+      const nonStringNonUndefinedArbitrary = fc.oneof(
+        fc.integer(),
+        fc.float(),
+        fc.bigInt(),
+        fc.boolean(),
+        fc.constant(null),
+      );
+
+      fc.assert(
+        fc.property(
+          nonStringNonUndefinedArbitrary,
+          (invalidValue) => {
+            assert.throws(
+              // @ts-expect-error intentional runtime validation test
+              () => path({ placeholder: invalidValue }),
+              {
+                name: "TypeError",
+                message: /Expected placeholder to be a string/,
+              },
+            );
+          },
+        ),
+        propertyParameters,
+      );
+    });
+  });
 });

--- a/packages/temporal/src/index.test.ts
+++ b/packages/temporal/src/index.test.ts
@@ -1569,3 +1569,67 @@ describe("default error messages include the input value", () => {
     }
   });
 });
+
+describe("placeholder values", () => {
+  it("instant() returns a valid Temporal.Instant placeholder", () => {
+    const parser = instant();
+    const p = parser.placeholder;
+    assert.ok(p instanceof Temporal.Instant);
+    assert.equal(p.epochMilliseconds, 0);
+  });
+
+  it("duration() returns a valid Temporal.Duration placeholder", () => {
+    const parser = duration();
+    const p = parser.placeholder;
+    assert.ok(p instanceof Temporal.Duration);
+    assert.equal(p.total("seconds"), 0);
+  });
+
+  it("zonedDateTime() returns a valid Temporal.ZonedDateTime placeholder", () => {
+    const parser = zonedDateTime();
+    const p = parser.placeholder;
+    assert.ok(p instanceof Temporal.ZonedDateTime);
+    assert.equal(p.timeZoneId, "UTC");
+  });
+
+  it("plainDate() returns a valid Temporal.PlainDate placeholder", () => {
+    const parser = plainDate();
+    const p = parser.placeholder;
+    assert.ok(p instanceof Temporal.PlainDate);
+    assert.equal(p.year, 1970);
+    assert.equal(p.month, 1);
+    assert.equal(p.day, 1);
+  });
+
+  it("plainTime() returns a valid Temporal.PlainTime placeholder", () => {
+    const parser = plainTime();
+    const p = parser.placeholder;
+    assert.ok(p instanceof Temporal.PlainTime);
+    assert.equal(p.hour, 0);
+    assert.equal(p.minute, 0);
+  });
+
+  it("plainDateTime() returns a valid Temporal.PlainDateTime placeholder", () => {
+    const parser = plainDateTime();
+    const p = parser.placeholder;
+    assert.ok(p instanceof Temporal.PlainDateTime);
+    assert.equal(p.year, 1970);
+    assert.equal(p.hour, 0);
+  });
+
+  it("plainYearMonth() returns a valid Temporal.PlainYearMonth placeholder", () => {
+    const parser = plainYearMonth();
+    const p = parser.placeholder;
+    assert.ok(p instanceof Temporal.PlainYearMonth);
+    assert.equal(p.year, 1970);
+    assert.equal(p.month, 1);
+  });
+
+  it("plainMonthDay() returns a valid Temporal.PlainMonthDay placeholder", () => {
+    const parser = plainMonthDay();
+    const p = parser.placeholder;
+    assert.ok(p instanceof Temporal.PlainMonthDay);
+    assert.equal(p.monthCode, "M01");
+    assert.equal(p.day, 1);
+  });
+});

--- a/packages/temporal/src/index.test.ts
+++ b/packages/temporal/src/index.test.ts
@@ -1408,3 +1408,164 @@ describe("Temporal API unavailability", () => {
     });
   }
 });
+
+describe("default error messages include the input value", () => {
+  const invalidInputs = [
+    "not-valid",
+    "2020/01/23",
+    "garbage",
+    "123abc",
+    "2020-01-23T",
+  ] as const;
+
+  it("instant default error message references the invalid input as a value term", () => {
+    const parser = instant();
+    for (const input of invalidInputs) {
+      const result = parser.parse(input);
+      assert.ok(!result.success);
+      assert.ok(
+        result.error.some((term) =>
+          term.type === "value" && term.value === input
+        ),
+        `Expected input ${
+          JSON.stringify(input)
+        } to appear as a value term in error: ${JSON.stringify(result.error)}`,
+      );
+    }
+  });
+
+  it("duration default error message references the invalid input as a value term", () => {
+    const parser = duration();
+    for (const input of invalidInputs) {
+      const result = parser.parse(input);
+      assert.ok(!result.success);
+      assert.ok(
+        result.error.some((term) =>
+          term.type === "value" && term.value === input
+        ),
+        `Expected input ${
+          JSON.stringify(input)
+        } to appear as a value term in error: ${JSON.stringify(result.error)}`,
+      );
+    }
+  });
+
+  it("zonedDateTime default error message references the invalid input as a value term", () => {
+    const parser = zonedDateTime();
+    for (const input of invalidInputs) {
+      const result = parser.parse(input);
+      assert.ok(!result.success);
+      assert.ok(
+        result.error.some((term) =>
+          term.type === "value" && term.value === input
+        ),
+        `Expected input ${
+          JSON.stringify(input)
+        } to appear as a value term in error: ${JSON.stringify(result.error)}`,
+      );
+    }
+  });
+
+  it("plainDate default error message references the invalid input as a value term", () => {
+    const parser = plainDate();
+    for (const input of invalidInputs) {
+      const result = parser.parse(input);
+      assert.ok(!result.success);
+      assert.ok(
+        result.error.some((term) =>
+          term.type === "value" && term.value === input
+        ),
+        `Expected input ${
+          JSON.stringify(input)
+        } to appear as a value term in error: ${JSON.stringify(result.error)}`,
+      );
+    }
+  });
+
+  it("plainTime default error message references the invalid input as a value term", () => {
+    const parser = plainTime();
+    const timeInvalidInputs = [
+      "not-valid",
+      "garbage",
+      "99:99:99",
+      "2020-01-23",
+    ];
+    for (const input of timeInvalidInputs) {
+      const result = parser.parse(input);
+      assert.ok(!result.success);
+      assert.ok(
+        result.error.some((term) =>
+          term.type === "value" && term.value === input
+        ),
+        `Expected input ${
+          JSON.stringify(input)
+        } to appear as a value term in error: ${JSON.stringify(result.error)}`,
+      );
+    }
+  });
+
+  it("plainDateTime default error message references the invalid input as a value term", () => {
+    const parser = plainDateTime();
+    for (const input of invalidInputs) {
+      const result = parser.parse(input);
+      assert.ok(!result.success);
+      assert.ok(
+        result.error.some((term) =>
+          term.type === "value" && term.value === input
+        ),
+        `Expected input ${
+          JSON.stringify(input)
+        } to appear as a value term in error: ${JSON.stringify(result.error)}`,
+      );
+    }
+  });
+
+  it("plainYearMonth default error message references the invalid input as a value term", () => {
+    const parser = plainYearMonth();
+    for (const input of invalidInputs) {
+      const result = parser.parse(input);
+      assert.ok(!result.success);
+      assert.ok(
+        result.error.some((term) =>
+          term.type === "value" && term.value === input
+        ),
+        `Expected input ${
+          JSON.stringify(input)
+        } to appear as a value term in error: ${JSON.stringify(result.error)}`,
+      );
+    }
+  });
+
+  it("plainMonthDay default error message references the invalid input as a value term", () => {
+    const parser = plainMonthDay();
+    for (const input of invalidInputs) {
+      const result = parser.parse(input);
+      assert.ok(!result.success);
+      assert.ok(
+        result.error.some((term) =>
+          term.type === "value" && term.value === input
+        ),
+        `Expected input ${
+          JSON.stringify(input)
+        } to appear as a value term in error: ${JSON.stringify(result.error)}`,
+      );
+    }
+  });
+
+  it("timeZone default error message references the invalid input as a value term", () => {
+    const parser = timeZone();
+    const tzInvalidInputs = ["not-valid", "garbage", "Fake/Zone", "123/456"];
+    for (const input of tzInvalidInputs) {
+      const result = parser.parse(input);
+      assert.ok(!result.success);
+      assert.ok(
+        result.error.some((term) =>
+          term.type === "value" && term.value === input
+        ),
+        `Expected input ${
+          JSON.stringify(input)
+        } to appear as a value term in error: ${JSON.stringify(result.error)}`,
+      );
+    }
+  });
+});

--- a/packages/valibot/src/index.test.ts
+++ b/packages/valibot/src/index.test.ts
@@ -1462,7 +1462,9 @@ describe("valibot()", () => {
         v.pipe(v.unknown(), v.string() as never),
         asyncInner,
       ] as never);
-      const parser = valibot(asyncSchema as never, { placeholder: "" });
+      const parser = valibot(asyncSchema as never, {
+        placeholder: "" as never,
+      });
       const result = parser.parse("hello");
       assert.ok(result.success);
     });

--- a/packages/valibot/src/index.test.ts
+++ b/packages/valibot/src/index.test.ts
@@ -523,6 +523,33 @@ describe("valibot()", () => {
       );
       assert.equal(parser.format({ raw: "hello" }), "hello");
     });
+
+    it("should use custom toString() for class instances", () => {
+      // Non-plain object whose String() is not "[object Object]" uses the
+      // toString() result directly (line 746 branch).
+      class NamedValue {
+        constructor(private name: string) {}
+        toString() {
+          return this.name;
+        }
+      }
+      const parser = valibot(
+        v.pipe(v.string(), v.transform((s) => new NamedValue(s) as never)),
+        { placeholder: new NamedValue("default") as never },
+      );
+      assert.equal(parser.format(new NamedValue("hello") as never), "hello");
+    });
+
+    it("should fall back to [object Object] for class without custom toString", () => {
+      // Non-plain object with proto !== Object.prototype and no custom
+      // toString returns "[object Object]" (line 748 false branch).
+      class Opaque {}
+      const parser = valibot(
+        v.pipe(v.string(), v.transform(() => new Opaque() as never)),
+        { placeholder: new Opaque() as never },
+      );
+      assert.equal(parser.format(new Opaque() as never), "[object Object]");
+    });
   });
 
   describe("error customization", () => {
@@ -856,6 +883,48 @@ describe("valibot()", () => {
         { placeholder: "dev" },
       );
       assert.equal(parser.metavar, "CHOICE");
+    });
+
+    it("should not expose choices for v.picklist() with numeric values", () => {
+      // Non-string picklist items: inferChoices returns undefined (line 508-509).
+      // The metavar is still CHOICE (picklist → CHOICE regardless of item types).
+      const parser = valibot(v.picklist([1, 2, 3] as never), {
+        placeholder: 1 as never,
+      });
+      assert.equal(parser.choices, undefined);
+      assert.equal(parser.metavar, "CHOICE");
+    });
+
+    it("should not expose choices for an empty v.picklist()", () => {
+      // Empty picklist: inferChoices returns undefined via the empty result
+      // path (line 512)
+      const parser = valibot(v.picklist([] as never), {
+        placeholder: "" as never,
+      });
+      assert.equal(parser.choices, undefined);
+    });
+
+    it("should infer VALUE metavar for v.variant() discriminated union", () => {
+      // v.variant() schemas are object-level discriminated unions, not
+      // suitable for choices; inferMetavar returns "VALUE" (line 464).
+      const schema = v.variant("type", [
+        v.object({ type: v.literal("a"), value: v.string() }),
+        v.object({ type: v.literal("b"), count: v.number() }),
+      ]);
+      const parser = valibot(schema as never, {
+        placeholder: { type: "a", value: "" } as never,
+      });
+      assert.equal(parser.metavar, "VALUE");
+    });
+
+    it("should not expose choices for v.union() where an option has no type", () => {
+      // Union option without a `type` field causes inferChoices to bail out
+      // (line 542).
+      const parser = valibot(
+        v.union([v.literal("a"), {} as never]) as never,
+        { placeholder: "a" as never },
+      );
+      assert.equal(parser.choices, undefined);
     });
   });
 
@@ -1358,6 +1427,45 @@ describe("valibot()", () => {
         () => valibot(asyncSchema as never, { placeholder: "" as never }),
         expectedError,
       );
+    });
+
+    it("should throw TypeError for union with v.pipe(v.unknown(), validation) arm", () => {
+      const asyncInner = v.pipeAsync(
+        v.string(),
+        // deno-lint-ignore require-await
+        v.checkAsync(async (val) => val === "ok", "not ok"),
+      );
+      // v.pipe(v.unknown(), v.minLength(1)) has a validation action so it is
+      // NOT a catch-all: the async arm is reachable and must be rejected.
+      // This exercises the `a.kind === "validation"` branch (line 147) in
+      // the isCatchAllSchema callback for the unknown/any path.
+      const asyncSchema = v.union([
+        v.pipe(v.unknown(), v.minLength(1) as never),
+        asyncInner,
+      ] as never);
+      assert.throws(
+        () => valibot(asyncSchema as never, { placeholder: "" as never }),
+        expectedError,
+      );
+    });
+
+    it("should not throw for union with v.pipe(v.unknown(), nested-string-schema) arm", () => {
+      const asyncInner = v.pipeAsync(
+        v.string(),
+        // deno-lint-ignore require-await
+        v.checkAsync(async (val) => val === "ok", "not ok"),
+      );
+      // v.pipe(v.unknown(), v.string()) has a nested schema (kind="schema")
+      // that is itself a catch-all, so the whole pipe is catch-all.  The
+      // async arm is unreachable.  This exercises the `a.kind === "schema"`
+      // recursive branch (line 148) in isCatchAllSchema for unknown/any.
+      const asyncSchema = v.union([
+        v.pipe(v.unknown(), v.string() as never),
+        asyncInner,
+      ] as never);
+      const parser = valibot(asyncSchema as never, { placeholder: "" });
+      const result = parser.parse("hello");
+      assert.ok(result.success);
     });
   });
 });

--- a/packages/valibot/src/index.test.ts
+++ b/packages/valibot/src/index.test.ts
@@ -916,6 +916,8 @@ describe("valibot()", () => {
       const parser = valibot(schema as never, {
         placeholder: { type: "a", value: "" } as never,
       });
+      assert.equal(parser.choices, undefined);
+      assert.equal(parser.suggest, undefined);
       assert.equal(parser.metavar, "VALUE");
     });
 

--- a/packages/valibot/src/index.test.ts
+++ b/packages/valibot/src/index.test.ts
@@ -917,11 +917,12 @@ describe("valibot()", () => {
       assert.equal(parser.metavar, "VALUE");
     });
 
-    it("should not expose choices for v.union() where an option has no type", () => {
-      // Union option without a `type` field causes inferChoices to bail out
-      // (line 542).
+    it("should not expose choices for v.union() with a catch-all v.any() member", () => {
+      // When a union contains a catch-all schema (v.any()), inferChoices
+      // detects it via isCatchAllSchema and returns undefined — no choices
+      // are exposed because the union can accept any value.
       const parser = valibot(
-        v.union([v.literal("a"), {} as never]) as never,
+        v.union([v.literal("a"), v.any()]) as never,
         { placeholder: "a" as never },
       );
       assert.equal(parser.choices, undefined);

--- a/packages/valibot/src/index.test.ts
+++ b/packages/valibot/src/index.test.ts
@@ -892,6 +892,7 @@ describe("valibot()", () => {
         placeholder: 1 as never,
       });
       assert.equal(parser.choices, undefined);
+      assert.equal(parser.suggest, undefined);
       assert.equal(parser.metavar, "CHOICE");
     });
 
@@ -902,6 +903,7 @@ describe("valibot()", () => {
         placeholder: "" as never,
       });
       assert.equal(parser.choices, undefined);
+      assert.equal(parser.suggest, undefined);
     });
 
     it("should infer VALUE metavar for v.variant() discriminated union", () => {
@@ -926,6 +928,7 @@ describe("valibot()", () => {
         { placeholder: "a" as never },
       );
       assert.equal(parser.choices, undefined);
+      assert.equal(parser.suggest, undefined);
     });
   });
 
@@ -1264,16 +1267,20 @@ describe("valibot()", () => {
         // deno-lint-ignore require-await
         v.checkAsync(async (val) => val === "ok", "not ok"),
       );
-      // v.fallback() always succeeds (returns fallback value on failure)
+      // v.fallback() always succeeds (returns fallback value on failure).
+      // Use a rejecting inner schema so the fallback branch actually fires.
       const asyncSchema = v.union([
-        v.fallback(v.string(), "default"),
+        v.fallback(v.pipe(v.string(), v.email()), "default"),
         asyncInner,
       ] as never);
       const parser = valibot(asyncSchema as never, {
         placeholder: "" as never,
       });
-      const result = parser.parse("hello");
+      const result = parser.parse("not-an-email");
       assert.ok(result.success);
+      if (result.success) {
+        assert.equal(result.value, "default");
+      }
     });
 
     it("should not reject union with v.pipe(v.unknown(), safe-transform) arm", () => {

--- a/packages/valibot/src/index.test.ts
+++ b/packages/valibot/src/index.test.ts
@@ -1286,8 +1286,7 @@ describe("valibot()", () => {
       // every value and the safe transformation never rejects.
       // Use `as never` to bypass TS strictness on the pipe argument types.
       const asyncSchema = v.union([
-        // deno-lint-ignore no-explicit-any
-        v.pipe(v.unknown(), v.trim() as any),
+        v.pipe(v.unknown(), v.trim() as never),
         asyncInner,
       ] as never);
       const parser = valibot(asyncSchema as never, {
@@ -1307,8 +1306,7 @@ describe("valibot()", () => {
       // the string pipe is still catch-all because every action accepts.
       const innerCatchAll = v.optional(v.string());
       const asyncSchema = v.union([
-        // deno-lint-ignore no-explicit-any
-        v.pipe(v.string(), innerCatchAll as any),
+        v.pipe(v.string(), innerCatchAll as never),
         asyncInner,
       ] as never);
       const parser = valibot(asyncSchema as never, {

--- a/packages/valibot/src/index.test.ts
+++ b/packages/valibot/src/index.test.ts
@@ -1172,5 +1172,192 @@ describe("valibot()", () => {
       assert.ok(result.success);
       if (result.success) assert.equal(result.value, "hello");
     });
+
+    it("should not reject union with v.any() catch-all arm", () => {
+      const asyncInner = v.pipeAsync(
+        v.string(),
+        // deno-lint-ignore require-await
+        v.checkAsync(async (val) => val === "ok", "not ok"),
+      );
+      // v.any() accepts every value of any type — async arm is unreachable
+      const asyncSchema = v.union([v.any(), asyncInner] as never);
+      const parser = valibot(asyncSchema as never, {
+        placeholder: "" as never,
+      });
+      const result = parser.parse("hello");
+      assert.ok(result.success);
+    });
+
+    it("should not reject union with v.fallback() catch-all arm", () => {
+      const asyncInner = v.pipeAsync(
+        v.string(),
+        // deno-lint-ignore require-await
+        v.checkAsync(async (val) => val === "ok", "not ok"),
+      );
+      // v.fallback() always succeeds (returns fallback value on failure)
+      const asyncSchema = v.union([
+        v.fallback(v.string(), "default"),
+        asyncInner,
+      ] as never);
+      const parser = valibot(asyncSchema as never, {
+        placeholder: "" as never,
+      });
+      const result = parser.parse("hello");
+      assert.ok(result.success);
+    });
+
+    it("should not reject union with v.pipe(v.unknown(), safe-transform) arm", () => {
+      const asyncInner = v.pipeAsync(
+        v.string(),
+        // deno-lint-ignore require-await
+        v.checkAsync(async (val) => val === "ok", "not ok"),
+      );
+      // v.pipe(v.unknown(), trim) is still a catch-all: unknown accepts
+      // every value and the safe transformation never rejects.
+      // Use `as never` to bypass TS strictness on the pipe argument types.
+      const asyncSchema = v.union([
+        // deno-lint-ignore no-explicit-any
+        v.pipe(v.unknown(), v.trim() as any),
+        asyncInner,
+      ] as never);
+      const parser = valibot(asyncSchema as never, {
+        placeholder: "" as never,
+      });
+      const result = parser.parse("  hello  ");
+      assert.ok(result.success);
+    });
+
+    it("should not reject union with nested schema in string pipe catch-all", () => {
+      const asyncInner = v.pipeAsync(
+        v.string(),
+        // deno-lint-ignore require-await
+        v.checkAsync(async (val) => val === "ok", "not ok"),
+      );
+      // A string pipe whose second element is itself a catch-all schema —
+      // the string pipe is still catch-all because every action accepts.
+      const innerCatchAll = v.optional(v.string());
+      const asyncSchema = v.union([
+        // deno-lint-ignore no-explicit-any
+        v.pipe(v.string(), innerCatchAll as any),
+        asyncInner,
+      ] as never);
+      const parser = valibot(asyncSchema as never, {
+        placeholder: "" as never,
+      });
+      const result = parser.parse("hello");
+      assert.ok(result.success);
+    });
+
+    it("should reject union whose string pipe arm has a validation action", () => {
+      const asyncInner = v.pipeAsync(
+        v.string(),
+        // deno-lint-ignore require-await
+        v.checkAsync(async (val) => val === "ok", "not ok"),
+      );
+      // v.email() is a validation — it can reject input, so the string pipe
+      // is NOT a catch-all and the async arm may be reached.
+      const asyncSchema = v.union([
+        v.pipe(v.string(), v.email()),
+        asyncInner,
+      ] as never);
+      assert.throws(
+        () => valibot(asyncSchema as never, { placeholder: "" as never }),
+        expectedError,
+      );
+    });
+
+    it("should reject async items inside containers after transform", () => {
+      const asyncInner = v.pipeAsync(
+        v.string(),
+        // deno-lint-ignore require-await
+        v.checkAsync(async (val) => val === "ok", "not ok"),
+      );
+      // After JSON.parse, array schema's item schema becomes reachable.
+      const asyncSchema = v.pipe(
+        v.string(),
+        v.transform(JSON.parse),
+        v.array(asyncInner as never),
+      );
+      assert.throws(
+        () => valibot(asyncSchema as never, { placeholder: "" as never }),
+        expectedError,
+      );
+    });
+
+    it("should reject async tuple items after transform", () => {
+      const asyncInner = v.pipeAsync(
+        v.string(),
+        // deno-lint-ignore require-await
+        v.checkAsync(async (val) => val === "ok", "not ok"),
+      );
+      const asyncSchema = v.pipe(
+        v.string(),
+        v.transform(JSON.parse),
+        v.tuple([asyncInner] as never),
+      );
+      assert.throws(
+        () => valibot(asyncSchema as never, { placeholder: "" as never }),
+        expectedError,
+      );
+    });
+
+    it("should reject async promise inner after transform", () => {
+      const asyncInner = v.pipeAsync(
+        v.string(),
+        // deno-lint-ignore require-await
+        v.checkAsync(async (val) => val === "ok", "not ok"),
+      );
+      const asyncSchema = v.pipe(
+        v.string(),
+        v.transform(JSON.parse),
+        v.promise(asyncInner as never),
+      );
+      assert.throws(
+        () => valibot(asyncSchema as never, { placeholder: "" as never }),
+        expectedError,
+      );
+    });
+
+    it("should not reject direct containers with async items (string never reaches them)", () => {
+      const asyncInner = v.pipeAsync(
+        v.string(),
+        // deno-lint-ignore require-await
+        v.checkAsync(async (val) => val === "ok", "not ok"),
+      );
+      // Without a preceding transform, CLI input is always a string.
+      // v.array(), v.tuple() and v.record() reject strings before visiting
+      // their members, so async members are unreachable at top level.
+      const arrParser = valibot(v.array(asyncInner as never), {
+        placeholder: "" as never,
+      });
+      assert.ok(!arrParser.parse("hello").success);
+
+      const recParser = valibot(
+        v.record(v.string(), asyncInner as never),
+        { placeholder: "" as never },
+      );
+      assert.ok(!recParser.parse("hello").success);
+    });
+
+    it("should reject variant with async arms after transform", () => {
+      const asyncInner = v.pipeAsync(
+        v.string(),
+        // deno-lint-ignore require-await
+        v.checkAsync(async (val) => val === "ok", "not ok"),
+      );
+      // After transform the input is no longer a string, so variant arms
+      // become reachable.
+      const asyncSchema = v.pipe(
+        v.string(),
+        v.transform(JSON.parse),
+        v.variant("type", [
+          v.object({ type: v.literal("a"), value: asyncInner as never }),
+        ]),
+      );
+      assert.throws(
+        () => valibot(asyncSchema as never, { placeholder: "" as never }),
+        expectedError,
+      );
+    });
   });
 });

--- a/packages/zod/src/index.test.ts
+++ b/packages/zod/src/index.test.ts
@@ -1468,6 +1468,15 @@ describe("inferChoices() — empty literal values array", () => {
     const parser = zod(emptyNativeEnum, { placeholder: "" as unknown });
     assert.equal(parser.choices, undefined);
   });
+
+  it("should return undefined for a z.enum([]) with empty entries object", () => {
+    // z.enum([]) in Zod v4 has _def.entries = {} (empty object), so
+    // inferChoices loops over Object.values({}) producing an empty Set,
+    // and result.size > 0 ? [...result] : undefined yields undefined
+    // (branch 10 at line 482).
+    const parser = zod(z.enum([] as never), { placeholder: "" as never });
+    assert.equal(parser.choices, undefined);
+  });
 });
 
 describe("format() — class instance branch", () => {

--- a/packages/zod/src/index.test.ts
+++ b/packages/zod/src/index.test.ts
@@ -1371,3 +1371,170 @@ describe("zod()", () => {
     });
   });
 });
+
+describe("inferMetavar() — non-coerce schemas", () => {
+  it("should infer BOOLEAN for z.boolean() (non-coerce)", () => {
+    // z.boolean() has typeName/type "ZodBoolean"/"boolean" — same branch as coerce
+    const parser = zod(z.boolean(), { placeholder: false });
+    assert.equal(parser.metavar, "BOOLEAN");
+  });
+
+  it("should infer DATE for z.date() (non-coerce)", () => {
+    const parser = zod(
+      z.date(),
+      // z.date() rejects strings, so we only test metavar inference here
+      { placeholder: new Date(0) },
+    );
+    assert.equal(parser.metavar, "DATE");
+  });
+
+  it("should infer NUMBER for z.number() (non-coerce)", () => {
+    const parser = zod(z.number(), { placeholder: 0 });
+    assert.equal(parser.metavar, "NUMBER");
+  });
+
+  it("should infer INTEGER for z.number().int() (non-coerce)", () => {
+    const parser = zod(z.number().int(), { placeholder: 0 });
+    assert.equal(parser.metavar, "INTEGER");
+  });
+});
+
+describe("analyzeBooleanInner() — cycle detection via z.lazy()", () => {
+  it("should not infinite-loop on a self-referential lazy schema", () => {
+    // Create a lazy schema that refers to itself — the WeakSet in
+    // analyzeBooleanInner must break the cycle and return isBoolean=false.
+    // deno-lint-ignore prefer-const
+    let lazySchema: z.ZodType<unknown>;
+    lazySchema = z.lazy(() => lazySchema);
+    // If cycle detection is broken this would recurse infinitely.
+    // Just constructing the parser is enough to exercise the guard.
+    const parser = zod(
+      lazySchema as z.Schema<unknown>,
+      { placeholder: null as unknown },
+    );
+    // The schema is not recognized as boolean, so no boolean-specific metavar.
+    assert.notEqual(parser.metavar, "BOOLEAN");
+  });
+
+  it("should resolve a non-cyclic lazy boolean schema as boolean", () => {
+    const lazyBool = z.lazy(() => z.boolean());
+    const parser = zod(lazyBool as z.Schema<boolean>, { placeholder: false });
+    assert.equal(parser.metavar, "BOOLEAN");
+    // Should parse boolean literals correctly
+    const trueResult = parser.parse("true");
+    assert.ok(trueResult.success);
+    assert.ok(trueResult.value);
+    const falseResult = parser.parse("false");
+    assert.ok(falseResult.success);
+    assert.ok(!falseResult.value);
+  });
+
+  it("should handle optional wrapping a self-referential lazy schema", () => {
+    // deno-lint-ignore prefer-const
+    let lazySchema: z.ZodType<unknown>;
+    lazySchema = z.lazy(() => lazySchema);
+    // optional unwraps to the lazy schema, which cycles back to itself
+    const wrapped = lazySchema.optional();
+    const parser = zod(
+      wrapped as z.Schema<unknown>,
+      { placeholder: null as unknown },
+    );
+    assert.notEqual(parser.metavar, "BOOLEAN");
+  });
+});
+
+describe("inferChoices() — empty literal values array", () => {
+  it("should return undefined for a literal schema with empty values array", () => {
+    // A synthetic schema whose _def.values is [] — the guard
+    //   result.length > 0 ? result : undefined
+    // should yield undefined, so no choices are exposed.
+    const emptyLiteralSchema = {
+      _def: { type: "literal", values: [] as string[] },
+      safeParse: (input: unknown) => ({ success: true, data: input }),
+    } as unknown as z.Schema<string>;
+    const parser = zod(emptyLiteralSchema, { placeholder: "" as unknown });
+    assert.equal(parser.choices, undefined);
+    assert.equal(parser.suggest, undefined);
+    assert.equal(parser.metavar, "VALUE");
+  });
+
+  it("should return undefined for a nativeEnum schema with empty values object", () => {
+    // A synthetic nativeEnum-like schema with an empty entries/values object.
+    // result.size > 0 ? [...result] : undefined should yield undefined.
+    const emptyNativeEnum = {
+      _def: { typeName: "ZodNativeEnum", values: {} },
+      safeParse: (input: unknown) => ({ success: true, data: input }),
+    } as unknown as z.Schema<string>;
+    const parser = zod(emptyNativeEnum, { placeholder: "" as unknown });
+    assert.equal(parser.choices, undefined);
+  });
+});
+
+describe("format() — class instance branch", () => {
+  it("should use String() for class instances whose toString returns [object Object]", () => {
+    // A class whose toString returns the default "[object Object]" string.
+    // The format() function should fall through to `return str` (line 827)
+    // rather than attempting JSON.stringify (which applies only to plain objects).
+    class MyValue {
+      readonly n: number;
+      constructor(n: number) {
+        this.n = n;
+      }
+      // No custom toString — default "[object Object]"
+    }
+    const parser = zod(
+      z.string().transform(() => new MyValue(42)),
+      { placeholder: new MyValue(0) },
+    );
+    // String(new MyValue(42)) === "[object Object]" but
+    // Object.getPrototypeOf(new MyValue(42)) !== Object.prototype,
+    // so the JSON.stringify branch is skipped and str ("[object Object]") is returned.
+    assert.equal(parser.format(new MyValue(42)), "[object Object]");
+  });
+
+  it("should use String() for class instances with a custom toString", () => {
+    // A class with a custom toString returns something other than "[object Object]",
+    // so format() returns it directly via the `if (str !== "[object Object]")` branch.
+    class NamedValue {
+      readonly name: string;
+      constructor(name: string) {
+        this.name = name;
+      }
+      toString() {
+        return `NamedValue(${this.name})`;
+      }
+    }
+    const parser = zod(
+      z.string().transform((s) => new NamedValue(s)),
+      { placeholder: new NamedValue("") },
+    );
+    assert.equal(parser.format(new NamedValue("hello")), "NamedValue(hello)");
+  });
+});
+
+describe("parse() — non-async errors are re-thrown", () => {
+  it("should propagate non-async errors thrown inside safeParse", () => {
+    // A schema whose transform throws a plain non-async error.
+    // The try/catch in doSafeParse re-throws it because isZodAsyncError()
+    // returns false for regular errors.
+    const schema = z.string().transform((s) => {
+      throw new RangeError(`out of range: ${s}`);
+    });
+    const parser = zod(schema, { placeholder: "" });
+    assert.throws(
+      () => parser.parse("hello"),
+      { name: "RangeError", message: "out of range: hello" },
+    );
+  });
+
+  it("should propagate TypeError thrown inside safeParse", () => {
+    const schema = z.string().transform(() => {
+      throw new TypeError("bad type");
+    });
+    const parser = zod(schema, { placeholder: "" });
+    assert.throws(
+      () => parser.parse("value"),
+      { name: "TypeError", message: "bad type" },
+    );
+  });
+});

--- a/packages/zod/src/index.test.ts
+++ b/packages/zod/src/index.test.ts
@@ -1443,29 +1443,24 @@ describe("analyzeBooleanInner() — cycle detection via z.lazy()", () => {
   });
 });
 
-describe("inferChoices() — empty literal values array", () => {
-  it("should return undefined for a literal schema with empty values array", () => {
-    // A synthetic schema whose _def.values is [] — the guard
-    //   result.length > 0 ? result : undefined
-    // should yield undefined, so no choices are exposed.
-    const emptyLiteralSchema = {
-      _def: { type: "literal", values: [] as string[] },
-      safeParse: (input: unknown) => ({ success: true, data: input }),
-    } as unknown as z.Schema<string>;
-    const parser = zod(emptyLiteralSchema, { placeholder: "" as unknown });
+describe("inferChoices() — non-string literal values", () => {
+  it("should return undefined for a z.literal(42) (numeric literal, no string choices)", () => {
+    // z.literal(42) has _def.values = [42].  inferChoices filters to string
+    // values only, producing stringValues = [], so the guard
+    //   stringValues.length > 0 ? stringValues : undefined
+    // yields undefined — no choices are exposed.
+    const parser = zod(z.literal(42), { placeholder: 42 });
     assert.equal(parser.choices, undefined);
-    assert.equal(parser.suggest, undefined);
     assert.equal(parser.metavar, "VALUE");
   });
 
-  it("should return undefined for a nativeEnum schema with empty values object", () => {
-    // A synthetic nativeEnum-like schema with an empty entries/values object.
-    // result.size > 0 ? [...result] : undefined should yield undefined.
-    const emptyNativeEnum = {
-      _def: { typeName: "ZodNativeEnum", values: {} },
-      safeParse: (input: unknown) => ({ success: true, data: input }),
-    } as unknown as z.Schema<string>;
-    const parser = zod(emptyNativeEnum, { placeholder: "" as unknown });
+  it("should return undefined for a z.nativeEnum({}) with empty values object", () => {
+    // z.nativeEnum({}) is a real Zod v4 schema with _def.entries = {},
+    // so inferChoices loops over an empty object and result.size === 0 →
+    // result.size > 0 ? [...result] : undefined yields undefined.
+    const parser = zod(z.nativeEnum({}) as z.Schema<never>, {
+      placeholder: "" as never,
+    });
     assert.equal(parser.choices, undefined);
   });
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,5 +17,8 @@ catalog:
   valibot: ^1.2.0
   zod: "^3.25.0 || ^4.0.0"
 
+allowBuilds:
+  esbuild: true
+
 engineStrict: true
 nodeVersion: 20.19.0


### PR DESCRIPTION
## Summary

Codecov reported 84% coverage before this branch. This PR brings overall branch coverage to 91.7% and line coverage to 87.7%, with every individual package at 80% or above.

## Approach

The goal was to add tests that catch real bugs, not pad numbers. Where the shape of a function lent itself to property-based testing, fast-check was used; traditional unit tests covered the rest. Some gaps that looked coverable turned out to be V8 coverage tracking artifacts (object literal property assignments, inner ternary branches) or dead code (Zod v3 compatibility paths, a `SuppressedError` polyfill that never fires on modern runtimes). Those were left alone rather than papered over with empty assertions.

## What was added

Most of the new tests live in *packages/core/*, which had the widest gaps. A few highlights:

- *valueparser.test.ts*: `integer()` now has a test for fractional bounds that produce no valid integer range (e.g. `{ min: 1.5, max: 1.9 }` should throw `RangeError`); `float()` and `bigint()` placeholder selection with positive or negative bounds; `choice([NaN])` throwing at construction.
- *dependency.test.ts*: derived parser behavior when the factory throws synchronously, covering the `placeholder` getter's catch block, the `parse()` error path, and `suggestWithDependency` returning early when the derived parser has no `suggest` method.
- *constructs.test.ts*: `or()` nested inside `object()` with no prior parse state, exercising the zero-input candidate search that runs during `complete()` for both sync and async parsers.
- *dependency-runtime.test.ts*: `fillMissingSourceDefaults()` propagating the exact error from `getMissingSourceValue`, and `FailedAwareRegistry.clone()` preserving multiple failed-source IDs.

Outside *packages/core/*, the additions are narrower but still behavioral: *man/src/man.test.ts* covers doc-hidden term rendering (an `optional` whose inner terms are all hidden should not emit `[` in the output, and should skip the entry's description too); *zod/src/index.test.ts* uses `z.literal(42)` and `z.nativeEnum({})` to test the non-string-value and empty-entries branches of `inferChoices`; *valibot/src/index.test.ts* replaces a fake `{}` schema with a real `v.any()` to test catch-all union suppression.

## Code review

After reaching the coverage target, Codex reviewed the test diff over four passes. Issues found and fixed included tautological assertions (`!result.includes("[") || result.includes(".TH")`), checks that only verified `typeof result === "string"` rather than content, an incorrect roff format check (`(FILE |` instead of `(\fIFILE\fR`), two tests built on synthetic fake Zod/Valibot schemas where the public API could do the same job, and a test that incorrectly claimed to exercise a dead code branch in `FailedAwareRegistry.clone()`.

## Infrastructure

*mise.toml* gains a `coverage` task that runs `deno test --coverage`, generates an LCOV report, and prints a per-file summary. The *coverage/* directory is added to *.gitignore*.