### PR TITLE
Improve error messages and docs for missing contexts option

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,12 +14,12 @@ To be released.
     arguments in its usage) and a required field fails the empty-buffer
     completion probe, the specific error from that field's `complete()` is now
     surfaced instead of the generic “No matching option, command, or argument
-    found.” message.  [[#803]]
+    found.” message.  [[#803], [#805]]
 
  -  Fixed the fallback message in `generateNoMatchError` for the case where a
     parser expects no CLI input at all.  The message is now “No value
     provided.” instead of the misleading “No matching option, command, or
-    argument found.”  [[#803]]
+    argument found.”  [[#803], [#805]]
 
  -  Added `negatableFlag()` for paired Boolean options such as `--color` and
     `--no-color`.  The parser returns `true` for positive flags and `false`
@@ -33,18 +33,19 @@ To be released.
 [#801]: https://github.com/dahlia/optique/issues/801
 [#802]: https://github.com/dahlia/optique/pull/802
 [#803]: https://github.com/dahlia/optique/issues/803
+[#805]: https://github.com/dahlia/optique/pull/805
 
 ### @optique/env
 
  -  `bindEnv()` now emits a distinct error message when other source contexts
     are registered via `run()`'s `contexts` option but the env context is not
-    included, making this misconfiguration easier to diagnose.  [[#803]]
+    included, making this misconfiguration easier to diagnose.  [[#803], [#805]]
 
 ### @optique/config
 
  -  `bindConfig()` now emits a distinct error message when other source
     contexts are registered via `run()`'s `contexts` option but the config
-    context is not included.  [[#803]]
+    context is not included.  [[#803], [#805]]
 
 
 Version 1.0.2

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,17 @@ To be released.
 
 ### @optique/core
 
+ -  When an `object()` parser expects no CLI input (no options, commands, or
+    arguments in its usage) and a required field fails the empty-buffer
+    completion probe, the specific error from that field's `complete()` is now
+    surfaced instead of the generic “No matching option, command, or argument
+    found.” message.  [[#803]]
+
+ -  Fixed the fallback message in `generateNoMatchError` for the case where a
+    parser expects no CLI input at all.  The message is now “No value
+    provided.” instead of the misleading “No matching option, command, or
+    argument found.”  [[#803]]
+
  -  Added `negatableFlag()` for paired Boolean options such as `--color` and
     `--no-color`.  The parser returns `true` for positive flags and `false`
     for negative flags, fails when neither side is provided, and composes with
@@ -21,6 +32,7 @@ To be released.
 
 [#801]: https://github.com/dahlia/optique/issues/801
 [#802]: https://github.com/dahlia/optique/pull/802
+[#803]: https://github.com/dahlia/optique/issues/803
 
 
 Version 1.0.2

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,15 +36,15 @@ To be released.
 
 ### @optique/env
 
- -  `bindEnv()` now emits a distinct error message when its env context was not
-    passed to `run()`'s `contexts` option, distinguishing this case from a
-    genuinely unset environment variable.  Previously both cases produced
-    “Missing required environment variable: KEY”.  [[#803]]
+ -  `bindEnv()` now emits a distinct error message when other source contexts
+    are registered via `run()`'s `contexts` option but the env context is not
+    included, making this misconfiguration easier to diagnose.  [[#803]]
 
 ### @optique/config
 
- -  `bindConfig()` now emits a distinct error message when its config context
-    was not passed to `run()`'s `contexts` option.  [[#803]]
+ -  `bindConfig()` now emits a distinct error message when other source
+    contexts are registered via `run()`'s `contexts` option but the config
+    context is not included.  [[#803]]
 
 
 Version 1.0.2

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,6 +41,11 @@ To be released.
     genuinely unset environment variable.  Previously both cases produced
     “Missing required environment variable: KEY”.  [[#803]]
 
+### @optique/config
+
+ -  `bindConfig()` now emits a distinct error message when its config context
+    was not passed to `run()`'s `contexts` option.  [[#803]]
+
 
 Version 1.0.2
 -------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,13 @@ To be released.
 [#802]: https://github.com/dahlia/optique/pull/802
 [#803]: https://github.com/dahlia/optique/issues/803
 
+### @optique/env
+
+ -  `bindEnv()` now emits a distinct error message when its env context was not
+    passed to `run()`'s `contexts` option, distinguishing this case from a
+    genuinely unset environment variable.  Previously both cases produced
+    “Missing required environment variable: KEY”.  [[#803]]
+
 
 Version 1.0.2
 -------------

--- a/docs/integrations/config.md
+++ b/docs/integrations/config.md
@@ -104,6 +104,12 @@ const portParser = bindConfig(option("--port", integer()), {
 
 Pass the config context to `runAsync()` (or `run()`) via the `contexts` option:
 
+> [!WARNING]
+> `bindConfig()` only reads configuration values when its context is registered
+> with the runner.  Omitting `contexts: [configContext]` from the `run()` call
+> causes the config lookup to be silently skipped and the parser falls back to
+> the default or fails with an error indicating the context was not registered.
+
 ~~~~ typescript twoslash
 import { z } from "zod";
 import { createConfigContext, bindConfig } from "@optique/config";

--- a/docs/integrations/env.md
+++ b/docs/integrations/env.md
@@ -108,6 +108,12 @@ const verbose = bindEnv(option("--verbose"), {
 Use `run()`, `runSync()`, or `runAsync()` from *@optique/run* with
 `contexts: [envContext]`.
 
+> [!WARNING]
+> `bindEnv()` only reads environment variables when its context is registered
+> with the runner.  If you omit `contexts: [envContext]` from the `run()` call,
+> the env lookup is silently skipped and the parser falls back to the default
+> or fails with an error indicating the context was not registered.
+
 ~~~~ typescript twoslash
 import { object } from "@optique/core/constructs";
 import { option } from "@optique/core/primitives";

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -3810,3 +3810,85 @@ describe("or(bindConfig(...), constant(...))", () => {
     assert.equal(result.value, "fallback");
   });
 });
+
+describe("bindConfig() error messages for unregistered context", () => {
+  test("emits a specific error when the config context was not registered", () => {
+    const schema = z.object({ host: z.string() });
+    const context = createConfigContext({ schema });
+    const parser = object({
+      host: bindConfig(fail<string>(), {
+        context,
+        key: (c) => c.host,
+      }),
+    });
+
+    // No annotations injected (context not registered with run())
+    const result = parse(parser, []);
+    assert.ok(!result.success);
+    if (!result.success) {
+      const formatted = formatMessage(result.error);
+      assert.ok(
+        formatted.includes("contexts option"),
+        `Expected "contexts option" in: ${formatted}`,
+      );
+    }
+  });
+
+  test("emits 'Missing required configuration value' when context is registered but key is absent", () => {
+    const schema = z.object({ host: z.string().optional() });
+    const context = createConfigContext({ schema });
+    const parser = object({
+      host: bindConfig(fail<string>(), {
+        context,
+        key: (c) => c.host,
+      }),
+    });
+
+    // Inject annotations with empty config data (key absent)
+    const annotations: Annotations = {
+      [context.id]: { data: { host: undefined } },
+    };
+    const result = parse(parser, [], { annotations });
+    assert.ok(!result.success);
+    if (!result.success) {
+      const formatted = formatMessage(result.error);
+      assert.ok(
+        formatted.includes("Missing required configuration value"),
+        `Expected "Missing required configuration value" in: ${formatted}`,
+      );
+      assert.ok(
+        !formatted.includes("contexts option"),
+        `Should NOT include "contexts option" in: ${formatted}`,
+      );
+    }
+  });
+
+  test("emits 'Missing required configuration value' when context is registered but config file not loaded (undefined annotation)", () => {
+    // Simulates the case where the config context is registered (key present in
+    // annotations) but no config file was found (annotation value is undefined).
+    const schema = z.object({ host: z.string() });
+    const context = createConfigContext({ schema });
+    const parser = object({
+      host: bindConfig(fail<string>(), {
+        context,
+        key: (c) => c.host,
+      }),
+    });
+
+    // Key present but value is undefined = registered, no config data
+    const annotations: Annotations = { [context.id]: undefined };
+    const result = parse(parser, [], { annotations });
+    assert.ok(!result.success);
+    if (!result.success) {
+      const formatted = formatMessage(result.error);
+      assert.ok(
+        formatted.includes("Missing required configuration value"),
+        `Expected "Missing required configuration value" in: ${formatted}`,
+      );
+      assert.ok(
+        !formatted.includes("contexts option"),
+        `Should NOT include "contexts option" in: ${formatted}`,
+      );
+    }
+  });
+});

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -3812,7 +3812,10 @@ describe("or(bindConfig(...), constant(...))", () => {
 });
 
 describe("bindConfig() error messages for unregistered context", () => {
-  test("emits a specific error when the config context was not registered", () => {
+  test("emits a specific error when the config context was not registered but other contexts were", () => {
+    // Simulates run() where another context was passed but configContext was
+    // omitted.  When annotations is non-null but the config context id is absent,
+    // bindConfig() surfaces a targeted error pointing to the contexts option.
     const schema = z.object({ host: z.string() });
     const context = createConfigContext({ schema });
     const parser = object({
@@ -3822,8 +3825,11 @@ describe("bindConfig() error messages for unregistered context", () => {
       }),
     });
 
-    // No annotations injected (context not registered with run())
-    const result = parse(parser, []);
+    // Inject annotations from a different context (simulates forgetting configContext).
+    const otherContextId = Symbol("other-context");
+    const result = parse(parser, [], {
+      annotations: { [otherContextId]: {} },
+    });
     assert.ok(!result.success);
     if (!result.success) {
       const formatted = formatMessage(result.error);

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -978,7 +978,6 @@ function getConfigOrDefault<
   // to avoid misleading low-level callers.
   const configContextAbsent = annotations != null &&
     !(contextId in annotations);
-  const contextRegistered = !configContextAbsent;
   const annotationValue = annotations?.[contextId] as
     | { readonly data: T; readonly meta?: TConfigMeta | undefined }
     | undefined;
@@ -1021,7 +1020,7 @@ function getConfigOrDefault<
   // Distinguish between the config context not being registered at all
   // (key absent from annotations) and a registered context with no matching
   // value (file not found, key absent in config data, etc.).
-  if (!contextRegistered) {
+  if (configContextAbsent) {
     return wrapForMode(mode, {
       success: false,
       error:

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -624,8 +624,9 @@ export interface BindConfigOptions<T, TValue, TConfigMeta = ConfigMeta> {
  * > ```
  * >
  * > Omitting `contexts` causes `bindConfig()` to skip the config lookup and
- * > fall through to the default or an error with a message indicating the
- * > context was not registered.
+ * > fall through to the default or an error.  When other contexts are
+ * > registered but this config context is not, the error explicitly names the
+ * > `contexts` option to aid diagnosis.
  *
  * @template M The parser mode (sync or async).
  * @template TValue The parser value type.

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -945,6 +945,11 @@ function getConfigOrDefault<
   // See: https://github.com/dahlia/optique/issues/136
   const annotations = getAnnotations(state);
   const contextId = options.context.id;
+  // Use a key-presence check rather than a value check: a registered config
+  // context can write `undefined` into its annotation slot (e.g. when no
+  // config file was found), which is distinct from the context never having
+  // been registered at all (key absent from annotations).
+  const contextRegistered = annotations != null && contextId in annotations;
   const annotationValue = annotations?.[contextId] as
     | { readonly data: T; readonly meta?: TConfigMeta | undefined }
     | undefined;
@@ -984,7 +989,17 @@ function getConfigOrDefault<
     return validateFallbackValue(mode, innerParser, options.default);
   }
 
-  // No value available
+  // Distinguish between the config context not being registered at all
+  // (key absent from annotations) and a registered context with no matching
+  // value (file not found, key absent in config data, etc.).
+  if (!contextRegistered) {
+    return wrapForMode(mode, {
+      success: false,
+      error:
+        message`Configuration value could not be read: the config context was not passed to run()'s contexts option.`,
+    });
+  }
+
   return wrapForMode(mode, {
     success: false,
     error: message`Missing required configuration value.`,

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -304,6 +304,14 @@ function validateWithSchema<T>(
 /**
  * Creates a config context for use with Optique parsers.
  *
+ * Pass the returned context to `run()`'s `contexts` option so that
+ * `bindConfig()` can read configuration values during parsing:
+ *
+ * ```typescript
+ * const configContext = createConfigContext({ schema });
+ * run(parser, { contexts: [configContext], contextOptions: { load } });
+ * ```
+ *
  * The config context implements the `SourceContext` interface and can be used
  * with `runWith()` from *@optique/core* or `run()`/`runAsync()` from
  * *@optique/run* to provide configuration file support. Each runner call
@@ -607,6 +615,17 @@ export interface BindConfigOptions<T, TValue, TConfigMeta = ConfigMeta> {
  * 2. Config file value (if available)
  * 3. Default value (if specified)
  * 4. Error (if none of the above)
+ *
+ * > **Important:** `bindConfig()` only reads configuration values when its
+ * > `ConfigContext` is registered with the runner via the `contexts` option:
+ * >
+ * > ```typescript
+ * > run(parser, { contexts: [configContext], contextOptions: { load } });
+ * > ```
+ * >
+ * > Omitting `contexts` causes `bindConfig()` to skip the config lookup and
+ * > fall through to the default or an error with a message indicating the
+ * > context was not registered.
  *
  * @template M The parser mode (sync or async).
  * @template TValue The parser value type.

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -968,7 +968,16 @@ function getConfigOrDefault<
   // context can write `undefined` into its annotation slot (e.g. when no
   // config file was found), which is distinct from the context never having
   // been registered at all (key absent from annotations).
-  const contextRegistered = annotations != null && contextId in annotations;
+  //
+  // We only treat the context as "detectably absent" when some annotations
+  // exist (the caller passed at least one context to run()) but this specific
+  // context id is missing.  When annotations is null entirely — meaning either
+  // run() was called without any contexts or parse() was called directly — we
+  // fall through to the generic "Missing required configuration value" message
+  // to avoid misleading low-level callers.
+  const configContextAbsent = annotations != null &&
+    !(contextId in annotations);
+  const contextRegistered = !configContextAbsent;
   const annotationValue = annotations?.[contextId] as
     | { readonly data: T; readonly meta?: TConfigMeta | undefined }
     | undefined;

--- a/packages/core/src/constructs.test.ts
+++ b/packages/core/src/constructs.test.ts
@@ -3311,6 +3311,79 @@ describe("object", () => {
       assert.equal(result.value.val, "x");
     }
   });
+
+  it("should propagate specific error from failing complete probe (sync)", () => {
+    // A field whose complete() always fails with a specific message.  Without
+    // the probe error propagation fix the caller would only see the generic
+    // "No value provided." message instead of the field-specific error.
+    const specificError = message`Specific field error.`;
+    const alwaysFailParser: Parser<"sync", string, undefined> = {
+      $valueType: [],
+      $stateType: [],
+      mode: "sync",
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(),
+      acceptingAnyToken: false,
+      initialState: undefined,
+      parse(_ctx) {
+        return { success: true, consumed: [], next: _ctx };
+      },
+      complete(_state) {
+        return { success: false, error: specificError };
+      },
+      suggest() {
+        return [];
+      },
+      getDocFragments() {
+        return { fragments: [] };
+      },
+    };
+
+    const parser = object({ field: alwaysFailParser });
+    const result = parseSync(parser, []);
+    assert.ok(!result.success);
+    if (!result.success) {
+      assert.deepEqual(result.error, specificError);
+    }
+  });
+
+  it("should propagate specific error from failing complete probe (async)", async () => {
+    const specificError = message`Specific async field error.`;
+    const alwaysFailParser: Parser<"async", string, undefined> = {
+      $valueType: [],
+      $stateType: [],
+      mode: "async",
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(),
+      acceptingAnyToken: false,
+      initialState: undefined,
+      parse(_ctx) {
+        return Promise.resolve({ success: true, consumed: [], next: _ctx });
+      },
+      complete(_state) {
+        return Promise.resolve({ success: false, error: specificError });
+      },
+      suggest() {
+        return {
+          async *[Symbol.asyncIterator](): AsyncIterableIterator<Suggestion> {
+            yield* [];
+          },
+        };
+      },
+      getDocFragments() {
+        return { fragments: [] };
+      },
+    };
+
+    const parser = object({ field: alwaysFailParser });
+    const result = await parseAsync(parser, []);
+    assert.ok(!result.success);
+    if (!result.success) {
+      assert.deepEqual(result.error, specificError);
+    }
+  });
 });
 
 describe("object() error customization", () => {
@@ -11234,6 +11307,100 @@ describe("branch coverage: generateNoMatchError variants", () => {
       assert.ok(
         formatted.includes("command") || formatted.includes("argument"),
       );
+    }
+  });
+
+  it("no options, commands, or arguments (all-false case) via or(fail(), fail())", () => {
+    // or() with two fail() branches has usage: [] on all branches, so
+    // noMatchContext is all-false.  When no input is given, generateNoMatchError
+    // should return "No value provided." rather than the old misleading message.
+    const parser = or(fail<string>(), fail<string>());
+    const result = parseSync(parser, []);
+    assert.ok(!result.success);
+    if (!result.success) {
+      const formatted = formatMessage(result.error);
+      assert.equal(formatted, "No value provided.");
+    }
+  });
+
+  it("all-false case with custom endOfInput keeps the custom message over probe error", () => {
+    // With a custom endOfInput, the probe error should NOT override it even
+    // when noMatchContext is all-false.  This verifies the precedence is correct.
+    const noCliParser: Parser<"sync", string, undefined> = {
+      $valueType: [],
+      $stateType: [],
+      mode: "sync",
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(),
+      acceptingAnyToken: false,
+      initialState: undefined,
+      parse(_ctx) {
+        return { success: true, consumed: [], next: _ctx };
+      },
+      complete(_state) {
+        return { success: false, error: message`Field-level error.` };
+      },
+      suggest() {
+        return [];
+      },
+      getDocFragments() {
+        return { fragments: [] };
+      },
+    };
+
+    const customMsg = message`Custom end-of-input message.`;
+    const parser = object(
+      { field: noCliParser },
+      { errors: { endOfInput: customMsg } },
+    );
+    const result = parseSync(parser, []);
+    assert.ok(!result.success);
+    if (!result.success) {
+      assert.deepEqual(result.error, customMsg);
+    }
+  });
+
+  it("async: all-false case with custom endOfInput keeps the custom message over probe error", async () => {
+    const noCliParser: Parser<"async", string, undefined> = {
+      $valueType: [],
+      $stateType: [],
+      mode: "async",
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(),
+      acceptingAnyToken: false,
+      initialState: undefined,
+      parse(_ctx) {
+        return Promise.resolve({ success: true, consumed: [], next: _ctx });
+      },
+      complete(_state) {
+        return Promise.resolve({
+          success: false,
+          error: message`Field-level error.`,
+        });
+      },
+      suggest() {
+        return {
+          async *[Symbol.asyncIterator](): AsyncIterableIterator<Suggestion> {
+            yield* [];
+          },
+        };
+      },
+      getDocFragments() {
+        return { fragments: [] };
+      },
+    };
+
+    const customMsg = message`Custom end-of-input message.`;
+    const parser = object(
+      { field: noCliParser },
+      { errors: { endOfInput: customMsg } },
+    );
+    const result = await parseAsync(parser, []);
+    assert.ok(!result.success);
+    if (!result.success) {
+      assert.deepEqual(result.error, customMsg);
     }
   });
 });

--- a/packages/core/src/constructs.ts
+++ b/packages/core/src/constructs.ts
@@ -1054,9 +1054,11 @@ function generateNoMatchError(context: NoMatchContext): Message {
     return message`No matching option or argument found.`;
   } else if (hasArguments && hasCommands && !hasOptions) {
     return message`No matching command or argument found.`;
-  } else {
-    // All three types present
+  } else if (hasOptions && hasCommands && hasArguments) {
     return message`No matching option, command, or argument found.`;
+  } else {
+    // No required CLI input is described by usage.
+    return message`No value provided.`;
   }
 }
 
@@ -5856,12 +5858,14 @@ export function object<
           trace: undefined,
           phase: "parse" as const,
         };
+      let probeError: { consumed: number; error: Message } | undefined;
       for (const [field, parser] of parserPairs) {
         const fieldState = getFieldState(field, parser);
         const completeResult = (parser as Parser<"sync", unknown, unknown>)
           .complete(fieldState, withChildExecPath(probeExec, field));
         if (!completeResult.success) {
           allCanComplete = false;
+          probeError = { consumed: 0, error: completeResult.error };
           break;
         }
       }
@@ -5872,6 +5876,19 @@ export function object<
           next: currentContext,
           consumed: [],
         };
+      }
+      // When no required CLI input is described by usage and the caller has
+      // not supplied a custom endOfInput error, the initial "no match" message
+      // is uninformative.  Surface the specific field error from the probe so
+      // callers get an actionable diagnosis.
+      if (
+        probeError !== undefined &&
+        options.errors?.endOfInput === undefined &&
+        !noMatchContext.hasOptions &&
+        !noMatchContext.hasCommands &&
+        !noMatchContext.hasArguments
+      ) {
+        return { ...probeError, success: false };
       }
     }
 
@@ -6027,6 +6044,7 @@ export function object<
           trace: undefined,
           phase: "parse" as const,
         };
+      let probeError: { consumed: number; error: Message } | undefined;
       for (const [field, parser] of parserPairs) {
         const fieldState = getFieldState(field, parser);
         const completeResult = await parser.complete(
@@ -6035,6 +6053,7 @@ export function object<
         );
         if (!completeResult.success) {
           allCanComplete = false;
+          probeError = { consumed: 0, error: completeResult.error };
           break;
         }
       }
@@ -6045,6 +6064,15 @@ export function object<
           next: currentContext,
           consumed: [],
         };
+      }
+      if (
+        probeError !== undefined &&
+        options.errors?.endOfInput === undefined &&
+        !noMatchContext.hasOptions &&
+        !noMatchContext.hasCommands &&
+        !noMatchContext.hasArguments
+      ) {
+        return { ...probeError, success: false };
       }
     }
 

--- a/packages/env/src/index.test.ts
+++ b/packages/env/src/index.test.ts
@@ -3571,3 +3571,115 @@ describe("or(bindEnv(...), constant(...))", () => {
     assert.equal(result.value, "fallback");
   });
 });
+
+describe("bindEnv() error messages for unregistered context", () => {
+  it("emits a specific error when the env context was not registered", () => {
+    const context = createEnvContext({ prefix: "" });
+    const parser = object({
+      editor: bindEnv(fail<string>(), {
+        context,
+        key: "EDITOR",
+        parser: string(),
+      }),
+    });
+
+    // No annotations injected (context not registered with run())
+    const result = parse(parser, []);
+    assert.ok(!result.success);
+    if (!result.success) {
+      const formatted = formatMessage(result.error);
+      assert.ok(
+        formatted.includes("contexts option"),
+        `Expected "contexts option" in: ${formatted}`,
+      );
+    }
+  });
+
+  it("does NOT emit the contexts-option error when context is registered but var is unset", () => {
+    // When the env context IS registered but the var is absent, we propagate
+    // the inner parser's own error rather than the "contexts option" message so
+    // that downstream composition errors (e.g. from bindConfig) are not masked.
+    const context = createEnvContext({
+      prefix: "",
+      source: (_key) => undefined, // env var not set
+    });
+    const parser = object({
+      editor: bindEnv(fail<string>(), {
+        context,
+        key: "EDITOR",
+        parser: string(),
+      }),
+    });
+
+    const annotations = getSyncAnnotations(context);
+    const result = parse(parser, [], { annotations });
+    assert.ok(!result.success);
+    if (!result.success) {
+      const formatted = formatMessage(result.error);
+      assert.ok(
+        !formatted.includes("contexts option"),
+        `Should NOT include "contexts option" in: ${formatted}`,
+      );
+      // The inner fail() parser's error propagates unchanged.
+      assert.ok(
+        formatted.includes("No value provided."),
+        `Expected inner parser's "No value provided." in: ${formatted}`,
+      );
+    }
+  });
+
+  it("async: emits a specific error when the env context was not registered (using async inner parser)", async () => {
+    // Uses a genuinely async inner parser to exercise the async mapModeValue branch.
+    const context = createEnvContext({ prefix: "" });
+    const asyncFail: Parser<"async", string, undefined> = {
+      $valueType: [] as readonly string[],
+      $stateType: [] as readonly undefined[],
+      mode: "async",
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(),
+      acceptingAnyToken: false,
+      initialState: undefined,
+      parse(_ctx) {
+        return Promise.resolve({
+          success: false,
+          consumed: 0,
+          error: message`No value provided.`,
+        });
+      },
+      complete(_state) {
+        return Promise.resolve({
+          success: false,
+          error: message`No value provided.`,
+        });
+      },
+      suggest() {
+        return {
+          async *[Symbol.asyncIterator]() {
+            yield* [];
+          },
+        };
+      },
+      getDocFragments() {
+        return { fragments: [] };
+      },
+    };
+    const parser = object({
+      editor: bindEnv(asyncFail, {
+        context,
+        key: "EDITOR",
+        parser: string(),
+      }),
+    });
+
+    const result = await parseAsync(parser, []);
+    assert.ok(!result.success);
+    if (!result.success) {
+      const formatted = formatMessage(result.error);
+      assert.ok(
+        formatted.includes("contexts option"),
+        `Expected "contexts option" in: ${formatted}`,
+      );
+    }
+  });
+});

--- a/packages/env/src/index.test.ts
+++ b/packages/env/src/index.test.ts
@@ -3573,7 +3573,10 @@ describe("or(bindEnv(...), constant(...))", () => {
 });
 
 describe("bindEnv() error messages for unregistered context", () => {
-  it("emits a specific error when the env context was not registered", () => {
+  it("emits a specific error when the env context was not registered but other contexts were", () => {
+    // Simulates run() where another context was passed but envContext was
+    // omitted.  When annotations is non-null but the env context id is absent,
+    // bindEnv() surfaces a targeted error pointing to the contexts option.
     const context = createEnvContext({ prefix: "" });
     const parser = object({
       editor: bindEnv(fail<string>(), {
@@ -3583,8 +3586,11 @@ describe("bindEnv() error messages for unregistered context", () => {
       }),
     });
 
-    // No annotations injected (context not registered with run())
-    const result = parse(parser, []);
+    // Inject annotations from a different context (simulates forgetting envContext).
+    const otherContextId = Symbol("other-context");
+    const result = parse(parser, [], {
+      annotations: { [otherContextId]: {} },
+    });
     assert.ok(!result.success);
     if (!result.success) {
       const formatted = formatMessage(result.error);
@@ -3672,7 +3678,11 @@ describe("bindEnv() error messages for unregistered context", () => {
       }),
     });
 
-    const result = await parseAsync(parser, []);
+    // Inject a different context annotation to simulate forgetting envContext.
+    const otherContextId = Symbol("other-context");
+    const result = await parseAsync(parser, [], {
+      annotations: { [otherContextId]: {} },
+    });
     assert.ok(!result.success);
     if (!result.success) {
       const formatted = formatMessage(result.error);

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -677,7 +677,7 @@ function getEnvOrDefault<M extends Mode, TValue>(
         (r) => (r.success ? r : unregisteredError),
       );
     }
-    return wrapForMode(mode, innerResult);
+    return innerResult;
   }
 
   if (envContextAbsent) {

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -646,12 +646,15 @@ function getEnvOrDefault<M extends Mode, TValue>(
   // environment variable" error when the env var is unset but the config
   // layer has a value.
   //
-  // If the env context was never registered (sourceData === undefined) and
-  // the inner parser also fails, replace its generic error with a targeted
-  // "contexts option" message so the caller knows what went wrong.  When the
-  // context IS registered, propagate the inner parser's own failure so that
-  // meaningful errors from downstream wrappers (e.g. config validation
-  // failures) are not masked.
+  // When the env context is detectably absent from annotations (the caller
+  // passed SOME annotations via run()'s contexts option but did not include
+  // this env context), replace a failing inner parser's error with a targeted
+  // "contexts option" message.  When annotations are null (low-level parse()
+  // call without any annotations, or run() without any contexts), we cannot
+  // distinguish "context forgotten" from "no contexts at all", so we preserve
+  // the inner parser's own error to avoid misleading low-level callers.
+  const envContextAbsent = annotations != null &&
+    !(options.context.id in annotations);
   if (innerParser != null) {
     const completeState = innerState ??
       (annotations != null &&
@@ -660,7 +663,7 @@ function getEnvOrDefault<M extends Mode, TValue>(
         ? injectAnnotations(innerParser.initialState, annotations)
         : innerParser.initialState);
     const innerResult = innerParser.complete(completeState, exec);
-    if (sourceData === undefined) {
+    if (envContextAbsent) {
       const unregisteredError: Result<TValue> = {
         success: false,
         error: message`Environment variable ${
@@ -676,9 +679,7 @@ function getEnvOrDefault<M extends Mode, TValue>(
     return wrapForMode(mode, innerResult);
   }
 
-  // Distinguish between the env context not being registered at all
-  // (sourceData === undefined) and the env var being genuinely absent.
-  if (sourceData === undefined) {
+  if (envContextAbsent) {
     return wrapForMode(mode, {
       success: false as const,
       error: message`Environment variable ${

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -95,6 +95,14 @@ function defaultEnvSource(key: string): string | undefined {
 /**
  * Creates an environment context for use with Optique runners.
  *
+ * Pass the returned context to `run()`'s `contexts` option so that
+ * `bindEnv()` can read environment variables during parsing:
+ *
+ * ```typescript
+ * const envContext = createEnvContext({ prefix: "MYAPP_" });
+ * run(parser, { contexts: [envContext] });
+ * ```
+ *
  * When calling `context.getAnnotations()` manually, pass the returned
  * annotations to low-level APIs such as `parse()`, `parseAsync()`,
  * `parser.complete()`, `suggest()`, or `getDocPage()`. Since environment
@@ -198,6 +206,17 @@ export interface BindEnvOptions<M extends Mode, TValue> {
  *  2. Environment variable value
  *  3. Default value
  *  4. Error
+ *
+ * > **Important:** `bindEnv()` only reads environment variables when its
+ * > `EnvContext` is registered with the runner via the `contexts` option:
+ * >
+ * > ```typescript
+ * > run(parser, { contexts: [envContext] });
+ * > ```
+ * >
+ * > Omitting `contexts` causes `bindEnv()` to skip the env lookup and fall
+ * > through to the default or an error with a message indicating the context
+ * > was not registered.
  *
  * @param parser Parser that reads CLI values.
  * @param options Environment binding options.

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -623,9 +623,16 @@ function getEnvOrDefault<M extends Mode, TValue>(
   // When the env variable is absent and no default is provided, fall back
   // to the inner parser's complete() so that downstream wrappers (e.g.,
   // bindConfig) can still supply their own value.  Without this, composing
-  // bindEnv(bindConfig(...)) would always fail with "Missing required
-  // environment variable" when the env var is unset, even if the config
+  // bindEnv(bindConfig(...)) would always fail with a bare "Missing required
+  // environment variable" error when the env var is unset but the config
   // layer has a value.
+  //
+  // If the env context was never registered (sourceData === undefined) and
+  // the inner parser also fails, replace its generic error with a targeted
+  // "contexts option" message so the caller knows what went wrong.  When the
+  // context IS registered, propagate the inner parser's own failure so that
+  // meaningful errors from downstream wrappers (e.g. config validation
+  // failures) are not masked.
   if (innerParser != null) {
     const completeState = innerState ??
       (annotations != null &&
@@ -633,7 +640,32 @@ function getEnvOrDefault<M extends Mode, TValue>(
           getTraits(innerParser).inheritsAnnotations === true
         ? injectAnnotations(innerParser.initialState, annotations)
         : innerParser.initialState);
-    return wrapForMode(mode, innerParser.complete(completeState, exec));
+    const innerResult = innerParser.complete(completeState, exec);
+    if (sourceData === undefined) {
+      const unregisteredError: Result<TValue> = {
+        success: false,
+        error: message`Environment variable ${
+          envVar(fullKey)
+        } could not be read: the env context was not passed to run()'s contexts option.`,
+      };
+      return mapModeValue(
+        mode,
+        innerResult,
+        (r) => (r.success ? r : unregisteredError),
+      );
+    }
+    return wrapForMode(mode, innerResult);
+  }
+
+  // Distinguish between the env context not being registered at all
+  // (sourceData === undefined) and the env var being genuinely absent.
+  if (sourceData === undefined) {
+    return wrapForMode(mode, {
+      success: false as const,
+      error: message`Environment variable ${
+        envVar(fullKey)
+      } could not be read: the env context was not passed to run()'s contexts option.`,
+    });
   }
 
   return wrapForMode(mode, {

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -215,8 +215,9 @@ export interface BindEnvOptions<M extends Mode, TValue> {
  * > ```
  * >
  * > Omitting `contexts` causes `bindEnv()` to skip the env lookup and fall
- * > through to the default or an error with a message indicating the context
- * > was not registered.
+ * > through to the default or an error.  When other contexts are registered
+ * > but this env context is not, the error explicitly names the `contexts`
+ * > option to aid diagnosis.
  *
  * @param parser Parser that reads CLI values.
  * @param options Environment binding options.

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -677,7 +677,7 @@ function getEnvOrDefault<M extends Mode, TValue>(
         (r) => (r.success ? r : unregisteredError),
       );
     }
-    return innerResult;
+    return wrapForMode(mode, innerResult);
   }
 
   if (envContextAbsent) {


### PR DESCRIPTION
Closes #803.


Summary
-------

Issue #803 reported that `bindEnv(fail<string>(), …)` silently failed when the user omitted `contexts: [envContext]` from the `run()` call. The error shown was “No matching option, command, or argument found”—a message that pointed nowhere.

The root problem has two layers: *@optique/core*'s `object()` parser discarded the specific failure from its empty-buffer completion probe and replaced it with a generic message, and neither *@optique/env* nor *@optique/config* distinguished between a genuinely missing value and a context that was never registered with the runner.


What changed
------------

**Error surfacing in `object()` (*packages/core/src/constructs.ts*):** When a parser has no CLI input in its usage (no options, commands, or arguments) and a required field fails the empty-buffer completion probe, the specific error from that field's `complete()` is now surfaced instead of the generic “No matching option, command, or argument found” message. A caller-supplied `endOfInput` handler and parsers that do have CLI usage retain their existing messages. The `generateNoMatchError` fallback for the all-false case (no required CLI input at all) now returns “No value provided” with a corrected comment.

**Targeted error in *@optique/env* (*packages/env/src/index.ts*):** When annotations are non-null (some contexts were registered via `run()`) but the env context id is absent, `getEnvOrDefault()` now emits “Environment variable `KEY` could not be read: the env context was not passed to `run()`'s contexts option” rather than propagating the inner parser's generic failure. When annotations are null entirely (direct `parse()` call or `run()` without any contexts), the existing error messages are preserved.

**Targeted error in *@optique/config* (*packages/config/src/index.ts*):** Same approach for `getConfigOrDefault()`. Uses a key-presence check (`contextId in annotations`) rather than a value check, since a registered config context can write `undefined` into its annotation slot when no config file was found.

**JSDoc:** Added a prominent note to `bindEnv()`, `createEnvContext()`, `bindConfig()`, and `createConfigContext()` explaining that the context must be passed to `run()`'s `contexts` option and describing what happens when it is omitted.

**VitePress docs:** Added `> [!WARNING]` callouts to *docs/integrations/env.md* and *docs/integrations/config.md* immediately before the “Run with contexts” code examples.


Test plan
---------

 -  `mise test:deno`, `mise test:node`, `mise test:bun` all pass (only pre-existing zsh completion tests fail, unrelated to these changes).
 -  New unit tests cover the probe error propagation (sync and async), the custom `endOfInput` precedence over probe errors, the env and config “contexts not registered” messages, and the false-positive case where `parse()` is called directly without annotations.