### PR TITLE
Raise coverage and fix meta option completion

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,8 @@ To be released.
     terminator.  Option values that merely look like help or version options
     no longer suppress later meta option suggestions, and configured
     single-dash aliases such as `-help` now appear after a bare `-` prompt.
+    Root value options declared after command terms are now recognized while
+    completing their values as well.
 
  -  Fixed dependency runtime resolution to preserve shared references to the
     same deferred parser state.  Reused deferred nodes now resolve to the same

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,8 +14,14 @@ To be released.
     Completion requests now include root-level meta options such as `--help`
     and `--version`, including plus-prefixed aliases such as `+h`, without
     treating those options as active help/version requests inside the
-    completion payload.  Plus-prefixed parser options are now recognized as
-    option-prefix completions as well.
+    completion payload.  These meta options are now suggested from empty
+    completion prompts and after subcommands using the current argument prefix.
+    Plus-prefixed parser options are now recognized as option-prefix
+    completions as well.
+
+ -  Fixed dependency runtime resolution to preserve shared references to the
+    same deferred parser state.  Reused deferred nodes now resolve to the same
+    result object instead of distinct but structurally equal objects.
 
  -  When an `object()` parser expects no CLI input (no options, commands, or
     arguments in its usage) and a required field fails the empty-buffer

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,13 @@ To be released.
 
 ### @optique/core
 
+ -  Fixed shell completion suggestions for configured help and version options.
+    Completion requests now include root-level meta options such as `--help`
+    and `--version`, including plus-prefixed aliases such as `+h`, without
+    treating those options as active help/version requests inside the
+    completion payload.  Plus-prefixed parser options are now recognized as
+    option-prefix completions as well.
+
  -  When an `object()` parser expects no CLI input (no options, commands, or
     arguments in its usage) and a required field fails the empty-buffer
     completion probe, the specific error from that field's `complete()` is now

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,7 +21,9 @@ To be released.
 
  -  Fixed root-level help and version option completion so those meta options
     are not suggested while completing an option value or after an options
-    terminator.
+    terminator.  Option values that merely look like help or version options
+    no longer suppress later meta option suggestions, and configured
+    single-dash aliases such as `-help` now appear after a bare `-` prompt.
 
  -  Fixed dependency runtime resolution to preserve shared references to the
     same deferred parser state.  Reused deferred nodes now resolve to the same

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,10 @@ To be released.
     Plus-prefixed parser options are now recognized as option-prefix
     completions as well.
 
+ -  Fixed root-level help and version option completion so those meta options
+    are not suggested while completing an option value or after an options
+    terminator.
+
  -  Fixed dependency runtime resolution to preserve shared references to the
     same deferred parser state.  Reused deferred nodes now resolve to the same
     result object instead of distinct but structurally equal objects.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,7 +25,8 @@ To be released.
     no longer suppress later meta option suggestions, and configured
     single-dash aliases such as `-help` now appear after a bare `-` prompt.
     Root value options declared after command terms are now recognized while
-    completing their values as well.
+    completing their values as well.  Completion requests no longer parse the
+    same argument prefix twice when deciding whether to add root meta options.
 
  -  Fixed dependency runtime resolution to preserve shared references to the
     same deferred parser state.  Reused deferred nodes now resolve to the same

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,9 @@ To be released.
     same deferred parser state.  Reused deferred nodes now resolve to the same
     result object instead of distinct but structurally equal objects.
 
+ -  Fixed documentation-only meta option parsers to forward default values and
+    use the wrapped parser's own initial state when rendering help fragments.
+
  -  When an `object()` parser expects no CLI input (no options, commands, or
     arguments in its usage) and a required field fails the empty-buffer
     completion probe, the specific error from that field's `complete()` is now

--- a/examples/gitique/src/index.test.ts
+++ b/examples/gitique/src/index.test.ts
@@ -3,6 +3,10 @@ import { describe, it } from "node:test";
 import { runParser } from "@optique/core/facade";
 import { program } from "./index.ts";
 
+function parseGitique(args: readonly string[]): unknown {
+  return runParser(program, args);
+}
+
 interface CliRunResult {
   readonly exitCode: number;
   readonly stdout: string;
@@ -99,6 +103,235 @@ describe("gitique CLI", () => {
     assert.match(
       result.stderr,
       /Error: `--format`: Unknown status format "weird"\. Choose "long", "short", or "porcelain"\./,
+    );
+  });
+
+  it("parses add command staging and output options", () => {
+    const result = parseGitique([
+      "add",
+      "--all",
+      "--force",
+      "--verbose",
+    ]);
+
+    assert.deepEqual(result, {
+      command: "add",
+      all: true,
+      force: true,
+      verbose: true,
+      files: [],
+    });
+  });
+
+  it("parses add command file arguments", () => {
+    const result = parseGitique(["add", "src/main.ts", "README.md"]);
+
+    assert.deepEqual(result, {
+      command: "add",
+      all: false,
+      force: false,
+      verbose: false,
+      files: ["src/main.ts", "README.md"],
+    });
+  });
+
+  it("parses commit options with a valid author override", () => {
+    const result = parseGitique([
+      "commit",
+      "-a",
+      "--allow-empty",
+      "--author",
+      "Jane Doe <jane@example.com>",
+      "-m",
+      "Initial commit",
+    ]);
+
+    assert.deepEqual(result, {
+      command: "commit",
+      message: "Initial commit",
+      all: true,
+      allowEmpty: true,
+      author: { name: "Jane Doe", email: "jane@example.com" },
+    });
+  });
+
+  it("rejects blank commit messages", () => {
+    const result = runGitique(["commit", "-m", "   "]);
+
+    assert.equal(result.exitCode, 1);
+    assert.match(
+      result.stderr,
+      /Commit message must contain non-whitespace characters\./,
+    );
+  });
+
+  it("parses diff options and commit references", () => {
+    const result = parseGitique([
+      "diff",
+      "--staged",
+      "--name-status",
+      "--unified",
+      "0",
+      "--diff-algorithm",
+      "patience",
+      "HEAD~1",
+      "HEAD",
+    ]);
+
+    assert.deepEqual(result, {
+      command: "diff",
+      stat: false,
+      numstat: false,
+      nameOnly: false,
+      nameStatus: true,
+      unified: 0,
+      algorithm: "patience",
+      cached: true,
+      staged: true,
+      commits: ["HEAD~1", "HEAD"],
+    });
+  });
+
+  it("rejects conflicting diff output modes", () => {
+    assert.throws(
+      () => parseGitique(["diff", "--stat", "--name-only"]),
+      /Only one of --stat, --numstat, --name-only, --name-status may be used at a time\./,
+    );
+  });
+
+  it("rejects too many diff commit references", () => {
+    const result = runGitique(["diff", "HEAD~2", "HEAD~1", "HEAD"]);
+
+    assert.equal(result.exitCode, 1);
+    assert.match(
+      result.stderr,
+      /Unexpected option or subcommand: `HEAD`\./,
+    );
+  });
+
+  it("parses log filters and shorthand format", () => {
+    const result = parseGitique([
+      "log",
+      "--oneline",
+      "--max-count",
+      "3",
+      "--since",
+      "2024-01-02",
+      "--until",
+      "2024-12-31",
+      "--author",
+      "jane",
+      "--grep",
+      "fix",
+    ]);
+
+    assert.equal(typeof result, "object");
+    assert.notEqual(result, null);
+    const parsed = result as {
+      readonly command: string;
+      readonly format: string;
+      readonly maxCount: number;
+      readonly since: Date;
+      readonly until: Date;
+      readonly author: string;
+      readonly grep: string;
+    };
+    assert.equal(parsed.command, "log");
+    assert.equal(parsed.format, "oneline");
+    assert.equal(parsed.maxCount, 3);
+    assert.equal(parsed.since.getFullYear(), 2024);
+    assert.equal(parsed.since.getMonth(), 0);
+    assert.equal(parsed.since.getDate(), 2);
+    assert.equal(parsed.until.getFullYear(), 2024);
+    assert.equal(parsed.until.getMonth(), 11);
+    assert.equal(parsed.until.getDate(), 31);
+    assert.equal(parsed.author, "jane");
+    assert.equal(parsed.grep, "fix");
+  });
+
+  it("rejects conflicting log format options", () => {
+    assert.throws(
+      () => parseGitique(["log", "--oneline", "--format", "full"]),
+      /Cannot use --oneline together with --format\./,
+    );
+  });
+
+  it("rejects malformed log dates", () => {
+    const result = runGitique(["log", "--until", "yesterday"]);
+
+    assert.equal(result.exitCode, 1);
+    assert.match(
+      result.stderr,
+      /Invalid date "yesterday"\. Use YYYY-MM-DD\./,
+    );
+  });
+
+  it("parses status shorthand formats", () => {
+    assert.deepEqual(parseGitique(["status", "--short", "--branch"]), {
+      command: "status",
+      format: "short",
+      short: true,
+      porcelain: false,
+      branch: true,
+    });
+    assert.deepEqual(parseGitique(["status", "--porcelain"]), {
+      command: "status",
+      format: "porcelain",
+      short: false,
+      porcelain: true,
+      branch: false,
+    });
+  });
+
+  it("rejects conflicting status format options", () => {
+    assert.throws(
+      () => parseGitique(["status", "--short", "--format", "long"]),
+      /Cannot use --short or --porcelain together with --format\./,
+    );
+  });
+
+  it("rejects conflicting status shorthand flags", () => {
+    assert.throws(
+      () => parseGitique(["status", "--short", "--porcelain"]),
+      /Cannot use --short and --porcelain together\./,
+    );
+  });
+
+  it("parses reset mode and file options", () => {
+    assert.deepEqual(parseGitique(["reset", "--hard", "HEAD~1"]), {
+      command: "reset",
+      mode: "hard",
+      soft: false,
+      hard: true,
+      quiet: false,
+      commit: "HEAD~1",
+      files: [],
+    });
+    assert.deepEqual(parseGitique(["reset", "--file", "src/main.ts", "-q"]), {
+      command: "reset",
+      mode: "mixed",
+      soft: false,
+      hard: false,
+      quiet: true,
+      commit: undefined,
+      files: ["src/main.ts"],
+    });
+  });
+
+  it("rejects conflicting reset mode options", () => {
+    assert.throws(
+      () => parseGitique(["reset", "--soft", "--mode", "hard"]),
+      /Cannot use --soft or --hard together with --mode\./,
+    );
+  });
+
+  it("rejects invalid reset mode choices", () => {
+    const result = runGitique(["reset", "--mode", "keep"]);
+
+    assert.equal(result.exitCode, 1);
+    assert.match(
+      result.stderr,
+      /Unknown reset mode "keep"\. Choose "soft", "mixed", or "hard"\./,
     );
   });
 });

--- a/examples/gitique/src/utils/formatters.test.ts
+++ b/examples/gitique/src/utils/formatters.test.ts
@@ -1,0 +1,213 @@
+import assert from "node:assert/strict";
+import { type Commit, createSignature } from "es-git";
+import { describe, it } from "node:test";
+import process from "node:process";
+import {
+  colors,
+  formatAddedFile,
+  formatCommitCreated,
+  formatCommitDetailed,
+  formatCommitOneline,
+  formatDiffNameOnly,
+  formatDiffNameStatus,
+  formatDiffStat,
+  formatDiffStats,
+  formatError,
+  formatFilePath,
+  formatStatusLong,
+  formatSuccess,
+  formatTimestamp,
+  formatWarning,
+  stripColors,
+  supportsColors,
+} from "./formatters.ts";
+
+describe("gitique formatters", () => {
+  it("formats commit summaries and detailed commit output", () => {
+    const commit = fakeCommit({
+      message: "Fix parser\n\nBody text",
+      name: "Jane Doe",
+      email: "jane@example.com",
+      timestamp: 1_704_067_200,
+    });
+
+    assert.equal(
+      formatCommitOneline("abcdef1234567890", commit),
+      `${colors.yellow}abcdef1${colors.reset} Fix parser`,
+    );
+    assert.equal(
+      formatCommitDetailed("abcdef1234567890", commit),
+      [
+        `${colors.yellow}commit abcdef1234567890${colors.reset}`,
+        "Author: Jane Doe <jane@example.com>",
+        "Date:   2024-01-01T00:00:00.000Z",
+        "",
+        "    Fix parser",
+        "    ",
+        "    Body text",
+        "",
+      ].join("\n"),
+    );
+  });
+
+  it("formats basic colored messages and strips color codes", () => {
+    assert.equal(
+      formatAddedFile("src/main.ts"),
+      `${colors.green}add${colors.reset} 'src/main.ts'`,
+    );
+    assert.equal(
+      formatCommitCreated("abcdef1234567890", "Initial commit\n\nBody", "main"),
+      `[main ${colors.yellow}abcdef1${colors.reset}] Initial commit`,
+    );
+    assert.equal(formatError("bad"), `${colors.red}error:${colors.reset} bad`);
+    assert.equal(
+      formatWarning("careful"),
+      `${colors.yellow}warning:${colors.reset} careful`,
+    );
+    assert.equal(formatSuccess("done"), `${colors.green}done${colors.reset}`);
+    assert.equal(
+      formatFilePath("src/main.ts"),
+      `${colors.cyan}src/main.ts${colors.reset}`,
+    );
+    assert.equal(
+      stripColors(`${colors.red}error:${colors.reset} bad`),
+      "error: bad",
+    );
+  });
+
+  it("formats status and diff entries", () => {
+    assert.equal(
+      formatStatusLong("src/main.ts", "Modified", true),
+      `${colors.green}        modified:   src/main.ts${colors.reset}`,
+    );
+    assert.equal(
+      formatStatusLong("src/new.ts", "Renamed", false, "src/old.ts"),
+      `${colors.red}        renamed:   src/old.ts -> src/new.ts${colors.reset}`,
+    );
+    assert.equal(formatDiffNameOnly("src/main.ts"), "src/main.ts");
+    assert.equal(
+      formatDiffNameStatus("src/main.ts", "Modified"),
+      "M\tsrc/main.ts",
+    );
+    assert.equal(
+      formatDiffNameStatus("src/new.ts", "Renamed", "src/old.ts"),
+      "R\tsrc/old.ts\tsrc/new.ts",
+    );
+    assert.equal(
+      formatDiffNameStatus("src/odd.ts", "Unknown"),
+      "?\tsrc/odd.ts",
+    );
+  });
+
+  it("formats diff statistics with singular and plural wording", () => {
+    assert.equal(
+      stripColors(formatDiffStats(1, 1, 1)),
+      "1 file changed, 1 insertion(+), 1 deletion(-)",
+    );
+    assert.equal(
+      stripColors(formatDiffStats(2, 3, 4)),
+      "2 files changed, 3 insertions(+), 4 deletions(-)",
+    );
+    assert.equal(stripColors(formatDiffStats(0, 0, 0)), "");
+  });
+
+  it("formats diff stat bars proportionally", () => {
+    assert.equal(
+      stripColors(formatDiffStat("src/main.ts", 3, 1, 4)),
+      " src/main.ts | 4 +++-",
+    );
+    assert.equal(
+      stripColors(formatDiffStat("src/delete.ts", 0, 2, 10)),
+      " src/delete.ts | 2 --",
+    );
+  });
+
+  it("formats timestamps using the runtime locale", () => {
+    assert.equal(
+      formatTimestamp(new Date("2024-01-01T00:00:00.000Z")),
+      new Date("2024-01-01T00:00:00.000Z").toLocaleString(),
+    );
+  });
+
+  it("detects color support from TTY and environment flags", () => {
+    const originalTerm = process.env.TERM;
+    const originalNoColor = process.env.NO_COLOR;
+    const stdoutDescriptor = Object.getOwnPropertyDescriptor(
+      process.stdout,
+      "isTTY",
+    );
+
+    try {
+      Object.defineProperty(process.stdout, "isTTY", {
+        configurable: true,
+        value: true,
+      });
+      process.env.TERM = "xterm-256color";
+      delete process.env.NO_COLOR;
+      assert.ok(supportsColors());
+
+      process.env.NO_COLOR = "1";
+      assert.ok(!supportsColors());
+
+      delete process.env.NO_COLOR;
+      process.env.TERM = "dumb";
+      assert.ok(!supportsColors());
+
+      Object.defineProperty(process.stdout, "isTTY", {
+        configurable: true,
+        value: false,
+      });
+      process.env.TERM = "xterm-256color";
+      assert.ok(!supportsColors());
+    } finally {
+      if (stdoutDescriptor == null) {
+        delete (process.stdout as { isTTY?: boolean }).isTTY;
+      } else {
+        Object.defineProperty(process.stdout, "isTTY", stdoutDescriptor);
+      }
+      if (originalTerm === undefined) {
+        delete process.env.TERM;
+      } else {
+        process.env.TERM = originalTerm;
+      }
+      if (originalNoColor === undefined) {
+        delete process.env.NO_COLOR;
+      } else {
+        process.env.NO_COLOR = originalNoColor;
+      }
+    }
+  });
+});
+
+function fakeCommit(options: {
+  readonly message: string;
+  readonly name: string;
+  readonly email: string;
+  readonly timestamp: number;
+}): Commit {
+  const signature = createSignature(options.name, options.email, {
+    timestamp: options.timestamp,
+    offset: 0,
+  });
+  return {
+    id: () => "abcdef1234567890",
+    message: () => options.message,
+    author: () => signature,
+    committer: () => signature,
+    summary: () => options.message.split("\n")[0],
+    body: () => null,
+    time: () => new Date(options.timestamp * 1000),
+    tree: () => {
+      throw new Error("tree not needed.");
+    },
+    asObject: () => {
+      throw new Error("object not needed.");
+    },
+    authorWithMailmap: (
+      _mailmap: Parameters<Commit["authorWithMailmap"]>[0],
+    ) => signature,
+    committerWithMailmap: (
+      _mailmap: Parameters<Commit["committerWithMailmap"]>[0],
+    ) => signature,
+  };
+}

--- a/packages/core/src/annotation-state.test.ts
+++ b/packages/core/src/annotation-state.test.ts
@@ -243,6 +243,33 @@ describe("annotation-state", () => {
   );
 
   it(
+    "getDelegatedAnnotationState() delegates built-in objects without annotation views",
+    () => {
+      const marker = Symbol.for(
+        "@test/getDelegatedAnnotationState-built-ins",
+      );
+      const annotations = { [marker]: true } satisfies Annotations;
+      const parentState = injectAnnotations(undefined, annotations);
+
+      for (
+        const state of [
+          [],
+          new Date(0),
+          new Map([["key", "value"]]),
+          new Set(["value"]),
+          /value/u,
+        ] as const
+      ) {
+        const delegated = getDelegatedAnnotationState(parentState, state);
+
+        assert.ok(hasDelegatedAnnotationCarrier(delegated));
+        assert.ok(getAnnotations(delegated)?.[marker]);
+        assert.equal(normalizeDelegatedAnnotationState(delegated), state);
+      }
+    },
+  );
+
+  it(
     "getDelegatedAnnotationState() tracks delegated plain-object clones",
     () => {
       const marker = Symbol.for(
@@ -756,6 +783,32 @@ describe("annotation-state", () => {
   );
 
   it(
+    "normalizeNestedDelegatedAnnotationState() preserves Map self references",
+    () => {
+      const map = new Map<unknown, unknown>();
+      map.set(map, map);
+
+      const normalized = normalizeNestedDelegatedAnnotationState(map);
+
+      assert.strictEqual(normalized, map);
+      assert.strictEqual(normalized.get(map), map);
+    },
+  );
+
+  it(
+    "normalizeNestedDelegatedAnnotationState() preserves Set self references",
+    () => {
+      const set = new Set<unknown>();
+      set.add(set);
+
+      const normalized = normalizeNestedDelegatedAnnotationState(set);
+
+      assert.strictEqual(normalized, set);
+      assert.ok(normalized.has(set));
+    },
+  );
+
+  it(
     "normalizeNestedDelegatedAnnotationState() preserves non-plain objects (Date, RegExp) as-is at the top level",
     () => {
       // Date and RegExp are non-plain objects whose prototype is not
@@ -767,6 +820,32 @@ describe("annotation-state", () => {
 
       assert.strictEqual(normalizeNestedDelegatedAnnotationState(date), date);
       assert.strictEqual(normalizeNestedDelegatedAnnotationState(re), re);
+    },
+  );
+
+  it(
+    "normalizeNestedDelegatedAnnotationState() ignores accessor-only properties",
+    () => {
+      const marker = Symbol.for("@test/accessor-only-property-parent");
+      const parentState = injectAnnotations(undefined, { [marker]: true });
+      const source = {
+        nested: getDelegatedAnnotationState(parentState, "seed"),
+        get computed() {
+          return "derived";
+        },
+      };
+
+      const normalized = normalizeNestedDelegatedAnnotationState(source);
+
+      assert.notStrictEqual(normalized, source);
+      assert.deepEqual(normalized, {
+        nested: "seed",
+        computed: "derived",
+      });
+      assert.equal(
+        Object.getOwnPropertyDescriptor(normalized, "computed")?.get,
+        Object.getOwnPropertyDescriptor(source, "computed")?.get,
+      );
     },
   );
 

--- a/packages/core/src/annotation-state.test.ts
+++ b/packages/core/src/annotation-state.test.ts
@@ -861,4 +861,81 @@ describe("annotation-state", () => {
       );
     },
   );
+
+  it(
+    "normalizeNestedDelegatedAnnotationState() falls back when an array subclass slice throws",
+    () => {
+      class BrokenSliceArray<T> extends Array<T> {
+        override slice(): T[] {
+          throw new TypeError("slice disabled.");
+        }
+      }
+      const marker = Symbol.for("@test/array-slice-fallback");
+      const annotations = { [marker]: true } satisfies Annotations;
+      const parentState = injectAnnotations(undefined, annotations);
+      const original = { value: "entry" };
+      const delegated = getDelegatedAnnotationState(parentState, original);
+      const source = new BrokenSliceArray<typeof delegated>();
+      source.push(delegated);
+
+      const normalized = normalizeNestedDelegatedAnnotationState(source);
+
+      assert.ok(Array.isArray(normalized));
+      assert.ok(!(normalized instanceof BrokenSliceArray));
+      assert.strictEqual(normalized[0], original);
+    },
+  );
+
+  it(
+    "normalizeNestedDelegatedAnnotationState() unwraps delegated Map own properties",
+    () => {
+      const marker = Symbol.for("@test/map-own-property");
+      const annotations = { [marker]: true } satisfies Annotations;
+      const parentState = injectAnnotations(undefined, annotations);
+      const original = { value: "metadata" };
+      const delegated = getDelegatedAnnotationState(parentState, original);
+      const source = new Map<string, string>([["mode", "prod"]]);
+      Object.defineProperty(source, "metadata", {
+        value: delegated,
+        enumerable: true,
+        configurable: true,
+      });
+
+      const normalized = normalizeNestedDelegatedAnnotationState(source);
+
+      assert.notStrictEqual(normalized, source);
+      assert.equal(normalized.get("mode"), "prod");
+      assert.strictEqual(
+        (normalized as Map<string, string> & { readonly metadata: unknown })
+          .metadata,
+        original,
+      );
+    },
+  );
+
+  it(
+    "normalizeNestedDelegatedAnnotationState() unwraps delegated Set own properties",
+    () => {
+      const marker = Symbol.for("@test/set-own-property");
+      const annotations = { [marker]: true } satisfies Annotations;
+      const parentState = injectAnnotations(undefined, annotations);
+      const original = { value: "metadata" };
+      const delegated = getDelegatedAnnotationState(parentState, original);
+      const source = new Set<string>(["prod"]);
+      Object.defineProperty(source, "metadata", {
+        value: delegated,
+        enumerable: true,
+        configurable: true,
+      });
+
+      const normalized = normalizeNestedDelegatedAnnotationState(source);
+
+      assert.notStrictEqual(normalized, source);
+      assert.ok(normalized.has("prod"));
+      assert.strictEqual(
+        (normalized as Set<string> & { readonly metadata: unknown }).metadata,
+        original,
+      );
+    },
+  );
 });

--- a/packages/core/src/annotation-state.test.ts
+++ b/packages/core/src/annotation-state.test.ts
@@ -796,6 +796,25 @@ describe("annotation-state", () => {
   );
 
   it(
+    "normalizeNestedDelegatedAnnotationState() preserves changed Map cycles",
+    () => {
+      const marker = Symbol.for("@test/map-cycle-with-carrier");
+      const parentState = injectAnnotations(undefined, { [marker]: true });
+      const original = { value: "seed" };
+      const delegated = getDelegatedAnnotationState(parentState, original);
+      const map = new Map<unknown, unknown>();
+      map.set(map, delegated);
+      map.set("self", map);
+
+      const normalized = normalizeNestedDelegatedAnnotationState(map);
+
+      assert.notStrictEqual(normalized, map);
+      assert.strictEqual(normalized.get(normalized), original);
+      assert.strictEqual(normalized.get("self"), normalized);
+    },
+  );
+
+  it(
     "normalizeNestedDelegatedAnnotationState() preserves Set self references",
     () => {
       const set = new Set<unknown>();
@@ -805,6 +824,25 @@ describe("annotation-state", () => {
 
       assert.strictEqual(normalized, set);
       assert.ok(normalized.has(set));
+    },
+  );
+
+  it(
+    "normalizeNestedDelegatedAnnotationState() preserves changed Set cycles",
+    () => {
+      const marker = Symbol.for("@test/set-cycle-with-carrier");
+      const parentState = injectAnnotations(undefined, { [marker]: true });
+      const original = { value: "seed" };
+      const delegated = getDelegatedAnnotationState(parentState, original);
+      const set = new Set<unknown>();
+      set.add(set);
+      set.add(delegated);
+
+      const normalized = normalizeNestedDelegatedAnnotationState(set);
+
+      assert.notStrictEqual(normalized, set);
+      assert.ok(normalized.has(normalized));
+      assert.ok(normalized.has(original));
     },
   );
 
@@ -820,6 +858,167 @@ describe("annotation-state", () => {
 
       assert.strictEqual(normalizeNestedDelegatedAnnotationState(date), date);
       assert.strictEqual(normalizeNestedDelegatedAnnotationState(re), re);
+    },
+  );
+
+  it(
+    "normalizeNestedDelegatedAnnotationState() ignores phantom object keys",
+    () => {
+      const marker = Symbol.for("@test/phantom-object-key");
+      const parentState = injectAnnotations(undefined, { [marker]: true });
+      const source = new Proxy({
+        value: getDelegatedAnnotationState(parentState, "seed"),
+      }, {
+        ownKeys(target) {
+          return [...Reflect.ownKeys(target), "phantom"];
+        },
+        getOwnPropertyDescriptor(target, key) {
+          if (key === "phantom") return undefined;
+          return Reflect.getOwnPropertyDescriptor(target, key);
+        },
+      });
+
+      const normalized = normalizeNestedDelegatedAnnotationState(source);
+
+      assert.notStrictEqual(normalized, source);
+      assert.deepEqual(normalized, { value: "seed" });
+      assert.ok(!Reflect.has(normalized, "phantom"));
+    },
+  );
+
+  it(
+    "normalizeNestedDelegatedAnnotationState() ignores phantom Map own keys",
+    () => {
+      const marker = Symbol.for("@test/phantom-map-key");
+      const parentState = injectAnnotations(undefined, { [marker]: true });
+      const map = new Map<string, unknown>([
+        ["value", getDelegatedAnnotationState(parentState, "seed")],
+      ]);
+      const source = new Proxy(map, {
+        ownKeys(target) {
+          return [...Reflect.ownKeys(target), "phantom"];
+        },
+        getOwnPropertyDescriptor(target, key) {
+          if (key === "phantom") return undefined;
+          return Reflect.getOwnPropertyDescriptor(target, key);
+        },
+        get(target, key, receiver) {
+          const value = Reflect.get(target, key, receiver);
+          return typeof value === "function" ? value.bind(target) : value;
+        },
+      });
+
+      const normalized = normalizeNestedDelegatedAnnotationState(source);
+
+      assert.notStrictEqual(normalized, source);
+      assert.equal(normalized.get("value"), "seed");
+      assert.ok(!Reflect.has(normalized, "phantom"));
+    },
+  );
+
+  it(
+    "normalizeNestedDelegatedAnnotationState() ignores disappearing Map own properties",
+    () => {
+      const marker = Symbol.for("@test/disappearing-map-property");
+      const parentState = injectAnnotations(undefined, { [marker]: true });
+      const delegated = getDelegatedAnnotationState(parentState, "seed");
+      let descriptorReads = 0;
+      const source = new Proxy(new Map<string, unknown>(), {
+        ownKeys(target) {
+          return [...Reflect.ownKeys(target), "meta"];
+        },
+        getOwnPropertyDescriptor(target, key) {
+          if (key !== "meta") {
+            return Reflect.getOwnPropertyDescriptor(target, key);
+          }
+          descriptorReads++;
+          return descriptorReads === 1
+            ? {
+              value: delegated,
+              enumerable: true,
+              writable: true,
+              configurable: true,
+            }
+            : undefined;
+        },
+        get(target, key, receiver) {
+          const value = Reflect.get(target, key, receiver);
+          return typeof value === "function" ? value.bind(target) : value;
+        },
+      });
+
+      const normalized = normalizeNestedDelegatedAnnotationState(source);
+
+      assert.notStrictEqual(normalized, source);
+      assert.ok(!Reflect.has(normalized, "meta"));
+    },
+  );
+
+  it(
+    "normalizeNestedDelegatedAnnotationState() ignores phantom Set own keys",
+    () => {
+      const marker = Symbol.for("@test/phantom-set-key");
+      const parentState = injectAnnotations(undefined, { [marker]: true });
+      const set = new Set([
+        getDelegatedAnnotationState(parentState, "seed"),
+      ]);
+      const source = new Proxy(set, {
+        ownKeys(target) {
+          return [...Reflect.ownKeys(target), "phantom"];
+        },
+        getOwnPropertyDescriptor(target, key) {
+          if (key === "phantom") return undefined;
+          return Reflect.getOwnPropertyDescriptor(target, key);
+        },
+        get(target, key, receiver) {
+          const value = Reflect.get(target, key, receiver);
+          return typeof value === "function" ? value.bind(target) : value;
+        },
+      });
+
+      const normalized = normalizeNestedDelegatedAnnotationState(source);
+
+      assert.notStrictEqual(normalized, source);
+      assert.ok(normalized.has("seed"));
+      assert.ok(!Reflect.has(normalized, "phantom"));
+    },
+  );
+
+  it(
+    "normalizeNestedDelegatedAnnotationState() ignores disappearing Set own properties",
+    () => {
+      const marker = Symbol.for("@test/disappearing-set-property");
+      const parentState = injectAnnotations(undefined, { [marker]: true });
+      const delegated = getDelegatedAnnotationState(parentState, "seed");
+      let descriptorReads = 0;
+      const source = new Proxy(new Set<unknown>(), {
+        ownKeys(target) {
+          return [...Reflect.ownKeys(target), "meta"];
+        },
+        getOwnPropertyDescriptor(target, key) {
+          if (key !== "meta") {
+            return Reflect.getOwnPropertyDescriptor(target, key);
+          }
+          descriptorReads++;
+          return descriptorReads === 1
+            ? {
+              value: delegated,
+              enumerable: true,
+              writable: true,
+              configurable: true,
+            }
+            : undefined;
+        },
+        get(target, key, receiver) {
+          const value = Reflect.get(target, key, receiver);
+          return typeof value === "function" ? value.bind(target) : value;
+        },
+      });
+
+      const normalized = normalizeNestedDelegatedAnnotationState(source);
+
+      assert.notStrictEqual(normalized, source);
+      assert.ok(!Reflect.has(normalized, "meta"));
     },
   );
 

--- a/packages/core/src/constructs.test.ts
+++ b/packages/core/src/constructs.test.ts
@@ -13194,6 +13194,162 @@ describe("branch coverage: constructs.ts edge cases", () => {
     }
   });
 
+  it("conditional() sync complete remaps deferred branch metadata before parse selection", () => {
+    const nestedKeys: DeferredMap = new Map<PropertyKey, DeferredMap | null>([
+      ["token", null],
+    ]);
+    const deferredBranch: Parser<
+      "sync",
+      { readonly token: string; readonly stable: string },
+      undefined
+    > = {
+      mode: "sync",
+      $valueType: [] as readonly {
+        readonly token: string;
+        readonly stable: string;
+      }[],
+      $stateType: [] as readonly undefined[],
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(),
+      acceptingAnyToken: false,
+      initialState: undefined,
+      parse(context) {
+        return {
+          success: true as const,
+          next: context,
+          consumed: [],
+        };
+      },
+      complete() {
+        return {
+          success: true as const,
+          value: { token: "", stable: "kept" },
+          deferred: true as const,
+          deferredKeys: nestedKeys,
+        };
+      },
+      *suggest() {},
+      getDocFragments() {
+        return { fragments: [] };
+      },
+    };
+    const parser = conditionalLocal(constant("fast"), {
+      fast: deferredBranch,
+    });
+
+    const completed = parser.complete(parser.initialState);
+
+    assert.deepEqual(completed, {
+      success: true,
+      value: ["fast", { token: "", stable: "kept" }],
+      deferred: true,
+      deferredKeys: new Map<PropertyKey, DeferredMap | null>([
+        [1, nestedKeys],
+      ]),
+    });
+  });
+
+  it("conditional() async complete remaps deferred scalar branch metadata", async () => {
+    const discriminator: Parser<"async", string, undefined> = {
+      mode: "async",
+      $valueType: [] as readonly string[],
+      $stateType: [] as readonly undefined[],
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(),
+      acceptingAnyToken: false,
+      initialState: undefined,
+      parse(context) {
+        return Promise.resolve({
+          success: true as const,
+          next: context,
+          consumed: [],
+        });
+      },
+      complete() {
+        return Promise.resolve({
+          success: true as const,
+          value: "fast",
+        });
+      },
+      async *suggest() {},
+      getDocFragments() {
+        return { fragments: [] };
+      },
+    };
+    const branch: Parser<"async", string, undefined> = {
+      ...discriminator,
+      complete() {
+        return Promise.resolve({
+          success: true as const,
+          value: "placeholder",
+          deferred: true as const,
+        });
+      },
+    };
+    const parser = conditionalLocal(discriminator, { fast: branch });
+
+    const completed = await parser.complete(parser.initialState);
+
+    assert.deepEqual(completed, {
+      success: true,
+      value: ["fast", "placeholder"],
+      deferred: true,
+      deferredKeys: new Map<PropertyKey, DeferredMap | null>([[1, null]]),
+    });
+  });
+
+  it("conditional() async complete remaps deferred default branch metadata", async () => {
+    const discriminator: Parser<"async", string, undefined> = {
+      mode: "async",
+      $valueType: [] as readonly string[],
+      $stateType: [] as readonly undefined[],
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(),
+      acceptingAnyToken: false,
+      initialState: undefined,
+      parse(context) {
+        return Promise.resolve({
+          success: true as const,
+          next: context,
+          consumed: [],
+        });
+      },
+      complete() {
+        return Promise.resolve({
+          success: false as const,
+          error: message`No mode selected.`,
+        });
+      },
+      async *suggest() {},
+      getDocFragments() {
+        return { fragments: [] };
+      },
+    };
+    const defaultBranch: Parser<"async", string, undefined> = {
+      ...discriminator,
+      complete() {
+        return Promise.resolve({
+          success: true as const,
+          value: "fallback",
+          deferred: true as const,
+        });
+      },
+    };
+    const parser = conditionalLocal(discriminator, {}, defaultBranch);
+
+    const completed = await parser.complete(parser.initialState);
+
+    assert.deepEqual(completed, {
+      success: true,
+      value: [undefined, "fallback"],
+      deferred: true,
+      deferredKeys: new Map<PropertyKey, DeferredMap | null>([[1, null]]),
+    });
+  });
+
   // ----- object() complete async: Phase 1 Cases 1/2/3 (lines 3083-3257) -----
   it("object() async complete Phase 1 Case 1: PendingDependencySourceState", async () => {
     // withDefault(option(...)) creates a parser with PendingDependencySourceState.
@@ -14086,6 +14242,22 @@ describe("branch coverage: constructs.ts edge cases", () => {
     const validation = parser.validateValue?.("not a domain");
     assert.ok(validation && typeof validation === "object");
     assert.ok(!validation.success);
+  });
+
+  it("group() exposes dependency source runtime nodes", () => {
+    const source = dependencyLocal(choice(["dev", "prod"] as const));
+    const inner = optionLocal("--mode", source);
+    const parser = group("Mode", inner);
+
+    const nodes = parser.getSuggestRuntimeNodes?.(parser.initialState, [
+      "mode",
+    ]);
+
+    assert.deepEqual(nodes, [{
+      path: ["mode"],
+      parser: inner,
+      state: inner.initialState,
+    }]);
   });
 
   it("longestMatch() prefers a definitive result over an equal provisional result", () => {
@@ -16890,6 +17062,52 @@ describe("branch coverage: constructs.ts edge cases", () => {
         );
       });
 
+      it("concat() complete remaps direct deferred array metadata", () => {
+        const localDeferredKeys = new Map<PropertyKey, DeferredMap | null>([
+          ["1", null],
+          ["named", nestedDeferredKeys],
+        ]);
+        const parser = concatLocal(
+          createSyncDeferredCompleteParser(
+            ["visible", "deferred"],
+            localDeferredKeys,
+          ) as never,
+          constant("tail") as never,
+        );
+
+        assertDeferredComposite(
+          parser.complete(parser.initialState),
+          ["visible", "deferred", "tail"],
+          new Map<PropertyKey, DeferredMap | null>([
+            [1, null],
+            ["named", nestedDeferredKeys],
+          ]),
+        );
+      });
+
+      it("concat() async complete remaps direct deferred array metadata", async () => {
+        const localDeferredKeys = new Map<PropertyKey, DeferredMap | null>([
+          ["1", null],
+          ["named", nestedDeferredKeys],
+        ]);
+        const parser = concatLocal(
+          createAsyncDeferredCompleteParser(
+            ["visible", "deferred"],
+            localDeferredKeys,
+          ) as never,
+          toAsyncParser(constant("tail")) as never,
+        );
+
+        assertDeferredComposite(
+          await parser.complete(parser.initialState),
+          ["visible", "deferred", "tail"],
+          new Map<PropertyKey, DeferredMap | null>([
+            [1, null],
+            ["named", nestedDeferredKeys],
+          ]),
+        );
+      });
+
       it("concat() phase-two seed remaps deferred tuple element metadata", () => {
         const parser = concatLocal(
           tupleLocal(
@@ -16942,6 +17160,52 @@ describe("branch coverage: constructs.ts edge cases", () => {
           new Map<PropertyKey, DeferredMap | null>([
             [0, null],
             [1, nestedDeferredKeys],
+          ]),
+        );
+      });
+
+      it("concat() phase-two seed remaps direct deferred array metadata", () => {
+        const localDeferredKeys = new Map<PropertyKey, DeferredMap | null>([
+          ["1", null],
+          ["named", nestedDeferredKeys],
+        ]);
+        const parser = concatLocal(
+          createSyncDeferredCompleteParser(
+            ["visible", "deferred"],
+            localDeferredKeys,
+          ) as never,
+          constant("tail") as never,
+        );
+
+        assertDeferredComposite(
+          getLocalPhase2SeedExtractor(parser)(parser.initialState),
+          ["visible", "deferred", "tail"],
+          new Map<PropertyKey, DeferredMap | null>([
+            [1, null],
+            ["named", nestedDeferredKeys],
+          ]),
+        );
+      });
+
+      it("concat() async phase-two seed remaps direct deferred array metadata", async () => {
+        const localDeferredKeys = new Map<PropertyKey, DeferredMap | null>([
+          ["1", null],
+          ["named", nestedDeferredKeys],
+        ]);
+        const parser = concatLocal(
+          createAsyncDeferredCompleteParser(
+            ["visible", "deferred"],
+            localDeferredKeys,
+          ) as never,
+          toAsyncParser(constant("tail")) as never,
+        );
+
+        assertDeferredComposite(
+          await getLocalPhase2SeedExtractor(parser)(parser.initialState),
+          ["visible", "deferred", "tail"],
+          new Map<PropertyKey, DeferredMap | null>([
+            [1, null],
+            ["named", nestedDeferredKeys],
           ]),
         );
       });
@@ -20621,6 +20885,104 @@ describe("merge()/concat() suggest with cross-parser dependencies", () => {
     assert.ok(
       texts.includes("strict"),
       `Expected "strict" in suggestions, got: ${JSON.stringify(texts)}`,
+    );
+  });
+
+  it("concat() suggest continues after a non-consuming async child", async () => {
+    const skippedAsync: Parser<"async", string, undefined> = {
+      mode: "async",
+      $valueType: [] as readonly string[],
+      $stateType: [] as readonly undefined[],
+      priority: 20,
+      usage: [],
+      leadingNames: new Set(["--skip"]),
+      acceptingAnyToken: false,
+      initialState: undefined,
+      parse(context) {
+        return Promise.resolve({
+          success: true as const,
+          next: context,
+          consumed: [],
+        });
+      },
+      complete() {
+        return Promise.resolve({ success: true as const, value: "skipped" });
+      },
+      suggest: async function* () {},
+      getDocFragments() {
+        return { fragments: [] };
+      },
+    };
+    const parser = concat(
+      tuple([skippedAsync]),
+      tuple([option("--mode", choice(["dev", "prod"] as const))]),
+      tuple([option("--level", choice(["debug", "strict"] as const))]),
+    );
+
+    const suggestions = await suggestAsync(
+      parser,
+      ["--mode", "prod", "--level", "s"],
+    );
+
+    assert.deepEqual(
+      suggestions.filter((s) => s.kind === "literal").map((s) => s.text),
+      ["strict"],
+    );
+  });
+
+  it("concat() suggest advances after a consuming async child", async () => {
+    const consumedAsync: Parser<"async", string, string> = {
+      mode: "async",
+      $valueType: [] as readonly string[],
+      $stateType: [] as readonly string[],
+      priority: 20,
+      usage: [{
+        type: "option",
+        names: ["--profile"],
+        metavar: "PROFILE",
+      }],
+      leadingNames: new Set(["--profile"]),
+      acceptingAnyToken: false,
+      initialState: "",
+      parse(context) {
+        if (context.buffer[0] !== "--profile" || context.buffer[1] == null) {
+          return Promise.resolve({
+            success: false as const,
+            consumed: 0,
+            error: message`missing profile.`,
+          });
+        }
+        return Promise.resolve({
+          success: true as const,
+          next: {
+            ...context,
+            buffer: context.buffer.slice(2),
+            state: context.buffer[1],
+          },
+          consumed: context.buffer.slice(0, 2),
+        });
+      },
+      complete(state) {
+        return Promise.resolve({ success: true as const, value: state });
+      },
+      suggest: async function* () {},
+      getDocFragments() {
+        return { fragments: [] };
+      },
+    };
+    const parser = concat(
+      tuple([consumedAsync]),
+      tuple([option("--target", choice(["api", "worker"] as const))]),
+    );
+
+    const suggestions = await suggestAsync(
+      parser,
+      ["--profile", "dev", "--target", "w"],
+    );
+
+    assert.deepEqual(
+      suggestions.filter((s) => s.kind === "literal").map((s) => s.text),
+      ["worker"],
     );
   });
 });

--- a/packages/core/src/constructs.test.ts
+++ b/packages/core/src/constructs.test.ts
@@ -165,6 +165,20 @@ function toAsyncParser<TValue, TState>(
   return asyncParser;
 }
 
+function getPhase2SeedExtractor<TValue, TState>(
+  parser: Parser<Mode, TValue, TState>,
+): Phase2SeedExtractor<Mode, TState, TValue> {
+  const extract = (parser as Parser<Mode, TValue, TState> & {
+    readonly [extractPhase2SeedKey]?: Phase2SeedExtractor<
+      Mode,
+      TState,
+      TValue
+    >;
+  })[extractPhase2SeedKey];
+  assert.ok(extract != null);
+  return extract;
+}
+
 function describeDuplicateSourceState(
   context: ParserContext<unknown>,
   sourceId: symbol,
@@ -20984,6 +20998,299 @@ describe("merge()/concat() suggest with cross-parser dependencies", () => {
       suggestions.filter((s) => s.kind === "literal").map((s) => s.text),
       ["worker"],
     );
+  });
+});
+
+describe("completion metadata contracts", () => {
+  function createSyncCompletingParser<TValue>(
+    valueResult: ValueParserResult<TValue>,
+  ): Parser<"sync", TValue, undefined> {
+    return {
+      mode: "sync",
+      $valueType: [] as readonly TValue[],
+      $stateType: [] as readonly undefined[],
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(),
+      acceptingAnyToken: false,
+      initialState: undefined,
+      parse(context) {
+        return {
+          success: true as const,
+          next: context,
+          consumed: [],
+        };
+      },
+      complete() {
+        return valueResult;
+      },
+      *suggest() {},
+      getDocFragments() {
+        return { fragments: [] };
+      },
+    };
+  }
+
+  function createAsyncCompletingParser<TValue>(
+    valueResult: ValueParserResult<TValue>,
+    deferCompletion = false,
+    onComplete?: () => void,
+  ): Parser<"async", TValue, undefined> {
+    const parser = {
+      mode: "async" as const,
+      $valueType: [] as readonly TValue[],
+      $stateType: [] as readonly undefined[],
+      priority: 0,
+      usage: [],
+      leadingNames: new Set<string>(),
+      acceptingAnyToken: false,
+      initialState: undefined,
+      parse(context: ParserContext<undefined>) {
+        return Promise.resolve({
+          success: true as const,
+          next: context,
+          consumed: [],
+        });
+      },
+      complete() {
+        onComplete?.();
+        return Promise.resolve(valueResult);
+      },
+      async *suggest() {},
+      getDocFragments() {
+        return { fragments: [] };
+      },
+      ...(deferCompletion
+        ? {
+          shouldDeferCompletion() {
+            return true;
+          },
+        }
+        : {}),
+    };
+    return parser;
+  }
+
+  it("or() complete should use the unique zero-input branch", () => {
+    const parser = or(
+      constant("fallback"),
+      option("--name", string()),
+    );
+
+    const completed = parser.complete(undefined);
+
+    assert.deepEqual(completed, {
+      success: true,
+      value: "fallback",
+    });
+  });
+
+  it("or() async complete should avoid async fallback probes during suggest", async () => {
+    const parser = or(
+      toAsyncParser(constant("fallback")),
+      toAsyncParser(option("--name", string())),
+    );
+
+    const completed = await parser.complete(undefined);
+    const probed = await parser.complete(undefined, {
+      usage: parser.usage,
+      phase: "suggest",
+      path: [],
+      trace: undefined,
+    });
+
+    assert.deepEqual(completed, {
+      success: true,
+      value: "fallback",
+    });
+    assert.ok(!probed.success);
+  });
+
+  it("or() phase-two seeds should follow zero-input fallback state", () => {
+    const parser = orLocal(
+      constant("fallback"),
+      optionLocal("--name", string()),
+    );
+    const extract = getPhase2SeedExtractor(parser);
+
+    const seed = extract(undefined);
+    const failedSeed = extract([
+      0,
+      {
+        success: false as const,
+        consumed: 0,
+        error: message`selected branch failed.`,
+      },
+    ]);
+
+    assert.deepEqual(seed, { value: "fallback" });
+    assert.equal(failedSeed, null);
+  });
+
+  it("object() complete should preserve opaque and scalar deferred fields", () => {
+    const parser = objectLocal({
+      opaque: createSyncCompletingParser({
+        success: true,
+        value: { token: "", stable: "kept" },
+        deferred: true,
+      }),
+      scalar: createSyncCompletingParser({
+        success: true,
+        value: "",
+        deferred: true,
+      }),
+    });
+
+    const completed = parser.complete(parser.initialState);
+
+    assert.deepEqual(completed, {
+      success: true,
+      value: {
+        opaque: { token: "", stable: "kept" },
+        scalar: "",
+      },
+      deferred: true,
+      deferredKeys: new Map<PropertyKey, DeferredMap | null>([
+        ["scalar", null],
+      ]),
+    });
+  });
+
+  it("object() async complete should run deferred fields after eager fields", async () => {
+    const calls: string[] = [];
+    const parser = objectLocal({
+      eager: createAsyncCompletingParser(
+        {
+          success: true,
+          value: "ready",
+        },
+        false,
+        () => calls.push("eager"),
+      ),
+      late: createAsyncCompletingParser(
+        {
+          success: true,
+          value: "",
+          deferred: true,
+        },
+        true,
+        () => calls.push("late"),
+      ),
+    });
+
+    const completed = await parser.complete(parser.initialState);
+
+    assert.deepEqual(calls, ["eager", "late"]);
+    assert.deepEqual(completed, {
+      success: true,
+      value: {
+        eager: "ready",
+        late: "",
+      },
+      deferred: true,
+      deferredKeys: new Map<PropertyKey, DeferredMap | null>([
+        ["late", null],
+      ]),
+    });
+  });
+
+  it("merge() complete should keep opaque deferred child results", () => {
+    const deferredObject = createSyncCompletingParser({
+      success: true,
+      value: { token: "", stable: "kept" },
+      deferred: true,
+    });
+    const parser = mergeLocal(
+      deferredObject,
+      objectLocal({ mode: constant("fast") }),
+    );
+
+    const completed = parser.complete(parser.initialState);
+
+    assert.deepEqual(completed, {
+      success: true,
+      value: {
+        token: "",
+        stable: "kept",
+        mode: "fast",
+      },
+      deferred: true,
+    });
+  });
+
+  it("merge() async complete should keep opaque deferred child results", async () => {
+    const deferredObject = createAsyncCompletingParser({
+      success: true,
+      value: { token: "", stable: "kept" },
+      deferred: true,
+    });
+    const parser = mergeLocal(
+      deferredObject,
+      objectLocal({ mode: toAsyncParser(constant("fast")) }),
+    );
+
+    const completed = await parser.complete(parser.initialState);
+
+    assert.deepEqual(completed, {
+      success: true,
+      value: {
+        token: "",
+        stable: "kept",
+        mode: "fast",
+      },
+      deferred: true,
+    });
+  });
+
+  it("concat() complete should remap numeric and symbolic deferred keys", () => {
+    const nestedKeys: DeferredMap = new Map<PropertyKey, DeferredMap | null>([
+      ["token", null],
+    ]);
+    const arrayChild = createSyncCompletingParser({
+      success: true,
+      value: ["", "stable"] as readonly string[],
+      deferred: true,
+      deferredKeys: new Map<PropertyKey, DeferredMap | null>([
+        ["1", null],
+        ["nested", nestedKeys],
+      ]),
+    }) as unknown as Parser<"sync", readonly string[], readonly unknown[]>;
+    const parser = concatLocal(
+      arrayChild,
+      tupleLocal([constant("tail")] as const),
+    );
+
+    const completed = parser.complete(parser.initialState);
+
+    assert.deepEqual(completed, {
+      success: true,
+      value: ["", "stable", "tail"],
+      deferred: true,
+      deferredKeys: new Map<PropertyKey, DeferredMap | null>([
+        [1, null],
+        ["nested", nestedKeys],
+      ]),
+    });
+  });
+
+  it("concat() async complete should preserve opaque deferred arrays", async () => {
+    const arrayChild = createAsyncCompletingParser({
+      success: true,
+      value: ["", "stable"] as readonly string[],
+      deferred: true,
+    }) as unknown as Parser<"async", readonly string[], readonly unknown[]>;
+    const parser = concatLocal(
+      arrayChild,
+      tupleLocal([toAsyncParser(constant("tail"))] as const),
+    );
+
+    const completed = await parser.complete(parser.initialState);
+
+    assert.deepEqual(completed, {
+      success: true,
+      value: ["", "stable", "tail"],
+      deferred: true,
+    });
   });
 });
 

--- a/packages/core/src/constructs.test.ts
+++ b/packages/core/src/constructs.test.ts
@@ -12551,6 +12551,155 @@ describe("branch coverage: conditional() complete/suggest edges", () => {
     assert.ok(texts.includes("--threads"));
     assert.ok(!texts.includes("--raw"));
   });
+
+  it("async complete resolves a deferred discriminator into a named branch", async () => {
+    let branchParseSawEmptyBuffer = false;
+    const branch = createSyncBranchParser(
+      "initial",
+      (context) => {
+        branchParseSawEmptyBuffer = context.buffer.length === 0;
+        return {
+          success: true,
+          next: {
+            ...context,
+            state: "parsed",
+          },
+          consumed: [],
+        };
+      },
+      "unused",
+    );
+    Object.defineProperty(branch, "complete", {
+      value(state: string) {
+        return {
+          success: true as const,
+          value: state === "parsed" ? "from-branch" : "wrong-state",
+          deferred: true as const,
+          deferredKeys: new Map<PropertyKey, DeferredMap | null>([
+            ["secret", null],
+          ]),
+        };
+      },
+      configurable: true,
+    });
+    const parser = conditional(
+      createAsyncDeferredDiscriminator({ success: true, value: "fast" }),
+      { fast: branch },
+    );
+
+    const completed = await parser.complete(parser.initialState);
+
+    assert.ok(completed.success);
+    if (!completed.success) return;
+    assert.ok(branchParseSawEmptyBuffer);
+    assert.deepEqual(completed.value, ["fast", "from-branch"]);
+    assert.equal(completed.deferred, true);
+    assert.deepEqual(
+      completed.deferredKeys,
+      new Map<PropertyKey, DeferredMap | null>([
+        [
+          1,
+          new Map<PropertyKey, DeferredMap | null>([["secret", null]]),
+        ],
+      ]),
+    );
+  });
+
+  it("async complete reports branch errors after deferred discriminator resolution", async () => {
+    const branch = createSyncBranchParser(
+      "initial",
+      (context) => ({
+        success: true,
+        next: {
+          ...context,
+          state: "parsed",
+        },
+        consumed: [],
+      }),
+      "unused",
+    );
+    Object.defineProperty(branch, "complete", {
+      value() {
+        return { success: false as const, error: message`branch failed.` };
+      },
+      configurable: true,
+    });
+    const parser = conditional(
+      createAsyncDeferredDiscriminator({ success: true, value: "fast" }),
+      { fast: branch },
+      constant("default"),
+      {
+        errors: {
+          branchError: (value, error) =>
+            message`branch ${value ?? "unknown"}: ${formatMessage(error)}`,
+        },
+      },
+    );
+
+    const completed = await parser.complete(parser.initialState);
+
+    assert.ok(!completed.success);
+    if (completed.success) return;
+    assert.equal(
+      formatMessage(completed.error),
+      'branch "fast": "branch failed."',
+    );
+  });
+
+  it("async complete uses the default branch for an unknown deferred discriminator", async () => {
+    const parser = conditional(
+      createAsyncDeferredDiscriminator({ success: true, value: "missing" }),
+      { fast: flag("--fast") },
+      createSyncBranchParser(
+        "initial",
+        (context) => ({
+          success: true,
+          next: {
+            ...context,
+            state: "parsed-default",
+          },
+          consumed: [],
+        }),
+        "default",
+      ),
+    );
+
+    const completed = await parser.complete(parser.initialState);
+
+    assert.deepEqual(completed, {
+      success: true,
+      value: [undefined, "default"],
+    });
+  });
+
+  it("async complete fails when a deferred discriminator has no branch or default", async () => {
+    const parser = conditional(
+      createAsyncDeferredDiscriminator({ success: true, value: "missing" }),
+      { fast: flag("--fast") },
+    );
+
+    const completed = await parser.complete(parser.initialState);
+
+    assert.ok(!completed.success);
+    if (completed.success) return;
+    assert.equal(formatMessage(completed.error), "No matching option found.");
+  });
+
+  it("async complete propagates deferred discriminator failures without a default", async () => {
+    const parser = conditional(
+      createAsyncDeferredDiscriminator({
+        success: false,
+        error: message`mode unavailable.`,
+      }),
+      { fast: flag("--fast") },
+    );
+
+    const completed = await parser.complete(parser.initialState);
+
+    assert.ok(!completed.success);
+    if (completed.success) return;
+    assert.equal(formatMessage(completed.error), "mode unavailable.");
+  });
 });
 
 describe("branch coverage: generateNoMatchError variants", () => {

--- a/packages/core/src/constructs.test.ts
+++ b/packages/core/src/constructs.test.ts
@@ -60,6 +60,7 @@ import {
 import { extractLiteralValues, formatUsage } from "@optique/core/usage";
 import {
   choice,
+  type DeferredMap,
   integer,
   string,
   type ValueParser,
@@ -13806,6 +13807,102 @@ describe("branch coverage: constructs.ts edge cases", () => {
         };
       }
 
+      function createSyncDeferredCompleteParser(
+        value: unknown,
+        deferredKeys?: DeferredMap,
+      ): Parser<"sync", unknown, undefined> {
+        return {
+          mode: "sync",
+          $valueType: [] as readonly unknown[],
+          $stateType: [] as readonly undefined[],
+          priority: 0,
+          usage: [],
+          leadingNames: new Set(),
+          acceptingAnyToken: false,
+          initialState: undefined,
+          parse(context) {
+            return {
+              success: true as const,
+              next: context,
+              consumed: [],
+            };
+          },
+          complete() {
+            return {
+              success: true as const,
+              value,
+              deferred: true as const,
+              ...(deferredKeys == null ? {} : { deferredKeys }),
+            };
+          },
+          *suggest() {},
+          getDocFragments() {
+            return { fragments: [] };
+          },
+        };
+      }
+
+      function createAsyncDeferredCompleteParser(
+        value: unknown,
+        deferredKeys?: DeferredMap,
+      ): Parser<"async", unknown, undefined> {
+        const syncParser = createSyncDeferredCompleteParser(
+          value,
+          deferredKeys,
+        );
+        return {
+          mode: "async",
+          $valueType: [] as readonly unknown[],
+          $stateType: [] as readonly undefined[],
+          priority: 0,
+          usage: [],
+          leadingNames: new Set(),
+          acceptingAnyToken: false,
+          initialState: undefined,
+          parse(context) {
+            return Promise.resolve(syncParser.parse(context));
+          },
+          complete(state, exec) {
+            return Promise.resolve(syncParser.complete(state, exec));
+          },
+          async *suggest(context, prefix) {
+            yield* syncParser.suggest(context, prefix);
+          },
+          getDocFragments() {
+            return { fragments: [] };
+          },
+        };
+      }
+
+      function assertDeferredComposite(
+        result: unknown,
+        expectedValue: unknown,
+        expectedKeys: DeferredMap,
+      ): void {
+        assert.ok(result != null && typeof result === "object");
+        assert.ok(!("then" in result), "deferred result must be resolved");
+        assert.ok(!("success" in result) || result.success === true);
+        assert.equal(
+          (result as { readonly deferred?: unknown }).deferred,
+          true,
+        );
+        assert.deepEqual(
+          (result as { readonly value?: unknown }).value,
+          expectedValue,
+        );
+        assert.deepEqual(
+          (result as { readonly deferredKeys?: unknown }).deferredKeys,
+          expectedKeys,
+        );
+      }
+
+      const nestedDeferredKeys: DeferredMap = new Map<
+        PropertyKey,
+        DeferredMap | null
+      >([
+        ["inner", null],
+      ]);
+
       it("object() reuses sync pre-completed defaults", () => {
         const { parser: modeParser, getCallCount } =
           createCountingSourceParser();
@@ -14098,6 +14195,190 @@ describe("branch coverage: constructs.ts edge cases", () => {
         assert.equal(childExec?.phase, "complete");
         assert.equal(childExec?.usage, parser.usage);
         assert.deepEqual(childExec?.path, [0]);
+      });
+
+      it("object() complete preserves deferred field metadata", () => {
+        const parser = objectLocal({
+          scalar: createSyncDeferredCompleteParser(""),
+          structured: createSyncDeferredCompleteParser({ ready: false }),
+          partial: createSyncDeferredCompleteParser(
+            { inner: "", stable: "kept" },
+            nestedDeferredKeys,
+          ),
+        });
+
+        assertDeferredComposite(
+          parser.complete(parser.initialState),
+          {
+            scalar: "",
+            structured: { ready: false },
+            partial: { inner: "", stable: "kept" },
+          },
+          new Map<PropertyKey, DeferredMap | null>([
+            ["scalar", null],
+            ["partial", nestedDeferredKeys],
+          ]),
+        );
+      });
+
+      it("object() async complete preserves deferred field metadata", async () => {
+        const parser = objectLocal({
+          scalar: createAsyncDeferredCompleteParser(""),
+          structured: createAsyncDeferredCompleteParser({ ready: false }),
+          partial: createAsyncDeferredCompleteParser(
+            { inner: "", stable: "kept" },
+            nestedDeferredKeys,
+          ),
+        });
+
+        assertDeferredComposite(
+          await parser.complete(parser.initialState),
+          {
+            scalar: "",
+            structured: { ready: false },
+            partial: { inner: "", stable: "kept" },
+          },
+          new Map<PropertyKey, DeferredMap | null>([
+            ["scalar", null],
+            ["partial", nestedDeferredKeys],
+          ]),
+        );
+      });
+
+      it("object() phase-two seed preserves deferred field metadata", () => {
+        const parser = objectLocal({
+          scalar: createSyncDeferredCompleteParser(""),
+          structured: createSyncDeferredCompleteParser({ ready: false }),
+          partial: createSyncDeferredCompleteParser(
+            { inner: "", stable: "kept" },
+            nestedDeferredKeys,
+          ),
+        });
+
+        assertDeferredComposite(
+          getLocalPhase2SeedExtractor(parser)(parser.initialState),
+          {
+            scalar: "",
+            structured: { ready: false },
+            partial: { inner: "", stable: "kept" },
+          },
+          new Map<PropertyKey, DeferredMap | null>([
+            ["scalar", null],
+            ["partial", nestedDeferredKeys],
+          ]),
+        );
+      });
+
+      it("object() async phase-two seed preserves deferred field metadata", async () => {
+        const parser = objectLocal({
+          scalar: createAsyncDeferredCompleteParser(""),
+          structured: createAsyncDeferredCompleteParser({ ready: false }),
+          partial: createAsyncDeferredCompleteParser(
+            { inner: "", stable: "kept" },
+            nestedDeferredKeys,
+          ),
+        });
+
+        assertDeferredComposite(
+          await getLocalPhase2SeedExtractor(parser)(parser.initialState),
+          {
+            scalar: "",
+            structured: { ready: false },
+            partial: { inner: "", stable: "kept" },
+          },
+          new Map<PropertyKey, DeferredMap | null>([
+            ["scalar", null],
+            ["partial", nestedDeferredKeys],
+          ]),
+        );
+      });
+
+      it("tuple() complete preserves deferred element metadata", () => {
+        const parser = tupleLocal(
+          [
+            createSyncDeferredCompleteParser(""),
+            createSyncDeferredCompleteParser({ ready: false }),
+            createSyncDeferredCompleteParser(
+              { inner: "", stable: "kept" },
+              nestedDeferredKeys,
+            ),
+          ] as const,
+        );
+
+        assertDeferredComposite(
+          parser.complete(parser.initialState),
+          ["", { ready: false }, { inner: "", stable: "kept" }],
+          new Map<PropertyKey, DeferredMap | null>([
+            [0, null],
+            [2, nestedDeferredKeys],
+          ]),
+        );
+      });
+
+      it("tuple() async complete preserves deferred element metadata", async () => {
+        const parser = tupleLocal(
+          [
+            createAsyncDeferredCompleteParser(""),
+            createAsyncDeferredCompleteParser({ ready: false }),
+            createAsyncDeferredCompleteParser(
+              { inner: "", stable: "kept" },
+              nestedDeferredKeys,
+            ),
+          ] as const,
+        );
+
+        assertDeferredComposite(
+          await parser.complete(parser.initialState),
+          ["", { ready: false }, { inner: "", stable: "kept" }],
+          new Map<PropertyKey, DeferredMap | null>([
+            [0, null],
+            [2, nestedDeferredKeys],
+          ]),
+        );
+      });
+
+      it("tuple() phase-two seed preserves deferred element metadata", () => {
+        const parser = tupleLocal(
+          [
+            createSyncDeferredCompleteParser(""),
+            createSyncDeferredCompleteParser({ ready: false }),
+            createSyncDeferredCompleteParser(
+              { inner: "", stable: "kept" },
+              nestedDeferredKeys,
+            ),
+          ] as const,
+        );
+
+        assertDeferredComposite(
+          getLocalPhase2SeedExtractor(parser)(parser.initialState),
+          ["", { ready: false }, { inner: "", stable: "kept" }],
+          new Map<PropertyKey, DeferredMap | null>([
+            [0, null],
+            [2, nestedDeferredKeys],
+          ]),
+        );
+      });
+
+      it("tuple() async phase-two seed preserves deferred element metadata", async () => {
+        const parser = tupleLocal(
+          [
+            createAsyncDeferredCompleteParser(""),
+            createAsyncDeferredCompleteParser({ ready: false }),
+            createAsyncDeferredCompleteParser(
+              { inner: "", stable: "kept" },
+              nestedDeferredKeys,
+            ),
+          ] as const,
+        );
+
+        assertDeferredComposite(
+          await getLocalPhase2SeedExtractor(parser)(parser.initialState),
+          ["", { ready: false }, { inner: "", stable: "kept" }],
+          new Map<PropertyKey, DeferredMap | null>([
+            [0, null],
+            [2, nestedDeferredKeys],
+          ]),
+        );
       });
 
       for (

--- a/packages/core/src/constructs.test.ts
+++ b/packages/core/src/constructs.test.ts
@@ -224,6 +224,46 @@ function tokenParserMetadata<TState>(
   };
 }
 
+function createAsyncFailingTokenParser(
+  token: string,
+): Parser<"async", string, undefined> {
+  return {
+    $valueType: [] as readonly string[],
+    $stateType: [] as readonly undefined[],
+    mode: "async",
+    priority: 0,
+    usage: [{ type: "option", names: [token as OptionName] }],
+    leadingNames: new Set([token]),
+    acceptingAnyToken: false,
+    initialState: undefined,
+    parse(context: ParserContext<undefined>) {
+      if (context.buffer[0] === token) {
+        return Promise.resolve({
+          success: false as const,
+          consumed: 1,
+          error: message`Missing value for ${token}.`,
+        });
+      }
+      return Promise.resolve({
+        success: false as const,
+        consumed: 0,
+        error: message`Expected ${token}.`,
+      });
+    },
+    complete() {
+      return Promise.resolve({ success: true as const, value: token });
+    },
+    async *suggest(_context: ParserContext<undefined>, prefix: string) {
+      if (token.startsWith(prefix)) {
+        yield { kind: "literal" as const, text: token };
+      }
+    },
+    getDocFragments() {
+      return { fragments: [] };
+    },
+  };
+}
+
 function createAsyncDeferredDiscriminator(
   result: ValueParserResult<string>,
 ): Parser<"async", string, string> {
@@ -13967,6 +14007,157 @@ describe("branch coverage: constructs.ts edge cases", () => {
     ]);
   });
 
+  it("object() normalizeValue normalizes changed fields only", () => {
+    const parser = objectLocal({
+      host: optionLocal("--host", domain({ lowercase: true })),
+      port: optionLocal("--port", integer()),
+    });
+    assert.ok(typeof parser.normalizeValue === "function");
+
+    const unchanged = { host: "example.com", port: 443 } as const;
+    assert.equal(parser.normalizeValue(unchanged), unchanged);
+    assert.deepEqual(
+      parser.normalizeValue({ host: "EXAMPLE.COM", port: 443 }),
+      {
+        host: "example.com",
+        port: 443,
+      },
+    );
+    assert.deepEqual(
+      parser.normalizeValue({ host: "not a domain", port: 443 }),
+      {
+        host: "not a domain",
+        port: 443,
+      },
+    );
+    assert.equal(parser.normalizeValue("not-object" as never), "not-object");
+  });
+
+  it("object() normalizeValue preserves fields whose normalizer throws", () => {
+    const throwingParser: Parser<"sync", string, undefined> = {
+      mode: "sync",
+      $valueType: [] as readonly string[],
+      $stateType: [] as readonly undefined[],
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(),
+      acceptingAnyToken: false,
+      initialState: undefined,
+      parse(context) {
+        return {
+          success: true as const,
+          next: context,
+          consumed: [],
+        };
+      },
+      complete() {
+        return { success: true as const, value: "fallback" };
+      },
+      *suggest() {},
+      getDocFragments() {
+        return { fragments: [] };
+      },
+    };
+    Object.defineProperty(throwingParser, "normalizeValue", {
+      value() {
+        throw new Error("object normalization failed.");
+      },
+    });
+    const parser = objectLocal({
+      host: optionLocal("--host", domain({ lowercase: true })),
+      sentinel: throwingParser,
+    });
+
+    assert.deepEqual(
+      parser.normalizeValue!({ host: "EXAMPLE.COM", sentinel: "keep" }),
+      {
+        host: "example.com",
+        sentinel: "keep",
+      },
+    );
+  });
+
+  it("group() forwards placeholder, normalization, and validation", () => {
+    const inner = optionLocal("--host", domain({ lowercase: true }));
+    const parser = group("Network", inner);
+
+    assert.equal(parser.placeholder, "example.com");
+    assert.equal(parser.normalizeValue?.("EXAMPLE.COM"), "example.com");
+    const validation = parser.validateValue?.("not a domain");
+    assert.ok(validation && typeof validation === "object");
+    assert.ok(!validation.success);
+  });
+
+  it("longestMatch() prefers a definitive result over an equal provisional result", () => {
+    const provisional = createProvisionalTokenParser("--mode", "provisional");
+    const definitive = createSyncBranchParser(
+      "initial",
+      (context) =>
+        context.buffer[0] === "--mode"
+          ? {
+            success: true as const,
+            next: {
+              ...context,
+              buffer: context.buffer.slice(1),
+              state: "definitive",
+            },
+            consumed: ["--mode"],
+          }
+          : {
+            success: false as const,
+            consumed: 0,
+            error: message`missing definitive token.`,
+          },
+      "definitive",
+      tokenParserMetadata("--mode"),
+    );
+    const parser = longestMatch(provisional, definitive);
+
+    const result = parseSync(parser, ["--mode"]);
+
+    assert.ok(result.success);
+    if (result.success) {
+      assert.equal(result.value, "definitive");
+    }
+  });
+
+  it("longestMatch() async prefers a definitive result over an equal provisional result", async () => {
+    const provisional = toAsyncParser(
+      createProvisionalTokenParser("--mode", "provisional"),
+    );
+    const definitive = toAsyncParser(
+      createSyncBranchParser(
+        "initial",
+        (context) =>
+          context.buffer[0] === "--mode"
+            ? {
+              success: true as const,
+              next: {
+                ...context,
+                buffer: context.buffer.slice(1),
+                state: "definitive",
+              },
+              consumed: ["--mode"],
+            }
+            : {
+              success: false as const,
+              consumed: 0,
+              error: message`missing definitive token.`,
+            },
+        "definitive",
+        tokenParserMetadata("--mode"),
+      ),
+    );
+    const parser = longestMatch(provisional, definitive);
+
+    const result = await parseAsync(parser, ["--mode"]);
+
+    assert.ok(result.success);
+    if (result.success) {
+      assert.equal(result.value, "definitive");
+    }
+  });
+
   // ----- merge() extractParserState: object initialState fields (lines 5188-5195) -----
   it("merge() extractParserState extracts matching fields from context state", () => {
     const p1 = object({
@@ -14514,6 +14705,76 @@ describe("branch coverage: constructs.ts edge cases", () => {
       asyncSuggestions.push(suggestion);
     }
     assert.ok(Array.isArray(asyncSuggestions));
+  });
+
+  it("tuple() async suggest advances past parsed options before suggesting", async () => {
+    const parser = tuple([
+      option("--first", asyncStringValue()),
+      option("--second", asyncStringValue()),
+    ]);
+
+    const suggestions: Suggestion[] = [];
+    for await (
+      const suggestion of parser.suggest({
+        buffer: ["--first", "ready"],
+        state: parser.initialState,
+        optionsTerminated: false,
+        usage: parser.usage,
+      }, "--")
+    ) {
+      suggestions.push(suggestion);
+    }
+
+    assert.ok(
+      suggestions.some((suggestion) =>
+        suggestion.kind === "literal" && suggestion.text === "--second"
+      ),
+    );
+  });
+
+  it("tuple() async suggest advances past zero-consuming fields", async () => {
+    const parser = tuple([
+      toAsyncParser(constant("implicit")),
+      option("--next", asyncStringValue()),
+    ]);
+
+    const suggestions: Suggestion[] = [];
+    for await (
+      const suggestion of parser.suggest({
+        buffer: ["--unknown"],
+        state: parser.initialState,
+        optionsTerminated: false,
+        usage: parser.usage,
+      }, "--")
+    ) {
+      suggestions.push(suggestion);
+    }
+
+    assert.ok(
+      suggestions.some((suggestion) =>
+        suggestion.kind === "literal" && suggestion.text === "--next"
+      ),
+    );
+  });
+
+  it("tuple() async suggest preserves context after consumed failures", async () => {
+    const first = createAsyncFailingTokenParser("--first");
+    const second = createAsyncFailingTokenParser("--first");
+    const parser = tuple([first, second], { allowDuplicates: true });
+
+    const suggestions: Suggestion[] = [];
+    for await (
+      const suggestion of parser.suggest({
+        buffer: ["--first"],
+        state: parser.initialState,
+        optionsTerminated: false,
+        usage: parser.usage,
+      }, "--")
+    ) {
+      suggestions.push(suggestion);
+    }
+
+    assert.deepEqual(suggestions, [{ kind: "literal", text: "--first" }]);
   });
 
   it("concat() suggest handles non-array state in async mode", async () => {
@@ -15850,6 +16111,152 @@ describe("branch coverage: constructs.ts edge cases", () => {
         assert.equal(getCallCount(), 1);
       });
 
+      it("conditional() extracts a discriminator-only sync seed", () => {
+        const parser = conditionalLocal(constant("missing"), {
+          cfg: optionLocal("--config", string()),
+        });
+
+        const seed = getLocalPhase2SeedExtractor(parser)(parser.initialState);
+
+        assert.deepEqual(seed, {
+          value: ["missing", undefined],
+        });
+      });
+
+      it("conditional() extracts a discriminator-only async seed", async () => {
+        const parser = conditionalLocal(toAsyncParser(constant("missing")), {
+          cfg: toAsyncParser(optionLocal("--config", string())),
+        });
+
+        const seed = await getLocalPhase2SeedExtractor(parser)(
+          parser.initialState,
+        );
+
+        assert.deepEqual(seed, {
+          value: ["missing", undefined],
+        });
+      });
+
+      it("conditional() extracts a selected sync default-branch seed", () => {
+        const parser = conditionalLocal(
+          optionLocal("--mode", choice(["cfg"] as const)),
+          { cfg: optionLocal("--config", string()) },
+          withDefaultLocal(optionLocal("--fallback", string()), "alpha"),
+        );
+
+        const seed = getLocalPhase2SeedExtractor(parser)({
+          ...parser.initialState,
+          selectedBranch: { kind: "default" as const },
+        });
+
+        assert.deepEqual(seed, {
+          value: [undefined, "alpha"],
+        });
+      });
+
+      it("conditional() extracts a selected async default-branch seed", async () => {
+        const parser = conditionalLocal(
+          toAsyncParser(optionLocal("--mode", choice(["cfg"] as const))),
+          { cfg: toAsyncParser(optionLocal("--config", string())) },
+          toAsyncParser(
+            withDefaultLocal(optionLocal("--fallback", string()), "alpha"),
+          ),
+        );
+
+        const seed = await getLocalPhase2SeedExtractor(parser)({
+          ...parser.initialState,
+          selectedBranch: { kind: "default" as const },
+        });
+
+        assert.deepEqual(seed, {
+          value: [undefined, "alpha"],
+        });
+      });
+
+      it("conditional() reuses a matching selected discriminator seed", () => {
+        let completeCalls = 0;
+        const discriminator: Parser<"sync", string, undefined> = {
+          mode: "sync",
+          $valueType: [] as readonly string[],
+          $stateType: [] as readonly undefined[],
+          priority: 0,
+          usage: [],
+          leadingNames: new Set(),
+          acceptingAnyToken: false,
+          initialState: undefined,
+          parse(context) {
+            return { success: true as const, next: context, consumed: [] };
+          },
+          complete() {
+            completeCalls++;
+            return { success: true as const, value: "cfg" };
+          },
+          *suggest() {},
+          getDocFragments() {
+            return { fragments: [] };
+          },
+        };
+        const parser = conditionalLocal(discriminator, {
+          cfg: withDefaultLocal(optionLocal("--config", string()), "alpha"),
+        });
+
+        const seed = getLocalPhase2SeedExtractor(parser)({
+          ...parser.initialState,
+          discriminatorValue: "cfg",
+          selectedBranch: { kind: "branch" as const, key: "cfg" },
+        });
+
+        assert.deepEqual(seed, {
+          value: ["cfg", "alpha"],
+        });
+        assert.equal(completeCalls, 0);
+      });
+
+      it("conditional() reuses a matching selected async discriminator seed", async () => {
+        let completeCalls = 0;
+        const discriminator: Parser<"async", string, undefined> = {
+          mode: "async",
+          $valueType: [] as readonly string[],
+          $stateType: [] as readonly undefined[],
+          priority: 0,
+          usage: [],
+          leadingNames: new Set(),
+          acceptingAnyToken: false,
+          initialState: undefined,
+          parse(context) {
+            return Promise.resolve({
+              success: true as const,
+              next: context,
+              consumed: [],
+            });
+          },
+          complete() {
+            completeCalls++;
+            return Promise.resolve({ success: true as const, value: "cfg" });
+          },
+          async *suggest() {},
+          getDocFragments() {
+            return { fragments: [] };
+          },
+        };
+        const parser = conditionalLocal(discriminator, {
+          cfg: toAsyncParser(
+            withDefaultLocal(optionLocal("--config", string()), "alpha"),
+          ),
+        });
+
+        const seed = await getLocalPhase2SeedExtractor(parser)({
+          ...parser.initialState,
+          discriminatorValue: "cfg",
+          selectedBranch: { kind: "branch" as const, key: "cfg" },
+        });
+
+        assert.deepEqual(seed, {
+          value: ["cfg", "alpha"],
+        });
+        assert.equal(completeCalls, 0);
+      });
+
       it("conditional() sync complete replays a deferred discriminator branch", () => {
         const parser = conditionalLocal(constant("cfg"), {
           cfg: createSyncDeferredCompleteParser(""),
@@ -16565,6 +16972,38 @@ describe("branch coverage: constructs.ts edge cases", () => {
         );
       });
 
+      it("concat() complete preserves opaque deferred array children", () => {
+        const parser = concatLocal(
+          createSyncDeferredCompleteParser(["head", "tail"]) as never,
+          constant("done") as never,
+        );
+
+        const result = parser.complete(parser.initialState);
+
+        assert.ok(result.success);
+        if (result.success) {
+          assert.equal(result.deferred, true);
+          assert.deepEqual(result.value, ["head", "tail", "done"]);
+          assert.equal(result.deferredKeys, undefined);
+        }
+      });
+
+      it("concat() async complete preserves opaque deferred array children", async () => {
+        const parser = concatLocal(
+          createAsyncDeferredCompleteParser(["head", "tail"]) as never,
+          toAsyncParser(constant("done")) as never,
+        );
+
+        const result = await parser.complete(parser.initialState);
+
+        assert.ok(result.success);
+        if (result.success) {
+          assert.equal(result.deferred, true);
+          assert.deepEqual(result.value, ["head", "tail", "done"]);
+          assert.equal(result.deferredKeys, undefined);
+        }
+      });
+
       it("concat() phase-two seed preserves opaque deferred scalar children", () => {
         const parser = concatLocal(
           createSyncDeferredCompleteParser({ ready: false }) as never,
@@ -16576,6 +17015,36 @@ describe("branch coverage: constructs.ts edge cases", () => {
           [{ ready: false }, "tail"],
           new Map<PropertyKey, DeferredMap | null>([[1, null]]),
         );
+      });
+
+      it("concat() phase-two seed preserves opaque deferred array children", () => {
+        const parser = concatLocal(
+          createSyncDeferredCompleteParser(["head", "tail"]) as never,
+          constant("done") as never,
+        );
+
+        const seed = getLocalPhase2SeedExtractor(parser)(parser.initialState);
+
+        assert.deepEqual(seed, {
+          value: ["head", "tail", "done"],
+          deferred: true,
+        });
+      });
+
+      it("concat() async phase-two seed preserves opaque deferred array children", async () => {
+        const parser = concatLocal(
+          createAsyncDeferredCompleteParser(["head", "tail"]) as never,
+          toAsyncParser(constant("done")) as never,
+        );
+
+        const seed = await getLocalPhase2SeedExtractor(parser)(
+          parser.initialState,
+        );
+
+        assert.deepEqual(seed, {
+          value: ["head", "tail", "done"],
+          deferred: true,
+        });
       });
 
       it("concat() async phase-two seed preserves opaque deferred scalar children", async () => {

--- a/packages/core/src/constructs.test.ts
+++ b/packages/core/src/constructs.test.ts
@@ -65,6 +65,7 @@ import {
 import {
   choice,
   type DeferredMap,
+  domain,
   integer,
   string,
   type ValueParser,
@@ -1807,6 +1808,365 @@ describe("or() - duplicate option handling", () => {
       assert.equal(result.provisional, true);
       assert.deepEqual(result.consumed, ["--next"]);
     }
+  });
+
+  it("keeps the active sync provisional branch across competing provisionals", () => {
+    const makeExec = (label: string): ExecutionContext => ({
+      usage: [],
+      phase: "parse",
+      path: [label],
+      trace: undefined,
+    });
+    const active = createSyncBranchParser(
+      [] as readonly string[],
+      (context) => {
+        const token = context.buffer[0];
+        if (token === "--first" || token === "--second") {
+          return {
+            success: true,
+            provisional: true,
+            next: {
+              ...context,
+              buffer: context.buffer.slice(1),
+              state: [...context.state, token],
+              exec: makeExec(`active:${token}`),
+            },
+            consumed: [token],
+          };
+        }
+        return {
+          success: false,
+          consumed: 0,
+          error: message`active failed.`,
+        };
+      },
+      "active",
+      tokenParserMetadata("--first"),
+    );
+    const competing = createSyncBranchParser(
+      [] as readonly string[],
+      (context) => {
+        if (context.buffer[0] === "--second") {
+          return {
+            success: true,
+            provisional: true,
+            next: {
+              ...context,
+              buffer: context.buffer.slice(1),
+              state: [...context.state, "--second"],
+              exec: makeExec("competing"),
+            },
+            consumed: ["--second"],
+          };
+        }
+        return {
+          success: false,
+          consumed: 0,
+          error: message`competing failed.`,
+        };
+      },
+      "competing",
+      tokenParserMetadata("--second"),
+    );
+    const parser = or(active, competing);
+    const exec = makeExec("root");
+    const first = parser.parse({
+      buffer: ["--first"],
+      state: parser.initialState,
+      optionsTerminated: false,
+      usage: parser.usage,
+      exec,
+    });
+    assert.ok(first.success);
+    if (!first.success) return;
+
+    const second = parser.parse({
+      buffer: ["--second"],
+      state: first.next.state,
+      optionsTerminated: false,
+      usage: parser.usage,
+      exec,
+    });
+
+    assert.ok(second.success);
+    if (second.success) {
+      assert.equal(second.provisional, true);
+      assert.deepEqual(second.consumed, ["--second"]);
+      const [, stored] = second.next.state as [
+        number,
+        ParserResult<readonly string[]>,
+      ];
+      assert.ok(stored.success);
+      if (stored.success) {
+        assert.deepEqual(stored.next.state, ["--first", "--second"]);
+      }
+    }
+  });
+
+  it("keeps the active async provisional branch across competing provisionals", async () => {
+    const makeExec = (label: string): ExecutionContext => ({
+      usage: [],
+      phase: "parse",
+      path: [label],
+      trace: undefined,
+    });
+    const activeSync = createSyncBranchParser(
+      [] as readonly string[],
+      (context) => {
+        const token = context.buffer[0];
+        if (token === "--first" || token === "--second") {
+          return {
+            success: true,
+            provisional: true,
+            next: {
+              ...context,
+              buffer: context.buffer.slice(1),
+              state: [...context.state, token],
+              exec: makeExec(`active:${token}`),
+            },
+            consumed: [token],
+          };
+        }
+        return {
+          success: false,
+          consumed: 0,
+          error: message`active failed.`,
+        };
+      },
+      "active",
+      tokenParserMetadata("--first"),
+    );
+    const competingSync = createSyncBranchParser(
+      [] as readonly string[],
+      (context) => {
+        if (context.buffer[0] === "--second") {
+          return {
+            success: true,
+            provisional: true,
+            next: {
+              ...context,
+              buffer: context.buffer.slice(1),
+              state: [...context.state, "--second"],
+              exec: makeExec("competing"),
+            },
+            consumed: ["--second"],
+          };
+        }
+        return {
+          success: false,
+          consumed: 0,
+          error: message`competing failed.`,
+        };
+      },
+      "competing",
+      tokenParserMetadata("--second"),
+    );
+    const parser = or(toAsyncParser(activeSync), toAsyncParser(competingSync));
+    const exec = makeExec("root");
+    const first = await parser.parse({
+      buffer: ["--first"],
+      state: parser.initialState,
+      optionsTerminated: false,
+      usage: parser.usage,
+      exec,
+    });
+    assert.ok(first.success);
+    if (!first.success) return;
+
+    const second = await parser.parse({
+      buffer: ["--second"],
+      state: first.next.state,
+      optionsTerminated: false,
+      usage: parser.usage,
+      exec,
+    });
+
+    assert.ok(second.success);
+    if (second.success) {
+      assert.equal(second.provisional, true);
+      assert.deepEqual(second.consumed, ["--second"]);
+      const [, stored] = second.next.state as [
+        number,
+        ParserResult<readonly string[]>,
+      ];
+      assert.ok(stored.success);
+      if (stored.success) {
+        assert.deepEqual(stored.next.state, ["--first", "--second"]);
+      }
+    }
+  });
+
+  it("delegates sync suggestions to the active consuming branch", () => {
+    const first = createSyncBranchParser(
+      "first-initial",
+      (context) =>
+        context.buffer[0] === "--first"
+          ? {
+            success: true,
+            next: {
+              ...context,
+              buffer: context.buffer.slice(1),
+              state: "first-active",
+            },
+            consumed: ["--first"],
+          }
+          : {
+            success: false,
+            consumed: 0,
+            error: message`first failed.`,
+          },
+      "first",
+      tokenParserMetadata("--first"),
+    );
+    const second = createSyncBranchParser(
+      "second-initial",
+      (context) =>
+        context.buffer[0] === "--second"
+          ? {
+            success: true,
+            next: {
+              ...context,
+              buffer: context.buffer.slice(1),
+              state: "second-active",
+            },
+            consumed: ["--second"],
+          }
+          : {
+            success: false,
+            consumed: 0,
+            error: message`second failed.`,
+          },
+      "second",
+      tokenParserMetadata("--second"),
+    );
+    const firstSuggestions: Suggestion[] = [
+      { kind: "literal", text: "--first-only" },
+    ];
+    const secondSuggestions: Suggestion[] = [
+      { kind: "literal", text: "--second-only" },
+    ];
+    Object.defineProperty(first, "suggest", {
+      value: function* () {
+        yield* firstSuggestions;
+      },
+    });
+    Object.defineProperty(second, "suggest", {
+      value: function* () {
+        yield* secondSuggestions;
+      },
+    });
+    const parser = or(first, second);
+    const parsed = parser.parse({
+      buffer: ["--first"],
+      state: parser.initialState,
+      optionsTerminated: false,
+      usage: parser.usage,
+    });
+    assert.ok(parsed.success);
+    if (!parsed.success) return;
+
+    const suggestions = [
+      ...parser.suggest(
+        {
+          buffer: [],
+          state: parsed.next.state,
+          optionsTerminated: false,
+          usage: parser.usage,
+        },
+        "--",
+      ),
+    ];
+
+    assert.deepEqual(suggestions, firstSuggestions);
+  });
+
+  it("delegates async suggestions to the active consuming branch", async () => {
+    const firstSync = createSyncBranchParser(
+      "first-initial",
+      (context) =>
+        context.buffer[0] === "--first"
+          ? {
+            success: true,
+            next: {
+              ...context,
+              buffer: context.buffer.slice(1),
+              state: "first-active",
+            },
+            consumed: ["--first"],
+          }
+          : {
+            success: false,
+            consumed: 0,
+            error: message`first failed.`,
+          },
+      "first",
+      tokenParserMetadata("--first"),
+    );
+    const secondSync = createSyncBranchParser(
+      "second-initial",
+      (context) =>
+        context.buffer[0] === "--second"
+          ? {
+            success: true,
+            next: {
+              ...context,
+              buffer: context.buffer.slice(1),
+              state: "second-active",
+            },
+            consumed: ["--second"],
+          }
+          : {
+            success: false,
+            consumed: 0,
+            error: message`second failed.`,
+          },
+      "second",
+      tokenParserMetadata("--second"),
+    );
+    const first = toAsyncParser(firstSync);
+    const second = toAsyncParser(secondSync);
+    const firstSuggestions: Suggestion[] = [
+      { kind: "literal", text: "--first-only" },
+    ];
+    const secondSuggestions: Suggestion[] = [
+      { kind: "literal", text: "--second-only" },
+    ];
+    Object.defineProperty(first, "suggest", {
+      async *value() {
+        yield* firstSuggestions;
+      },
+    });
+    Object.defineProperty(second, "suggest", {
+      async *value() {
+        yield* secondSuggestions;
+      },
+    });
+    const parser = or(first, second);
+    const parsed = await parser.parse({
+      buffer: ["--first"],
+      state: parser.initialState,
+      optionsTerminated: false,
+      usage: parser.usage,
+    });
+    assert.ok(parsed.success);
+    if (!parsed.success) return;
+
+    const suggestions: Suggestion[] = [];
+    for await (
+      const suggestion of parser.suggest(
+        {
+          buffer: [],
+          state: parsed.next.state,
+          optionsTerminated: false,
+          usage: parser.usage,
+        },
+        "--",
+      )
+    ) {
+      suggestions.push(suggestion);
+    }
+
+    assert.deepEqual(suggestions, firstSuggestions);
   });
 });
 
@@ -13264,6 +13624,71 @@ describe("branch coverage: constructs.ts edge cases", () => {
     assert.ok(allEntries.length >= 2);
   });
 
+  it("tuple() normalizeValue normalizes changed elements only", () => {
+    const parser = tupleLocal(
+      [
+        optionLocal("--host", domain({ lowercase: true })),
+        optionLocal("--port", integer()),
+      ] as const,
+    );
+    assert.ok(typeof parser.normalizeValue === "function");
+
+    const unchanged = ["example.com", 443] as const;
+    assert.equal(parser.normalizeValue(unchanged), unchanged);
+    assert.deepEqual(parser.normalizeValue(["EXAMPLE.COM", 443]), [
+      "example.com",
+      443,
+    ]);
+    assert.deepEqual(parser.normalizeValue(["not a domain", 443]), [
+      "not a domain",
+      443,
+    ]);
+    assert.equal(parser.normalizeValue("not-array" as never), "not-array");
+  });
+
+  it("tuple() normalizeValue preserves elements whose normalizer throws", () => {
+    const throwingParser: Parser<"sync", string, undefined> = {
+      mode: "sync",
+      $valueType: [] as readonly string[],
+      $stateType: [] as readonly undefined[],
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(),
+      acceptingAnyToken: false,
+      initialState: undefined,
+      parse(context) {
+        return {
+          success: true as const,
+          next: context,
+          consumed: [],
+        };
+      },
+      complete() {
+        return { success: true as const, value: "fallback" };
+      },
+      *suggest() {},
+      getDocFragments() {
+        return { fragments: [] };
+      },
+    };
+    Object.defineProperty(throwingParser, "normalizeValue", {
+      value() {
+        throw new Error("normalization failed.");
+      },
+    });
+    const parser = tupleLocal(
+      [
+        optionLocal("--host", domain({ lowercase: true })),
+        throwingParser,
+      ] as const,
+    );
+
+    assert.deepEqual(parser.normalizeValue!(["EXAMPLE.COM", "keep"]), [
+      "example.com",
+      "keep",
+    ]);
+  });
+
   // ----- merge() extractParserState: object initialState fields (lines 5188-5195) -----
   it("merge() extractParserState extracts matching fields from context state", () => {
     const p1 = object({
@@ -14613,6 +15038,38 @@ describe("branch coverage: constructs.ts edge cases", () => {
         };
       }
 
+      function createSyncFailingCompleteParser(
+        error: Message,
+      ): Parser<"sync", unknown, undefined> {
+        return {
+          mode: "sync",
+          $valueType: [] as readonly unknown[],
+          $stateType: [] as readonly undefined[],
+          priority: 0,
+          usage: [],
+          leadingNames: new Set(),
+          acceptingAnyToken: false,
+          initialState: undefined,
+          parse(context) {
+            return {
+              success: true as const,
+              next: context,
+              consumed: [],
+            };
+          },
+          complete() {
+            return {
+              success: false as const,
+              error,
+            };
+          },
+          *suggest() {},
+          getDocFragments() {
+            return { fragments: [] };
+          },
+        };
+      }
+
       function createAsyncDeferredCompleteParser(
         value: unknown,
         deferredKeys?: DeferredMap,
@@ -14621,6 +15078,34 @@ describe("branch coverage: constructs.ts edge cases", () => {
           value,
           deferredKeys,
         );
+        return {
+          mode: "async",
+          $valueType: [] as readonly unknown[],
+          $stateType: [] as readonly undefined[],
+          priority: 0,
+          usage: [],
+          leadingNames: new Set(),
+          acceptingAnyToken: false,
+          initialState: undefined,
+          parse(context) {
+            return Promise.resolve(syncParser.parse(context));
+          },
+          complete(state, exec) {
+            return Promise.resolve(syncParser.complete(state, exec));
+          },
+          async *suggest(context, prefix) {
+            yield* syncParser.suggest(context, prefix);
+          },
+          getDocFragments() {
+            return { fragments: [] };
+          },
+        };
+      }
+
+      function createAsyncFailingCompleteParser(
+        error: Message,
+      ): Parser<"async", unknown, undefined> {
+        const syncParser = createSyncFailingCompleteParser(error);
         return {
           mode: "async",
           $valueType: [] as readonly unknown[],
@@ -14848,6 +15333,38 @@ describe("branch coverage: constructs.ts edge cases", () => {
         assert.equal(getCallCount(), 1);
       });
 
+      it("merge() complete clears stale deferred keys for overwritten fields", () => {
+        const parser = mergeLocal(
+          objectLocal({
+            value: createSyncDeferredCompleteParser(""),
+          }),
+          objectLocal({
+            value: constant("resolved"),
+          }),
+        );
+
+        assert.deepEqual(parser.complete(parser.initialState), {
+          success: true,
+          value: { value: "resolved" },
+        });
+      });
+
+      it("merge() async complete clears stale deferred keys for overwritten fields", async () => {
+        const parser = mergeLocal(
+          objectLocal({
+            value: createAsyncDeferredCompleteParser(""),
+          }),
+          objectLocal({
+            value: toAsyncParser(constant("resolved")),
+          }),
+        );
+
+        assert.deepEqual(await parser.complete(parser.initialState), {
+          success: true,
+          value: { value: "resolved" },
+        });
+      });
+
       it("merge() extracts sync seeds across child boundaries", () => {
         const { parser: modeParser, getCallCount } =
           createCountingSourceParser();
@@ -14914,6 +15431,42 @@ describe("branch coverage: constructs.ts edge cases", () => {
           ]),
         );
         assert.equal(getCallCount(), 1);
+      });
+
+      it("merge() sync seed clears stale deferred keys for overwritten fields", () => {
+        const parser = mergeLocal(
+          objectLocal({
+            value: createSyncDeferredCompleteParser(""),
+          }),
+          objectLocal({
+            value: constant("resolved"),
+          }),
+        );
+
+        assert.deepEqual(
+          getLocalPhase2SeedExtractor(parser)(parser.initialState),
+          {
+            value: { value: "resolved" },
+          },
+        );
+      });
+
+      it("merge() async seed clears stale deferred keys for overwritten fields", async () => {
+        const parser = mergeLocal(
+          objectLocal({
+            value: createAsyncDeferredCompleteParser(""),
+          }),
+          objectLocal({
+            value: toAsyncParser(constant("resolved")),
+          }),
+        );
+
+        assert.deepEqual(
+          await getLocalPhase2SeedExtractor(parser)(parser.initialState),
+          {
+            value: { value: "resolved" },
+          },
+        );
       });
 
       it("merge() returns no phase-two seed when no child can complete", () => {
@@ -15017,6 +15570,305 @@ describe("branch coverage: constructs.ts edge cases", () => {
           value: ["cfg", { mode: "alpha" }],
         });
         assert.equal(getCallCount(), 1);
+      });
+
+      it("conditional() sync complete replays a deferred discriminator branch", () => {
+        const parser = conditionalLocal(constant("cfg"), {
+          cfg: createSyncDeferredCompleteParser(""),
+        });
+
+        assertDeferredComposite(
+          parser.complete(parser.initialState),
+          ["cfg", ""],
+          new Map<PropertyKey, DeferredMap | null>([[1, null]]),
+        );
+      });
+
+      it("conditional() sync complete remaps nested deferred branch keys", () => {
+        const parser = conditionalLocal(constant("cfg"), {
+          cfg: createSyncDeferredCompleteParser(
+            { inner: "", stable: "kept" },
+            nestedDeferredKeys,
+          ),
+        });
+
+        assertDeferredComposite(
+          parser.complete(parser.initialState),
+          ["cfg", { inner: "", stable: "kept" }],
+          new Map<PropertyKey, DeferredMap | null>([[1, nestedDeferredKeys]]),
+        );
+      });
+
+      it("conditional() async complete replays a deferred discriminator branch", async () => {
+        const parser = conditionalLocal(toAsyncParser(constant("cfg")), {
+          cfg: createAsyncDeferredCompleteParser(""),
+        });
+
+        assertDeferredComposite(
+          await parser.complete(parser.initialState),
+          ["cfg", ""],
+          new Map<PropertyKey, DeferredMap | null>([[1, null]]),
+        );
+      });
+
+      it("conditional() async complete remaps nested deferred branch keys", async () => {
+        const parser = conditionalLocal(toAsyncParser(constant("cfg")), {
+          cfg: createAsyncDeferredCompleteParser(
+            { inner: "", stable: "kept" },
+            nestedDeferredKeys,
+          ),
+        });
+
+        assertDeferredComposite(
+          await parser.complete(parser.initialState),
+          ["cfg", { inner: "", stable: "kept" }],
+          new Map<PropertyKey, DeferredMap | null>([[1, nestedDeferredKeys]]),
+        );
+      });
+
+      it("conditional() sync complete reports deferred branch errors", () => {
+        const parser = conditionalLocal(
+          constant("cfg"),
+          {
+            cfg: createSyncFailingCompleteParser(message`branch failed`),
+          },
+          constant(null),
+          {
+            errors: {
+              branchError: (key, error) =>
+                message`branch ${text(key ?? "?")} failed: ${
+                  text(formatMessage(error))
+                }`,
+            },
+          },
+        );
+
+        const result = parser.complete(parser.initialState);
+
+        assert.ok(!result.success);
+        if (!result.success) {
+          assert.equal(
+            formatMessage(result.error),
+            "branch cfg failed: branch failed",
+          );
+        }
+      });
+
+      it("conditional() async complete reports deferred branch errors", async () => {
+        const parser = conditionalLocal(
+          toAsyncParser(constant("cfg")),
+          {
+            cfg: createAsyncFailingCompleteParser(message`branch failed`),
+          },
+          toAsyncParser(constant(null)),
+          {
+            errors: {
+              branchError: (key, error) =>
+                message`branch ${text(key ?? "?")} failed: ${
+                  text(formatMessage(error))
+                }`,
+            },
+          },
+        );
+
+        const result = await parser.complete(parser.initialState);
+
+        assert.ok(!result.success);
+        if (!result.success) {
+          assert.equal(
+            formatMessage(result.error),
+            "branch cfg failed: branch failed",
+          );
+        }
+      });
+
+      it("conditional() sync complete fails when discriminator selects no branch", () => {
+        const parser = conditionalLocal(constant("missing"), {
+          cfg: constant("ok"),
+        });
+
+        const result = parser.complete(parser.initialState);
+
+        assert.ok(!result.success);
+        if (!result.success) {
+          assert.equal(formatMessage(result.error), "No value provided.");
+        }
+      });
+
+      it("conditional() async complete fails when discriminator selects no branch", async () => {
+        const parser = conditionalLocal(toAsyncParser(constant("missing")), {
+          cfg: toAsyncParser(constant("ok")),
+        });
+
+        const result = await parser.complete(parser.initialState);
+
+        assert.ok(!result.success);
+        if (!result.success) {
+          assert.equal(formatMessage(result.error), "No value provided.");
+        }
+      });
+
+      it("conditional() sync complete surfaces deferred discriminator errors", () => {
+        const parser = conditionalLocal(fail<string>(), {
+          cfg: constant("ok"),
+        });
+
+        const result = parser.complete(parser.initialState);
+
+        assert.ok(!result.success);
+        if (!result.success) {
+          assert.equal(formatMessage(result.error), "No value provided.");
+        }
+      });
+
+      it("conditional() async complete surfaces deferred discriminator errors", async () => {
+        const parser = conditionalLocal(
+          toAsyncParser(fail<string>()),
+          {
+            cfg: toAsyncParser(constant("ok")),
+          },
+        );
+
+        const result = await parser.complete(parser.initialState);
+
+        assert.ok(!result.success);
+        if (!result.success) {
+          assert.equal(formatMessage(result.error), "No value provided.");
+        }
+      });
+
+      it("conditional() sync complete uses a deferred default branch", () => {
+        const parser = conditionalLocal(
+          fail<string>(),
+          { cfg: optionLocal("--config", string()) },
+          createSyncDeferredCompleteParser(""),
+        );
+
+        assertDeferredComposite(
+          parser.complete(parser.initialState),
+          [undefined, ""],
+          new Map<PropertyKey, DeferredMap | null>([[1, null]]),
+        );
+      });
+
+      it("conditional() sync complete remaps nested deferred default keys", () => {
+        const parser = conditionalLocal(
+          fail<string>(),
+          { cfg: optionLocal("--config", string()) },
+          createSyncDeferredCompleteParser(
+            { inner: "", stable: "kept" },
+            nestedDeferredKeys,
+          ),
+        );
+
+        assertDeferredComposite(
+          parser.complete(parser.initialState),
+          [undefined, { inner: "", stable: "kept" }],
+          new Map<PropertyKey, DeferredMap | null>([[1, nestedDeferredKeys]]),
+        );
+      });
+
+      it("conditional() async complete uses a deferred default branch", async () => {
+        const parser = conditionalLocal(
+          toAsyncParser(fail<string>()),
+          { cfg: optionLocal("--config", string()) },
+          createAsyncDeferredCompleteParser(""),
+        );
+
+        assertDeferredComposite(
+          await parser.complete(parser.initialState),
+          [undefined, ""],
+          new Map<PropertyKey, DeferredMap | null>([[1, null]]),
+        );
+      });
+
+      it("conditional() async complete remaps nested deferred default keys", async () => {
+        const parser = conditionalLocal(
+          toAsyncParser(fail<string>()),
+          { cfg: optionLocal("--config", string()) },
+          createAsyncDeferredCompleteParser(
+            { inner: "", stable: "kept" },
+            nestedDeferredKeys,
+          ),
+        );
+
+        assertDeferredComposite(
+          await parser.complete(parser.initialState),
+          [undefined, { inner: "", stable: "kept" }],
+          new Map<PropertyKey, DeferredMap | null>([[1, nestedDeferredKeys]]),
+        );
+      });
+
+      it("conditional() sync complete wraps selected branch errors", () => {
+        const parser = conditionalLocal(
+          optionLocal("--mode", choice(["cfg"])),
+          {
+            cfg: createSyncFailingCompleteParser(message`branch failed`),
+          },
+          constant(null),
+          {
+            errors: {
+              branchError: (key, error) =>
+                message`selected ${text(key ?? "?")}: ${
+                  text(formatMessage(error))
+                }`,
+            },
+          },
+        );
+        const parsed = parser.parse({
+          buffer: ["--mode", "cfg"],
+          state: parser.initialState,
+          optionsTerminated: false,
+          usage: parser.usage,
+        });
+        assert.ok(parsed.success);
+        if (!parsed.success) return;
+
+        const result = parser.complete(parsed.next.state);
+
+        assert.ok(!result.success);
+        if (!result.success) {
+          assert.equal(
+            formatMessage(result.error),
+            "selected cfg: branch failed",
+          );
+        }
+      });
+
+      it("conditional() async complete wraps selected branch errors", async () => {
+        const parser = conditionalLocal(
+          toAsyncParser(optionLocal("--mode", choice(["cfg"]))),
+          {
+            cfg: createAsyncFailingCompleteParser(message`branch failed`),
+          },
+          toAsyncParser(constant(null)),
+          {
+            errors: {
+              branchError: (key, error) =>
+                message`selected ${text(key ?? "?")}: ${
+                  text(formatMessage(error))
+                }`,
+            },
+          },
+        );
+        const parsed = await parser.parse({
+          buffer: ["--mode", "cfg"],
+          state: parser.initialState,
+          optionsTerminated: false,
+          usage: parser.usage,
+        });
+        assert.ok(parsed.success);
+        if (!parsed.success) return;
+
+        const result = await parser.complete(parsed.next.state);
+
+        assert.ok(!result.success);
+        if (!result.success) {
+          assert.equal(
+            formatMessage(result.error),
+            "selected cfg: branch failed",
+          );
+        }
       });
 
       it("object() seeds child completion with a fallback exec", () => {
@@ -15297,6 +16149,170 @@ describe("branch coverage: constructs.ts edge cases", () => {
         );
       });
 
+      it("concat() complete remaps deferred tuple element metadata", () => {
+        const parser = concatLocal(
+          tupleLocal(
+            [
+              createSyncDeferredCompleteParser(""),
+              createSyncDeferredCompleteParser(
+                { inner: "", stable: "kept" },
+                nestedDeferredKeys,
+              ),
+            ] as const,
+          ),
+          tupleLocal(
+            [
+              createSyncDeferredCompleteParser({ ready: false }),
+            ] as const,
+          ),
+        );
+
+        assertDeferredComposite(
+          parser.complete(parser.initialState),
+          ["", { inner: "", stable: "kept" }, { ready: false }],
+          new Map<PropertyKey, DeferredMap | null>([
+            [0, null],
+            [1, nestedDeferredKeys],
+          ]),
+        );
+      });
+
+      it("concat() async complete remaps deferred tuple element metadata", async () => {
+        const parser = concatLocal(
+          tupleLocal(
+            [
+              createAsyncDeferredCompleteParser(""),
+              createAsyncDeferredCompleteParser(
+                { inner: "", stable: "kept" },
+                nestedDeferredKeys,
+              ),
+            ] as const,
+          ),
+          tupleLocal(
+            [
+              createAsyncDeferredCompleteParser({ ready: false }),
+            ] as const,
+          ),
+        );
+
+        assertDeferredComposite(
+          await parser.complete(parser.initialState),
+          ["", { inner: "", stable: "kept" }, { ready: false }],
+          new Map<PropertyKey, DeferredMap | null>([
+            [0, null],
+            [1, nestedDeferredKeys],
+          ]),
+        );
+      });
+
+      it("concat() phase-two seed remaps deferred tuple element metadata", () => {
+        const parser = concatLocal(
+          tupleLocal(
+            [
+              createSyncDeferredCompleteParser(""),
+              createSyncDeferredCompleteParser(
+                { inner: "", stable: "kept" },
+                nestedDeferredKeys,
+              ),
+            ] as const,
+          ),
+          tupleLocal(
+            [
+              createSyncDeferredCompleteParser({ ready: false }),
+            ] as const,
+          ),
+        );
+
+        assertDeferredComposite(
+          getLocalPhase2SeedExtractor(parser)(parser.initialState),
+          ["", { inner: "", stable: "kept" }, { ready: false }],
+          new Map<PropertyKey, DeferredMap | null>([
+            [0, null],
+            [1, nestedDeferredKeys],
+          ]),
+        );
+      });
+
+      it("concat() async phase-two seed remaps deferred tuple element metadata", async () => {
+        const parser = concatLocal(
+          tupleLocal(
+            [
+              createAsyncDeferredCompleteParser(""),
+              createAsyncDeferredCompleteParser(
+                { inner: "", stable: "kept" },
+                nestedDeferredKeys,
+              ),
+            ] as const,
+          ),
+          tupleLocal(
+            [
+              createAsyncDeferredCompleteParser({ ready: false }),
+            ] as const,
+          ),
+        );
+
+        assertDeferredComposite(
+          await getLocalPhase2SeedExtractor(parser)(parser.initialState),
+          ["", { inner: "", stable: "kept" }, { ready: false }],
+          new Map<PropertyKey, DeferredMap | null>([
+            [0, null],
+            [1, nestedDeferredKeys],
+          ]),
+        );
+      });
+
+      it("concat() complete preserves opaque deferred scalar children", () => {
+        const parser = concatLocal(
+          createSyncDeferredCompleteParser({ ready: false }) as never,
+          createSyncDeferredCompleteParser("tail") as never,
+        );
+
+        assertDeferredComposite(
+          parser.complete(parser.initialState),
+          [{ ready: false }, "tail"],
+          new Map<PropertyKey, DeferredMap | null>([[1, null]]),
+        );
+      });
+
+      it("concat() async complete preserves opaque deferred scalar children", async () => {
+        const parser = concatLocal(
+          createAsyncDeferredCompleteParser({ ready: false }) as never,
+          createAsyncDeferredCompleteParser("tail") as never,
+        );
+
+        assertDeferredComposite(
+          await parser.complete(parser.initialState),
+          [{ ready: false }, "tail"],
+          new Map<PropertyKey, DeferredMap | null>([[1, null]]),
+        );
+      });
+
+      it("concat() phase-two seed preserves opaque deferred scalar children", () => {
+        const parser = concatLocal(
+          createSyncDeferredCompleteParser({ ready: false }) as never,
+          createSyncDeferredCompleteParser("tail") as never,
+        );
+
+        assertDeferredComposite(
+          getLocalPhase2SeedExtractor(parser)(parser.initialState),
+          [{ ready: false }, "tail"],
+          new Map<PropertyKey, DeferredMap | null>([[1, null]]),
+        );
+      });
+
+      it("concat() async phase-two seed preserves opaque deferred scalar children", async () => {
+        const parser = concatLocal(
+          createAsyncDeferredCompleteParser({ ready: false }) as never,
+          createAsyncDeferredCompleteParser("tail") as never,
+        );
+
+        assertDeferredComposite(
+          await getLocalPhase2SeedExtractor(parser)(parser.initialState),
+          [{ ready: false }, "tail"],
+          new Map<PropertyKey, DeferredMap | null>([[1, null]]),
+        );
+      });
+
       for (
         const [name, buildExclusive] of [
           [
@@ -15369,6 +16385,102 @@ describe("branch coverage: constructs.ts edge cases", () => {
           });
         });
       }
+
+      for (
+        const [name, buildExclusive] of [
+          [
+            "or()",
+            (
+              seedableParser: Parser<
+                "async",
+                string,
+                { readonly ready: boolean }
+              >,
+            ) => orLocal(seedableParser, optionLocal("--required", string())),
+          ],
+          [
+            "longestMatch()",
+            (
+              seedableParser: Parser<
+                "async",
+                string,
+                { readonly ready: boolean }
+              >,
+            ) =>
+              longestMatchLocal(
+                seedableParser,
+                optionLocal("--required", string()),
+              ),
+          ],
+        ] as const
+      ) {
+        it(`${name} extracts async seeds from a unique zero-input branch`, async () => {
+          const seedableParser: Parser<"async", string, { ready: boolean }> = {
+            mode: "async",
+            $valueType: [] as readonly string[],
+            $stateType: [] as readonly { ready: boolean }[],
+            priority: 0,
+            usage: [],
+            leadingNames: new Set(),
+            acceptingAnyToken: false,
+            initialState: { ready: false },
+            parse(context) {
+              return Promise.resolve({
+                success: true as const,
+                next: {
+                  ...context,
+                  state: { ready: true },
+                },
+                consumed: [],
+              });
+            },
+            complete() {
+              return Promise.resolve({
+                success: false as const,
+                error: message`Missing seeded value.`,
+              });
+            },
+            async *suggest() {},
+            getDocFragments() {
+              return { fragments: [] };
+            },
+          };
+          Object.defineProperty(seedableParser, extractPhase2SeedKey, {
+            value: (state: { ready: boolean }) =>
+              Promise.resolve(state.ready ? { value: "seed" } : null),
+          });
+
+          const parser = buildExclusive(seedableParser);
+          const seed = await getLocalPhase2SeedExtractor(parser)(
+            parser.initialState,
+          );
+
+          assert.deepEqual(seed, {
+            value: "seed",
+          });
+        });
+      }
+
+      it("or() does not extract a seed from ambiguous zero-input branches", () => {
+        const parser = orLocal(constant("left"), constant("right"));
+
+        const seed = getLocalPhase2SeedExtractor(parser)(parser.initialState);
+
+        assert.equal(seed, null);
+      });
+
+      it("or() does not extract an async seed from ambiguous zero-input branches", async () => {
+        const parser = orLocal(
+          toAsyncParser(constant("left")),
+          toAsyncParser(constant("right")),
+        );
+
+        const seed = await getLocalPhase2SeedExtractor(parser)(
+          parser.initialState,
+        );
+
+        assert.equal(seed, null);
+      });
 
       it(
         "conditional() extracts sync completion-only seeds from the default branch",

--- a/packages/core/src/constructs.test.ts
+++ b/packages/core/src/constructs.test.ts
@@ -175,6 +175,27 @@ function describeDuplicateSourceState(
     : "missing-source";
 }
 
+function createSyncBranchParser<TState>(
+  initialState: TState,
+  parse: (context: ParserContext<TState>) => ParserResult<TState>,
+  value: string,
+): Parser<"sync", string, TState> {
+  return {
+    $valueType: [] as readonly string[],
+    $stateType: [] as readonly TState[],
+    mode: "sync",
+    priority: 0,
+    usage: [],
+    leadingNames: new Set(),
+    acceptingAnyToken: false,
+    initialState,
+    parse,
+    complete: () => ({ success: true, value }),
+    suggest: function* () {},
+    getDocFragments: () => ({ fragments: [] }),
+  };
+}
+
 describe("or", () => {
   it("should throw TypeError when called with no parsers", () => {
     assert.throws(
@@ -1428,6 +1449,259 @@ describe("or() - duplicate option handling", () => {
     assert.equal(result.success, false);
     if (!result.success) {
       assert.equal(formatMessage(result.error), "replayed failed.");
+    }
+  });
+
+  it("should switch sync branch after a zero-consumed fallback", () => {
+    const parser = or(constant("fallback"), option("--name", string()));
+    const firstPass = parser.parse({
+      buffer: [],
+      state: parser.initialState,
+      optionsTerminated: false,
+      usage: parser.usage,
+    });
+    assert.ok(firstPass.success);
+
+    const secondPass = parser.parse({
+      buffer: ["--name", "demo"],
+      state: firstPass.next.state,
+      optionsTerminated: false,
+      usage: parser.usage,
+    });
+    assert.ok(secondPass.success);
+    if (secondPass.success) {
+      assert.deepEqual(secondPass.consumed, ["--name", "demo"]);
+    }
+  });
+
+  it("should return replayed sync failure after shared-branch switch", () => {
+    const parserA = createSyncBranchParser(
+      "a-initial",
+      (context) => {
+        if (context.buffer[0] === "--shared") {
+          return {
+            success: true,
+            next: {
+              ...context,
+              buffer: context.buffer.slice(1),
+              state: "a-consumed",
+            },
+            consumed: ["--shared"],
+          };
+        }
+        return {
+          success: false,
+          consumed: 0,
+          error: message`a failed.`,
+        };
+      },
+      "a",
+    );
+    const parserB = createSyncBranchParser(
+      "b-initial",
+      (context) => {
+        if (
+          context.buffer[0] === "--shared" && context.state === "b-initial"
+        ) {
+          return {
+            success: true,
+            next: {
+              ...context,
+              buffer: context.buffer.slice(1),
+              state: "b-checked",
+            },
+            consumed: ["--shared"],
+          };
+        }
+        if (context.buffer[0] === "--b" && context.state === "b-initial") {
+          return {
+            success: true,
+            next: {
+              ...context,
+              buffer: context.buffer.slice(1),
+              state: "b-first-pass",
+            },
+            consumed: ["--b"],
+          };
+        }
+        if (context.buffer[0] === "--b" && context.state === "b-checked") {
+          return {
+            success: false,
+            consumed: 1,
+            error: message`replayed failed.`,
+          };
+        }
+        return {
+          success: false,
+          consumed: 0,
+          error: message`b failed.`,
+        };
+      },
+      "b",
+    );
+    const parser = or(parserA, parserB);
+
+    const first = parser.parse({
+      buffer: ["--shared"],
+      state: parser.initialState,
+      optionsTerminated: false,
+      usage: parser.usage,
+    });
+    assert.ok(first.success);
+    if (!first.success) return;
+
+    const result = parser.parse({
+      buffer: ["--b"],
+      state: first.next.state,
+      optionsTerminated: false,
+      usage: parser.usage,
+    });
+
+    assert.equal(result.success, false);
+    if (!result.success) {
+      assert.equal(formatMessage(result.error), "replayed failed.");
+    }
+  });
+
+  it("should use a sync provisional branch only when no definitive branch consumes", () => {
+    const provisional = createSyncBranchParser(
+      undefined,
+      (context) => {
+        if (context.buffer[0] === "--draft") {
+          return {
+            success: true,
+            provisional: true,
+            next: {
+              ...context,
+              buffer: context.buffer.slice(1),
+              state: undefined,
+            },
+            consumed: ["--draft"],
+          };
+        }
+        return {
+          success: false,
+          consumed: 0,
+          error: message`draft failed.`,
+        };
+      },
+      "draft",
+    );
+    const parser = or(provisional, option("--real", string()));
+
+    const result = parser.parse({
+      buffer: ["--draft"],
+      state: parser.initialState,
+      optionsTerminated: false,
+      usage: parser.usage,
+    });
+
+    assert.ok(result.success);
+    if (result.success) {
+      assert.equal(result.provisional, true);
+      assert.deepEqual(result.consumed, ["--draft"]);
+    }
+  });
+
+  it("should replay a sync provisional branch that shares active input", () => {
+    const active = createSyncBranchParser(
+      "active-initial",
+      (context) => {
+        if (context.buffer[0] === "--shared") {
+          return {
+            success: true,
+            next: {
+              ...context,
+              buffer: context.buffer.slice(1),
+              state: "active-consumed",
+            },
+            consumed: ["--shared"],
+          };
+        }
+        return {
+          success: false,
+          consumed: 0,
+          error: message`active failed.`,
+        };
+      },
+      "active",
+    );
+    const provisional = createSyncBranchParser(
+      "provisional-initial",
+      (context) => {
+        if (
+          context.buffer[0] === "--shared" &&
+          context.state === "provisional-initial"
+        ) {
+          return {
+            success: true,
+            next: {
+              ...context,
+              buffer: context.buffer.slice(1),
+              state: "provisional-checked",
+            },
+            consumed: ["--shared"],
+          };
+        }
+        if (
+          context.buffer[0] === "--next" &&
+          context.state === "provisional-initial"
+        ) {
+          return {
+            success: true,
+            provisional: true,
+            next: {
+              ...context,
+              buffer: context.buffer.slice(1),
+              state: "provisional-first-pass",
+            },
+            consumed: ["--next"],
+          };
+        }
+        if (
+          context.buffer[0] === "--next" &&
+          context.state === "provisional-checked"
+        ) {
+          return {
+            success: true,
+            next: {
+              ...context,
+              buffer: context.buffer.slice(1),
+              state: "provisional-replayed",
+            },
+            consumed: ["--next"],
+          };
+        }
+        return {
+          success: false,
+          consumed: 0,
+          error: message`provisional failed.`,
+        };
+      },
+      "provisional",
+    );
+    const parser = or(active, provisional);
+
+    const first = parser.parse({
+      buffer: ["--shared"],
+      state: parser.initialState,
+      optionsTerminated: false,
+      usage: parser.usage,
+    });
+    assert.ok(first.success);
+    if (!first.success) return;
+
+    const result = parser.parse({
+      buffer: ["--next"],
+      state: first.next.state,
+      optionsTerminated: false,
+      usage: parser.usage,
+    });
+
+    assert.ok(result.success);
+    if (result.success) {
+      assert.equal(result.provisional, true);
+      assert.deepEqual(result.consumed, ["--next"]);
     }
   });
 });

--- a/packages/core/src/constructs.test.ts
+++ b/packages/core/src/constructs.test.ts
@@ -1231,6 +1231,135 @@ describe("or", () => {
 });
 
 describe("or() inside object() — zero-input complete path", () => {
+  it("complete treats malformed exclusive state as unselected", () => {
+    const parser = or(constant("default"), option("--mode", string()));
+
+    const result = parser.complete(
+      { selected: "not-an-exclusive-state" } as never,
+    );
+
+    assert.ok(result.success);
+    if (result.success) {
+      assert.equal(result.value, "default");
+    }
+  });
+
+  it("complete returns the selected branch failure from explicit state", () => {
+    const parser = or(option("--left", string()), option("--right", string()));
+
+    const result = parser.complete([
+      0,
+      {
+        success: false as const,
+        consumed: 1,
+        error: message`left failed.`,
+      },
+    ]);
+
+    assert.ok(!result.success);
+    if (!result.success) {
+      assert.deepEqual(result.error, message`left failed.`);
+    }
+  });
+
+  it("suggest treats malformed and zero-consumed state as provisional", () => {
+    const parser = or(option("--alpha", string()), option("--beta", string()));
+    const baseContext = {
+      buffer: [],
+      optionsTerminated: false,
+      usage: parser.usage,
+      state: { selected: "not-an-exclusive-state" },
+    };
+
+    assert.deepEqual([...parser.suggest(baseContext as never, "--")], [
+      { kind: "literal", text: "--alpha" },
+      { kind: "literal", text: "--beta" },
+    ]);
+
+    assert.deepEqual(
+      [
+        ...parser.suggest({
+          ...baseContext,
+          state: [
+            0,
+            {
+              success: true as const,
+              next: {
+                ...baseContext,
+                state: undefined,
+              },
+              consumed: [],
+            },
+          ],
+        }, "--"),
+      ],
+      [
+        { kind: "literal", text: "--alpha" },
+        { kind: "literal", text: "--beta" },
+      ],
+    );
+  });
+
+  it("async suggest treats malformed exclusive state as unselected", async () => {
+    const parser = or(
+      toAsyncParser(option("--alpha", string())),
+      option("--beta", string()),
+    );
+    const suggestions: Suggestion[] = [];
+
+    for await (
+      const suggestion of parser.suggest({
+        buffer: [],
+        optionsTerminated: false,
+        usage: parser.usage,
+        state: { selected: "not-an-exclusive-state" } as never,
+      }, "--")
+    ) {
+      suggestions.push(suggestion);
+    }
+
+    assert.deepEqual(suggestions, [
+      { kind: "literal", text: "--alpha" },
+      { kind: "literal", text: "--beta" },
+    ]);
+  });
+
+  it("getSuggestRuntimeNodes ignores invalid exclusive states", () => {
+    const parser = or(option("--left", string()), option("--right", string()));
+
+    assert.deepEqual(
+      parser.getSuggestRuntimeNodes?.({ selected: "bad" } as never, ["choice"]),
+      [],
+    );
+    assert.deepEqual(
+      parser.getSuggestRuntimeNodes?.([
+        0,
+        {
+          success: false as const,
+          consumed: 1,
+          error: message`left failed.`,
+        },
+      ], ["choice"]),
+      [],
+    );
+    assert.deepEqual(
+      parser.getSuggestRuntimeNodes?.([
+        3,
+        {
+          success: true as const,
+          next: {
+            buffer: [],
+            optionsTerminated: false,
+            usage: parser.usage,
+            state: undefined,
+          },
+          consumed: ["--left", "value"],
+        },
+      ] as never, ["choice"]),
+      [],
+    );
+  });
+
   it("completes a zero-consumed constant() branch when the field was never parsed", () => {
     // When or() is nested inside object(), its complete() is called with
     // state=undefined for fields that were never touched.  The zero-input

--- a/packages/core/src/constructs.test.ts
+++ b/packages/core/src/constructs.test.ts
@@ -9117,6 +9117,41 @@ describe("conditional", () => {
       assert.ok(!result.success);
     });
 
+    it("should preserve invalid discriminator errors instead of falling back", () => {
+      const parser = conditional(
+        option("--type", choice(["a", "b"])),
+        {
+          a: constant("A"),
+          b: constant("B"),
+        },
+        option("--default", string()),
+      );
+
+      const result = parseSync(parser, ["--type", "invalid"]);
+
+      assert.ok(!result.success);
+      if (!result.success) {
+        assert.match(formatMessage(result.error), /Expected one of/u);
+      }
+    });
+
+    it("should preserve default branch errors after it consumes input", () => {
+      const parser = conditional(
+        option("--type", choice(["a"])),
+        {
+          a: constant("A"),
+        },
+        option("--name", string()),
+      );
+
+      const result = parseSync(parser, ["--name"]);
+
+      assert.ok(!result.success);
+      if (!result.success) {
+        assert.match(formatMessage(result.error), /requires `STRING`/u);
+      }
+    });
+
     it("should use static noMatch error override", () => {
       const parser = conditional(
         option("--type", choice(["a"])),
@@ -11179,6 +11214,79 @@ describe("group() with command() - issue #116", () => {
     assert.ok(
       topSection.entries.some((e: DocEntry) =>
         e.term.type === "command" && e.term.name === "api"
+      ),
+    );
+  });
+});
+
+describe("group() hidden visibility", () => {
+  it("should apply hidden visibility recursively to usage terms", () => {
+    const parser = group(
+      "Hidden",
+      object({
+        maybe: optional(option("--maybe", string())),
+        files: multiple(argument(string({ metavar: "FILE" }))),
+        mode: or(
+          option("--json"),
+          command("status", object({ verbose: flag("--verbose") })),
+        ),
+        rest: passThrough(),
+      }),
+      { hidden: "doc" },
+    );
+
+    const leaves: Array<
+      | { readonly type: "argument"; readonly hidden?: unknown }
+      | { readonly type: "command"; readonly hidden?: unknown }
+      | { readonly type: "option"; readonly hidden?: unknown }
+      | { readonly type: "passthrough"; readonly hidden?: unknown }
+    > = [];
+    const visit = (usage: typeof parser.usage): void => {
+      for (const term of usage) {
+        if (term.type === "optional" || term.type === "multiple") {
+          visit(term.terms);
+        } else if (term.type === "exclusive") {
+          for (const branch of term.terms) visit(branch);
+        } else if (
+          term.type === "argument" || term.type === "command" ||
+          term.type === "option" || term.type === "passthrough"
+        ) {
+          leaves.push(term);
+        }
+      }
+    };
+
+    visit(parser.usage);
+
+    assert.ok(leaves.some((term) => term.type === "argument"));
+    assert.ok(leaves.some((term) => term.type === "command"));
+    assert.ok(leaves.some((term) => term.type === "option"));
+    assert.ok(leaves.some((term) => term.type === "passthrough"));
+    assert.ok(leaves.every((term) => term.hidden === "doc"));
+  });
+
+  it("should omit doc-hidden grouped entries from documentation", () => {
+    const parser = group(
+      "Hidden",
+      object({
+        quiet: flag("--quiet"),
+        mode: option("--mode", string()),
+      }),
+      { hidden: "doc" },
+    );
+
+    const doc = getDocPage(parser, []);
+
+    assert.ok(doc != null);
+    assert.ok(!doc.sections.some((section) => section.title === "Hidden"));
+    assert.ok(
+      !doc.sections.some((section) =>
+        section.entries.some((entry) =>
+          entry.term.type === "option" &&
+          entry.term.names.some((name) =>
+            name === "--mode" || name === "--quiet"
+          )
+        )
       ),
     );
   });
@@ -15976,6 +16084,39 @@ describe("branch coverage: constructs.ts edge cases", () => {
         assert.equal(getCallCount(), 1);
       });
 
+      it("concat() complete reuses direct sync source completions", () => {
+        const { parser: modeParser, getCallCount } =
+          createCountingSourceParser();
+        const parser = concatLocal(
+          modeParser as never,
+          constant("tail") as never,
+        );
+
+        const completed = parser.complete(parser.initialState);
+
+        assert.deepEqual(completed, {
+          success: true,
+          value: ["alpha", "tail"],
+        });
+        assert.equal(getCallCount(), 1);
+      });
+
+      it("concat() extracts direct sync source seeds", () => {
+        const { parser: modeParser, getCallCount } =
+          createCountingSourceParser();
+        const parser = concatLocal(
+          modeParser as never,
+          constant("tail") as never,
+        );
+
+        const seed = getLocalPhase2SeedExtractor(parser)(parser.initialState);
+
+        assert.deepEqual(seed, {
+          value: ["alpha", "tail"],
+        });
+        assert.equal(getCallCount(), 1);
+      });
+
       it("concat() extracts async seeds across child boundaries", async () => {
         const { parser: modeParser, getCallCount } =
           createCountingSourceParser();
@@ -15992,6 +16133,41 @@ describe("branch coverage: constructs.ts edge cases", () => {
 
         assert.deepEqual(seed, {
           value: ["alpha"],
+        });
+        assert.equal(getCallCount(), 1);
+      });
+
+      it("concat() complete reuses direct async source completions", async () => {
+        const { parser: modeParser, getCallCount } =
+          createCountingSourceParser();
+        const parser = concatLocal(
+          modeParser as never,
+          toAsyncParser(constant("tail")) as never,
+        );
+
+        const completed = await parser.complete(parser.initialState);
+
+        assert.deepEqual(completed, {
+          success: true,
+          value: ["alpha", "tail"],
+        });
+        assert.equal(getCallCount(), 1);
+      });
+
+      it("concat() extracts direct async source seeds", async () => {
+        const { parser: modeParser, getCallCount } =
+          createCountingSourceParser();
+        const parser = concatLocal(
+          modeParser as never,
+          toAsyncParser(constant("tail")) as never,
+        );
+
+        const seed = await getLocalPhase2SeedExtractor(parser)(
+          parser.initialState,
+        );
+
+        assert.deepEqual(seed, {
+          value: ["alpha", "tail"],
         });
         assert.equal(getCallCount(), 1);
       });
@@ -16441,6 +16617,64 @@ describe("branch coverage: constructs.ts edge cases", () => {
           value: ["cfg", "alpha"],
         });
         assert.equal(completeCalls, 0);
+      });
+
+      it("conditional() phase-two seed preserves deferred discriminator and branch metadata", () => {
+        const parser = conditionalLocal(
+          createSyncDeferredCompleteParser(
+            "cfg",
+            nestedDeferredKeys,
+          ) as Parser<"sync", string, undefined>,
+          {
+            cfg: createSyncDeferredCompleteParser(""),
+          },
+        );
+
+        assertDeferredComposite(
+          getLocalPhase2SeedExtractor(parser)(parser.initialState),
+          ["cfg", ""],
+          new Map<PropertyKey, DeferredMap | null>([
+            [0, nestedDeferredKeys],
+            [1, null],
+          ]),
+        );
+      });
+
+      it("conditional() async phase-two seed preserves deferred discriminator and branch metadata", async () => {
+        const parser = conditionalLocal(
+          createAsyncDeferredCompleteParser(
+            "cfg",
+            nestedDeferredKeys,
+          ) as Parser<"async", string, undefined>,
+          {
+            cfg: createAsyncDeferredCompleteParser(""),
+          },
+        );
+
+        assertDeferredComposite(
+          await getLocalPhase2SeedExtractor(parser)(parser.initialState),
+          ["cfg", ""],
+          new Map<PropertyKey, DeferredMap | null>([
+            [0, nestedDeferredKeys],
+            [1, null],
+          ]),
+        );
+      });
+
+      it("conditional() phase-two seed preserves opaque deferred branch metadata", () => {
+        const parser = conditionalLocal(
+          constant("cfg"),
+          {
+            cfg: createSyncDeferredCompleteParser({ ready: false }),
+          },
+        );
+
+        const seed = getLocalPhase2SeedExtractor(parser)(parser.initialState);
+
+        assert.deepEqual(seed, {
+          value: ["cfg", { ready: false }],
+          deferred: true,
+        });
       });
 
       it("conditional() sync complete replays a deferred discriminator branch", () => {
@@ -20308,6 +20542,96 @@ describe("branch coverage: constructs.ts edge cases", () => {
       usage: parser.usage,
     });
     assert.ok(!failed.success);
+  });
+
+  it("conditional() sync parse continues a preselected branch", () => {
+    const parser = conditional(
+      option("--mode", choice(["fast", "slow"])),
+      {
+        fast: option("--threads", integer()),
+        slow: flag("--verbose"),
+      },
+    );
+
+    const parsed = parser.parse({
+      buffer: ["--threads", "4"],
+      state: {
+        ...parser.initialState,
+        discriminatorValue: "fast",
+        selectedBranch: { kind: "branch", key: "fast" as const },
+      },
+      optionsTerminated: false,
+      usage: parser.usage,
+    });
+
+    assert.ok(parsed.success);
+    if (parsed.success) {
+      assert.deepEqual(parsed.consumed, ["--threads", "4"]);
+    }
+  });
+
+  it("conditional() sync parse commits a zero-consuming default at end of input", () => {
+    const parser = conditional(
+      option("--mode", choice(["fast"])),
+      {
+        fast: flag("--fast"),
+      },
+      constant("default"),
+    );
+
+    const result = parseSync(parser, []);
+
+    assert.ok(result.success);
+    if (result.success) {
+      assert.deepEqual(result.value, [undefined, "default"]);
+    }
+  });
+
+  it("conditional() sync parse preserves provisional default branch results", () => {
+    const defaultBranch: Parser<"sync", string, undefined> = {
+      mode: "sync",
+      $valueType: [] as readonly string[],
+      $stateType: [] as readonly undefined[],
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(),
+      acceptingAnyToken: false,
+      initialState: undefined,
+      parse(context) {
+        return {
+          success: true as const,
+          provisional: true as const,
+          next: context,
+          consumed: [],
+        };
+      },
+      complete() {
+        return { success: true as const, value: "default" };
+      },
+      suggest: function* () {},
+      getDocFragments() {
+        return { fragments: [] };
+      },
+    };
+    const parser = conditional(
+      option("--mode", choice(["fast"])),
+      {
+        fast: flag("--fast"),
+      },
+      defaultBranch,
+    );
+
+    const parsed = parser.parse({
+      buffer: [],
+      state: parser.initialState,
+      optionsTerminated: false,
+      usage: parser.usage,
+    });
+
+    assert.ok(parsed.success);
+    if (parsed.success) {
+      assert.ok(parsed.provisional);
+    }
   });
 
   it("conditional() async complete returns default branch failure", async () => {

--- a/packages/core/src/constructs.test.ts
+++ b/packages/core/src/constructs.test.ts
@@ -57,7 +57,11 @@ import {
   option,
   passThrough,
 } from "@optique/core/primitives";
-import { extractLiteralValues, formatUsage } from "@optique/core/usage";
+import {
+  extractLiteralValues,
+  formatUsage,
+  type OptionName,
+} from "@optique/core/usage";
 import {
   choice,
   type DeferredMap,
@@ -72,6 +76,7 @@ import {
   concat as concatLocal,
   conditional as conditionalLocal,
   longestMatch as longestMatchLocal,
+  merge as mergeLocal,
   object as objectLocal,
   or as orLocal,
   tuple as tupleLocal,
@@ -179,21 +184,103 @@ function createSyncBranchParser<TState>(
   initialState: TState,
   parse: (context: ParserContext<TState>) => ParserResult<TState>,
   value: string,
+  metadata: Partial<
+    Pick<
+      Parser<"sync", string, TState>,
+      "acceptingAnyToken" | "leadingNames" | "priority" | "usage"
+    >
+  > = {},
 ): Parser<"sync", string, TState> {
   return {
     $valueType: [] as readonly string[],
     $stateType: [] as readonly TState[],
     mode: "sync",
-    priority: 0,
-    usage: [],
-    leadingNames: new Set(),
-    acceptingAnyToken: false,
+    priority: metadata.priority ?? 0,
+    usage: metadata.usage ?? [],
+    leadingNames: metadata.leadingNames ?? new Set(),
+    acceptingAnyToken: metadata.acceptingAnyToken ?? false,
     initialState,
     parse,
     complete: () => ({ success: true, value }),
     suggest: function* () {},
     getDocFragments: () => ({ fragments: [] }),
   };
+}
+
+function tokenParserMetadata<TState>(
+  token: string,
+): Partial<
+  Pick<
+    Parser<"sync", string, TState>,
+    "leadingNames" | "usage"
+  >
+> {
+  return {
+    leadingNames: new Set([token]),
+    usage: token.startsWith("-")
+      ? [{ type: "option", names: [token as OptionName] }]
+      : [{ type: "literal", value: token }],
+  };
+}
+
+function createAsyncDeferredDiscriminator(
+  result: ValueParserResult<string>,
+): Parser<"async", string, string> {
+  return {
+    $valueType: [] as readonly string[],
+    $stateType: [] as readonly string[],
+    mode: "async",
+    priority: 1,
+    usage: [{ type: "option", names: ["--mode"], metavar: "MODE" }],
+    leadingNames: new Set(["--mode"]),
+    acceptingAnyToken: false,
+    initialState: "initial",
+    parse(context) {
+      return Promise.resolve({
+        success: true as const,
+        provisional: true as const,
+        next: { ...context, state: "deferred" },
+        consumed: [],
+      });
+    },
+    complete() {
+      return Promise.resolve(result);
+    },
+    async *suggest(_context, prefix) {
+      if ("--mode".startsWith(prefix)) {
+        yield { kind: "literal" as const, text: "--mode" };
+      }
+    },
+    getDocFragments: () => ({ fragments: [] }),
+  };
+}
+
+function createProvisionalTokenParser(
+  token: string,
+  value: string,
+): Parser<"sync", string, string> {
+  return createSyncBranchParser(
+    "initial",
+    (context) =>
+      context.buffer[0] === token
+        ? {
+          success: true,
+          provisional: true,
+          next: {
+            ...context,
+            buffer: context.buffer.slice(1),
+            state: value,
+          },
+          consumed: [token],
+        }
+        : {
+          success: false,
+          consumed: 0,
+          error: message`${token} missing.`,
+        },
+    value,
+    tokenParserMetadata(token),
+  );
 }
 
 describe("or", () => {
@@ -1496,6 +1583,7 @@ describe("or() - duplicate option handling", () => {
         };
       },
       "a",
+      tokenParserMetadata("--shared"),
     );
     const parserB = createSyncBranchParser(
       "b-initial",
@@ -1538,6 +1626,13 @@ describe("or() - duplicate option handling", () => {
         };
       },
       "b",
+      {
+        leadingNames: new Set(["--shared", "--b"]),
+        usage: [
+          { type: "option", names: ["--shared"] },
+          { type: "option", names: ["--b"] },
+        ],
+      },
     );
     const parser = or(parserA, parserB);
 
@@ -1586,6 +1681,7 @@ describe("or() - duplicate option handling", () => {
         };
       },
       "draft",
+      tokenParserMetadata("--draft"),
     );
     const parser = or(provisional, option("--real", string()));
 
@@ -1625,6 +1721,7 @@ describe("or() - duplicate option handling", () => {
         };
       },
       "active",
+      tokenParserMetadata("--shared"),
     );
     const provisional = createSyncBranchParser(
       "provisional-initial",
@@ -1679,6 +1776,13 @@ describe("or() - duplicate option handling", () => {
         };
       },
       "provisional",
+      {
+        leadingNames: new Set(["--shared", "--next"]),
+        usage: [
+          { type: "option", names: ["--shared"] },
+          { type: "option", names: ["--next"] },
+        ],
+      },
     );
     const parser = or(active, provisional);
 
@@ -11565,6 +11669,399 @@ describe("branch coverage: conditional() complete/suggest edges", () => {
     assert.ok(serialized.includes('"literal"'));
     assert.ok(serialized.includes('"fast"'));
   });
+
+  it("async speculative parse propagates a consuming branch error", async () => {
+    const failingBranch = createSyncBranchParser(
+      "initial",
+      (context) =>
+        context.buffer[0] === "--threads"
+          ? {
+            success: false,
+            consumed: 1,
+            error: message`invalid thread count.`,
+          }
+          : {
+            success: false,
+            consumed: 0,
+            error: message`threads missing.`,
+          },
+      "unused",
+      tokenParserMetadata("--threads"),
+    );
+    const parser = conditional(
+      createAsyncDeferredDiscriminator({ success: true, value: "fast" }),
+      {
+        fast: failingBranch,
+        slow: object({ verbose: flag("--verbose") }),
+      },
+    );
+
+    const result = await parser.parse({
+      buffer: ["--threads"],
+      state: parser.initialState,
+      optionsTerminated: false,
+      usage: parser.usage,
+    });
+
+    assert.ok(!result.success);
+    if (!result.success) {
+      assert.ok(result.consumed > 0);
+      assert.equal(formatMessage(result.error), "invalid thread count.");
+    }
+  });
+
+  it("async speculative parse skips default after provisional ambiguity", async () => {
+    const parser = conditional(
+      createAsyncDeferredDiscriminator({ success: true, value: "one" }),
+      {
+        one: createProvisionalTokenParser("--shared", "one"),
+        two: createProvisionalTokenParser("--shared", "two"),
+      },
+      flag("--shared"),
+    );
+
+    const result = await parser.parse({
+      buffer: ["--shared"],
+      state: parser.initialState,
+      optionsTerminated: false,
+      usage: parser.usage,
+    });
+
+    assert.ok(result.success);
+    if (!result.success) return;
+    assert.equal(result.provisional, true);
+    assert.deepEqual(result.consumed, []);
+    assert.equal(result.next.buffer[0], "--shared");
+  });
+
+  it("async speculative parse commits a consuming default branch", async () => {
+    const parser = conditional(
+      createAsyncDeferredDiscriminator({ success: true, value: "missing" }),
+      {
+        fast: flag("--fast"),
+      },
+      createProvisionalTokenParser("--default", "default"),
+    );
+
+    const result = await parser.parse({
+      buffer: ["--default"],
+      state: parser.initialState,
+      optionsTerminated: false,
+      usage: parser.usage,
+    });
+
+    assert.ok(result.success);
+    if (!result.success) return;
+    assert.equal(result.provisional, true);
+    assert.deepEqual(result.consumed, ["--default"]);
+    const completed = await parser.complete(result.next.state);
+    assert.deepEqual(completed, {
+      success: true,
+      value: [undefined, "default"],
+    });
+  });
+
+  it("async speculative parse propagates consuming default failures", async () => {
+    const failingDefault = createSyncBranchParser(
+      "initial",
+      (context) =>
+        context.buffer[0] === "--default"
+          ? {
+            success: false,
+            consumed: 1,
+            error: message`default branch failed.`,
+          }
+          : {
+            success: false,
+            consumed: 0,
+            error: message`default missing.`,
+          },
+      "unused",
+      tokenParserMetadata("--default"),
+    );
+    const parser = conditional(
+      createAsyncDeferredDiscriminator({ success: true, value: "missing" }),
+      {
+        fast: flag("--fast"),
+      },
+      failingDefault,
+    );
+
+    const result = await parser.parse({
+      buffer: ["--default"],
+      state: parser.initialState,
+      optionsTerminated: false,
+      usage: parser.usage,
+    });
+
+    assert.ok(!result.success);
+    if (!result.success) {
+      assert.equal(formatMessage(result.error), "default branch failed.");
+    }
+  });
+
+  it("async speculative parse remembers zero-consuming defaults at end of input", async () => {
+    const defaultBranch = createSyncBranchParser(
+      { ready: false },
+      (context) => ({
+        success: true,
+        next: {
+          ...context,
+          state: { ready: true },
+        },
+        consumed: [],
+      }),
+      "default",
+    );
+    Object.defineProperty(defaultBranch, "complete", {
+      value(state: { readonly ready: boolean }) {
+        return {
+          success: true as const,
+          value: state.ready ? "ready" : "not ready",
+        };
+      },
+      configurable: true,
+    });
+    const parser = conditional(
+      createAsyncDeferredDiscriminator({ success: true, value: "missing" }),
+      {
+        fast: flag("--fast"),
+      },
+      defaultBranch,
+    );
+
+    const result = await parser.parse({
+      buffer: [],
+      state: parser.initialState,
+      optionsTerminated: false,
+      usage: parser.usage,
+    });
+
+    assert.ok(result.success);
+    if (!result.success) return;
+    assert.equal(result.provisional, true);
+    assert.deepEqual(result.consumed, []);
+    const completed = await parser.complete(result.next.state);
+    assert.deepEqual(completed, {
+      success: true,
+      value: [undefined, "ready"],
+    });
+  });
+
+  it("async speculative complete probes avoid branch side effects", async () => {
+    let branchCompleteCalls = 0;
+    const branch: Parser<"sync", string, string> = createSyncBranchParser(
+      "initial",
+      (context) =>
+        context.buffer[0] === "--fast"
+          ? {
+            success: true,
+            next: {
+              ...context,
+              buffer: context.buffer.slice(1),
+              state: "parsed",
+            },
+            consumed: ["--fast"],
+          }
+          : {
+            success: false,
+            consumed: 0,
+            error: message`fast missing.`,
+          },
+      "done",
+      tokenParserMetadata("--fast"),
+    );
+    Object.defineProperty(branch, "complete", {
+      value(state: string) {
+        branchCompleteCalls++;
+        return { success: true as const, value: state };
+      },
+      configurable: true,
+    });
+    const parser = conditional(
+      createAsyncDeferredDiscriminator({ success: true, value: "fast" }),
+      { fast: branch },
+    );
+
+    const parsed = await parser.parse({
+      buffer: ["--fast"],
+      state: parser.initialState,
+      optionsTerminated: false,
+      usage: parser.usage,
+    });
+    assert.ok(parsed.success);
+    if (!parsed.success) return;
+
+    const probed = await parser.complete(parsed.next.state, {
+      usage: parser.usage,
+      phase: "parse",
+      path: [],
+      trace: undefined,
+    });
+
+    assert.ok(probed.success);
+    assert.equal(branchCompleteCalls, 0);
+  });
+
+  it("async speculative complete fails before completing a wrong branch", async () => {
+    let branchCompleteCalls = 0;
+    const branch: Parser<"sync", string, string> = createSyncBranchParser(
+      "initial",
+      (context) =>
+        context.buffer[0] === "--fast"
+          ? {
+            success: true,
+            next: {
+              ...context,
+              buffer: context.buffer.slice(1),
+              state: "parsed",
+            },
+            consumed: ["--fast"],
+          }
+          : {
+            success: false,
+            consumed: 0,
+            error: message`fast missing.`,
+          },
+      "done",
+      tokenParserMetadata("--fast"),
+    );
+    Object.defineProperty(branch, "complete", {
+      value() {
+        branchCompleteCalls++;
+        return { success: true as const, value: "should not run" };
+      },
+      configurable: true,
+    });
+    const parser = conditional(
+      createAsyncDeferredDiscriminator({
+        success: false,
+        error: message`mode unavailable.`,
+      }),
+      { fast: branch },
+    );
+
+    const parsed = await parser.parse({
+      buffer: ["--fast"],
+      state: parser.initialState,
+      optionsTerminated: false,
+      usage: parser.usage,
+    });
+    assert.ok(parsed.success);
+    if (!parsed.success) return;
+
+    const completed = await parser.complete(parsed.next.state);
+
+    assert.ok(!completed.success);
+    if (!completed.success) {
+      assert.equal(formatMessage(completed.error), "mode unavailable.");
+    }
+    assert.equal(branchCompleteCalls, 0);
+  });
+
+  it("async speculative complete reports custom branch mismatches", async () => {
+    const parser = conditional(
+      createAsyncDeferredDiscriminator({ success: true, value: "slow" }),
+      {
+        fast: flag("--fast"),
+        slow: flag("--slow"),
+      },
+      constant("default"),
+      {
+        errors: {
+          branchMismatch: (
+            resolved: string,
+            speculative: string,
+          ) => [text(`resolved ${resolved}, consumed ${speculative}.`)],
+        },
+      },
+    );
+
+    const parsed = await parser.parse({
+      buffer: ["--fast"],
+      state: parser.initialState,
+      optionsTerminated: false,
+      usage: parser.usage,
+    });
+    assert.ok(parsed.success);
+    if (!parsed.success) return;
+
+    const completed = await parser.complete(parsed.next.state);
+
+    assert.ok(!completed.success);
+    if (!completed.success) {
+      assert.equal(
+        formatMessage(completed.error),
+        "resolved slow, consumed fast.",
+      );
+    }
+  });
+
+  it("async complete probes without selection return a placeholder", async () => {
+    let discriminatorCompleteCalls = 0;
+    let defaultCompleteCalls = 0;
+    const discriminator = createAsyncDeferredDiscriminator({
+      success: true,
+      value: "fast",
+    });
+    Object.defineProperty(discriminator, "complete", {
+      value() {
+        discriminatorCompleteCalls++;
+        return Promise.resolve({ success: true as const, value: "fast" });
+      },
+      configurable: true,
+    });
+    const defaultBranch = createSyncBranchParser(
+      "initial",
+      (context) => ({
+        success: true,
+        next: context,
+        consumed: [],
+      }),
+      "default",
+    );
+    Object.defineProperty(defaultBranch, "complete", {
+      value() {
+        defaultCompleteCalls++;
+        return { success: true as const, value: "default" };
+      },
+      configurable: true,
+    });
+    const parser = conditional(
+      discriminator,
+      { fast: flag("--fast") },
+      defaultBranch,
+    );
+
+    const completed = await parser.complete(parser.initialState, {
+      usage: parser.usage,
+      phase: "suggest",
+      path: [],
+      trace: undefined,
+    });
+
+    assert.ok(completed.success);
+    assert.equal(discriminatorCompleteCalls, 0);
+    assert.equal(defaultCompleteCalls, 0);
+  });
+
+  it("async suggest resolves sync discriminators before default suggestions", async () => {
+    const parser = conditional(
+      constant("fast"),
+      {
+        fast: toAsyncParser(
+          object({ threads: option("--threads", integer()) }),
+        ),
+      },
+      toAsyncParser(object({ raw: flag("--raw") })),
+    );
+
+    const suggestions = await suggestAsync(parser, ["--"]);
+    const texts = suggestions.map((s) => s.kind === "literal" ? s.text : "");
+
+    assert.ok(texts.includes("--threads"));
+    assert.ok(!texts.includes("--raw"));
+  });
 });
 
 describe("branch coverage: generateNoMatchError variants", () => {
@@ -14287,6 +14784,151 @@ describe("branch coverage: constructs.ts edge cases", () => {
           value: ["alpha"],
         });
         assert.equal(getCallCount(), 1);
+      });
+
+      it("merge() complete preserves deferred child metadata", () => {
+        const { parser: modeParser, getCallCount } =
+          createCountingSourceParser();
+        const parser = mergeLocal(
+          objectLocal({
+            mode: modeParser,
+          }),
+          objectLocal({
+            scalar: createSyncDeferredCompleteParser(""),
+            nested: createSyncDeferredCompleteParser(
+              { inner: "", stable: "kept" },
+              nestedDeferredKeys,
+            ),
+          }),
+        );
+
+        assertDeferredComposite(
+          parser.complete(parser.initialState),
+          {
+            mode: "alpha",
+            scalar: "",
+            nested: { inner: "", stable: "kept" },
+          },
+          new Map<PropertyKey, DeferredMap | null>([
+            ["scalar", null],
+            ["nested", nestedDeferredKeys],
+          ]),
+        );
+        assert.equal(getCallCount(), 1);
+      });
+
+      it("merge() async complete preserves deferred child metadata", async () => {
+        const { parser: modeParser, getCallCount } =
+          createCountingSourceParser();
+        const parser = mergeLocal(
+          objectLocal({
+            mode: modeParser,
+          }),
+          objectLocal({
+            scalar: createAsyncDeferredCompleteParser(""),
+            nested: createAsyncDeferredCompleteParser(
+              { inner: "", stable: "kept" },
+              nestedDeferredKeys,
+            ),
+          }),
+        );
+
+        assertDeferredComposite(
+          await parser.complete(parser.initialState),
+          {
+            mode: "alpha",
+            scalar: "",
+            nested: { inner: "", stable: "kept" },
+          },
+          new Map<PropertyKey, DeferredMap | null>([
+            ["scalar", null],
+            ["nested", nestedDeferredKeys],
+          ]),
+        );
+        assert.equal(getCallCount(), 1);
+      });
+
+      it("merge() extracts sync seeds across child boundaries", () => {
+        const { parser: modeParser, getCallCount } =
+          createCountingSourceParser();
+        const parser = mergeLocal(
+          objectLocal({
+            mode: modeParser,
+          }),
+          objectLocal({
+            scalar: createSyncDeferredCompleteParser(""),
+            nested: createSyncDeferredCompleteParser(
+              { inner: "", stable: "kept" },
+              nestedDeferredKeys,
+            ),
+          }),
+          objectLocal({
+            required: optionLocal("--required", string()),
+          }),
+        );
+
+        assertDeferredComposite(
+          getLocalPhase2SeedExtractor(parser)(parser.initialState),
+          {
+            mode: "alpha",
+            scalar: "",
+            nested: { inner: "", stable: "kept" },
+          },
+          new Map<PropertyKey, DeferredMap | null>([
+            ["scalar", null],
+            ["nested", nestedDeferredKeys],
+          ]),
+        );
+        assert.equal(getCallCount(), 1);
+      });
+
+      it("merge() extracts async seeds across child boundaries", async () => {
+        const { parser: modeParser, getCallCount } =
+          createCountingSourceParser();
+        const parser = mergeLocal(
+          objectLocal({
+            mode: modeParser,
+          }),
+          objectLocal({
+            scalar: createAsyncDeferredCompleteParser(""),
+            nested: createAsyncDeferredCompleteParser(
+              { inner: "", stable: "kept" },
+              nestedDeferredKeys,
+            ),
+          }),
+          objectLocal({
+            required: toAsyncParser(optionLocal("--required", string())),
+          }),
+        );
+
+        assertDeferredComposite(
+          await getLocalPhase2SeedExtractor(parser)(parser.initialState),
+          {
+            mode: "alpha",
+            scalar: "",
+            nested: { inner: "", stable: "kept" },
+          },
+          new Map<PropertyKey, DeferredMap | null>([
+            ["scalar", null],
+            ["nested", nestedDeferredKeys],
+          ]),
+        );
+        assert.equal(getCallCount(), 1);
+      });
+
+      it("merge() returns no phase-two seed when no child can complete", () => {
+        const parser = mergeLocal(
+          objectLocal({
+            left: optionLocal("--left", string()),
+          }),
+          objectLocal({
+            right: optionLocal("--right", string()),
+          }),
+        );
+
+        const seed = getLocalPhase2SeedExtractor(parser)(parser.initialState);
+
+        assert.equal(seed, null);
       });
 
       it("conditional() extracts sync seeds from the selected branch", () => {

--- a/packages/core/src/dependency-metadata.test.ts
+++ b/packages/core/src/dependency-metadata.test.ts
@@ -9,8 +9,12 @@ import {
   createDependencySourceState,
   dependency,
   dependencyId,
+  dependencyIds,
+  derivedValueParserMarker,
   deriveFrom,
   isDependencySourceState,
+  parseWithDependency,
+  suggestWithDependency,
 } from "./internal/dependency.ts";
 import { choice } from "./valueparser.ts";
 import type { NonEmptyString } from "./nonempty.ts";
@@ -20,6 +24,7 @@ import {
   type ParserDependencyMetadata,
 } from "./dependency-metadata.ts";
 import { message } from "./message.ts";
+import type { Suggestion } from "./parser.ts";
 
 // =============================================================================
 // Shared test fixtures
@@ -55,6 +60,16 @@ async function resolveExtractResult(
     | undefined,
 ) {
   return await result;
+}
+
+async function collectSuggestions(
+  suggestions: Iterable<Suggestion> | AsyncIterable<Suggestion>,
+): Promise<readonly Suggestion[]> {
+  const collected: Suggestion[] = [];
+  for await (const suggestion of suggestions) {
+    collected.push(suggestion);
+  }
+  return collected;
 }
 
 function createDerivedFromMulti(
@@ -222,6 +237,84 @@ describe("extractDependencyMetadata", () => {
     const result = metadata.derived.replayParse("debug", ["prod"]);
     assert.ok(!(result instanceof Promise));
     assert.ok(!result.success);
+  });
+
+  test("derived capability replaySuggest works", async () => {
+    const env = createEnvSource();
+    const logLevel = createDerivedLogLevel(env);
+    const metadata = extractDependencyMetadata(logLevel);
+    assert.ok(metadata?.derived?.replaySuggest !== undefined);
+
+    const suggestions = await collectSuggestions(
+      metadata.derived.replaySuggest("", ["prod"]),
+    );
+
+    assert.deepEqual(
+      suggestions.flatMap((suggestion) =>
+        suggestion.kind === "literal" ? [suggestion.text] : []
+      ),
+      ["warn", "error"],
+    );
+  });
+
+  test("derived capability omits replaySuggest when parser has no suggester", () => {
+    const env = createEnvSource();
+    const valueParser = {
+      [derivedValueParserMarker]: true,
+      [dependencyId]: env[dependencyId],
+      mode: "sync" as const,
+      metavar: "LEVEL" as NonEmptyString,
+      placeholder: "",
+      parse: () => ({ success: true as const, value: "debug" }),
+      format: String,
+      [parseWithDependency]: (rawInput: string) => ({
+        success: true as const,
+        value: rawInput,
+      }),
+    };
+
+    const metadata = extractDependencyMetadata(valueParser);
+
+    assert.ok(metadata?.derived !== undefined);
+    assert.equal(metadata.derived.replaySuggest, undefined);
+  });
+
+  test("derived capability replaySuggest passes tuple dependencies unchanged", async () => {
+    const env = createEnvSource();
+    const region = createEnvSource();
+    const valueParser = {
+      [derivedValueParserMarker]: true,
+      [dependencyIds]: [env[dependencyId], region[dependencyId]] as const,
+      mode: "sync" as const,
+      metavar: "URL" as NonEmptyString,
+      placeholder: "",
+      parse: () => ({ success: true as const, value: "dev.dev" }),
+      format: String,
+      [parseWithDependency]: (rawInput: string) => ({
+        success: true as const,
+        value: rawInput,
+      }),
+      *[suggestWithDependency](
+        _prefix: string,
+        dependencies: readonly unknown[],
+      ) {
+        yield {
+          kind: "literal" as const,
+          text: dependencies.join("."),
+          description: undefined,
+        };
+      },
+    };
+
+    const metadata = extractDependencyMetadata(valueParser);
+    assert.ok(metadata?.derived?.replaySuggest !== undefined);
+    const suggestions = await collectSuggestions(
+      metadata.derived.replaySuggest("", ["prod", "dev"]),
+    );
+
+    assert.deepEqual(suggestions, [
+      { kind: "literal", text: "prod.dev", description: undefined },
+    ]);
   });
 
   test("single-source derive() exposes getDefaultDependencyValues", () => {

--- a/packages/core/src/dependency-runtime.test.ts
+++ b/packages/core/src/dependency-runtime.test.ts
@@ -412,7 +412,7 @@ function makeDerivedValueParser(
       return String(value);
     },
     [derivedValueParserMarker]: true,
-  } as DerivedValueParser<"sync", unknown, unknown>;
+  };
   if (options.dependencyIds != null) {
     Object.defineProperty(parser, dependencyIds, {
       value: options.dependencyIds,

--- a/packages/core/src/dependency-runtime.test.ts
+++ b/packages/core/src/dependency-runtime.test.ts
@@ -1430,6 +1430,7 @@ describe("resolveStateWithRuntime", () => {
       success: true,
       value: "warn:prod",
     });
+    assert.strictEqual(record.nested[0], record[symbolKey]);
   });
 
   test("returns original cyclic containers when no deferred state changes", () => {
@@ -1577,6 +1578,8 @@ describe("resolveStateWithRuntimeAsync", () => {
     assert.deepEqual(record.first, expected);
     assert.deepEqual(record.nested[0], expected);
     assert.deepEqual(record[symbolKey], expected);
+    assert.strictEqual(record.first, record.nested[0]);
+    assert.strictEqual(record.first, record[symbolKey]);
   });
 });
 

--- a/packages/core/src/dependency-runtime.test.ts
+++ b/packages/core/src/dependency-runtime.test.ts
@@ -21,6 +21,7 @@ import {
   replayDerivedParser,
   replayDerivedParserAsync,
   resolveStateWithRuntime,
+  resolveStateWithRuntimeAsync,
   type RuntimeNode,
 } from "./dependency-runtime.ts";
 import type { ParserDependencyMetadata } from "./dependency-metadata.ts";
@@ -28,12 +29,16 @@ import {
   createDeferredParseState,
   createDependencySourceState,
   createPendingDependencySourceState,
+  defaultValues,
   dependencyId,
+  dependencyIds,
   DependencyRegistry,
+  type DerivedValueParser,
+  derivedValueParserMarker,
   isDependencySourceState,
   parseWithDependency,
 } from "./internal/dependency.ts";
-import { message } from "./message.ts";
+import { formatMessage, message } from "./message.ts";
 import { unmatchedNonCliDependencySourceStateMarker } from "./internal/parser.ts";
 import type { DependencyRegistryLike } from "./registry-types.ts";
 import type { ValueParserResult } from "./valueparser.ts";
@@ -276,6 +281,28 @@ describe("createDependencyFingerprint", () => {
     const fp2 = createDependencyFingerprint([obj]);
     assert.equal(fp1, fp2);
   });
+
+  test("separates primitive edge cases and tuple boundaries", () => {
+    const fn = () => "value";
+
+    assert.notEqual(
+      createDependencyFingerprint([0]),
+      createDependencyFingerprint([-0]),
+    );
+    assert.notEqual(
+      createDependencyFingerprint(["ab", "c"]),
+      createDependencyFingerprint(["a", "bc"]),
+    );
+    assert.notEqual(
+      createDependencyFingerprint([null]),
+      createDependencyFingerprint([undefined]),
+    );
+    assert.equal(
+      createDependencyFingerprint([fn]),
+      createDependencyFingerprint([fn]),
+    );
+    assert.equal(typeof createDependencyFingerprint([1n]), "string");
+  });
 });
 
 describe("createReplayKey", () => {
@@ -359,6 +386,44 @@ function unwrappingExtract(
     return bareExtract(state[0]);
   }
   return bareExtract(state);
+}
+
+function makeDerivedValueParser(
+  sourceId: symbol,
+  replay: (
+    rawInput: string,
+    dependencyValue: unknown,
+  ) => ValueParserResult<unknown> | Promise<ValueParserResult<unknown>>,
+  options: {
+    readonly dependencyIds?: readonly symbol[];
+    readonly defaultValues?: () => readonly unknown[];
+  } = {},
+): DerivedValueParser<"sync", unknown, unknown> {
+  const parser: DerivedValueParser<"sync", unknown, unknown> = {
+    mode: "sync",
+    metavar: "VALUE",
+    placeholder: "value",
+    [dependencyId]: sourceId,
+    [parseWithDependency]: replay,
+    parse(input: string) {
+      return { success: true, value: input };
+    },
+    format(value: unknown) {
+      return String(value);
+    },
+    [derivedValueParserMarker]: true,
+  } as DerivedValueParser<"sync", unknown, unknown>;
+  if (options.dependencyIds != null) {
+    Object.defineProperty(parser, dependencyIds, {
+      value: options.dependencyIds,
+    });
+  }
+  if (options.defaultValues != null) {
+    Object.defineProperty(parser, defaultValues, {
+      value: options.defaultValues,
+    });
+  }
+  return parser;
 }
 
 describe("collectExplicitSourceValues", () => {
@@ -950,6 +1015,101 @@ describe("fillMissingSourceDefaultsAsync", () => {
     assert.ok(runtime.hasSource(sourceId));
     assert.equal(runtime.getSource(sourceId), "async-dev");
   });
+
+  test("skips async defaults for sources that are already resolved or blocked", async () => {
+    const runtime = createDependencyRuntimeContext();
+    const existingId = Symbol("existing");
+    const failedId = Symbol("failed");
+    const matchedId = Symbol("matched");
+    const transformedId = Symbol("transformed");
+    const missingGetterId = Symbol("missing-getter");
+    runtime.registerSource(existingId, "cli", "cli");
+    runtime.markSourceFailed(failedId);
+
+    const calls: string[] = [];
+    const sourceNode = (
+      sourceId: symbol,
+      path: string,
+      extra: Partial<ParserDependencyMetadata["source"]> = {},
+      matched?: boolean,
+    ): RuntimeNode => ({
+      path: [path],
+      parser: {
+        dependencyMetadata: {
+          source: {
+            kind: "source",
+            sourceId,
+            extractSourceValue: bareExtract,
+            preservesSourceValue: true,
+            getMissingSourceValue: () => {
+              calls.push(path);
+              return Promise.resolve({
+                success: true as const,
+                value: `${path}-default`,
+              });
+            },
+            ...extra,
+          },
+        },
+      },
+      state: undefined,
+      matched,
+    });
+
+    const failures = await fillMissingSourceDefaultsAsync([
+      { path: ["plain"], parser: {}, state: undefined },
+      sourceNode(existingId, "existing"),
+      sourceNode(failedId, "failed"),
+      sourceNode(matchedId, "matched", {}, true),
+      sourceNode(transformedId, "transformed", { preservesSourceValue: false }),
+      sourceNode(missingGetterId, "missing-getter", {
+        getMissingSourceValue: undefined,
+      }),
+    ], runtime);
+
+    assert.deepEqual(failures, []);
+    assert.deepEqual(calls, []);
+    assert.equal(runtime.getSource(existingId), "cli");
+    assert.ok(!runtime.hasSource(matchedId));
+    assert.ok(!runtime.hasSource(transformedId));
+    assert.ok(!runtime.hasSource(missingGetterId));
+  });
+
+  test("reports async default thunks that throw non-Error values", async () => {
+    const runtime = createDependencyRuntimeContext();
+    const sourceId = Symbol("env");
+    const nodes: RuntimeNode[] = [{
+      path: ["env"],
+      parser: {
+        dependencyMetadata: {
+          source: {
+            kind: "source",
+            sourceId,
+            extractSourceValue: bareExtract,
+            preservesSourceValue: true,
+            getMissingSourceValue: () => {
+              throw "missing env";
+            },
+          },
+        },
+      },
+      state: undefined,
+    }];
+
+    const failures = await fillMissingSourceDefaultsAsync(nodes, runtime);
+
+    assert.equal(failures.length, 1);
+    assert.equal(failures[0].sourceId, sourceId);
+    assert.deepEqual(failures[0].path, ["env"]);
+    assert.ok(!failures[0].error.success);
+    if (!failures[0].error.success) {
+      assert.equal(
+        formatMessage(failures[0].error.error),
+        'Default value evaluation failed: "missing env"',
+      );
+    }
+    assert.ok(!runtime.hasSource(sourceId));
+  });
 });
 
 describe("replayDerivedParser", () => {
@@ -1165,6 +1325,126 @@ describe("extractRawInputFromState", () => {
 });
 
 describe("resolveStateWithRuntime", () => {
+  test("resolves deferred parse states with explicit single and multiple dependencies", () => {
+    const singleId = Symbol("single");
+    const firstId = Symbol("first");
+    const secondId = Symbol("second");
+    const runtime = createDependencyRuntimeContext();
+    runtime.registerSource(singleId, "prod", "cli");
+    runtime.registerSource(firstId, "us", "cli");
+    runtime.registerSource(secondId, "blue", "cli");
+
+    const single = createDeferredParseState(
+      "warn",
+      makeDerivedValueParser(singleId, (raw, dependency) => ({
+        success: true,
+        value: `${raw}:${dependency}`,
+      })),
+      { success: false, error: message`pending` },
+    );
+    const multi = createDeferredParseState(
+      "deploy",
+      makeDerivedValueParser(
+        firstId,
+        (raw, dependencies) => ({
+          success: true,
+          value: `${raw}:${(dependencies as readonly unknown[]).join("/")}`,
+        }),
+        { dependencyIds: [firstId, secondId] },
+      ),
+      { success: false, error: message`pending` },
+    );
+
+    assert.deepEqual(resolveStateWithRuntime(single, runtime), {
+      success: true,
+      value: "warn:prod",
+    });
+    assert.deepEqual(resolveStateWithRuntime(multi, runtime), {
+      success: true,
+      value: "deploy:us/blue",
+    });
+  });
+
+  test("keeps preliminary deferred results when only defaults resolved dependencies", () => {
+    const sourceId = Symbol("env");
+    let replays = 0;
+    const deferred = createDeferredParseState(
+      "warn",
+      makeDerivedValueParser(
+        sourceId,
+        () => {
+          replays++;
+          return { success: true, value: "replayed" };
+        },
+        { defaultValues: () => ["dev"] },
+      ),
+      { success: true, value: "preliminary" },
+    );
+
+    const runtime = createDependencyRuntimeContext();
+    const resolved = resolveStateWithRuntime(deferred, runtime);
+
+    assert.deepEqual(resolved, { success: true, value: "preliminary" });
+    assert.equal(replays, 0);
+  });
+
+  test("preserves dependency source states and clones only changed containers", () => {
+    const sourceId = Symbol("env");
+    const runtime = createDependencyRuntimeContext();
+    runtime.registerSource(sourceId, "prod", "cli");
+    const source = createDependencySourceState(
+      { success: true, value: "prod" },
+      sourceId,
+    );
+    const deferred = createDeferredParseState(
+      "warn",
+      makeDerivedValueParser(sourceId, (raw, dependency) => ({
+        success: true,
+        value: `${raw}:${dependency}`,
+      })),
+      { success: false, error: message`pending` },
+    );
+    const symbolKey = Symbol("derived");
+    const state = {
+      unchanged: source,
+      nested: [deferred],
+      [symbolKey]: deferred,
+    };
+
+    const resolved = resolveStateWithRuntime(state, runtime);
+
+    assert.notStrictEqual(resolved, state);
+    assert.ok(resolved != null && typeof resolved === "object");
+    const record = resolved as {
+      readonly unchanged: unknown;
+      readonly nested: readonly unknown[];
+      readonly [symbolKey]: unknown;
+    };
+    assert.strictEqual(record.unchanged, source);
+    assert.notStrictEqual(record.nested, state.nested);
+    assert.deepEqual(record.nested[0], {
+      success: true,
+      value: "warn:prod",
+    });
+    assert.deepEqual(record[symbolKey], {
+      success: true,
+      value: "warn:prod",
+    });
+  });
+
+  test("returns original cyclic containers when no deferred state changes", () => {
+    const runtime = createDependencyRuntimeContext();
+    const state: { self?: unknown; nested: readonly unknown[] } = {
+      nested: [],
+    };
+    state.self = state;
+
+    const resolved = resolveStateWithRuntime(state, runtime);
+
+    assert.strictEqual(resolved, state);
+    assert.strictEqual(state.self, state);
+  });
+
   test("throws when sync deferred replay receives a thenable", () => {
     const depId = Symbol("env");
     const deferred = createDeferredParseState(
@@ -1192,6 +1472,111 @@ describe("resolveStateWithRuntime", () => {
           /resolveStateWithRuntime\(\) received an async parseWithDependency\(\) result/i,
       },
     );
+  });
+});
+
+describe("resolveStateWithRuntimeAsync", () => {
+  test("awaits deferred replay and preserves preliminary default-only results", async () => {
+    const explicitId = Symbol("explicit");
+    const defaultId = Symbol("default");
+    const runtime = createDependencyRuntimeContext();
+    runtime.registerSource(explicitId, "prod", "cli");
+    let defaultReplays = 0;
+    const state = [
+      createDeferredParseState(
+        "warn",
+        makeDerivedValueParser(
+          explicitId,
+          (raw, dependency) =>
+            Promise.resolve({
+              success: true,
+              value: `${raw}:${dependency}`,
+            }),
+        ),
+        { success: false, error: message`pending` },
+      ),
+      createDeferredParseState(
+        "info",
+        makeDerivedValueParser(
+          defaultId,
+          () => {
+            defaultReplays++;
+            return Promise.resolve({ success: true, value: "replayed" });
+          },
+          { defaultValues: () => ["dev"] },
+        ),
+        { success: true, value: "preliminary" },
+      ),
+    ];
+
+    const resolved = await resolveStateWithRuntimeAsync(state, runtime);
+
+    assert.deepEqual(resolved, [
+      { success: true, value: "warn:prod" },
+      { success: true, value: "preliminary" },
+    ]);
+    assert.equal(defaultReplays, 0);
+  });
+
+  test("keeps unresolved async deferred states at their preliminary result", async () => {
+    const sourceId = Symbol("missing");
+    const runtime = createDependencyRuntimeContext();
+    const preliminary = { success: false as const, error: message`pending` };
+    const state = {
+      value: createDeferredParseState(
+        "warn",
+        makeDerivedValueParser(
+          sourceId,
+          () =>
+            Promise.resolve({
+              success: true,
+              value: "unreachable",
+            }),
+        ),
+        preliminary,
+      ),
+    };
+
+    const resolved = await resolveStateWithRuntimeAsync(state, runtime);
+
+    assert.deepEqual(resolved, { value: preliminary });
+  });
+
+  test("resolves a shared async deferred state at every reference", async () => {
+    const sourceId = Symbol("env");
+    const runtime = createDependencyRuntimeContext();
+    runtime.registerSource(sourceId, "prod", "cli");
+    const deferred = createDeferredParseState(
+      "warn",
+      makeDerivedValueParser(
+        sourceId,
+        (raw, dependency) =>
+          Promise.resolve({
+            success: true,
+            value: `${raw}:${dependency}`,
+          }),
+      ),
+      { success: false, error: message`pending` },
+    );
+    const symbolKey = Symbol("shared");
+    const state = {
+      first: deferred,
+      nested: [deferred],
+      [symbolKey]: deferred,
+    };
+
+    const resolved = await resolveStateWithRuntimeAsync(state, runtime);
+
+    assert.ok(resolved != null && typeof resolved === "object");
+    const record = resolved as {
+      readonly first: unknown;
+      readonly nested: readonly unknown[];
+      readonly [symbolKey]: unknown;
+    };
+    const expected = { success: true, value: "warn:prod" };
+    assert.deepEqual(record.first, expected);
+    assert.deepEqual(record.nested[0], expected);
+    assert.deepEqual(record[symbolKey], expected);
   });
 });
 

--- a/packages/core/src/dependency-runtime.ts
+++ b/packages/core/src/dependency-runtime.ts
@@ -1091,16 +1091,16 @@ function resolveDeferredInState(
 ): unknown {
   if (state == null) return state;
 
-  if (typeof state === "object") {
-    if (visited.has(state)) return state;
-    visited.add(state);
-  }
-
   if (isDeferredParseState(state)) {
     return resolveSingleDeferred(state, runtime);
   }
 
   if (isDependencySourceState(state)) return state;
+
+  if (typeof state === "object") {
+    if (visited.has(state)) return state;
+    visited.add(state);
+  }
 
   if (Array.isArray(state)) {
     const resolved = state.map((item) =>
@@ -1158,11 +1158,6 @@ async function resolveDeferredInStateAsync(
 ): Promise<unknown> {
   if (state == null) return state;
 
-  if (typeof state === "object") {
-    if (visited.has(state)) return state;
-    visited.add(state);
-  }
-
   if (isDeferredParseState(state)) {
     const deferred = state;
     const isMultiDep = deferred.dependencyIds != null &&
@@ -1188,6 +1183,11 @@ async function resolveDeferredInStateAsync(
   }
 
   if (isDependencySourceState(state)) return state;
+
+  if (typeof state === "object") {
+    if (visited.has(state)) return state;
+    visited.add(state);
+  }
 
   if (Array.isArray(state)) {
     const resolved = await Promise.all(

--- a/packages/core/src/dependency-runtime.ts
+++ b/packages/core/src/dependency-runtime.ts
@@ -988,6 +988,31 @@ function resolveSingleDeferred(
   return result;
 }
 
+function resolveSingleDeferredAsync(
+  deferred: DeferredParseState<unknown>,
+  runtime: DependencyRuntimeContext,
+): Promise<unknown> {
+  const isMultiDep = deferred.dependencyIds != null &&
+    deferred.dependencyIds.length > 0;
+  const depIds = isMultiDep ? deferred.dependencyIds! : [deferred.dependencyId];
+  const resolution = runtime.resolveDependencies({
+    dependencyIds: depIds,
+    defaultValues: deferred.defaultValues,
+  });
+  if (resolution.kind !== "resolved") {
+    return Promise.resolve(deferred.preliminaryResult);
+  }
+
+  if (resolution.usedDefaults.every((d) => d)) {
+    return Promise.resolve(deferred.preliminaryResult);
+  }
+
+  const depValue = isMultiDep ? resolution.values : resolution.values[0];
+  return Promise.resolve(
+    deferred.parser[parseWithDependency](deferred.rawInput, depValue),
+  );
+}
+
 /**
  * Recursively collects dependency source values from {@link DependencySourceState}
  * objects found in the state tree and registers them in the runtime.
@@ -1088,11 +1113,19 @@ function resolveDeferredInState(
   state: unknown,
   runtime: DependencyRuntimeContext,
   visited: WeakSet<object> = new WeakSet<object>(),
+  deferredCache: WeakMap<
+    DeferredParseState<unknown>,
+    ValueParserResult<unknown>
+  > = new WeakMap(),
 ): unknown {
   if (state == null) return state;
 
   if (isDeferredParseState(state)) {
-    return resolveSingleDeferred(state, runtime);
+    const cached = deferredCache.get(state);
+    if (cached !== undefined) return cached;
+    const resolved = resolveSingleDeferred(state, runtime);
+    deferredCache.set(state, resolved);
+    return resolved;
   }
 
   if (isDependencySourceState(state)) return state;
@@ -1104,7 +1137,7 @@ function resolveDeferredInState(
 
   if (Array.isArray(state)) {
     const resolved = state.map((item) =>
-      resolveDeferredInState(item, runtime, visited)
+      resolveDeferredInState(item, runtime, visited, deferredCache)
     );
     return resolved.every((item, index) => item === state[index])
       ? state
@@ -1114,7 +1147,10 @@ function resolveDeferredInState(
   if (isPlainObject(state)) {
     const keys = Reflect.ownKeys(state);
     const resolvedEntries = keys.map((key) =>
-      [key, resolveDeferredInState(state[key], runtime, visited)] as const
+      [
+        key,
+        resolveDeferredInState(state[key], runtime, visited, deferredCache),
+      ] as const
     );
     if (resolvedEntries.every(([key, value]) => value === state[key])) {
       return state;
@@ -1155,31 +1191,17 @@ async function resolveDeferredInStateAsync(
   state: unknown,
   runtime: DependencyRuntimeContext,
   visited: WeakSet<object> = new WeakSet<object>(),
+  deferredCache: WeakMap<DeferredParseState<unknown>, Promise<unknown>> =
+    new WeakMap(),
 ): Promise<unknown> {
   if (state == null) return state;
 
   if (isDeferredParseState(state)) {
-    const deferred = state;
-    const isMultiDep = deferred.dependencyIds != null &&
-      deferred.dependencyIds.length > 0;
-    const depIds = isMultiDep
-      ? deferred.dependencyIds!
-      : [deferred.dependencyId];
-    const resolution = runtime.resolveDependencies({
-      dependencyIds: depIds,
-      defaultValues: deferred.defaultValues,
-    });
-    if (resolution.kind !== "resolved") return deferred.preliminaryResult;
-
-    // If every dependency value came from defaults, skip the replay.
-    if (resolution.usedDefaults.every((d) => d)) {
-      return deferred.preliminaryResult;
-    }
-
-    const depValue = isMultiDep ? resolution.values : resolution.values[0];
-    return Promise.resolve(
-      deferred.parser[parseWithDependency](deferred.rawInput, depValue),
-    );
+    const cached = deferredCache.get(state);
+    if (cached !== undefined) return cached;
+    const resolved = resolveSingleDeferredAsync(state, runtime);
+    deferredCache.set(state, resolved);
+    return resolved;
   }
 
   if (isDependencySourceState(state)) return state;
@@ -1191,7 +1213,9 @@ async function resolveDeferredInStateAsync(
 
   if (Array.isArray(state)) {
     const resolved = await Promise.all(
-      state.map((item) => resolveDeferredInStateAsync(item, runtime, visited)),
+      state.map((item) =>
+        resolveDeferredInStateAsync(item, runtime, visited, deferredCache)
+      ),
     );
     return resolved.every((item, index) => item === state[index])
       ? state
@@ -1208,6 +1232,7 @@ async function resolveDeferredInStateAsync(
             state[key],
             runtime,
             visited,
+            deferredCache,
           ),
         ] as const;
       }),

--- a/packages/core/src/dependency.test.ts
+++ b/packages/core/src/dependency.test.ts
@@ -4435,8 +4435,10 @@ describe("coverage-guided dependency parser tests", () => {
         metavar: "VALUE",
         placeholder: "ok" as const,
         parse(_input: string): ValueParserResult<"ok"> {
-          const thenable = () => undefined;
-          thenable.then = () => undefined;
+          const thenable: (() => undefined) & { then: () => undefined } = Object
+            .assign(() => undefined, {
+              then: () => undefined,
+            });
           // @ts-expect-error: intentional function-thenable regression coverage.
           return thenable;
         },

--- a/packages/core/src/dependency.test.ts
+++ b/packages/core/src/dependency.test.ts
@@ -4692,6 +4692,127 @@ describe("coverage-guided dependency parser tests", () => {
     }
   });
 
+  test("parse failures after default resolution should preserve dependency snapshots", async () => {
+    const modeParser = dependency(choice(["dev", "prod"] as const));
+    const regionParser = dependency(choice(["ap", "eu"] as const));
+
+    const syncMulti = deriveFrom({
+      metavar: "VALUE",
+      mode: "sync",
+      dependencies: [modeParser, regionParser] as const,
+      factory: (mode: "dev" | "prod", _region: "ap" | "eu") => {
+        if (mode === "prod") {
+          throw new Error("prod unavailable");
+        }
+        return choice(["ok"] as const);
+      },
+      defaultValues: () => ["prod", "ap"] as const,
+    });
+    const syncMultiResult = syncMulti.parse("ok");
+    assert.ok(!syncMultiResult.success);
+    assert.deepEqual(
+      getSnapshottedDefaultDependencyValues(syncMultiResult),
+      ["prod", "ap"],
+    );
+
+    const asyncMulti = deriveFromAsync({
+      metavar: "VALUE",
+      dependencies: [modeParser, regionParser] as const,
+      factory: (mode: "dev" | "prod", _region: "ap" | "eu") => {
+        if (mode === "prod") {
+          throw new Error("async prod unavailable");
+        }
+        return asyncChoice(["ok"] as const);
+      },
+      defaultValues: () => ["prod", "ap"] as const,
+    });
+    const asyncMultiResult = await asyncMulti.parse("ok");
+    assert.ok(!asyncMultiResult.success);
+    assert.deepEqual(
+      getSnapshottedDefaultDependencyValues(asyncMultiResult),
+      ["prod", "ap"],
+    );
+
+    const asyncFromSyncMulti = deriveFromSync({
+      metavar: "VALUE",
+      dependencies: [
+        dependency(asyncChoice(["dev", "prod"] as const)),
+      ] as const,
+      factory: (mode: "dev" | "prod") => {
+        if (mode === "prod") {
+          throw new Error("async source prod unavailable");
+        }
+        return choice(["ok"] as const);
+      },
+      defaultValues: () => ["prod"] as const,
+    });
+    const asyncFromSyncMultiResult = await asyncFromSyncMulti.parse("ok");
+    assert.ok(!asyncFromSyncMultiResult.success);
+    assert.deepEqual(
+      getSnapshottedDefaultDependencyValues(asyncFromSyncMultiResult),
+      ["prod"],
+    );
+
+    const singleSync = modeParser.derive({
+      metavar: "VALUE",
+      mode: "sync",
+      factory: (mode: "dev" | "prod") => {
+        if (mode === "prod") {
+          throw "single prod unavailable";
+        }
+        return choice(["ok"] as const);
+      },
+      defaultValue: () => "prod" as const,
+    });
+    const singleSyncResult = singleSync.parse("ok");
+    assert.ok(!singleSyncResult.success);
+    assert.deepEqual(
+      getSnapshottedDefaultDependencyValues(singleSyncResult),
+      ["prod"],
+    );
+    assert.deepEqual(
+      singleSyncResult.error,
+      message`Derived parser error: ${"single prod unavailable"}`,
+    );
+
+    const singleAsync = modeParser.deriveAsync({
+      metavar: "VALUE",
+      factory: (mode: "dev" | "prod") => {
+        if (mode === "prod") {
+          throw new Error("single async prod unavailable");
+        }
+        return asyncChoice(["ok"] as const);
+      },
+      defaultValue: () => "prod" as const,
+    });
+    const singleAsyncResult = await singleAsync.parse("ok");
+    assert.ok(!singleAsyncResult.success);
+    assert.deepEqual(
+      getSnapshottedDefaultDependencyValues(singleAsyncResult),
+      ["prod"],
+    );
+
+    const singleAsyncFromSync = dependency(
+      asyncChoice(["dev", "prod"] as const),
+    ).derive({
+      metavar: "VALUE",
+      mode: "sync",
+      factory: (mode: "dev" | "prod") => {
+        if (mode === "prod") {
+          throw new Error("single async-source prod unavailable");
+        }
+        return choice(["ok"] as const);
+      },
+      defaultValue: () => "prod" as const,
+    });
+    const singleAsyncFromSyncResult = await singleAsyncFromSync.parse("ok");
+    assert.ok(!singleAsyncFromSyncResult.success);
+    assert.deepEqual(
+      getSnapshottedDefaultDependencyValues(singleAsyncFromSyncResult),
+      ["prod"],
+    );
+  });
+
   test("deriveFromSync async mode should use defaults for format and suggest", async () => {
     const modeParser = dependency(asyncChoice(["dev", "prod"] as const));
     const regionParser = dependency(asyncChoice(["ap", "eu"] as const));

--- a/packages/core/src/dependency.test.ts
+++ b/packages/core/src/dependency.test.ts
@@ -4711,6 +4711,70 @@ describe("coverage-guided dependency parser tests", () => {
       .map((suggestion) => suggestion.text);
     assert.ok(texts.includes("dev-ap"));
   });
+
+  test("sync multi-source derived parser preserves values when defaults fail", () => {
+    const derived = deriveFromSync({
+      metavar: "VALUE",
+      dependencies: [] as const,
+      factory: () => choice(["ok"] as const),
+      defaultValues: (): readonly [] => {
+        throw new Error("defaults unavailable");
+      },
+    });
+
+    assert.equal(derived.placeholder, undefined);
+    assert.equal(derived.format("sentinel" as never), "sentinel");
+    assert.deepEqual([...(derived.suggest?.("o") ?? [])], []);
+    assert.equal(derived.normalize?.("sentinel" as never), "sentinel");
+
+    const result = derived.parse("ok");
+    assert.ok(!result.success);
+    assert.equal(getSnapshottedDefaultDependencyValues(result), undefined);
+  });
+
+  test("sync multi-source derived parser preserves values when normalize throws", () => {
+    const derived = deriveFromSync({
+      metavar: "VALUE",
+      dependencies: [] as const,
+      factory: () => ({
+        mode: "sync" as const,
+        metavar: "VALUE",
+        placeholder: "ok",
+        parse(input: string): ValueParserResult<string> {
+          return { success: true, value: input };
+        },
+        format(value: string): string {
+          return value;
+        },
+        normalize(): string {
+          throw new Error("cannot normalize");
+        },
+      }),
+      defaultValues: () => [] as const,
+    });
+
+    assert.equal(derived.normalize?.("sentinel"), "sentinel");
+  });
+
+  test("async multi-source derived parser preserves values when defaults fail", async () => {
+    const derived = deriveFromAsync({
+      metavar: "VALUE",
+      dependencies: [] as const,
+      factory: () => asyncChoice(["ok"] as const),
+      defaultValues: (): readonly [] => {
+        throw new Error("defaults unavailable");
+      },
+    });
+
+    assert.equal(derived.placeholder, undefined);
+    assert.equal(derived.format("sentinel" as never), "sentinel");
+    assert.deepEqual(await collectSuggestions(derived.suggest!("o")), []);
+    assert.equal(derived.normalize?.("sentinel" as never), "sentinel");
+
+    const result = await derived.parse("ok");
+    assert.ok(!result.success);
+    assert.equal(getSnapshottedDefaultDependencyValues(result), undefined);
+  });
 });
 
 describe("property-based tests", () => {

--- a/packages/core/src/dependency.test.ts
+++ b/packages/core/src/dependency.test.ts
@@ -4425,6 +4425,34 @@ describe("coverage-guided dependency parser tests", () => {
     });
   });
 
+  test("sync derived parsers should reject function thenables", () => {
+    const modeParser = dependency(choice(["sync", "async"] as const));
+    const derived = deriveFromSync({
+      metavar: "VALUE",
+      dependencies: [modeParser] as const,
+      factory: () => ({
+        mode: "sync" as const,
+        metavar: "VALUE",
+        placeholder: "ok" as const,
+        parse(_input: string): ValueParserResult<"ok"> {
+          const thenable = () => undefined;
+          thenable.then = () => undefined;
+          // @ts-expect-error: intentional function-thenable regression coverage.
+          return thenable;
+        },
+        format(value: "ok"): string {
+          return value;
+        },
+      }),
+      defaultValues: () => ["sync"] as const,
+    });
+
+    assert.throws(() => derived.parse("ok"), {
+      name: "TypeError",
+      message: /promise-like result/i,
+    });
+  });
+
   test("suggestWithDependency should return empty when both factories fail", async () => {
     const envParser = dependency(choice(["dev", "prod"] as const));
     const regionParser = dependency(choice(["local", "remote"] as const));
@@ -4690,6 +4718,29 @@ describe("coverage-guided dependency parser tests", () => {
         message`Factory error: ${"single-async-source-error"}`,
       );
     }
+
+    const asyncMulti = deriveFromAsync({
+      metavar: "VALUE",
+      dependencies: [modeParser, regionParser] as const,
+      factory: (mode: "ok" | "boom", _region: "us" | "eu") => {
+        if (mode === "boom") {
+          throw new Error("async-multi-factory-error");
+        }
+        return asyncChoice(["value"] as const);
+      },
+      defaultValues: () => ["ok", "us"] as const,
+    });
+    const asyncMultiResult = await asyncMulti[parseWithDependency](
+      "value",
+      ["boom", "us"] as const,
+    );
+    assert.ok(!asyncMultiResult.success);
+    if (!asyncMultiResult.success) {
+      assert.deepEqual(
+        asyncMultiResult.error,
+        message`Factory error: ${"async-multi-factory-error"}`,
+      );
+    }
   });
 
   test("parse failures after default resolution should preserve dependency snapshots", async () => {
@@ -4895,6 +4946,109 @@ describe("coverage-guided dependency parser tests", () => {
     const result = await derived.parse("ok");
     assert.ok(!result.success);
     assert.equal(getSnapshottedDefaultDependencyValues(result), undefined);
+  });
+
+  test("async-from-sync multi-source parser preserves values when defaults fail", async () => {
+    const derived = deriveFromSync({
+      metavar: "VALUE",
+      dependencies: [
+        dependency(asyncChoice(["dev", "prod"] as const)),
+      ] as const,
+      factory: () => choice(["ok", "sentinel"] as const),
+      defaultValues: (): readonly ["dev"] => {
+        throw new Error("defaults unavailable");
+      },
+    });
+
+    assert.equal(derived.placeholder, undefined);
+    assert.equal(derived.format("sentinel"), "sentinel");
+    assert.equal(derived.normalize?.("sentinel"), "sentinel");
+    assert.deepEqual(await collectSuggestions(derived.suggest!("o")), []);
+
+    const result = await derived.parse("ok");
+    assert.ok(!result.success);
+    assert.deepEqual(
+      result.error,
+      message`Derived parser error: ${"defaults unavailable"}`,
+    );
+    assert.equal(getSnapshottedDefaultDependencyValues(result), undefined);
+  });
+
+  test("async-from-sync multi-source parser reports dependency factory errors", async () => {
+    const derived = deriveFromSync({
+      metavar: "VALUE",
+      dependencies: [
+        dependency(asyncChoice(["dev", "prod"] as const)),
+      ] as const,
+      factory: (mode: "dev" | "prod") => {
+        if (mode === "prod") {
+          throw new Error("prod parser unavailable");
+        }
+        return choice(["ok"] as const);
+      },
+      defaultValues: () => ["dev"] as const,
+    });
+
+    const result = await derived[parseWithDependency](
+      "ok",
+      ["prod"] as const,
+    );
+    assert.ok(!result.success);
+    if (!result.success) {
+      assert.deepEqual(
+        result.error,
+        message`Factory error: ${"prod parser unavailable"}`,
+      );
+    }
+  });
+
+  test("async-from-sync single-source parser preserves values when defaults fail", async () => {
+    const source = dependency(asyncChoice(["dev", "prod"] as const));
+    const derived = source.derive({
+      metavar: "VALUE",
+      mode: "sync",
+      factory: () => choice(["ok", "sentinel"] as const),
+      defaultValue: (): "dev" => {
+        throw new Error("single default unavailable");
+      },
+    });
+
+    assert.equal(derived.placeholder, undefined);
+    assert.equal(derived.format("sentinel"), "sentinel");
+    assert.equal(derived.normalize?.("sentinel"), "sentinel");
+    assert.deepEqual(await collectSuggestions(derived.suggest!("o")), []);
+
+    const result = await derived.parse("ok");
+    assert.ok(!result.success);
+    assert.deepEqual(
+      result.error,
+      message`Derived parser error: ${"single default unavailable"}`,
+    );
+    assert.equal(getSnapshottedDefaultDependencyValues(result), undefined);
+  });
+
+  test("async-from-sync single-source parser reports dependency factory errors", async () => {
+    const source = dependency(asyncChoice(["dev", "prod"] as const));
+    const derived = source.derive({
+      metavar: "VALUE",
+      mode: "sync",
+      factory: (mode: "dev" | "prod") => {
+        if (mode === "prod") {
+          throw new Error("single prod unavailable");
+        }
+        return choice(["ok"] as const);
+      },
+      defaultValue: () => "dev" as const,
+    });
+
+    const result = await derived[parseWithDependency]("ok", "prod");
+    assert.ok(!result.success);
+    if (!result.success) {
+      assert.deepEqual(
+        result.error,
+        message`Factory error: ${"single prod unavailable"}`,
+      );
+    }
   });
 });
 

--- a/packages/core/src/doc.test.ts
+++ b/packages/core/src/doc.test.ts
@@ -7,6 +7,7 @@ import {
   type DocPageFormatOptions,
   type DocSection,
   formatDocPage,
+  isDocEntryHidden,
 } from "@optique/core/doc";
 import { message, valueSet } from "@optique/core/message";
 import assert from "node:assert/strict";
@@ -27,6 +28,40 @@ describe("formatDocPage", () => {
     const result = formatDocPage("myapp", page);
     const expected = "\n  test                        A test command\n";
     assert.equal(result, expected);
+  });
+
+  it("should compute maxWidth from visible atomic usage terms", () => {
+    const page: DocPage = {
+      usage: [
+        { type: "optional", terms: [{ type: "literal", value: "sub" }] },
+        {
+          type: "multiple",
+          min: 0,
+          terms: [{ type: "passthrough" }],
+        },
+        {
+          type: "exclusive",
+          terms: [
+            [{ type: "command", name: "secret", hidden: true }],
+            [{ type: "ellipsis" }],
+          ],
+        },
+      ],
+      sections: [],
+    };
+
+    assert.throws(
+      () => formatDocPage("app", page, { maxWidth: 11 }),
+      {
+        name: "RangeError",
+        message: "maxWidth must be at least 12, got 11.",
+      },
+    );
+    const result = formatDocPage("app", page, { maxWidth: 12 });
+    assert.ok(result.startsWith("Usage: app"));
+    assert.ok(result.includes("sub"));
+    assert.ok(result.includes("[...]"));
+    assert.ok(!result.includes("secret"));
   });
 
   it("should format a page with brief", () => {
@@ -2630,6 +2665,30 @@ describe("branch coverage: doc.ts edge cases", () => {
     assert.ok(result.includes("..."), "should show ellipsis for truncation");
   });
 
+  it("showChoices: maxItems should count only value terms", () => {
+    const page: DocPage = {
+      sections: [{
+        entries: [{
+          term: { type: "option", names: ["--color"] },
+          choices: [
+            { type: "text", text: "try " },
+            { type: "value", value: "red" },
+            { type: "text", text: " or " },
+            { type: "value", value: "green" },
+            { type: "text", text: " first" },
+          ],
+        }],
+      }],
+    };
+
+    const result = formatDocPage("myapp", page, {
+      showChoices: { maxItems: 1 },
+    });
+
+    assert.ok(result.includes("choices: try red, ..."));
+    assert.ok(!result.includes("green"));
+  });
+
   it("showChoices: maxItems 0 throws RangeError", () => {
     const page: DocPage = {
       sections: [{
@@ -2949,6 +3008,34 @@ describe("branch coverage: doc.ts edge cases", () => {
         formatDocPage("app", page, { colors: false, maxWidth: 1 });
       });
     });
+  });
+});
+
+describe("isDocEntryHidden", () => {
+  it("should follow hidden flags for doc-hideable terms", () => {
+    const entries: readonly DocEntry[] = [
+      { term: { type: "argument", metavar: "FILE", hidden: true } },
+      { term: { type: "option", names: ["--secret"], hidden: "doc" } },
+      { term: { type: "command", name: "internal", hidden: "help" } },
+      { term: { type: "passthrough", hidden: true } },
+    ];
+
+    for (const entry of entries) {
+      assert.ok(isDocEntryHidden(entry));
+    }
+  });
+
+  it("should keep usage-only and structural terms visible in docs", () => {
+    const entries: readonly DocEntry[] = [
+      { term: { type: "option", names: ["--verbose"], hidden: "usage" } },
+      { term: { type: "literal", value: "--" } },
+      { term: { type: "ellipsis" } },
+      { term: { type: "optional", terms: [] } },
+    ];
+
+    for (const entry of entries) {
+      assert.ok(!isDocEntryHidden(entry));
+    }
   });
 });
 

--- a/packages/core/src/facade.test.ts
+++ b/packages/core/src/facade.test.ts
@@ -16,7 +16,11 @@ import type {
 } from "@optique/core/context";
 import type { DocSection } from "@optique/core/doc";
 import { defineInheritedAnnotationParser } from "./internal/parser.ts";
-import type { ExecutionContext, Parser } from "@optique/core/parser";
+import {
+  createParserContext,
+  type ExecutionContext,
+  type Parser,
+} from "@optique/core/parser";
 import {
   type RunOptions,
   runParser,
@@ -126,6 +130,100 @@ function createPhaseTwoSeedParser(
       };
     },
     *suggest() {},
+    getDocFragments() {
+      return { fragments: [] };
+    },
+  };
+}
+
+function createSyncStallingPhaseTwoParser(
+  tokenKey: symbol,
+): Parser<"sync", string, string | undefined> {
+  return {
+    mode: "sync",
+    $valueType: [] as readonly string[],
+    $stateType: [] as readonly (string | undefined)[],
+    priority: 0,
+    usage: [],
+    leadingNames: new Set(),
+    acceptingAnyToken: false,
+    initialState: undefined,
+    parse(context) {
+      const token = getAnnotations(context.state)?.[tokenKey];
+      if (typeof token !== "string" || context.buffer.length < 1) {
+        return {
+          success: true as const,
+          next: context,
+          consumed: [],
+        };
+      }
+      return {
+        success: true as const,
+        next: createParserContext(
+          {
+            buffer: context.buffer.slice(1),
+            state: token,
+            optionsTerminated: context.optionsTerminated,
+          },
+          context.exec!,
+        ),
+        consumed: [context.buffer[0]!],
+      };
+    },
+    complete(state) {
+      return {
+        success: true as const,
+        value: state ?? "phase1",
+      };
+    },
+    *suggest() {},
+    getDocFragments() {
+      return { fragments: [] };
+    },
+  };
+}
+
+function createAsyncStallingPhaseTwoParser(
+  tokenKey: symbol,
+): Parser<"async", string, string | undefined> {
+  return {
+    mode: "async",
+    $valueType: [] as readonly string[],
+    $stateType: [] as readonly (string | undefined)[],
+    priority: 0,
+    usage: [],
+    leadingNames: new Set(),
+    acceptingAnyToken: false,
+    initialState: undefined,
+    parse(context) {
+      const token = getAnnotations(context.state)?.[tokenKey];
+      if (typeof token !== "string" || context.buffer.length < 1) {
+        return Promise.resolve({
+          success: true as const,
+          next: context,
+          consumed: [],
+        });
+      }
+      return Promise.resolve({
+        success: true as const,
+        next: createParserContext(
+          {
+            buffer: context.buffer.slice(1),
+            state: token,
+            optionsTerminated: context.optionsTerminated,
+          },
+          context.exec!,
+        ),
+        consumed: [context.buffer[0]!],
+      });
+    },
+    complete(state) {
+      return Promise.resolve({
+        success: true as const,
+        value: state ?? "phase1",
+      });
+    },
+    async *suggest() {},
     getDocFragments() {
       return { fragments: [] };
     },
@@ -5984,6 +6082,27 @@ describe("runWith", () => {
       assert.equal(result, "phase2:hidden");
     });
 
+    it("should hide phase-two seed array shells when every data item is deferred", async () => {
+      const tokenKey = Symbol.for("@test/phase-two-hide-array-shell");
+      let phase2Parsed: unknown = "not-called";
+      const parser = createPhaseTwoSeedParser(tokenKey, {
+        value: ["prompt-placeholder"],
+        deferred: true,
+        deferredKeys: new Map<PropertyKey, DeferredMap | null>([
+          [0, null],
+        ]),
+      });
+      const context = createPhaseTwoCaptureContext(tokenKey, (parsed) => {
+        phase2Parsed = parsed;
+        return parsed === undefined ? "hidden" : "visible";
+      });
+
+      const result = await runWith(parser, "test", [context], { args: [] });
+
+      assert.equal(phase2Parsed, undefined);
+      assert.equal(result, "phase2:hidden");
+    });
+
     it("should hide phase-two seed values when deferred metadata is stale", async () => {
       const tokenKey = Symbol.for("@test/phase-two-hide-stale-keys");
       let phase2Parsed: unknown = "not-called";
@@ -6003,6 +6122,40 @@ describe("runWith", () => {
 
       assert.equal(phase2Parsed, undefined);
       assert.equal(result, "phase2:hidden");
+    });
+
+    it("should use sync phase-two seeds when parsers stop before consuming input", () => {
+      const tokenKey = Symbol.for("@test/sync-stalled-phase-two-seed");
+      const parser = createSyncStallingPhaseTwoParser(tokenKey);
+      let phase2Parsed: unknown = "not-called";
+      const context = createPhaseTwoCaptureContext(tokenKey, (parsed) => {
+        phase2Parsed = parsed;
+        return parsed === "phase1" ? "phase2" : "missing";
+      });
+
+      const result = runWithSync(parser, "test", [context], {
+        args: ["--from-context"],
+      });
+
+      assert.equal(phase2Parsed, "phase1");
+      assert.equal(result, "phase2");
+    });
+
+    it("should use async phase-two seeds when parsers stop before consuming input", async () => {
+      const tokenKey = Symbol.for("@test/async-stalled-phase-two-seed");
+      const parser = createAsyncStallingPhaseTwoParser(tokenKey);
+      let phase2Parsed: unknown = "not-called";
+      const context = createPhaseTwoCaptureContext(tokenKey, (parsed) => {
+        phase2Parsed = parsed;
+        return parsed === "phase1" ? "phase2" : "missing";
+      });
+
+      const result = await runWithAsync(parser, "test", [context], {
+        args: ["--from-context"],
+      });
+
+      assert.equal(phase2Parsed, "phase1");
+      assert.equal(result, "phase2");
     });
 
     it("should handle mixed single-pass and two-pass contexts", async () => {
@@ -7867,6 +8020,33 @@ describe("runWithSync", () => {
 
       runWithSync(parser, "test", [context], { args: [] });
       assert.deepEqual(disposed, ["async"]);
+    });
+
+    it("should reject Promise-returning Symbol.asyncDispose in sync mode", () => {
+      const context: SourceContext = {
+        id: Symbol.for("@test/sync-async-dispose-promise"),
+        phase: "single-pass",
+        getAnnotations() {
+          return {
+            [Symbol.for("@test/sync-async-dispose-promise")]: { value: true },
+          };
+        },
+        [Symbol.asyncDispose]() {
+          return Promise.resolve();
+        },
+      };
+
+      const parser = object({
+        name: withDefault(option("--name", string()), "default"),
+      });
+
+      assert.throws(
+        () => runWithSync(parser, "test", [context], { args: [] }),
+        {
+          name: "TypeError",
+          message: /returned a Promise from Symbol\.asyncDispose in sync mode/u,
+        },
+      );
     });
 
     it("should dispose remaining contexts when one sync dispose fails", () => {

--- a/packages/core/src/facade.test.ts
+++ b/packages/core/src/facade.test.ts
@@ -3770,6 +3770,81 @@ describe("Subcommand help edge cases (Issue #26 comprehensive coverage)", () => 
       assert.ok(suggestions.includes("--version"));
     });
 
+    it("should include meta options in empty root completion suggestions", () => {
+      const parser = command("build", option("--target", string()));
+
+      let completionOutput = "";
+
+      runParser(parser, "myapp", ["completion", "bash", ""], {
+        help: { option: true, onShow: () => "help" },
+        version: { option: true, value: "1.0.0" },
+        completion: { command: true },
+        stdout: (text) => {
+          completionOutput += text;
+        },
+      });
+
+      const suggestions = completionOutput.split("\n").filter((s) =>
+        s.length > 0
+      );
+      assert.ok(suggestions.includes("build"));
+      assert.ok(suggestions.includes("--help"));
+      assert.ok(suggestions.includes("--version"));
+    });
+
+    it("should include meta options after subcommands", () => {
+      const parser = command(
+        "build",
+        object({
+          target: option("--target", string()),
+        }),
+      );
+
+      let completionOutput = "";
+
+      runParser(parser, "myapp", ["completion", "bash", "build", "--"], {
+        help: { option: true, onShow: () => "help" },
+        version: { option: true, value: "1.0.0" },
+        completion: { command: true },
+        stdout: (text) => {
+          completionOutput += text;
+        },
+      });
+
+      const suggestions = completionOutput.split("\n").filter((s) =>
+        s.length > 0
+      );
+      assert.ok(suggestions.includes("--target"));
+      assert.ok(suggestions.includes("--help"));
+      assert.ok(suggestions.includes("--version"));
+    });
+
+    it("should filter meta options by the current argument prefix", () => {
+      const parser = command(
+        "build",
+        object({
+          target: option("--target", string()),
+        }),
+      );
+
+      let completionOutput = "";
+
+      runParser(parser, "myapp", ["completion", "bash", "build", "--h"], {
+        help: { option: true, onShow: () => "help" },
+        version: { option: true, value: "1.0.0" },
+        completion: { command: true },
+        stdout: (text) => {
+          completionOutput += text;
+        },
+      });
+
+      const suggestions = completionOutput.split("\n").filter((s) =>
+        s.length > 0
+      );
+      assert.ok(suggestions.includes("--help"));
+      assert.ok(!suggestions.includes("--version"));
+    });
+
     it("should not duplicate user options that shadow meta options in completion suggestions", () => {
       const parser = object({
         help: option("--help", string()),

--- a/packages/core/src/facade.test.ts
+++ b/packages/core/src/facade.test.ts
@@ -3746,6 +3746,303 @@ describe("Subcommand help edge cases (Issue #26 comprehensive coverage)", () => 
       assert.ok(suggestions.includes("--format"));
     });
 
+    it("should include meta options in completion suggestions", () => {
+      const parser = object({
+        verbose: option("--verbose"),
+      });
+
+      let completionOutput = "";
+
+      runParser(parser, "myapp", ["completion", "bash", "--"], {
+        help: { option: true, onShow: () => "help" },
+        version: { option: true, value: "1.0.0" },
+        completion: { command: true },
+        stdout: (text) => {
+          completionOutput += text;
+        },
+      });
+
+      const suggestions = completionOutput.split("\n").filter((s) =>
+        s.length > 0
+      );
+      assert.ok(suggestions.includes("--verbose"));
+      assert.ok(suggestions.includes("--help"));
+      assert.ok(suggestions.includes("--version"));
+    });
+
+    it("should not duplicate user options that shadow meta options in completion suggestions", () => {
+      const parser = object({
+        help: option("--help", string()),
+      });
+
+      let completionOutput = "";
+
+      runParser(parser, "myapp", ["completion", "bash", "--h"], {
+        help: { option: true, onShow: () => "help" },
+        completion: { command: true },
+        stdout: (text) => {
+          completionOutput += text;
+        },
+      });
+
+      const suggestions = completionOutput.split("\n").filter((s) =>
+        s.length > 0
+      );
+      assert.equal(
+        suggestions.filter((suggestion) => suggestion === "--help").length,
+        1,
+      );
+    });
+
+    it("should respect hidden meta options in completion suggestions", () => {
+      const parser = object({
+        verbose: option("--verbose"),
+      });
+
+      let completionOutput = "";
+
+      runParser(parser, "myapp", ["completion", "bash", "--"], {
+        help: { option: { hidden: true }, onShow: () => "help" },
+        version: { option: { hidden: true }, value: "1.0.0" },
+        completion: { command: true },
+        stdout: (text) => {
+          completionOutput += text;
+        },
+      });
+
+      const suggestions = completionOutput.split("\n").filter((s) =>
+        s.length > 0
+      );
+      assert.ok(suggestions.includes("--verbose"));
+      assert.ok(!suggestions.includes("--help"));
+      assert.ok(!suggestions.includes("--version"));
+    });
+
+    it("should keep long meta options out of bare short-option completion", () => {
+      const parser = object({
+        verbose: option("-v"),
+      });
+
+      let completionOutput = "";
+
+      runParser(parser, "myapp", ["completion", "bash", "-"], {
+        help: { option: true, onShow: () => "help" },
+        version: { option: true, value: "1.0.0" },
+        completion: { command: true },
+        stdout: (text) => {
+          completionOutput += text;
+        },
+      });
+
+      const suggestions = completionOutput.split("\n").filter((s) =>
+        s.length > 0
+      );
+      assert.ok(suggestions.includes("-v"));
+      assert.ok(!suggestions.includes("--help"));
+      assert.ok(!suggestions.includes("--version"));
+    });
+
+    it("should include short meta aliases in bare short-option completion", () => {
+      const parser = object({
+        verbose: option("-v"),
+      });
+
+      let completionOutput = "";
+
+      runParser(parser, "myapp", ["completion", "bash", "-"], {
+        help: { option: { names: ["-h", "--help"] }, onShow: () => "help" },
+        version: {
+          option: { names: ["-V", "--version"] },
+          value: "1.0.0",
+        },
+        completion: { command: true },
+        stdout: (text) => {
+          completionOutput += text;
+        },
+      });
+
+      const suggestions = completionOutput.split("\n").filter((s) =>
+        s.length > 0
+      );
+      assert.ok(suggestions.includes("-v"));
+      assert.ok(suggestions.includes("-h"));
+      assert.ok(suggestions.includes("-V"));
+      assert.ok(!suggestions.includes("--help"));
+      assert.ok(!suggestions.includes("--version"));
+    });
+
+    it("should include slash-prefixed meta options in slash completion", () => {
+      const parser = object({
+        verbose: option("/v"),
+      });
+
+      let completionOutput = "";
+
+      runParser(parser, "myapp", ["completion", "bash", "/"], {
+        help: { option: { names: ["/?"] }, onShow: () => "help" },
+        version: { option: { names: ["/V"] }, value: "1.0.0" },
+        completion: { command: true },
+        stdout: (text) => {
+          completionOutput += text;
+        },
+      });
+
+      const suggestions = completionOutput.split("\n").filter((s) =>
+        s.length > 0
+      );
+      assert.ok(suggestions.includes("/v"));
+      assert.ok(suggestions.includes("/?"));
+      assert.ok(suggestions.includes("/V"));
+    });
+
+    it("should include plus-prefixed options in plus completion", () => {
+      const parser = object({
+        verbose: option("+verbose"),
+      });
+
+      let completionOutput = "";
+
+      runParser(parser, "myapp", ["completion", "bash", "+"], {
+        help: { option: { names: ["+h"] }, onShow: () => "help" },
+        version: { option: { names: ["+V"] }, value: "1.0.0" },
+        completion: { command: true },
+        stdout: (text) => {
+          completionOutput += text;
+        },
+      });
+
+      const suggestions = completionOutput.split("\n").filter((s) =>
+        s.length > 0
+      );
+      assert.ok(suggestions.includes("+verbose"));
+      assert.ok(suggestions.includes("+h"));
+      assert.ok(suggestions.includes("+V"));
+    });
+
+    it("should filter meta options by completion prefix", () => {
+      const parser = object({
+        verbose: option("--verbose"),
+      });
+
+      let completionOutput = "";
+
+      runParser(parser, "myapp", ["completion", "bash", "--h"], {
+        help: { option: true, onShow: () => "help" },
+        version: { option: true, value: "1.0.0" },
+        completion: { command: true },
+        stdout: (text) => {
+          completionOutput += text;
+        },
+      });
+
+      const suggestions = completionOutput.split("\n").filter((s) =>
+        s.length > 0
+      );
+      assert.ok(suggestions.includes("--help"));
+      assert.ok(!suggestions.includes("--version"));
+    });
+
+    it("should not add meta options for non-option root completion", () => {
+      const parser = command("build", option("--verbose"));
+
+      let completionOutput = "";
+
+      runParser(parser, "myapp", ["completion", "bash", "b"], {
+        help: { option: true, onShow: () => "help" },
+        version: { option: true, value: "1.0.0" },
+        completion: { command: true },
+        stdout: (text) => {
+          completionOutput += text;
+        },
+      });
+
+      const suggestions = completionOutput.split("\n").filter((s) =>
+        s.length > 0
+      );
+      assert.ok(suggestions.includes("build"));
+      assert.ok(!suggestions.includes("--help"));
+      assert.ok(!suggestions.includes("--version"));
+    });
+
+    it("should preserve file suggestions while adding root meta options", () => {
+      const parser: Parser<"sync", string, undefined> = {
+        mode: "sync",
+        $valueType: [] as readonly string[],
+        $stateType: [] as readonly undefined[],
+        priority: 0,
+        usage: [],
+        leadingNames: new Set(),
+        acceptingAnyToken: true,
+        initialState: undefined,
+        parse() {
+          return { success: false, consumed: 0, error: message`missing` };
+        },
+        complete() {
+          return { success: false, error: message`missing` };
+        },
+        *suggest() {
+          yield { kind: "file", type: "file", pattern: "--" };
+        },
+        getDocFragments() {
+          return { fragments: [] };
+        },
+      };
+
+      let completionOutput = "";
+
+      runParser(parser, "myapp", ["completion", "bash", "--"], {
+        help: { option: true, onShow: () => "help" },
+        version: { option: true, value: "1.0.0" },
+        completion: { command: true },
+        stdout: (text) => {
+          completionOutput += text;
+        },
+      });
+
+      const suggestions = completionOutput.split("\n").filter((s) =>
+        s.length > 0
+      );
+      assert.ok(
+        suggestions.some((suggestion) =>
+          suggestion.startsWith("__FILE__:file")
+        ),
+      );
+      assert.ok(suggestions.includes("--help"));
+      assert.ok(suggestions.includes("--version"));
+    });
+
+    it("should not let meta options in completion payload change parser context", () => {
+      const parser = command(
+        "build",
+        object({
+          verbose: option("--verbose"),
+        }),
+      );
+
+      for (
+        const completionArgs of [
+          ["completion", "bash", "build", "--help", ""],
+          ["completion", "bash", "build", "--version", ""],
+        ]
+      ) {
+        let completionOutput = "";
+
+        runParser(parser, "myapp", completionArgs, {
+          help: { option: true, onShow: () => "help" },
+          version: { option: true, value: "1.0.0" },
+          completion: { command: true },
+          stdout: (text) => {
+            completionOutput += text;
+          },
+        });
+
+        const suggestions = completionOutput.split("\n").filter((s) =>
+          s.length > 0
+        );
+        assert.deepEqual(suggestions, []);
+      }
+    });
+
     it("should provide completion suggestions for zsh format", () => {
       const parser = object({
         verbose: option("--verbose"),

--- a/packages/core/src/facade.test.ts
+++ b/packages/core/src/facade.test.ts
@@ -3969,6 +3969,62 @@ describe("Subcommand help edge cases (Issue #26 comprehensive coverage)", () => 
       assert.ok(suggestions.includes("--version"));
     });
 
+    it("should add meta options after an option value matching a meta name", () => {
+      const parser = command(
+        "build",
+        object({
+          output: option("--output", string()),
+        }),
+      );
+
+      let completionOutput = "";
+
+      runParser(parser, "myapp", [
+        "completion",
+        "bash",
+        "build",
+        "--output",
+        "--help",
+        "",
+      ], {
+        help: { option: true, onShow: () => "help" },
+        version: { option: true, value: "1.0.0" },
+        completion: { command: true },
+        stdout: (text) => {
+          completionOutput += text;
+        },
+      });
+
+      const suggestions = completionOutput.split("\n").filter((s) =>
+        s.length > 0
+      );
+      assert.ok(suggestions.includes("--help"));
+      assert.ok(suggestions.includes("--version"));
+    });
+
+    it("should not add meta options while completing a root option value", () => {
+      const parser = object({
+        output: option("--output", string()),
+      });
+
+      let completionOutput = "";
+
+      runParser(parser, "myapp", ["completion", "bash", "--output", ""], {
+        help: { option: true, onShow: () => "help" },
+        version: { option: true, value: "1.0.0" },
+        completion: { command: true },
+        stdout: (text) => {
+          completionOutput += text;
+        },
+      });
+
+      const suggestions = completionOutput.split("\n").filter((s) =>
+        s.length > 0
+      );
+      assert.ok(!suggestions.includes("--help"));
+      assert.ok(!suggestions.includes("--version"));
+    });
+
     it("should add meta options after a flag sharing a value option name", () => {
       const parser = or(
         command("build", object({ target: flag("--target") })),
@@ -4409,6 +4465,38 @@ describe("Subcommand help edge cases (Issue #26 comprehensive coverage)", () => 
       assert.ok(suggestions.includes("-v"));
       assert.ok(suggestions.includes("-h"));
       assert.ok(suggestions.includes("-V"));
+      assert.ok(!suggestions.includes("--help"));
+      assert.ok(!suggestions.includes("--version"));
+    });
+
+    it("should include single-dash meta aliases in bare short-option completion", () => {
+      const parser = object({
+        verbose: option("-v"),
+      });
+
+      let completionOutput = "";
+
+      runParser(parser, "myapp", ["completion", "bash", "-"], {
+        help: {
+          option: { names: ["-help", "--help"] },
+          onShow: () => "help",
+        },
+        version: {
+          option: { names: ["-version", "--version"] },
+          value: "1.0.0",
+        },
+        completion: { command: true },
+        stdout: (text) => {
+          completionOutput += text;
+        },
+      });
+
+      const suggestions = completionOutput.split("\n").filter((s) =>
+        s.length > 0
+      );
+      assert.ok(suggestions.includes("-v"));
+      assert.ok(suggestions.includes("-help"));
+      assert.ok(suggestions.includes("-version"));
       assert.ok(!suggestions.includes("--help"));
       assert.ok(!suggestions.includes("--version"));
     });

--- a/packages/core/src/facade.test.ts
+++ b/packages/core/src/facade.test.ts
@@ -44,7 +44,7 @@ import {
 } from "@optique/core/primitives";
 import type { Program } from "@optique/core/program";
 import type { OptionName } from "@optique/core/usage";
-import type { ValueParser } from "@optique/core/valueparser";
+import type { DeferredMap, ValueParser } from "@optique/core/valueparser";
 import { integer, string } from "@optique/core/valueparser";
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
@@ -82,6 +82,93 @@ function getRuntimeExtractPhase2SeedKey(): symbol {
   );
   assert.ok(key, "expected command() to expose extractPhase2SeedKey");
   return key;
+}
+
+function createPhaseTwoSeedParser(
+  tokenKey: symbol,
+  seed: {
+    readonly value: unknown;
+    readonly deferred?: true;
+    readonly deferredKeys?: DeferredMap;
+  },
+): Parser<"sync", unknown, undefined> {
+  return {
+    mode: "sync",
+    $valueType: [] as readonly unknown[],
+    $stateType: [] as readonly undefined[],
+    priority: 0,
+    usage: [],
+    leadingNames: new Set(),
+    acceptingAnyToken: false,
+    initialState: undefined,
+    parse(context) {
+      return {
+        success: true as const,
+        next: context,
+        consumed: [],
+      };
+    },
+    complete(state) {
+      const token = getAnnotations(state)?.[tokenKey];
+      if (typeof token === "string") {
+        return {
+          success: true as const,
+          value: `phase2:${token}`,
+        };
+      }
+      return {
+        success: true as const,
+        value: seed.value,
+        ...(seed.deferred ? { deferred: true as const } : {}),
+        ...(seed.deferredKeys == null
+          ? {}
+          : { deferredKeys: seed.deferredKeys }),
+      };
+    },
+    *suggest() {},
+    getDocFragments() {
+      return { fragments: [] };
+    },
+  };
+}
+
+function createPhaseTwoCaptureContext(
+  tokenKey: symbol,
+  getToken: (parsed: unknown) => string,
+): SourceContext {
+  return {
+    id: tokenKey,
+    phase: "two-pass",
+    getAnnotations(request?: unknown) {
+      if (isPhase1ContextRequest(request)) return {};
+      return { [tokenKey]: getToken(getPhase2ContextParsed(request)) };
+    },
+  };
+}
+
+type PhaseTwoScrubbedConfig = {
+  readonly config: string;
+  readonly prompt: unknown;
+  readonly nested: {
+    readonly source: string;
+    readonly prompt: unknown;
+  };
+  readonly list: readonly unknown[];
+  readonly [key: symbol]: unknown;
+};
+
+function isPhaseTwoScrubbedConfig(
+  value: unknown,
+): value is PhaseTwoScrubbedConfig {
+  return value != null &&
+    typeof value === "object" &&
+    "config" in value &&
+    (value as { readonly config?: unknown }).config === "optique.json" &&
+    "nested" in value &&
+    (value as { readonly nested?: unknown }).nested != null &&
+    typeof (value as { readonly nested?: unknown }).nested === "object" &&
+    "list" in value &&
+    Array.isArray((value as { readonly list?: unknown }).list);
 }
 
 describe("runParser", () => {
@@ -5777,6 +5864,145 @@ describe("runWith", () => {
 
       assert.ok(reusedIdentity);
       assert.deepEqual(result, { name: "default" });
+    });
+
+    it("should hide deferred non-plain phase-two seed values from contexts", async () => {
+      const tokenKey = Symbol.for("@test/phase-two-hide-non-plain-leaf");
+      let phase2Parsed: unknown = "not-called";
+      const parser = createPhaseTwoSeedParser(tokenKey, {
+        value: new URL("https://example.com/config.json"),
+        deferred: true,
+        deferredKeys: new Map(),
+      });
+      const context = createPhaseTwoCaptureContext(tokenKey, (parsed) => {
+        phase2Parsed = parsed;
+        return parsed === undefined ? "hidden" : "visible";
+      });
+
+      const result = await runWith(parser, "test", [context], { args: [] });
+
+      assert.equal(phase2Parsed, undefined);
+      assert.equal(result, "phase2:hidden");
+    });
+
+    it("should hide deferred class instance seed values from contexts", async () => {
+      class DeferredSecret {
+        constructor(readonly token: string) {}
+      }
+
+      const tokenKey = Symbol.for("@test/phase-two-hide-class-leaf");
+      let phase2Parsed: unknown = "not-called";
+      const parser = createPhaseTwoSeedParser(tokenKey, {
+        value: new DeferredSecret("prompt-placeholder"),
+        deferred: true,
+        deferredKeys: new Map<PropertyKey, DeferredMap | null>([
+          ["token", null],
+        ]),
+      });
+      const context = createPhaseTwoCaptureContext(tokenKey, (parsed) => {
+        phase2Parsed = parsed;
+        return parsed === undefined ? "hidden" : "visible";
+      });
+
+      const result = await runWith(parser, "test", [context], { args: [] });
+
+      assert.equal(phase2Parsed, undefined);
+      assert.equal(result, "phase2:hidden");
+    });
+
+    it("should scrub only deferred fields from structured phase-two seed values", async () => {
+      const tokenKey = Symbol.for("@test/phase-two-scrub-structured");
+      const symbolKey = Symbol("source");
+      const seedValue = {
+        config: "optique.json",
+        prompt: "prompt-placeholder",
+        nested: {
+          source: "env",
+          prompt: "prompt-placeholder",
+        },
+        list: ["prompt-placeholder", "kept"],
+        [symbolKey]: "symbol-value",
+      };
+      const deferredKeys = new Map<PropertyKey, DeferredMap | null>([
+        ["prompt", null],
+        [
+          "nested",
+          new Map<PropertyKey, DeferredMap | null>([
+            ["prompt", null],
+          ]),
+        ],
+        [
+          "list",
+          new Map<PropertyKey, DeferredMap | null>([
+            [0, null],
+          ]),
+        ],
+      ]);
+      let phase2Parsed: unknown;
+      const parser = createPhaseTwoSeedParser(tokenKey, {
+        value: seedValue,
+        deferred: true,
+        deferredKeys,
+      });
+      const context = createPhaseTwoCaptureContext(tokenKey, (parsed) => {
+        phase2Parsed = parsed;
+        return isPhaseTwoScrubbedConfig(parsed) ? parsed.config : "missing";
+      });
+
+      const result = await runWith(parser, "test", [context], { args: [] });
+
+      assert.ok(isPhaseTwoScrubbedConfig(phase2Parsed));
+      assert.equal(phase2Parsed.config, "optique.json");
+      assert.equal(phase2Parsed.prompt, undefined);
+      assert.deepEqual(phase2Parsed.nested, {
+        source: "env",
+        prompt: undefined,
+      });
+      assert.deepEqual(phase2Parsed.list, [undefined, "kept"]);
+      assert.equal(phase2Parsed[symbolKey], "symbol-value");
+      assert.equal(result, "phase2:optique.json");
+    });
+
+    it("should hide phase-two seed object shells when every data field is deferred", async () => {
+      const tokenKey = Symbol.for("@test/phase-two-hide-object-shell");
+      let phase2Parsed: unknown = "not-called";
+      const parser = createPhaseTwoSeedParser(tokenKey, {
+        value: { prompt: "prompt-placeholder" },
+        deferred: true,
+        deferredKeys: new Map<PropertyKey, DeferredMap | null>([
+          ["prompt", null],
+        ]),
+      });
+      const context = createPhaseTwoCaptureContext(tokenKey, (parsed) => {
+        phase2Parsed = parsed;
+        return parsed === undefined ? "hidden" : "visible";
+      });
+
+      const result = await runWith(parser, "test", [context], { args: [] });
+
+      assert.equal(phase2Parsed, undefined);
+      assert.equal(result, "phase2:hidden");
+    });
+
+    it("should hide phase-two seed values when deferred metadata is stale", async () => {
+      const tokenKey = Symbol.for("@test/phase-two-hide-stale-keys");
+      let phase2Parsed: unknown = "not-called";
+      const parser = createPhaseTwoSeedParser(tokenKey, {
+        value: { config: "optique.json" },
+        deferred: true,
+        deferredKeys: new Map<PropertyKey, DeferredMap | null>([
+          ["removed", null],
+        ]),
+      });
+      const context = createPhaseTwoCaptureContext(tokenKey, (parsed) => {
+        phase2Parsed = parsed;
+        return parsed === undefined ? "hidden" : "visible";
+      });
+
+      const result = await runWith(parser, "test", [context], { args: [] });
+
+      assert.equal(phase2Parsed, undefined);
+      assert.equal(result, "phase2:hidden");
     });
 
     it("should handle mixed single-pass and two-pass contexts", async () => {

--- a/packages/core/src/facade.test.ts
+++ b/packages/core/src/facade.test.ts
@@ -4025,6 +4025,57 @@ describe("Subcommand help edge cases (Issue #26 comprehensive coverage)", () => 
       assert.ok(!suggestions.includes("--version"));
     });
 
+    it("should not add meta options while completing a root option value after a command term", () => {
+      const parser = object({
+        command: command(
+          "build",
+          object({ target: option("--target", string()) }),
+        ),
+        output: option("--output", string()),
+      });
+
+      let completionOutput = "";
+
+      runParser(parser, "myapp", ["completion", "bash", "--output", ""], {
+        help: { option: true, onShow: () => "help" },
+        version: { option: true, value: "1.0.0" },
+        completion: { command: true },
+        stdout: (text) => {
+          completionOutput += text;
+        },
+      });
+
+      const suggestions = completionOutput.split("\n").filter((s) =>
+        s.length > 0
+      );
+      assert.ok(!suggestions.includes("--help"));
+      assert.ok(!suggestions.includes("--version"));
+    });
+
+    it("should not add meta options while completing a root option value sharing a command option name", () => {
+      const parser = object({
+        command: command("build", object({ output: flag("--output") })),
+        output: option("--output", string()),
+      }, { allowDuplicates: true });
+
+      let completionOutput = "";
+
+      runParser(parser, "myapp", ["completion", "bash", "--output", ""], {
+        help: { option: true, onShow: () => "help" },
+        version: { option: true, value: "1.0.0" },
+        completion: { command: true },
+        stdout: (text) => {
+          completionOutput += text;
+        },
+      });
+
+      const suggestions = completionOutput.split("\n").filter((s) =>
+        s.length > 0
+      );
+      assert.ok(!suggestions.includes("--help"));
+      assert.ok(!suggestions.includes("--version"));
+    });
+
     it("should add meta options after a flag sharing a value option name", () => {
       const parser = or(
         command("build", object({ target: flag("--target") })),

--- a/packages/core/src/facade.test.ts
+++ b/packages/core/src/facade.test.ts
@@ -230,6 +230,32 @@ function createAsyncStallingPhaseTwoParser(
   };
 }
 
+function countSyncParserParses<T, S>(
+  parser: Parser<"sync", T, S>,
+  onParse: () => void,
+): Parser<"sync", T, S> {
+  return {
+    ...parser,
+    parse(context) {
+      onParse();
+      return parser.parse(context);
+    },
+  };
+}
+
+function countAsyncParserParses<T, S>(
+  parser: Parser<"async", T, S>,
+  onParse: () => void,
+): Parser<"async", T, S> {
+  return {
+    ...parser,
+    parse(context) {
+      onParse();
+      return parser.parse(context);
+    },
+  };
+}
+
 function createPhaseTwoCaptureContext(
   tokenKey: symbol,
   getToken: (parsed: unknown) => string,
@@ -4023,6 +4049,63 @@ describe("Subcommand help edge cases (Issue #26 comprehensive coverage)", () => 
       );
       assert.ok(!suggestions.includes("--help"));
       assert.ok(!suggestions.includes("--version"));
+    });
+
+    it("should parse sync completion arguments only once", () => {
+      let parseCalls = 0;
+      const parser = countSyncParserParses(
+        object({ output: option("--output", string()) }),
+        () => {
+          parseCalls++;
+        },
+      );
+
+      runParser(parser, "myapp", ["completion", "bash", "--output", ""], {
+        help: { option: true, onShow: () => "help" },
+        version: { option: true, value: "1.0.0" },
+        completion: { command: true },
+        stdout: () => {},
+      });
+
+      assert.equal(parseCalls, 2);
+    });
+
+    it("should parse async completion arguments only once", async () => {
+      let parseCalls = 0;
+      const asyncStringParser: ValueParser<"async", string> = {
+        mode: "async",
+        metavar: "TEXT",
+        parse(input: string) {
+          return Promise.resolve({ success: true as const, value: input });
+        },
+        format(value: string) {
+          return value;
+        },
+        async *suggest(prefix: string) {
+          yield { kind: "literal" as const, text: prefix };
+        },
+        placeholder: "",
+      };
+      const parser = countAsyncParserParses(
+        option("--output", asyncStringParser),
+        () => {
+          parseCalls++;
+        },
+      );
+
+      await runParser(parser, "myapp", [
+        "completion",
+        "bash",
+        "--output",
+        "",
+      ], {
+        help: { option: true, onShow: () => "help" },
+        version: { option: true, value: "1.0.0" },
+        completion: { command: true },
+        stdout: () => {},
+      });
+
+      assert.equal(parseCalls, 2);
     });
 
     it("should not add meta options while completing a root option value after a command term", () => {

--- a/packages/core/src/facade.test.ts
+++ b/packages/core/src/facade.test.ts
@@ -3819,6 +3819,473 @@ describe("Subcommand help edge cases (Issue #26 comprehensive coverage)", () => 
       assert.ok(suggestions.includes("--version"));
     });
 
+    it("should not add meta options while completing an option value", () => {
+      const parser = command(
+        "build",
+        object({
+          output: option("--output", string()),
+        }),
+      );
+
+      let completionOutput = "";
+
+      runParser(parser, "myapp", [
+        "completion",
+        "bash",
+        "build",
+        "--output",
+        "",
+      ], {
+        help: { option: true, onShow: () => "help" },
+        version: { option: true, value: "1.0.0" },
+        completion: { command: true },
+        stdout: (text) => {
+          completionOutput += text;
+        },
+      });
+
+      const suggestions = completionOutput.split("\n").filter((s) =>
+        s.length > 0
+      );
+      assert.ok(!suggestions.includes("--help"));
+      assert.ok(!suggestions.includes("--version"));
+    });
+
+    it("should not add meta options for option-like option values", () => {
+      const parser = command(
+        "build",
+        object({
+          output: option("--output", string()),
+        }),
+      );
+
+      let completionOutput = "";
+
+      runParser(parser, "myapp", [
+        "completion",
+        "bash",
+        "build",
+        "--output",
+        "--",
+      ], {
+        help: { option: true, onShow: () => "help" },
+        version: { option: true, value: "1.0.0" },
+        completion: { command: true },
+        stdout: (text) => {
+          completionOutput += text;
+        },
+      });
+
+      const suggestions = completionOutput.split("\n").filter((s) =>
+        s.length > 0
+      );
+      assert.ok(!suggestions.includes("--help"));
+      assert.ok(!suggestions.includes("--version"));
+    });
+
+    it("should not add meta options after an options terminator", () => {
+      const parser = command("build", option("--target", string()));
+
+      let completionOutput = "";
+
+      runParser(parser, "myapp", ["completion", "bash", "build", "--", ""], {
+        help: { option: true, onShow: () => "help" },
+        version: { option: true, value: "1.0.0" },
+        completion: { command: true },
+        stdout: (text) => {
+          completionOutput += text;
+        },
+      });
+
+      const suggestions = completionOutput.split("\n").filter((s) =>
+        s.length > 0
+      );
+      assert.ok(!suggestions.includes("--help"));
+      assert.ok(!suggestions.includes("--version"));
+    });
+
+    it("should add meta options after a completed equals-form option value", () => {
+      const parser = command(
+        "build",
+        object({
+          output: option("--output", string()),
+        }),
+      );
+
+      let completionOutput = "";
+
+      runParser(parser, "myapp", [
+        "completion",
+        "bash",
+        "build",
+        "--output=dist",
+        "",
+      ], {
+        help: { option: true, onShow: () => "help" },
+        version: { option: true, value: "1.0.0" },
+        completion: { command: true },
+        stdout: (text) => {
+          completionOutput += text;
+        },
+      });
+
+      const suggestions = completionOutput.split("\n").filter((s) =>
+        s.length > 0
+      );
+      assert.ok(suggestions.includes("--help"));
+      assert.ok(suggestions.includes("--version"));
+    });
+
+    it("should add meta options after a terminator-like option value", () => {
+      const parser = command(
+        "build",
+        object({
+          output: option("--output", string()),
+        }),
+      );
+
+      let completionOutput = "";
+
+      runParser(parser, "myapp", [
+        "completion",
+        "bash",
+        "build",
+        "--output",
+        "--",
+        "",
+      ], {
+        help: { option: true, onShow: () => "help" },
+        version: { option: true, value: "1.0.0" },
+        completion: { command: true },
+        stdout: (text) => {
+          completionOutput += text;
+        },
+      });
+
+      const suggestions = completionOutput.split("\n").filter((s) =>
+        s.length > 0
+      );
+      assert.ok(suggestions.includes("--help"));
+      assert.ok(suggestions.includes("--version"));
+    });
+
+    it("should add meta options after a flag sharing a value option name", () => {
+      const parser = or(
+        command("build", object({ target: flag("--target") })),
+        command("deploy", object({ target: option("--target", string()) })),
+      );
+
+      let completionOutput = "";
+
+      runParser(parser, "myapp", [
+        "completion",
+        "bash",
+        "build",
+        "--target",
+        "--",
+      ], {
+        help: { option: true, onShow: () => "help" },
+        version: { option: true, value: "1.0.0" },
+        completion: { command: true },
+        stdout: (text) => {
+          completionOutput += text;
+        },
+      });
+
+      const suggestions = completionOutput.split("\n").filter((s) =>
+        s.length > 0
+      );
+      assert.ok(suggestions.includes("--help"));
+      assert.ok(suggestions.includes("--version"));
+    });
+
+    it("should honor a terminator after a flag sharing a value option name", () => {
+      const parser = or(
+        command("build", object({ target: flag("--target") })),
+        command("deploy", object({ target: option("--target", string()) })),
+      );
+
+      let completionOutput = "";
+
+      runParser(parser, "myapp", [
+        "completion",
+        "bash",
+        "build",
+        "--target",
+        "--",
+        "",
+      ], {
+        help: { option: true, onShow: () => "help" },
+        version: { option: true, value: "1.0.0" },
+        completion: { command: true },
+        stdout: (text) => {
+          completionOutput += text;
+        },
+      });
+
+      const suggestions = completionOutput.split("\n").filter((s) =>
+        s.length > 0
+      );
+      assert.ok(!suggestions.includes("--help"));
+      assert.ok(!suggestions.includes("--version"));
+    });
+
+    it("should not add meta options while completing a selected value option sharing a flag name", () => {
+      const parser = or(
+        command("build", object({ target: option("--target", string()) })),
+        command("deploy", object({ target: flag("--target") })),
+      );
+
+      let completionOutput = "";
+
+      runParser(parser, "myapp", [
+        "completion",
+        "bash",
+        "build",
+        "--target",
+        "",
+      ], {
+        help: { option: true, onShow: () => "help" },
+        version: { option: true, value: "1.0.0" },
+        completion: { command: true },
+        stdout: (text) => {
+          completionOutput += text;
+        },
+      });
+
+      const suggestions = completionOutput.split("\n").filter((s) =>
+        s.length > 0
+      );
+      assert.ok(!suggestions.includes("--help"));
+      assert.ok(!suggestions.includes("--version"));
+    });
+
+    it("should add meta options after an ambiguous exclusive flag option", () => {
+      const parser = command(
+        "tool",
+        or(
+          object({ target: flag("--target") }),
+          object({ target: option("--target", string()) }),
+        ),
+      );
+
+      let completionOutput = "";
+
+      runParser(parser, "myapp", [
+        "completion",
+        "bash",
+        "tool",
+        "--target",
+        "--",
+      ], {
+        help: { option: true, onShow: () => "help" },
+        version: { option: true, value: "1.0.0" },
+        completion: { command: true },
+        stdout: (text) => {
+          completionOutput += text;
+        },
+      });
+
+      const suggestions = completionOutput.split("\n").filter((s) =>
+        s.length > 0
+      );
+      assert.ok(suggestions.includes("--help"));
+      assert.ok(suggestions.includes("--version"));
+    });
+
+    it("should honor a terminator after an ambiguous exclusive flag option", () => {
+      const parser = command(
+        "tool",
+        or(
+          object({ target: flag("--target") }),
+          object({ target: option("--target", string()) }),
+        ),
+      );
+
+      let completionOutput = "";
+
+      runParser(parser, "myapp", [
+        "completion",
+        "bash",
+        "tool",
+        "--target",
+        "--",
+        "",
+      ], {
+        help: { option: true, onShow: () => "help" },
+        version: { option: true, value: "1.0.0" },
+        completion: { command: true },
+        stdout: (text) => {
+          completionOutput += text;
+        },
+      });
+
+      const suggestions = completionOutput.split("\n").filter((s) =>
+        s.length > 0
+      );
+      assert.ok(!suggestions.includes("--help"));
+      assert.ok(!suggestions.includes("--version"));
+    });
+
+    it("should not treat nested command options as current value slots", () => {
+      const parser = command(
+        "outer",
+        command("inner", option("--output", string())),
+      );
+
+      let completionOutput = "";
+
+      runParser(parser, "myapp", [
+        "completion",
+        "bash",
+        "outer",
+        "--output",
+        "",
+      ], {
+        help: { option: true, onShow: () => "help" },
+        version: { option: true, value: "1.0.0" },
+        completion: { command: true },
+        stdout: (text) => {
+          completionOutput += text;
+        },
+      });
+
+      const suggestions = completionOutput.split("\n").filter((s) =>
+        s.length > 0
+      );
+      assert.ok(suggestions.includes("--help"));
+      assert.ok(suggestions.includes("--version"));
+    });
+
+    it("should not add meta options while completing a sibling option before a nested command", () => {
+      const parser = command(
+        "outer",
+        object({
+          inner: command("inner", object({})),
+          global: option("--global", string()),
+        }),
+      );
+
+      let completionOutput = "";
+
+      runParser(parser, "myapp", [
+        "completion",
+        "bash",
+        "outer",
+        "--global",
+        "",
+      ], {
+        help: { option: true, onShow: () => "help" },
+        version: { option: true, value: "1.0.0" },
+        completion: { command: true },
+        stdout: (text) => {
+          completionOutput += text;
+        },
+      });
+
+      const suggestions = completionOutput.split("\n").filter((s) =>
+        s.length > 0
+      );
+      assert.ok(!suggestions.includes("--help"));
+      assert.ok(!suggestions.includes("--version"));
+    });
+
+    it("should not treat unselected branch options as current value slots", () => {
+      const parser = command(
+        "tool",
+        or(
+          command(
+            "deploy",
+            object({ target: option("--target", string()) }),
+          ),
+          command("status", object({})),
+        ),
+      );
+
+      let completionOutput = "";
+
+      runParser(parser, "myapp", [
+        "completion",
+        "bash",
+        "tool",
+        "--target",
+        "",
+      ], {
+        help: { option: true, onShow: () => "help" },
+        version: { option: true, value: "1.0.0" },
+        completion: { command: true },
+        stdout: (text) => {
+          completionOutput += text;
+        },
+      });
+
+      const suggestions = completionOutput.split("\n").filter((s) =>
+        s.length > 0
+      );
+      assert.ok(suggestions.includes("--help"));
+      assert.ok(suggestions.includes("--version"));
+    });
+
+    it("should not add meta options while completing an option from a duplicate command branch", () => {
+      const parser = or(
+        command("tool", object({ a: option("--a", string()) })),
+        command("tool", object({ b: option("--b", string()) })),
+      );
+
+      let completionOutput = "";
+
+      runParser(parser, "myapp", [
+        "completion",
+        "bash",
+        "tool",
+        "--b",
+        "",
+      ], {
+        help: { option: true, onShow: () => "help" },
+        version: { option: true, value: "1.0.0" },
+        completion: { command: true },
+        stdout: (text) => {
+          completionOutput += text;
+        },
+      });
+
+      const suggestions = completionOutput.split("\n").filter((s) =>
+        s.length > 0
+      );
+      assert.ok(!suggestions.includes("--help"));
+      assert.ok(!suggestions.includes("--version"));
+    });
+
+    it("should not treat nested duplicate command branch options as current value slots", () => {
+      const parser = or(
+        command("tool", command("deploy", option("--target", string()))),
+        command("tool", command("status", object({}))),
+      );
+
+      let completionOutput = "";
+
+      runParser(parser, "myapp", [
+        "completion",
+        "bash",
+        "tool",
+        "--target",
+        "",
+      ], {
+        help: { option: true, onShow: () => "help" },
+        version: { option: true, value: "1.0.0" },
+        completion: { command: true },
+        stdout: (text) => {
+          completionOutput += text;
+        },
+      });
+
+      const suggestions = completionOutput.split("\n").filter((s) =>
+        s.length > 0
+      );
+      assert.ok(suggestions.includes("--help"));
+      assert.ok(suggestions.includes("--version"));
+    });
+
     it("should filter meta options by the current argument prefix", () => {
       const parser = command(
         "build",

--- a/packages/core/src/facade.ts
+++ b/packages/core/src/facade.ts
@@ -927,246 +927,61 @@ interface MetaCommandGroups {
   readonly completionOptionGroup?: string;
 }
 
+function createMetaOptionDocParser(
+  source: Parser<"sync", unknown, unknown>,
+): Parser<"sync", null, null> {
+  return {
+    mode: "sync",
+    $valueType: [],
+    $stateType: [],
+    priority: 200,
+    usage: source.usage,
+    leadingNames: source.leadingNames,
+    acceptingAnyToken: false,
+    initialState: null,
+    parse: () => ({
+      success: false,
+      error: message`Documentation-only meta option.`,
+      consumed: 0,
+    }),
+    complete: (state) => ({ success: true, value: state }),
+    suggest: function* () {},
+    getDocFragments: (state) => source.getDocFragments(state),
+  };
+}
+
 function combineWithHelpVersion(
   originalParser: Parser<Mode, unknown, unknown>,
   helpParsers: HelpParsers,
   versionParsers: VersionParsers,
   completionParsers: CompletionParsers,
   groups?: MetaCommandGroups,
-  helpOptionNames?: readonly string[],
-  versionOptionNames?: readonly string[],
 ): Parser<Mode, unknown, unknown> {
   const parsers: Parser<Mode, unknown, unknown>[] = [];
-
-  const effectiveHelpOptionNames = helpOptionNames ?? ["--help"];
-  const effectiveVersionOptionNames = versionOptionNames ?? ["--version"];
 
   // Add options FIRST - they are more specific and should have priority
 
   // Add help option (standalone) - accepts any mix of options and arguments
   if (helpParsers.helpOption) {
-    // Create a lenient help parser that accepts help flag anywhere
-    // and ignores all other options/arguments
-    const lenientHelpParser: Parser<"sync", unknown, unknown> = {
-      mode: "sync",
-      $valueType: [],
-      $stateType: [],
-      priority: 200, // Very high priority
-      usage: helpParsers.helpOption.usage,
-      leadingNames: helpParsers.helpOption.leadingNames,
-      acceptingAnyToken: false,
-      initialState: null,
-
-      parse(context) {
-        const { buffer, optionsTerminated } = context;
-
-        // If options are terminated (after --), don't match
-        if (optionsTerminated) {
-          return {
-            success: false,
-            error: message`Options terminated.`,
-            consumed: 0,
-          };
-        }
-
-        let helpFound = false;
-        let helpIndex = -1;
-
-        // Look for help option names and version option names to implement
-        // last-option-wins
-        let versionIndex = -1;
-        for (let i = 0; i < buffer.length; i++) {
-          if (buffer[i] === "--") break; // Stop at options terminator
-          if (effectiveHelpOptionNames.includes(buffer[i])) {
-            helpFound = true;
-            helpIndex = i;
-          }
-          if (effectiveVersionOptionNames.includes(buffer[i])) {
-            versionIndex = i;
-          }
-        }
-
-        // If both help and version options are present, but version comes
-        // last, don't match
-        if (helpFound && versionIndex > helpIndex) {
-          return {
-            success: false,
-            error: message`Version option wins.`,
-            consumed: 0,
-          };
-        }
-
-        // Multiple help options is OK - just show help
-
-        if (helpFound) {
-          // Extract command names that appear before the help option
-          const commands: string[] = [];
-          for (let i = 0; i < helpIndex; i++) {
-            const arg = buffer[i];
-            // Include non-option arguments as commands (don't start with -)
-            if (!arg.startsWith("-")) {
-              commands.push(arg);
-            }
-          }
-
-          // Consume all remaining arguments and return success
-          return {
-            success: true,
-            next: {
-              ...context,
-              buffer: [],
-              state: {
-                [metaResultBrand]: true,
-                help: true,
-                version: false,
-                completion: false,
-                commands,
-                helpFlag: true,
-              },
-            },
-            consumed: buffer.slice(0),
-          };
-        }
-
-        // Help option not found
-        return {
-          success: false,
-          error: message`Flag ${
-            optionName(effectiveHelpOptionNames[0])
-          } not found.`,
-          consumed: 0,
-        };
-      },
-
-      complete(state) {
-        return { success: true, value: state };
-      },
-
-      *suggest(_context, prefix) {
-        for (const name of effectiveHelpOptionNames) {
-          if (name.startsWith(prefix)) {
-            yield { kind: "literal", text: name } as const;
-          }
-        }
-      },
-
-      getDocFragments(state) {
-        return helpParsers.helpOption?.getDocFragments(state) ??
-          { fragments: [] };
-      },
-    };
+    const helpOptionDocParser = createMetaOptionDocParser(
+      helpParsers.helpOption,
+    );
 
     const wrappedHelp = groups?.helpOptionGroup
-      ? group(groups.helpOptionGroup, lenientHelpParser)
-      : lenientHelpParser;
+      ? group(groups.helpOptionGroup, helpOptionDocParser)
+      : helpOptionDocParser;
     parsers.push(wrappedHelp);
   }
 
   // Add version option (standalone) - accepts any mix of options and arguments
   if (versionParsers.versionOption) {
-    // Create a lenient version parser that accepts version flag anywhere
-    // and ignores all other options/arguments
-    const lenientVersionParser: Parser<"sync", unknown, unknown> = {
-      mode: "sync",
-      $valueType: [],
-      $stateType: [],
-      priority: 200, // Very high priority
-      usage: versionParsers.versionOption.usage,
-      leadingNames: versionParsers.versionOption.leadingNames,
-      acceptingAnyToken: false,
-      initialState: null,
-
-      parse(context) {
-        const { buffer, optionsTerminated } = context;
-
-        // If options are terminated (after --), don't match
-        if (optionsTerminated) {
-          return {
-            success: false,
-            error: message`Options terminated.`,
-            consumed: 0,
-          };
-        }
-
-        let versionFound = false;
-        let versionIndex = -1;
-
-        // Look for version option names and help option names to implement
-        // last-option-wins
-        let helpIndex = -1;
-        for (let i = 0; i < buffer.length; i++) {
-          if (buffer[i] === "--") break; // Stop at options terminator
-          if (effectiveVersionOptionNames.includes(buffer[i])) {
-            versionFound = true;
-            versionIndex = i;
-          }
-          if (effectiveHelpOptionNames.includes(buffer[i])) {
-            helpIndex = i;
-          }
-        }
-
-        // If both version and help options are present, but help comes last,
-        // don't match
-        if (versionFound && helpIndex > versionIndex) {
-          return {
-            success: false,
-            error: message`Help option wins.`,
-            consumed: 0,
-          };
-        }
-
-        // Multiple version options is OK - just show version
-
-        if (versionFound) {
-          // Consume all remaining arguments and return success
-          return {
-            success: true,
-            next: {
-              ...context,
-              buffer: [],
-              state: {
-                [metaResultBrand]: true,
-                help: false,
-                version: true,
-                completion: false,
-                versionFlag: true,
-              },
-            },
-            consumed: buffer.slice(0),
-          };
-        }
-
-        // Version option not found
-        return {
-          success: false,
-          error: message`Flag ${
-            optionName(effectiveVersionOptionNames[0])
-          } not found.`,
-          consumed: 0,
-        };
-      },
-
-      complete(state) {
-        return { success: true, value: state };
-      },
-
-      *suggest(_context, prefix) {
-        for (const name of effectiveVersionOptionNames) {
-          if (name.startsWith(prefix)) {
-            yield { kind: "literal", text: name } as const;
-          }
-        }
-      },
-
-      getDocFragments(state) {
-        return versionParsers.versionOption?.getDocFragments(state) ??
-          { fragments: [] };
-      },
-    };
+    const versionOptionDocParser = createMetaOptionDocParser(
+      versionParsers.versionOption,
+    );
 
     const wrappedVersion = groups?.versionOptionGroup
-      ? group(groups.versionOptionGroup, lenientVersionParser)
-      : lenientVersionParser;
+      ? group(groups.versionOptionGroup, versionOptionDocParser)
+      : versionOptionDocParser;
     parsers.push(wrappedVersion);
   }
 
@@ -2150,8 +1965,6 @@ export function runParser<
         completionCommandGroup: completionCommandConfig?.group,
         completionOptionGroup: completionOptionConfig?.group,
       },
-      helpOptionConfig ? [...helpOptionNames] : undefined,
-      versionOptionConfig ? [...versionOptionNames] : undefined,
     );
 
   // Helper function to handle parsed result

--- a/packages/core/src/facade.ts
+++ b/packages/core/src/facade.ts
@@ -1740,7 +1740,7 @@ function getSyncCompletionArgumentContext(
       return getFailedCompletionArgumentContext(
         result,
         context,
-        parser.usage,
+        parser,
         rootOptionSuggestions,
       );
     }
@@ -1769,7 +1769,7 @@ async function getAsyncCompletionArgumentContext(
       return getFailedCompletionArgumentContext(
         result,
         context,
-        parser.usage,
+        parser,
         rootOptionSuggestions,
       );
     }
@@ -1806,13 +1806,14 @@ function createCompletionArgumentParserContext(
 function getFailedCompletionArgumentContext(
   result: Extract<ParserResult<unknown>, { readonly success: false }>,
   context: ParserContext<unknown>,
-  usage: Usage,
+  parser: Parser<Mode, unknown, unknown>,
   rootOptionSuggestions: readonly LiteralSuggestion[],
 ): CompletionArgumentContext {
   const activeValueOptionNames = collectActiveValueOptionNames(
-    usage,
+    parser.usage,
     context.exec?.commandPath ?? [],
     result.consumed > 0,
+    parser.leadingNames,
   );
   const token = context.buffer[0];
   return {
@@ -1836,23 +1837,73 @@ function collectActiveValueOptionNames(
   usage: Usage,
   commandPath: readonly string[],
   includeDirectAfterCommandOptions: boolean,
+  rootLeadingNames: ReadonlySet<string>,
 ): ReadonlySet<string> {
   const optionNames: CurrentOptionNames = {
     value: new Set(),
     flag: new Set(),
   };
-  collectActiveOptionNames(
-    usage,
-    commandPath,
-    optionNames,
-    false,
-    includeDirectAfterCommandOptions,
-  );
+  if (commandPath.length === 0) {
+    collectRootOptionNames(usage, optionNames, rootLeadingNames);
+    return optionNames.value;
+  } else {
+    collectActiveOptionNames(
+      usage,
+      commandPath,
+      optionNames,
+      false,
+      includeDirectAfterCommandOptions,
+    );
+  }
   const names = new Set(optionNames.value);
   for (const name of optionNames.flag) {
     names.delete(name);
   }
   return names;
+}
+
+function collectRootOptionNames(
+  usage: Usage,
+  names: CurrentOptionNames,
+  rootLeadingNames: ReadonlySet<string>,
+): void {
+  for (const term of usage) {
+    collectRootOptionNamesFromTerm(term, names, rootLeadingNames);
+  }
+}
+
+function collectRootOptionNamesFromTerm(
+  term: Usage[number],
+  names: CurrentOptionNames,
+  rootLeadingNames: ReadonlySet<string>,
+): void {
+  switch (term.type) {
+    case "option":
+      for (const name of term.names) {
+        if (!rootLeadingNames.has(name)) continue;
+        if (term.metavar != null) {
+          names.value.add(name);
+        } else {
+          names.flag.add(name);
+        }
+      }
+      return;
+    case "optional":
+    case "multiple":
+      collectRootOptionNames(term.terms, names, rootLeadingNames);
+      return;
+    case "exclusive":
+      for (const branch of term.terms) {
+        collectRootOptionNames(branch, names, rootLeadingNames);
+      }
+      return;
+    case "argument":
+    case "command":
+    case "literal":
+    case "passthrough":
+    case "ellipsis":
+      return;
+  }
 }
 
 function collectActiveOptionNames(

--- a/packages/core/src/facade.ts
+++ b/packages/core/src/facade.ts
@@ -1621,10 +1621,15 @@ function handleCompletion<M extends Mode, THelp, TError>(
     parser.mode,
     () => {
       const syncParser = parser as Parser<"sync", unknown, unknown>;
+      const argumentContext = getSyncCompletionArgumentContext(
+        syncParser,
+        args.slice(0, -1),
+      );
       const suggestions = withRootOptionSuggestions(
         suggest(syncParser, args as [string, ...string[]]),
         args,
         rootOptionSuggestions,
+        argumentContext,
       );
       for (const chunk of shell.encodeSuggestions(suggestions)) {
         stdout(chunk);
@@ -1636,13 +1641,23 @@ function handleCompletion<M extends Mode, THelp, TError>(
       return result;
     },
     async () => {
+      const asyncParser = parser as Parser<"async", unknown, unknown>;
       const suggestions = await suggestAsync(
-        parser as Parser<"async", unknown, unknown>,
+        asyncParser,
         args as [string, ...string[]],
+      );
+      const argumentContext = await getAsyncCompletionArgumentContext(
+        asyncParser,
+        args.slice(0, -1),
       );
       for (
         const chunk of shell.encodeSuggestions(
-          withRootOptionSuggestions(suggestions, args, rootOptionSuggestions),
+          withRootOptionSuggestions(
+            suggestions,
+            args,
+            rootOptionSuggestions,
+            argumentContext,
+          ),
         )
       ) {
         stdout(chunk);
@@ -1656,18 +1671,29 @@ function withRootOptionSuggestions(
   suggestions: readonly Suggestion[],
   args: readonly string[],
   extraSuggestions: readonly LiteralSuggestion[],
+  argumentContext: CompletionArgumentContext,
 ): readonly Suggestion[] {
   if (extraSuggestions.length === 0) return suggestions;
 
   const prefix = args.at(-1) ?? "";
   const completedArgs = args.slice(0, -1);
+  if (argumentContext.optionsTerminated) {
+    return suggestions;
+  }
+
+  if (argumentContext.completingOptionValue) {
+    return suggestions;
+  }
+
   const metaNames = new Set(
     extraSuggestions.map((suggestion) => suggestion.text),
   );
   if (
     completedArgs.some((arg) =>
       metaNames.has(arg) ||
-      [...metaNames].some((name) => arg.startsWith(`${name}=`))
+      extraSuggestions.some((suggestion) =>
+        arg.startsWith(`${suggestion.text}=`)
+      )
     )
   ) {
     return suggestions;
@@ -1693,6 +1719,302 @@ function withRootOptionSuggestions(
     seen.add(suggestion.text);
   }
   return combined;
+}
+
+interface CompletionArgumentContext {
+  readonly completingOptionValue: boolean;
+  readonly optionsTerminated: boolean;
+}
+
+interface CurrentOptionNames {
+  readonly value: Set<string>;
+  readonly flag: Set<string>;
+}
+
+function getSyncCompletionArgumentContext(
+  parser: Parser<"sync", unknown, unknown>,
+  args: readonly string[],
+): CompletionArgumentContext {
+  const valueOptionNames = collectValueOptionNames(parser.usage);
+  let context = createCompletionArgumentParserContext(parser, args);
+
+  while (context.buffer.length > 0) {
+    const previousBuffer = context.buffer;
+    const result = parser.parse(context);
+    if (result instanceof Promise) {
+      throw new RunParserError("Synchronous parser returned async result.");
+    }
+    if (!result.success) {
+      return getFailedCompletionArgumentContext(
+        result,
+        context,
+        parser.usage,
+        valueOptionNames,
+      );
+    }
+    context = result.next;
+    if (isCompletionBufferUnchanged(previousBuffer, context.buffer)) break;
+  }
+
+  return {
+    completingOptionValue: false,
+    optionsTerminated: context.optionsTerminated,
+  };
+}
+
+async function getAsyncCompletionArgumentContext(
+  parser: Parser<"async", unknown, unknown>,
+  args: readonly string[],
+): Promise<CompletionArgumentContext> {
+  const valueOptionNames = collectValueOptionNames(parser.usage);
+  let context = createCompletionArgumentParserContext(parser, args);
+
+  while (context.buffer.length > 0) {
+    const previousBuffer = context.buffer;
+    const result = await parser.parse(context);
+    if (!result.success) {
+      return getFailedCompletionArgumentContext(
+        result,
+        context,
+        parser.usage,
+        valueOptionNames,
+      );
+    }
+    context = result.next;
+    if (isCompletionBufferUnchanged(previousBuffer, context.buffer)) break;
+  }
+
+  return {
+    completingOptionValue: false,
+    optionsTerminated: context.optionsTerminated,
+  };
+}
+
+function createCompletionArgumentParserContext(
+  parser: Parser<Mode, unknown, unknown>,
+  args: readonly string[],
+): ParserContext<unknown> {
+  return createParserContext(
+    {
+      buffer: args,
+      state: parser.initialState,
+      optionsTerminated: false,
+    },
+    {
+      usage: parser.usage,
+      phase: "suggest",
+      path: [],
+      trace: createInputTrace(),
+    },
+  );
+}
+
+function getFailedCompletionArgumentContext(
+  result: Extract<ParserResult<unknown>, { readonly success: false }>,
+  context: ParserContext<unknown>,
+  usage: Usage,
+  valueOptionNames: ReadonlySet<string>,
+): CompletionArgumentContext {
+  const duplicateCommandBranchValueOptionNames = result.consumed > 0
+    ? new Set<string>()
+    : collectDuplicateCommandBranchValueOptionNames(
+      usage,
+      context.exec?.commandPath ?? [],
+    );
+  return {
+    completingOptionValue: result.consumed > 0
+      ? valueOptionNames.has(context.buffer[0])
+      : duplicateCommandBranchValueOptionNames.has(context.buffer[0]),
+    optionsTerminated: context.optionsTerminated,
+  };
+}
+
+function isCompletionBufferUnchanged(
+  before: readonly string[],
+  after: readonly string[],
+): boolean {
+  return before.length === after.length &&
+    before.every((arg, index) => arg === after[index]);
+}
+
+function collectValueOptionNames(usage: Usage): ReadonlySet<string> {
+  const optionNames: CurrentOptionNames = {
+    value: new Set(),
+    flag: new Set(),
+  };
+  collectOptionNamesFromUsage(usage, optionNames);
+  return optionNames.value;
+}
+
+function collectDuplicateCommandBranchValueOptionNames(
+  usage: Usage,
+  commandPath: readonly string[],
+): ReadonlySet<string> {
+  const optionNames: CurrentOptionNames = {
+    value: new Set(),
+    flag: new Set(),
+  };
+  collectDuplicateCommandBranchOptionNames(usage, commandPath, optionNames);
+  const names = new Set(optionNames.value);
+  for (const name of optionNames.flag) {
+    names.delete(name);
+  }
+  return names;
+}
+
+function collectDuplicateCommandBranchOptionNames(
+  usage: Usage,
+  commandPath: readonly string[],
+  names: CurrentOptionNames,
+): void {
+  if (commandPath.length > 0) {
+    const [commandName, ...rest] = commandPath;
+    for (let i = 0; i < usage.length; i++) {
+      const term = usage[i];
+      if (term.type === "command" && term.name === commandName) {
+        collectDuplicateCommandBranchOptionNames(
+          usage.slice(i + 1),
+          rest,
+          names,
+        );
+      } else if (term.type === "optional" || term.type === "multiple") {
+        collectDuplicateCommandBranchOptionNames(
+          term.terms,
+          commandPath,
+          names,
+        );
+      } else if (term.type === "exclusive") {
+        for (const branch of term.terms) {
+          collectDuplicateCommandBranchOptionNames(
+            branch,
+            commandPath,
+            names,
+          );
+        }
+      }
+    }
+  }
+
+  for (const term of usage) {
+    if (term.type === "optional" || term.type === "multiple") {
+      collectDuplicateCommandBranchOptionNames(term.terms, commandPath, names);
+    } else if (term.type === "exclusive") {
+      if (commandPath.length > 0) {
+        const matchingBranches = term.terms
+          .map((branch) => getUsageAfterDirectCommandPath(branch, commandPath))
+          .filter((branch): branch is Usage => branch != null);
+        if (matchingBranches.length > 1) {
+          for (const branch of matchingBranches) {
+            collectOptionNamesAtCurrentCommandDepth(branch, names);
+          }
+        }
+      }
+      for (const branch of term.terms) {
+        collectDuplicateCommandBranchOptionNames(branch, commandPath, names);
+      }
+    }
+  }
+}
+
+function getUsageAfterDirectCommandPath(
+  usage: Usage,
+  commandPath: readonly string[],
+): Usage | null {
+  let scopedUsage = usage;
+  for (const commandName of commandPath) {
+    let nextUsage: Usage | null = null;
+    for (let i = 0; i < scopedUsage.length; i++) {
+      const term = scopedUsage[i];
+      if (term.type === "command" && term.name === commandName) {
+        nextUsage = scopedUsage.slice(i + 1);
+        break;
+      }
+    }
+    if (nextUsage == null) return null;
+    scopedUsage = nextUsage;
+  }
+  return scopedUsage;
+}
+
+function collectOptionNamesAtCurrentCommandDepth(
+  usage: Usage,
+  names: CurrentOptionNames,
+): void {
+  for (const term of usage) {
+    if (collectOptionNamesAtCurrentCommandDepthFromTerm(term, names)) {
+      return;
+    }
+  }
+}
+
+function collectOptionNamesAtCurrentCommandDepthFromTerm(
+  term: Usage[number],
+  names: CurrentOptionNames,
+): boolean {
+  switch (term.type) {
+    case "command":
+      return true;
+    case "option":
+      if (term.metavar != null) {
+        for (const name of term.names) names.value.add(name);
+      } else {
+        for (const name of term.names) names.flag.add(name);
+      }
+      return false;
+    case "optional":
+    case "multiple":
+      collectOptionNamesAtCurrentCommandDepth(term.terms, names);
+      return false;
+    case "exclusive":
+      for (const branch of term.terms) {
+        collectOptionNamesAtCurrentCommandDepth(branch, names);
+      }
+      return false;
+    case "argument":
+    case "literal":
+    case "passthrough":
+    case "ellipsis":
+      return false;
+  }
+}
+
+function collectOptionNamesFromUsage(
+  usage: Usage,
+  names: CurrentOptionNames,
+): void {
+  for (const term of usage) {
+    collectOptionNamesFromTerm(term, names);
+  }
+}
+
+function collectOptionNamesFromTerm(
+  term: Usage[number],
+  names: CurrentOptionNames,
+): void {
+  switch (term.type) {
+    case "option":
+      if (term.metavar != null) {
+        for (const name of term.names) names.value.add(name);
+      } else {
+        for (const name of term.names) names.flag.add(name);
+      }
+      return;
+    case "optional":
+    case "multiple":
+      collectOptionNamesFromUsage(term.terms, names);
+      return;
+    case "exclusive":
+      for (const branch of term.terms) {
+        collectOptionNamesFromUsage(branch, names);
+      }
+      return;
+    case "argument":
+    case "command":
+    case "literal":
+    case "passthrough":
+    case "ellipsis":
+      return;
+  }
 }
 
 function getRootMetaOptionSuggestions(

--- a/packages/core/src/facade.ts
+++ b/packages/core/src/facade.ts
@@ -1653,11 +1653,23 @@ function withRootOptionSuggestions(
   args: readonly string[],
   extraSuggestions: readonly LiteralSuggestion[],
 ): readonly Suggestion[] {
-  if (args.length !== 1 || extraSuggestions.length === 0) return suggestions;
+  if (extraSuggestions.length === 0) return suggestions;
 
-  const prefix = args[0];
+  const prefix = args.at(-1) ?? "";
+  const completedArgs = args.slice(0, -1);
+  const metaNames = new Set(
+    extraSuggestions.map((suggestion) => suggestion.text),
+  );
   if (
-    !(prefix.startsWith("--") || prefix.startsWith("-") ||
+    completedArgs.some((arg) =>
+      metaNames.has(arg) ||
+      [...metaNames].some((name) => arg.startsWith(`${name}=`))
+    )
+  ) {
+    return suggestions;
+  }
+  if (
+    !(prefix === "" || prefix.startsWith("--") || prefix.startsWith("-") ||
       prefix.startsWith("/") || prefix.startsWith("+"))
   ) {
     return suggestions;
@@ -1671,7 +1683,7 @@ function withRootOptionSuggestions(
   const combined = [...suggestions];
   for (const suggestion of extraSuggestions) {
     if (prefix === "-" && suggestion.text.length !== 2) continue;
-    if (!suggestion.text.startsWith(prefix)) continue;
+    if (prefix !== "" && !suggestion.text.startsWith(prefix)) continue;
     if (seen.has(suggestion.text)) continue;
     combined.push(suggestion);
     seen.add(suggestion.text);

--- a/packages/core/src/facade.ts
+++ b/packages/core/src/facade.ts
@@ -38,12 +38,15 @@ import {
   type Parser,
   type ParserContext,
   type ParserResult,
-  suggest,
-  suggestAsync,
   type Suggestion,
 } from "./parser.ts";
 import { dispatchByMode } from "./internal/mode-dispatch.ts";
-import { createDependencyRuntimeContext } from "./dependency-runtime.ts";
+import {
+  collectExplicitSourceValues,
+  collectExplicitSourceValuesAsync,
+  createDependencyRuntimeContext,
+  type RuntimeNode,
+} from "./dependency-runtime.ts";
 import { createInputTrace } from "./input-trace.ts";
 import { completeOrExtractPhase2Seed } from "./phase2-seed.ts";
 import { argument, command, constant, flag, option } from "./primitives.ts";
@@ -1621,16 +1624,16 @@ function handleCompletion<M extends Mode, THelp, TError>(
     parser.mode,
     () => {
       const syncParser = parser as Parser<"sync", unknown, unknown>;
-      const argumentContext = getSyncCompletionArgumentContext(
+      const completionSuggestions = getSyncCompletionSuggestions(
         syncParser,
-        args.slice(0, -1),
+        args,
         rootOptionSuggestions,
       );
       const suggestions = withRootOptionSuggestions(
-        suggest(syncParser, args as [string, ...string[]]),
+        completionSuggestions.suggestions,
         args,
         rootOptionSuggestions,
-        argumentContext,
+        completionSuggestions.argumentContext,
       );
       for (const chunk of shell.encodeSuggestions(suggestions)) {
         stdout(chunk);
@@ -1643,22 +1646,18 @@ function handleCompletion<M extends Mode, THelp, TError>(
     },
     async () => {
       const asyncParser = parser as Parser<"async", unknown, unknown>;
-      const suggestions = await suggestAsync(
+      const completionSuggestions = await getAsyncCompletionSuggestions(
         asyncParser,
-        args as [string, ...string[]],
-      );
-      const argumentContext = await getAsyncCompletionArgumentContext(
-        asyncParser,
-        args.slice(0, -1),
+        args,
         rootOptionSuggestions,
       );
       for (
         const chunk of shell.encodeSuggestions(
           withRootOptionSuggestions(
-            suggestions,
+            completionSuggestions.suggestions,
             args,
             rootOptionSuggestions,
-            argumentContext,
+            completionSuggestions.argumentContext,
           ),
         )
       ) {
@@ -1718,36 +1717,121 @@ interface CompletionArgumentContext {
   readonly optionsTerminated: boolean;
 }
 
+interface CompletionSuggestionResult {
+  readonly suggestions: readonly Suggestion[];
+  readonly argumentContext: CompletionArgumentContext;
+}
+
 interface CurrentOptionNames {
   readonly value: Set<string>;
   readonly flag: Set<string>;
 }
 
-function getSyncCompletionArgumentContext(
+function getSyncCompletionSuggestions(
   parser: Parser<"sync", unknown, unknown>,
   args: readonly string[],
   rootOptionSuggestions: readonly LiteralSuggestion[],
-): CompletionArgumentContext {
-  let context = createCompletionArgumentParserContext(parser, args);
+): CompletionSuggestionResult {
+  const prefix = args.at(-1) ?? "";
+  let context = createCompletionArgumentParserContext(
+    parser,
+    args.slice(0, -1),
+  );
 
   while (context.buffer.length > 0) {
-    const previousBuffer = context.buffer;
     const result = parser.parse(context);
     if (result instanceof Promise) {
       throw new RunParserError("Synchronous parser returned async result.");
     }
     if (!result.success) {
-      return getFailedCompletionArgumentContext(
+      const argumentContext = getFailedCompletionArgumentContext(
         result,
         context,
         parser,
         rootOptionSuggestions,
       );
+      return {
+        suggestions: Array.from(
+          parser.suggest(withCompletionSuggestRuntime(parser, context), prefix),
+        ),
+        argumentContext,
+      };
     }
+    const previousBuffer = context.buffer;
     context = result.next;
-    if (isCompletionBufferUnchanged(previousBuffer, context.buffer)) break;
+    if (isCompletionBufferUnchanged(previousBuffer, context.buffer)) {
+      return {
+        suggestions: [],
+        argumentContext: getCompletedCompletionArgumentContext(context),
+      };
+    }
   }
 
+  return {
+    suggestions: Array.from(
+      parser.suggest(withCompletionSuggestRuntime(parser, context), prefix),
+    ),
+    argumentContext: getCompletedCompletionArgumentContext(context),
+  };
+}
+
+async function getAsyncCompletionSuggestions(
+  parser: Parser<"async", unknown, unknown>,
+  args: readonly string[],
+  rootOptionSuggestions: readonly LiteralSuggestion[],
+): Promise<CompletionSuggestionResult> {
+  const prefix = args.at(-1) ?? "";
+  let context = createCompletionArgumentParserContext(
+    parser,
+    args.slice(0, -1),
+  );
+
+  while (context.buffer.length > 0) {
+    const result = await parser.parse(context);
+    if (!result.success) {
+      const argumentContext = getFailedCompletionArgumentContext(
+        result,
+        context,
+        parser,
+        rootOptionSuggestions,
+      );
+      const suggestions: Suggestion[] = [];
+      const suggestContext = await withCompletionSuggestRuntimeAsync(
+        parser,
+        context,
+      );
+      for await (const suggestion of parser.suggest(suggestContext, prefix)) {
+        suggestions.push(suggestion);
+      }
+      return { suggestions, argumentContext };
+    }
+    const previousBuffer = context.buffer;
+    context = result.next;
+    if (isCompletionBufferUnchanged(previousBuffer, context.buffer)) {
+      return {
+        suggestions: [],
+        argumentContext: getCompletedCompletionArgumentContext(context),
+      };
+    }
+  }
+
+  const suggestions: Suggestion[] = [];
+  const suggestContext = await withCompletionSuggestRuntimeAsync(
+    parser,
+    context,
+  );
+  for await (const suggestion of parser.suggest(suggestContext, prefix)) {
+    suggestions.push(suggestion);
+  }
+  return {
+    suggestions,
+    argumentContext: getCompletedCompletionArgumentContext(context),
+  };
+}
+
+function getCompletedCompletionArgumentContext(
+  context: ParserContext<unknown>,
+): CompletionArgumentContext {
   return {
     completingOptionValue: false,
     completedRootOption: false,
@@ -1755,33 +1839,65 @@ function getSyncCompletionArgumentContext(
   };
 }
 
-async function getAsyncCompletionArgumentContext(
-  parser: Parser<"async", unknown, unknown>,
-  args: readonly string[],
-  rootOptionSuggestions: readonly LiteralSuggestion[],
-): Promise<CompletionArgumentContext> {
-  let context = createCompletionArgumentParserContext(parser, args);
-
-  while (context.buffer.length > 0) {
-    const previousBuffer = context.buffer;
-    const result = await parser.parse(context);
-    if (!result.success) {
-      return getFailedCompletionArgumentContext(
-        result,
-        context,
-        parser,
-        rootOptionSuggestions,
-      );
-    }
-    context = result.next;
-    if (isCompletionBufferUnchanged(previousBuffer, context.buffer)) break;
+function withCompletionSuggestRuntime<TState>(
+  parser: Parser<Mode, unknown, TState>,
+  context: ParserContext<TState>,
+): ParserContext<TState> {
+  const runtime = createDependencyRuntimeContext();
+  const nodes = getCompletionSuggestRuntimeNodes(
+    parser,
+    context.state,
+    context.exec?.path ?? [],
+  );
+  if (nodes.length > 0) {
+    collectExplicitSourceValues(nodes, runtime);
   }
+  return addCompletionSuggestRuntime(context, runtime);
+}
 
+async function withCompletionSuggestRuntimeAsync<TState>(
+  parser: Parser<Mode, unknown, TState>,
+  context: ParserContext<TState>,
+): Promise<ParserContext<TState>> {
+  const runtime = createDependencyRuntimeContext();
+  const nodes = getCompletionSuggestRuntimeNodes(
+    parser,
+    context.state,
+    context.exec?.path ?? [],
+  );
+  if (nodes.length > 0) {
+    await collectExplicitSourceValuesAsync(nodes, runtime);
+  }
+  return addCompletionSuggestRuntime(context, runtime);
+}
+
+function addCompletionSuggestRuntime<TState>(
+  context: ParserContext<TState>,
+  runtime: ReturnType<typeof createDependencyRuntimeContext>,
+): ParserContext<TState> {
   return {
-    completingOptionValue: false,
-    completedRootOption: false,
-    optionsTerminated: context.optionsTerminated,
+    ...context,
+    dependencyRegistry: runtime.registry,
+    exec: context.exec
+      ? {
+        ...context.exec,
+        dependencyRuntime: runtime,
+        dependencyRegistry: runtime.registry,
+      }
+      : undefined,
   };
+}
+
+function getCompletionSuggestRuntimeNodes<TState>(
+  parser: Parser<Mode, unknown, TState>,
+  state: TState,
+  path: readonly PropertyKey[],
+): readonly RuntimeNode[] {
+  if (typeof parser.getSuggestRuntimeNodes === "function") {
+    return parser.getSuggestRuntimeNodes(state, path);
+  }
+  if (parser.dependencyMetadata?.source == null) return [];
+  return [{ path, parser, state }];
 }
 
 function createCompletionArgumentParserContext(

--- a/packages/core/src/facade.ts
+++ b/packages/core/src/facade.ts
@@ -40,6 +40,7 @@ import {
   type ParserResult,
   suggest,
   suggestAsync,
+  type Suggestion,
 } from "./parser.ts";
 import { dispatchByMode } from "./internal/mode-dispatch.ts";
 import { createDependencyRuntimeContext } from "./dependency-runtime.ts";
@@ -49,6 +50,7 @@ import { argument, command, constant, flag, option } from "./primitives.ts";
 import {
   formatUsage,
   type HiddenVisibility,
+  isSuggestionHidden,
   type OptionName,
   type Usage,
 } from "./usage.ts";
@@ -74,6 +76,8 @@ import type {
 } from "./context.ts";
 
 export type { ParserValuePlaceholder, SourceContext, SourceContextRequest };
+
+type LiteralSuggestion = Extract<Suggestion, { readonly kind: "literal" }>;
 
 type SuppressedErrorConstructor = new (
   error: unknown,
@@ -1515,6 +1519,7 @@ function handleCompletion<M extends Mode, THelp, TError>(
   completionOptionDisplayName?: string,
   isOptionMode?: boolean,
   sectionOrder?: (a: DocSection, b: DocSection) => number,
+  rootOptionSuggestions: readonly LiteralSuggestion[] = [],
 ): ModeValue<M, THelp | TError> {
   const shellName = completionArgs[0] || "";
   const args = completionArgs.slice(1);
@@ -1612,7 +1617,11 @@ function handleCompletion<M extends Mode, THelp, TError>(
     parser.mode,
     () => {
       const syncParser = parser as Parser<"sync", unknown, unknown>;
-      const suggestions = suggest(syncParser, args as [string, ...string[]]);
+      const suggestions = withRootOptionSuggestions(
+        suggest(syncParser, args as [string, ...string[]]),
+        args,
+        rootOptionSuggestions,
+      );
       for (const chunk of shell.encodeSuggestions(suggestions)) {
         stdout(chunk);
       }
@@ -1627,12 +1636,78 @@ function handleCompletion<M extends Mode, THelp, TError>(
         parser as Parser<"async", unknown, unknown>,
         args as [string, ...string[]],
       );
-      for (const chunk of shell.encodeSuggestions(suggestions)) {
+      for (
+        const chunk of shell.encodeSuggestions(
+          withRootOptionSuggestions(suggestions, args, rootOptionSuggestions),
+        )
+      ) {
         stdout(chunk);
       }
       return callOnCompletion(0);
     },
   );
+}
+
+function withRootOptionSuggestions(
+  suggestions: readonly Suggestion[],
+  args: readonly string[],
+  extraSuggestions: readonly LiteralSuggestion[],
+): readonly Suggestion[] {
+  if (args.length !== 1 || extraSuggestions.length === 0) return suggestions;
+
+  const prefix = args[0];
+  if (
+    !(prefix.startsWith("--") || prefix.startsWith("-") ||
+      prefix.startsWith("/") || prefix.startsWith("+"))
+  ) {
+    return suggestions;
+  }
+
+  const seen = new Set(
+    suggestions.flatMap((suggestion) =>
+      suggestion.kind === "literal" ? [suggestion.text] : []
+    ),
+  );
+  const combined = [...suggestions];
+  for (const suggestion of extraSuggestions) {
+    if (prefix === "-" && suggestion.text.length !== 2) continue;
+    if (!suggestion.text.startsWith(prefix)) continue;
+    if (seen.has(suggestion.text)) continue;
+    combined.push(suggestion);
+    seen.add(suggestion.text);
+  }
+  return combined;
+}
+
+function getRootMetaOptionSuggestions(
+  helpOptionConfig: OptionSubConfig | null | undefined,
+  helpOptionNames: readonly string[],
+  versionOptionConfig: OptionSubConfig | null | undefined,
+  versionOptionNames: readonly string[],
+): readonly LiteralSuggestion[] {
+  const suggestions: LiteralSuggestion[] = [];
+  if (
+    helpOptionConfig != null && !isSuggestionHidden(helpOptionConfig.hidden)
+  ) {
+    suggestions.push(
+      ...helpOptionNames.map((name): LiteralSuggestion => ({
+        kind: "literal",
+        text: name,
+      })),
+    );
+  }
+  if (
+    versionOptionConfig != null &&
+    !isSuggestionHidden(versionOptionConfig.hidden)
+  ) {
+    suggestions.push(
+      ...versionOptionNames.map((name): LiteralSuggestion => ({
+        kind: "literal",
+        text: name,
+      })),
+    );
+  }
+  return suggestions;
 }
 
 /**
@@ -1881,6 +1956,12 @@ export function runParser<
     completionCommandConfig?.names ?? ["completion"];
   const completionOptionNames: readonly string[] =
     completionOptionConfig?.names ?? ["--completion"];
+  const rootOptionSuggestions = getRootMetaOptionSuggestions(
+    helpOptionConfig,
+    helpOptionNames,
+    versionOptionConfig,
+    versionOptionNames,
+  );
 
   // Validate only meta/meta collisions. Parser-defined names may now overlap
   // with meta names; the runner resolves those cases parser-first at runtime.
@@ -2010,6 +2091,7 @@ export function runParser<
           completionOptionNames[0],
           classified.source === "option",
           sectionOrder,
+          rootOptionSuggestions,
         ) as InferValue<TParser>;
 
       case "help": {

--- a/packages/core/src/facade.ts
+++ b/packages/core/src/facade.ts
@@ -1624,6 +1624,7 @@ function handleCompletion<M extends Mode, THelp, TError>(
       const argumentContext = getSyncCompletionArgumentContext(
         syncParser,
         args.slice(0, -1),
+        rootOptionSuggestions,
       );
       const suggestions = withRootOptionSuggestions(
         suggest(syncParser, args as [string, ...string[]]),
@@ -1649,6 +1650,7 @@ function handleCompletion<M extends Mode, THelp, TError>(
       const argumentContext = await getAsyncCompletionArgumentContext(
         asyncParser,
         args.slice(0, -1),
+        rootOptionSuggestions,
       );
       for (
         const chunk of shell.encodeSuggestions(
@@ -1676,7 +1678,6 @@ function withRootOptionSuggestions(
   if (extraSuggestions.length === 0) return suggestions;
 
   const prefix = args.at(-1) ?? "";
-  const completedArgs = args.slice(0, -1);
   if (argumentContext.optionsTerminated) {
     return suggestions;
   }
@@ -1685,17 +1686,7 @@ function withRootOptionSuggestions(
     return suggestions;
   }
 
-  const metaNames = new Set(
-    extraSuggestions.map((suggestion) => suggestion.text),
-  );
-  if (
-    completedArgs.some((arg) =>
-      metaNames.has(arg) ||
-      extraSuggestions.some((suggestion) =>
-        arg.startsWith(`${suggestion.text}=`)
-      )
-    )
-  ) {
+  if (argumentContext.completedRootOption) {
     return suggestions;
   }
   if (
@@ -1712,7 +1703,7 @@ function withRootOptionSuggestions(
   );
   const combined = [...suggestions];
   for (const suggestion of extraSuggestions) {
-    if (prefix === "-" && suggestion.text.length !== 2) continue;
+    if (prefix === "-" && suggestion.text.startsWith("--")) continue;
     if (prefix !== "" && !suggestion.text.startsWith(prefix)) continue;
     if (seen.has(suggestion.text)) continue;
     combined.push(suggestion);
@@ -1723,6 +1714,7 @@ function withRootOptionSuggestions(
 
 interface CompletionArgumentContext {
   readonly completingOptionValue: boolean;
+  readonly completedRootOption: boolean;
   readonly optionsTerminated: boolean;
 }
 
@@ -1734,8 +1726,8 @@ interface CurrentOptionNames {
 function getSyncCompletionArgumentContext(
   parser: Parser<"sync", unknown, unknown>,
   args: readonly string[],
+  rootOptionSuggestions: readonly LiteralSuggestion[],
 ): CompletionArgumentContext {
-  const valueOptionNames = collectValueOptionNames(parser.usage);
   let context = createCompletionArgumentParserContext(parser, args);
 
   while (context.buffer.length > 0) {
@@ -1749,7 +1741,7 @@ function getSyncCompletionArgumentContext(
         result,
         context,
         parser.usage,
-        valueOptionNames,
+        rootOptionSuggestions,
       );
     }
     context = result.next;
@@ -1758,6 +1750,7 @@ function getSyncCompletionArgumentContext(
 
   return {
     completingOptionValue: false,
+    completedRootOption: false,
     optionsTerminated: context.optionsTerminated,
   };
 }
@@ -1765,8 +1758,8 @@ function getSyncCompletionArgumentContext(
 async function getAsyncCompletionArgumentContext(
   parser: Parser<"async", unknown, unknown>,
   args: readonly string[],
+  rootOptionSuggestions: readonly LiteralSuggestion[],
 ): Promise<CompletionArgumentContext> {
-  const valueOptionNames = collectValueOptionNames(parser.usage);
   let context = createCompletionArgumentParserContext(parser, args);
 
   while (context.buffer.length > 0) {
@@ -1777,7 +1770,7 @@ async function getAsyncCompletionArgumentContext(
         result,
         context,
         parser.usage,
-        valueOptionNames,
+        rootOptionSuggestions,
       );
     }
     context = result.next;
@@ -1786,6 +1779,7 @@ async function getAsyncCompletionArgumentContext(
 
   return {
     completingOptionValue: false,
+    completedRootOption: false,
     optionsTerminated: context.optionsTerminated,
   };
 }
@@ -1813,18 +1807,19 @@ function getFailedCompletionArgumentContext(
   result: Extract<ParserResult<unknown>, { readonly success: false }>,
   context: ParserContext<unknown>,
   usage: Usage,
-  valueOptionNames: ReadonlySet<string>,
+  rootOptionSuggestions: readonly LiteralSuggestion[],
 ): CompletionArgumentContext {
-  const duplicateCommandBranchValueOptionNames = result.consumed > 0
-    ? new Set<string>()
-    : collectDuplicateCommandBranchValueOptionNames(
-      usage,
-      context.exec?.commandPath ?? [],
-    );
+  const activeValueOptionNames = collectActiveValueOptionNames(
+    usage,
+    context.exec?.commandPath ?? [],
+    result.consumed > 0,
+  );
+  const token = context.buffer[0];
   return {
-    completingOptionValue: result.consumed > 0
-      ? valueOptionNames.has(context.buffer[0])
-      : duplicateCommandBranchValueOptionNames.has(context.buffer[0]),
+    completingOptionValue: (result.consumed === 0 || result.consumed === 1) &&
+      activeValueOptionNames.has(token),
+    completedRootOption: result.consumed === 0 &&
+      isRootOptionToken(token, rootOptionSuggestions),
     optionsTerminated: context.optionsTerminated,
   };
 }
@@ -1837,24 +1832,22 @@ function isCompletionBufferUnchanged(
     before.every((arg, index) => arg === after[index]);
 }
 
-function collectValueOptionNames(usage: Usage): ReadonlySet<string> {
-  const optionNames: CurrentOptionNames = {
-    value: new Set(),
-    flag: new Set(),
-  };
-  collectOptionNamesFromUsage(usage, optionNames);
-  return optionNames.value;
-}
-
-function collectDuplicateCommandBranchValueOptionNames(
+function collectActiveValueOptionNames(
   usage: Usage,
   commandPath: readonly string[],
+  includeDirectAfterCommandOptions: boolean,
 ): ReadonlySet<string> {
   const optionNames: CurrentOptionNames = {
     value: new Set(),
     flag: new Set(),
   };
-  collectDuplicateCommandBranchOptionNames(usage, commandPath, optionNames);
+  collectActiveOptionNames(
+    usage,
+    commandPath,
+    optionNames,
+    false,
+    includeDirectAfterCommandOptions,
+  );
   const names = new Set(optionNames.value);
   for (const name of optionNames.flag) {
     names.delete(name);
@@ -1862,86 +1855,83 @@ function collectDuplicateCommandBranchValueOptionNames(
   return names;
 }
 
-function collectDuplicateCommandBranchOptionNames(
+function collectActiveOptionNames(
   usage: Usage,
   commandPath: readonly string[],
   names: CurrentOptionNames,
+  fromExclusive: boolean,
+  includeDirectAfterCommandOptions: boolean,
 ): void {
-  if (commandPath.length > 0) {
-    const [commandName, ...rest] = commandPath;
-    for (let i = 0; i < usage.length; i++) {
-      const term = usage[i];
-      if (term.type === "command" && term.name === commandName) {
-        collectDuplicateCommandBranchOptionNames(
-          usage.slice(i + 1),
-          rest,
-          names,
-        );
-      } else if (term.type === "optional" || term.type === "multiple") {
-        collectDuplicateCommandBranchOptionNames(
-          term.terms,
-          commandPath,
-          names,
-        );
-      } else if (term.type === "exclusive") {
-        for (const branch of term.terms) {
-          collectDuplicateCommandBranchOptionNames(
-            branch,
-            commandPath,
-            names,
-          );
-        }
-      }
-    }
+  if (commandPath.length === 0) {
+    collectOptionNamesAtCurrentCommandDepth(usage, names, false);
+    return;
   }
 
-  for (const term of usage) {
-    if (term.type === "optional" || term.type === "multiple") {
-      collectDuplicateCommandBranchOptionNames(term.terms, commandPath, names);
+  const [commandName, ...rest] = commandPath;
+  for (let i = 0; i < usage.length; i++) {
+    const term = usage[i];
+    if (term.type === "command" && term.name === commandName) {
+      const remainingUsage = usage.slice(i + 1);
+      if (rest.length === 0) {
+        collectOptionNamesAtCurrentCommandDepth(
+          remainingUsage,
+          names,
+          !fromExclusive && includeDirectAfterCommandOptions,
+        );
+      } else {
+        collectActiveOptionNames(
+          remainingUsage,
+          rest,
+          names,
+          fromExclusive,
+          includeDirectAfterCommandOptions,
+        );
+      }
     } else if (term.type === "exclusive") {
-      if (commandPath.length > 0) {
-        const matchingBranches = term.terms
-          .map((branch) => getUsageAfterDirectCommandPath(branch, commandPath))
-          .filter((branch): branch is Usage => branch != null);
-        if (matchingBranches.length > 1) {
-          for (const branch of matchingBranches) {
-            collectOptionNamesAtCurrentCommandDepth(branch, names);
-          }
-        }
-      }
       for (const branch of term.terms) {
-        collectDuplicateCommandBranchOptionNames(branch, commandPath, names);
+        collectActiveOptionNames(
+          branch,
+          commandPath,
+          names,
+          true,
+          includeDirectAfterCommandOptions,
+        );
       }
+    } else if (term.type === "optional" || term.type === "multiple") {
+      collectActiveOptionNames(
+        term.terms,
+        commandPath,
+        names,
+        fromExclusive,
+        includeDirectAfterCommandOptions,
+      );
     }
   }
 }
 
-function getUsageAfterDirectCommandPath(
-  usage: Usage,
-  commandPath: readonly string[],
-): Usage | null {
-  let scopedUsage = usage;
-  for (const commandName of commandPath) {
-    let nextUsage: Usage | null = null;
-    for (let i = 0; i < scopedUsage.length; i++) {
-      const term = scopedUsage[i];
-      if (term.type === "command" && term.name === commandName) {
-        nextUsage = scopedUsage.slice(i + 1);
-        break;
-      }
-    }
-    if (nextUsage == null) return null;
-    scopedUsage = nextUsage;
-  }
-  return scopedUsage;
+function isRootOptionToken(
+  token: string | undefined,
+  rootOptionSuggestions: readonly LiteralSuggestion[],
+): boolean {
+  return token != null &&
+    rootOptionSuggestions.some((suggestion) =>
+      token === suggestion.text || token.startsWith(`${suggestion.text}=`)
+    );
 }
 
 function collectOptionNamesAtCurrentCommandDepth(
   usage: Usage,
   names: CurrentOptionNames,
+  afterMatchedCommand: boolean,
 ): void {
   for (const term of usage) {
-    if (collectOptionNamesAtCurrentCommandDepthFromTerm(term, names)) {
+    if (
+      collectOptionNamesAtCurrentCommandDepthFromTerm(
+        term,
+        names,
+        afterMatchedCommand,
+      )
+    ) {
       return;
     }
   }
@@ -1950,10 +1940,11 @@ function collectOptionNamesAtCurrentCommandDepth(
 function collectOptionNamesAtCurrentCommandDepthFromTerm(
   term: Usage[number],
   names: CurrentOptionNames,
+  afterMatchedCommand: boolean,
 ): boolean {
   switch (term.type) {
     case "command":
-      return true;
+      return !afterMatchedCommand;
     case "option":
       if (term.metavar != null) {
         for (const name of term.names) names.value.add(name);
@@ -1963,11 +1954,15 @@ function collectOptionNamesAtCurrentCommandDepthFromTerm(
       return false;
     case "optional":
     case "multiple":
-      collectOptionNamesAtCurrentCommandDepth(term.terms, names);
+      collectOptionNamesAtCurrentCommandDepth(
+        term.terms,
+        names,
+        afterMatchedCommand,
+      );
       return false;
     case "exclusive":
       for (const branch of term.terms) {
-        collectOptionNamesAtCurrentCommandDepth(branch, names);
+        collectOptionNamesAtCurrentCommandDepth(branch, names, false);
       }
       return false;
     case "argument":
@@ -1975,45 +1970,6 @@ function collectOptionNamesAtCurrentCommandDepthFromTerm(
     case "passthrough":
     case "ellipsis":
       return false;
-  }
-}
-
-function collectOptionNamesFromUsage(
-  usage: Usage,
-  names: CurrentOptionNames,
-): void {
-  for (const term of usage) {
-    collectOptionNamesFromTerm(term, names);
-  }
-}
-
-function collectOptionNamesFromTerm(
-  term: Usage[number],
-  names: CurrentOptionNames,
-): void {
-  switch (term.type) {
-    case "option":
-      if (term.metavar != null) {
-        for (const name of term.names) names.value.add(name);
-      } else {
-        for (const name of term.names) names.flag.add(name);
-      }
-      return;
-    case "optional":
-    case "multiple":
-      collectOptionNamesFromUsage(term.terms, names);
-      return;
-    case "exclusive":
-      for (const branch of term.terms) {
-        collectOptionNamesFromUsage(branch, names);
-      }
-      return;
-    case "argument":
-    case "command":
-    case "literal":
-    case "passthrough":
-    case "ellipsis":
-      return;
   }
 }
 

--- a/packages/core/src/facade.ts
+++ b/packages/core/src/facade.ts
@@ -950,7 +950,11 @@ function createMetaOptionDocParser(
     }),
     complete: (state) => ({ success: true, value: state }),
     suggest: function* () {},
-    getDocFragments: (state) => source.getDocFragments(state),
+    getDocFragments: (_state, defaultValue) =>
+      source.getDocFragments(
+        { kind: "available", state: source.initialState },
+        defaultValue,
+      ),
   };
 }
 

--- a/packages/core/src/modifiers.test.ts
+++ b/packages/core/src/modifiers.test.ts
@@ -10201,6 +10201,46 @@ describe("multiple() phase-two seed extraction", () => {
     );
   });
 
+  it("returns null from the sync seed hook when no item has a seed", () => {
+    const parser = multipleLocal(createSyncDeferredItemParser());
+
+    const seed = extractPhase2Seed(parser, []);
+
+    assert.equal(seed, null);
+  });
+
+  it("returns null from the async seed hook when no item has a seed", async () => {
+    const parser = multipleLocal(createAsyncDeferredItemParser());
+
+    const seed = await extractPhase2Seed(parser, []);
+
+    assert.equal(seed, null);
+  });
+
+  it("combines non-empty sync item seeds from the seed hook", () => {
+    const parser = multipleLocal(createSyncDeferredItemParser());
+
+    const seed = extractPhase2Seed(parser, [
+      "scalar",
+      "structured",
+      "partial",
+    ]);
+
+    assertDeferredItems(seed);
+  });
+
+  it("combines non-empty async item seeds from the seed hook", async () => {
+    const parser = multipleLocal(createAsyncDeferredItemParser());
+
+    const seed = await extractPhase2Seed(parser, [
+      "scalar",
+      "structured",
+      "partial",
+    ]);
+
+    assertDeferredItems(seed);
+  });
+
   it("unwraps injected annotation wrappers before extracting item seeds", () => {
     const marker = Symbol.for("@test/multiple-phase-two-seed");
     const child: Parser<"sync", string, string> = {
@@ -10655,6 +10695,19 @@ describe("validateValue forwarding through modifiers (#414)", () => {
       }
     });
 
+    it("keeps the original array when inner validation does not canonicalize", () => {
+      const parser = multiple(option("-x", integer({ min: 1, max: 10 })));
+      const values = [1, 5, 10] as const;
+
+      const result = parser.validateValue!(values);
+
+      assert.ok(result && typeof result === "object" && "success" in result);
+      assert.ok(result.success);
+      if (result.success) {
+        assert.equal(result.value, values);
+      }
+    });
+
     it("preserves canonicalized element values in async mode", async () => {
       const upcaseString: ValueParser<"async", string> = {
         mode: "async",
@@ -10672,6 +10725,106 @@ describe("validateValue forwarding through modifiers (#414)", () => {
       if (result.success) {
         assert.deepEqual(result.value, ["FOO", "BAR"]);
       }
+    });
+
+    it("returns the first async element validation failure", async () => {
+      const asyncFormat: ValueParser<"async", string> = {
+        mode: "async",
+        metavar: "FORMAT",
+        placeholder: "json",
+        parse(input) {
+          return Promise.resolve(
+            input === "json" || input === "yaml"
+              ? { success: true as const, value: input }
+              : {
+                success: false as const,
+                error: message`Invalid value: ${text(input)}.`,
+              },
+          );
+        },
+        format(value) {
+          return value;
+        },
+      };
+      const parser = multiple(option("-x", asyncFormat));
+
+      const result = await parser.validateValue!(["json", "xml"]);
+
+      assert.ok(!result.success);
+      if (!result.success) {
+        assertErrorIncludes(result.error, "Invalid value");
+      }
+    });
+
+    it("validates arity without an inner validateValue callback", () => {
+      const parser = multiple(constant("ready"), { min: 1 });
+      assert.ok(typeof parser.validateValue === "function");
+
+      const result = parser.validateValue!(["ready"]);
+
+      assert.ok(result && typeof result === "object" && "success" in result);
+      assert.ok(result.success);
+      if (result.success) {
+        assert.deepEqual(result.value, ["ready"]);
+      }
+    });
+
+    it("builds placeholders from the inner parser minimum arity", () => {
+      const parser = multiple(option("-x", string()), { min: 3 });
+
+      assert.deepEqual(parser.placeholder, ["", "", ""]);
+    });
+
+    it("falls back to an empty placeholder when the inner placeholder throws", () => {
+      const throwingPlaceholder: Parser<"sync", string, undefined> = {
+        mode: "sync",
+        $valueType: [] as readonly string[],
+        $stateType: [] as readonly undefined[],
+        priority: 0,
+        usage: [],
+        leadingNames: new Set(),
+        acceptingAnyToken: false,
+        initialState: undefined,
+        parse(context) {
+          return {
+            success: true as const,
+            next: context,
+            consumed: [],
+          };
+        },
+        complete() {
+          return { success: true as const, value: "fallback" };
+        },
+        *suggest() {},
+        getDocFragments() {
+          return { fragments: [] };
+        },
+      };
+      Object.defineProperty(throwingPlaceholder, "placeholder", {
+        get() {
+          throw new Error("placeholder unavailable.");
+        },
+      });
+      const parser = multiple(throwingPlaceholder, { min: 1 });
+
+      assert.deepEqual(parser.placeholder, []);
+    });
+
+    it("normalizes only changed elements and preserves invalid ones", () => {
+      const normalizingParser = option("-x", domain({ lowercase: true }));
+      const parser = multiple(normalizingParser);
+      assert.ok(typeof parser.normalizeValue === "function");
+
+      const unchanged = ["example.com"] as const;
+      assert.equal(parser.normalizeValue!(unchanged), unchanged);
+      assert.deepEqual(parser.normalizeValue!(["EXAMPLE.COM"]), [
+        "example.com",
+      ]);
+      assert.deepEqual(parser.normalizeValue!(["not a domain"]), [
+        "not a domain",
+      ]);
+      const sentinel = "not-array" as never;
+      assert.equal(parser.normalizeValue!(sentinel), sentinel);
     });
 
     it("rejects non-array fallback values", () => {

--- a/packages/core/src/modifiers.test.ts
+++ b/packages/core/src/modifiers.test.ts
@@ -3395,6 +3395,72 @@ describe("multiple", () => {
     );
   });
 
+  it("should fallback to unwrapped primitive state in async suggest()", async () => {
+    const baseParser: Parser<"async", string, string> = {
+      mode: "async",
+      $valueType: [] as const,
+      $stateType: [] as const,
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(),
+      acceptingAnyToken: false,
+      initialState: "",
+      parse(context) {
+        const [head, ...tail] = context.buffer;
+        if (head === undefined) {
+          return Promise.resolve({
+            success: false as const,
+            consumed: 0,
+            error: message`Expected a value.`,
+          });
+        }
+        return Promise.resolve({
+          success: true as const,
+          consumed: [head],
+          next: { ...context, buffer: tail, state: head },
+        });
+      },
+      complete(state) {
+        return Promise.resolve({
+          success: true as const,
+          value: state.toUpperCase(),
+        });
+      },
+      async *suggest(context) {
+        if (typeof context.state !== "string") {
+          throw new TypeError("Expected string state.");
+        }
+        yield { kind: "literal" as const, text: "beta" };
+      },
+      getDocFragments() {
+        return { fragments: [] };
+      },
+    };
+
+    const parser = multiple(baseParser);
+    const parseResult = await parser.parse({
+      buffer: ["alpha"],
+      state: injectAnnotations(parser.initialState, {
+        [Symbol.for("@test/fallback-suggest-async")]: true,
+      }),
+      optionsTerminated: false,
+      usage: parser.usage,
+    });
+    assert.ok(parseResult.success);
+    if (!parseResult.success) {
+      return;
+    }
+    const suggestions = await collectSuggestions(parser.suggest({
+      buffer: [],
+      state: parseResult.next.state,
+      optionsTerminated: false,
+      usage: parser.usage,
+    }, ""));
+    assert.ok(
+      suggestions.some((s) => s.kind === "literal" && s.text === "beta"),
+    );
+  });
+
   it("should pass annotations to inner suggest state", () => {
     const annotation = Symbol.for("@test/multiple-suggest-annotations");
     const baseParser: Parser<"sync", string, string> = {
@@ -10346,6 +10412,112 @@ describe("multiple() dependency source extraction", () => {
     assert.deepEqual(result, { success: true, value: "prod" });
     assert.deepEqual(visited, [latest, earlier]);
   });
+
+  it("scans sync source states from newest to oldest", () => {
+    const sourceId = Symbol("mode");
+    const earliest = Symbol("earliest");
+    const middle = Symbol("middle");
+    const latest = Symbol("latest");
+    const visited: unknown[] = [];
+    const inner: Parser<"sync", string, symbol | null> = {
+      mode: "sync" as const,
+      $valueType: [] as const,
+      $stateType: [] as const,
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(),
+      acceptingAnyToken: false,
+      initialState: null,
+      parse: () => ({
+        success: false as const,
+        consumed: 0,
+        error: message`No parse.`,
+      }),
+      complete: () => ({
+        success: false as const,
+        error: message`No completion.`,
+      }),
+      suggest: function* () {},
+      getDocFragments: () => ({ fragments: [] }),
+    };
+    Object.defineProperty(inner, "dependencyMetadata", {
+      value: {
+        source: {
+          kind: "source" as const,
+          sourceId,
+          preservesSourceValue: true,
+          extractSourceValue(state: unknown) {
+            visited.push(state);
+            return state === middle
+              ? { success: true as const, value: "stage" }
+              : undefined;
+          },
+        },
+      },
+      configurable: true,
+      enumerable: false,
+    });
+    const parser = multiple(inner);
+
+    const result = parser.dependencyMetadata?.source?.extractSourceValue([
+      earliest,
+      middle,
+      latest,
+    ]);
+
+    assert.deepEqual(result, { success: true, value: "stage" });
+    assert.deepEqual(visited, [latest, middle]);
+  });
+
+  it("returns undefined when no repeated source state has a value", () => {
+    const sourceId = Symbol("mode");
+    const visited: unknown[] = [];
+    const inner: Parser<"sync", string, string | null> = {
+      mode: "sync" as const,
+      $valueType: [] as const,
+      $stateType: [] as const,
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(),
+      acceptingAnyToken: false,
+      initialState: null,
+      parse: () => ({
+        success: false as const,
+        consumed: 0,
+        error: message`No parse.`,
+      }),
+      complete: () => ({
+        success: false as const,
+        error: message`No completion.`,
+      }),
+      suggest: function* () {},
+      getDocFragments: () => ({ fragments: [] }),
+    };
+    Object.defineProperty(inner, "dependencyMetadata", {
+      value: {
+        source: {
+          kind: "source" as const,
+          sourceId,
+          preservesSourceValue: true,
+          extractSourceValue(state: unknown) {
+            visited.push(state);
+            return undefined;
+          },
+        },
+      },
+      configurable: true,
+      enumerable: false,
+    });
+    const parser = multiple(inner);
+
+    const result = parser.dependencyMetadata?.source?.extractSourceValue([
+      "dev",
+      "prod",
+    ]);
+
+    assert.equal(result, undefined);
+    assert.deepEqual(visited, ["prod", "dev"]);
+  });
 });
 
 describe("multiple() value helpers", () => {
@@ -10606,9 +10778,524 @@ describe("multiple() phase-two seed extraction", () => {
 
     assert.deepEqual(seed, { value: ["optique.json"] });
   });
+
+  it("unwraps injected annotation wrappers before sync item completion", () => {
+    const marker = Symbol.for("@test/multiple-complete-sync-wrapper");
+    const child: Parser<"sync", string, string> = {
+      mode: "sync",
+      $valueType: [] as readonly string[],
+      $stateType: [] as readonly string[],
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(),
+      acceptingAnyToken: false,
+      initialState: "",
+      parse(context) {
+        return { success: true as const, next: context, consumed: [] };
+      },
+      complete(state) {
+        return { success: true as const, value: state.toUpperCase() };
+      },
+      *suggest() {},
+      getDocFragments() {
+        return { fragments: [] };
+      },
+    };
+    const parser = multipleLocal(child, { min: 1 });
+    const wrapped = injectAnnotations("dev", { [marker]: true });
+
+    const result = parser.complete([wrapped]);
+
+    assert.deepEqual(result, { success: true, value: ["DEV"] });
+  });
+
+  it("unwraps injected annotation wrappers before async item completion", async () => {
+    const marker = Symbol.for("@test/multiple-complete-async-wrapper");
+    const child: Parser<"async", string, string> = {
+      mode: "async",
+      $valueType: [] as readonly string[],
+      $stateType: [] as readonly string[],
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(),
+      acceptingAnyToken: false,
+      initialState: "",
+      parse(context) {
+        return Promise.resolve({
+          success: true as const,
+          next: context,
+          consumed: [],
+        });
+      },
+      complete(state) {
+        return Promise.resolve({
+          success: true as const,
+          value: state.toUpperCase(),
+        });
+      },
+      async *suggest() {},
+      getDocFragments() {
+        return { fragments: [] };
+      },
+    };
+    const parser = multipleLocal(child, { min: 1 });
+    const wrapped = injectAnnotations("dev", { [marker]: true });
+
+    const result = await parser.complete([wrapped]);
+
+    assert.deepEqual(result, { success: true, value: ["DEV"] });
+  });
+
+  it("propagates sync item completion exceptions for plain states", () => {
+    const completionError = new TypeError("Plain completion failed.");
+    const child: Parser<"sync", string, string> = {
+      mode: "sync",
+      $valueType: [] as readonly string[],
+      $stateType: [] as readonly string[],
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(),
+      acceptingAnyToken: false,
+      initialState: "",
+      parse(context) {
+        return { success: true as const, next: context, consumed: [] };
+      },
+      complete() {
+        throw completionError;
+      },
+      *suggest() {},
+      getDocFragments() {
+        return { fragments: [] };
+      },
+    };
+    const parser = multipleLocal(child, { min: 1 });
+
+    assert.throws(() => parser.complete(["dev"]), completionError);
+  });
+
+  it("propagates async item completion exceptions for plain states", async () => {
+    const completionError = new TypeError("Plain async completion failed.");
+    const child: Parser<"async", string, string> = {
+      mode: "async",
+      $valueType: [] as readonly string[],
+      $stateType: [] as readonly string[],
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(),
+      acceptingAnyToken: false,
+      initialState: "",
+      parse(context) {
+        return Promise.resolve({
+          success: true as const,
+          next: context,
+          consumed: [],
+        });
+      },
+      complete() {
+        throw completionError;
+      },
+      async *suggest() {},
+      getDocFragments() {
+        return { fragments: [] };
+      },
+    };
+    const parser = multipleLocal(child, { min: 1 });
+
+    await assert.rejects(() => parser.complete(["dev"]), completionError);
+  });
+
+  it("unwraps injected annotation wrappers before sync item parse retries", () => {
+    const marker = Symbol.for("@test/multiple-parse-sync-wrapper");
+    const child: Parser<"sync", string, string> = {
+      mode: "sync",
+      $valueType: [] as readonly string[],
+      $stateType: [] as readonly string[],
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(),
+      acceptingAnyToken: false,
+      initialState: "",
+      parse(context) {
+        return {
+          success: true as const,
+          next: { ...context, state: context.state.toUpperCase() },
+          consumed: ["--mode"],
+        };
+      },
+      complete(state) {
+        return { success: true as const, value: state };
+      },
+      *suggest() {},
+      getDocFragments() {
+        return { fragments: [] };
+      },
+    };
+    const parser = multipleLocal(child, { min: 1 });
+    const wrapped = injectAnnotations("dev", { [marker]: true });
+
+    const result = parser.parse({
+      buffer: ["--mode"],
+      state: [wrapped],
+      optionsTerminated: false,
+      usage: parser.usage,
+    });
+
+    assert.ok(result.success);
+    assert.equal(unwrapPrimitiveState(result.next.state[0]), "DEV");
+    assert.ok(getAnnotations(result.next.state[0])?.[marker]);
+  });
+
+  it("unwraps injected annotation wrappers before async item parse retries", async () => {
+    const marker = Symbol.for("@test/multiple-parse-async-wrapper");
+    const child: Parser<"async", string, string> = {
+      mode: "async",
+      $valueType: [] as readonly string[],
+      $stateType: [] as readonly string[],
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(),
+      acceptingAnyToken: false,
+      initialState: "",
+      parse(context) {
+        return Promise.resolve({
+          success: true as const,
+          next: { ...context, state: context.state.toUpperCase() },
+          consumed: ["--mode"],
+        });
+      },
+      complete(state) {
+        return Promise.resolve({ success: true as const, value: state });
+      },
+      async *suggest() {},
+      getDocFragments() {
+        return { fragments: [] };
+      },
+    };
+    const parser = multipleLocal(child, { min: 1 });
+    const wrapped = injectAnnotations("dev", { [marker]: true });
+
+    const result = await parser.parse({
+      buffer: ["--mode"],
+      state: [wrapped],
+      optionsTerminated: false,
+      usage: parser.usage,
+    });
+
+    assert.ok(result.success);
+    assert.equal(unwrapPrimitiveState(result.next.state[0]), "DEV");
+    assert.ok(getAnnotations(result.next.state[0])?.[marker]);
+  });
+
+  it("propagates sync item parse exceptions for plain states", () => {
+    const parseError = new TypeError("Plain parse failed.");
+    const child: Parser<"sync", string, string> = {
+      mode: "sync",
+      $valueType: [] as readonly string[],
+      $stateType: [] as readonly string[],
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(),
+      acceptingAnyToken: false,
+      initialState: "",
+      parse() {
+        throw parseError;
+      },
+      complete(state) {
+        return { success: true as const, value: state };
+      },
+      *suggest() {},
+      getDocFragments() {
+        return { fragments: [] };
+      },
+    };
+    const parser = multipleLocal(child, { min: 1 });
+
+    assert.throws(
+      () =>
+        parser.parse({
+          buffer: ["--mode"],
+          state: ["dev"],
+          optionsTerminated: false,
+          usage: parser.usage,
+        }),
+      parseError,
+    );
+  });
+
+  it("propagates async item parse exceptions for plain states", async () => {
+    const parseError = new TypeError("Plain async parse failed.");
+    const child: Parser<"async", string, string> = {
+      mode: "async",
+      $valueType: [] as readonly string[],
+      $stateType: [] as readonly string[],
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(),
+      acceptingAnyToken: false,
+      initialState: "",
+      parse() {
+        throw parseError;
+      },
+      complete(state) {
+        return Promise.resolve({ success: true as const, value: state });
+      },
+      async *suggest() {},
+      getDocFragments() {
+        return { fragments: [] };
+      },
+    };
+    const parser = multipleLocal(child, { min: 1 });
+
+    await assert.rejects(
+      () =>
+        parser.parse({
+          buffer: ["--mode"],
+          state: ["dev"],
+          optionsTerminated: false,
+          usage: parser.usage,
+        }),
+      parseError,
+    );
+  });
+
+  it("retries sync item phase-two seeds after primitive-wrapper TypeErrors", () => {
+    const marker = Symbol.for("@test/multiple-phase-two-sync-typeerror");
+    const child: Parser<"sync", string, string> = {
+      mode: "sync",
+      $valueType: [] as readonly string[],
+      $stateType: [] as readonly string[],
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(),
+      acceptingAnyToken: false,
+      initialState: "",
+      parse(context) {
+        return { success: true as const, next: context, consumed: [] };
+      },
+      complete() {
+        return { success: false as const, error: message`Missing item.` };
+      },
+      *suggest() {},
+      getDocFragments() {
+        return { fragments: [] };
+      },
+    };
+    Object.defineProperty(child, extractPhase2SeedKey, {
+      value(state: string) {
+        return { value: state.toUpperCase() };
+      },
+    });
+    const parser = multipleLocal(child, { min: 1 });
+    const wrapped = injectAnnotations("dev", { [marker]: true });
+
+    const seed = extractPhase2Seed(parser, [wrapped]);
+
+    assert.deepEqual(seed, { value: ["DEV"] });
+  });
+
+  it("propagates sync item phase-two exceptions for plain states", () => {
+    const seedError = new TypeError("Plain phase-two seed failed.");
+    const child: Parser<"sync", string, string> = {
+      mode: "sync",
+      $valueType: [] as readonly string[],
+      $stateType: [] as readonly string[],
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(),
+      acceptingAnyToken: false,
+      initialState: "",
+      parse(context) {
+        return { success: true as const, next: context, consumed: [] };
+      },
+      complete() {
+        return { success: false as const, error: message`Missing item.` };
+      },
+      *suggest() {},
+      getDocFragments() {
+        return { fragments: [] };
+      },
+    };
+    Object.defineProperty(child, extractPhase2SeedKey, {
+      value() {
+        throw seedError;
+      },
+    });
+    const parser = multipleLocal(child, { min: 1 });
+
+    assert.throws(() => extractPhase2Seed(parser, ["dev"]), seedError);
+  });
+
+  it("retries async item phase-two seeds after primitive-wrapper TypeErrors", async () => {
+    const marker = Symbol.for("@test/multiple-phase-two-async-typeerror");
+    const child: Parser<"async", string, string> = {
+      mode: "async",
+      $valueType: [] as readonly string[],
+      $stateType: [] as readonly string[],
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(),
+      acceptingAnyToken: false,
+      initialState: "",
+      parse(context) {
+        return Promise.resolve({
+          success: true as const,
+          next: context,
+          consumed: [],
+        });
+      },
+      complete() {
+        return Promise.resolve({
+          success: false as const,
+          error: message`Missing item.`,
+        });
+      },
+      async *suggest() {},
+      getDocFragments() {
+        return { fragments: [] };
+      },
+    };
+    Object.defineProperty(child, extractPhase2SeedKey, {
+      value(state: string) {
+        return Promise.resolve({ value: state.toUpperCase() });
+      },
+    });
+    const parser = multipleLocal(child, { min: 1 });
+    const wrapped = injectAnnotations("dev", { [marker]: true });
+
+    const seed = await extractPhase2Seed(parser, [wrapped]);
+
+    assert.deepEqual(seed, { value: ["DEV"] });
+  });
+
+  it("retries async item phase-two seeds after null wrapper results", async () => {
+    const marker = Symbol.for("@test/multiple-phase-two-async-null");
+    const child: Parser<"async", string, string> = {
+      mode: "async",
+      $valueType: [] as readonly string[],
+      $stateType: [] as readonly string[],
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(),
+      acceptingAnyToken: false,
+      initialState: "",
+      parse(context) {
+        return Promise.resolve({
+          success: true as const,
+          next: context,
+          consumed: [],
+        });
+      },
+      complete() {
+        return Promise.resolve({
+          success: false as const,
+          error: message`Missing item.`,
+        });
+      },
+      async *suggest() {},
+      getDocFragments() {
+        return { fragments: [] };
+      },
+    };
+    Object.defineProperty(child, extractPhase2SeedKey, {
+      value(state: string | object) {
+        return Promise.resolve(
+          typeof state === "string" ? { value: state.toUpperCase() } : null,
+        );
+      },
+    });
+    const parser = multipleLocal(child, { min: 1 });
+    const wrapped = injectAnnotations("dev", { [marker]: true });
+
+    const seed = await extractPhase2Seed(parser, [wrapped]);
+
+    assert.deepEqual(seed, { value: ["DEV"] });
+  });
+
+  it("propagates async item phase-two exceptions for plain states", async () => {
+    const seedError = new TypeError("Plain async phase-two seed failed.");
+    const child: Parser<"async", string, string> = {
+      mode: "async",
+      $valueType: [] as readonly string[],
+      $stateType: [] as readonly string[],
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(),
+      acceptingAnyToken: false,
+      initialState: "",
+      parse(context) {
+        return Promise.resolve({
+          success: true as const,
+          next: context,
+          consumed: [],
+        });
+      },
+      complete() {
+        return Promise.resolve({
+          success: false as const,
+          error: message`Missing item.`,
+        });
+      },
+      async *suggest() {},
+      getDocFragments() {
+        return { fragments: [] };
+      },
+    };
+    Object.defineProperty(child, extractPhase2SeedKey, {
+      value() {
+        return Promise.reject(seedError);
+      },
+    });
+    const parser = multipleLocal(child, { min: 1 });
+
+    await assert.rejects(() => extractPhase2Seed(parser, ["dev"]), seedError);
+  });
 });
 
 describe("withDefault() phase-two seed extraction", () => {
+  it("ignores primitive outer states for sync optional-like seeds", () => {
+    const parser = optionalLocal(option("--name", string()));
+
+    const seed = extractPhase2Seed(
+      parser as Parser<"sync", string | undefined, [string] | undefined>,
+      "not-an-outer-state" as never,
+    );
+
+    assert.equal(seed, null);
+  });
+
+  it("ignores primitive outer states for async optional-like seeds", async () => {
+    const inner: Parser<"async", string, string> = {
+      mode: "async",
+      $valueType: [] as readonly string[],
+      $stateType: [] as readonly string[],
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(),
+      acceptingAnyToken: false,
+      initialState: "",
+      parse(context) {
+        return Promise.resolve({
+          success: true as const,
+          next: context,
+          consumed: [],
+        });
+      },
+      complete(state) {
+        return Promise.resolve({ success: true as const, value: state });
+      },
+      suggest: async function* () {},
+      getDocFragments: () => ({ fragments: [] }),
+    };
+    const parser = optionalLocal(inner);
+
+    const seed = await extractPhase2Seed(
+      parser as Parser<"async", string | undefined, [string] | undefined>,
+      "not-an-outer-state" as never,
+    );
+
+    assert.equal(seed, null);
+  });
+
   it("preserves default-only seeds", () => {
     const seed = completeOrExtractPhase2Seed(
       withDefault(option("--name", string()), "fallback"),

--- a/packages/core/src/modifiers.test.ts
+++ b/packages/core/src/modifiers.test.ts
@@ -9720,6 +9720,224 @@ describe(
       );
 
       it(
+        `${name} phase-two seed extraction retries null delegated seeds`,
+        () => {
+          let completeCalls = 0;
+          let extractCalls = 0;
+          const inner: Parser<"sync", string, string> = {
+            mode: "sync",
+            $valueType: [] as readonly string[],
+            $stateType: [] as readonly string[],
+            priority: 0,
+            usage: [],
+            leadingNames: new Set<string>(),
+            acceptingAnyToken: false,
+            initialState: "seed",
+            parse(context) {
+              return {
+                success: true as const,
+                next: context,
+                consumed: [],
+              };
+            },
+            complete() {
+              completeCalls++;
+              return {
+                success: false as const,
+                error: message`Missing value.`,
+              };
+            },
+            suggest() {
+              return [];
+            },
+            getDocFragments() {
+              return { fragments: [] };
+            },
+          };
+          Object.defineProperty(inner, extractPhase2SeedKey, {
+            value(state: string | object) {
+              extractCalls++;
+              return typeof state === "string"
+                ? { value: state.toUpperCase() }
+                : null;
+            },
+          });
+          const parser = wrap(inner);
+          const outerState = injectAnnotations(["live"] as [string], {
+            [Symbol.for(`@test/issue-594/${name}/phase2-null-retry`)]: true,
+          });
+
+          const seed = extractPhase2Seed(parser, outerState);
+
+          assert.deepEqual(seed, { value: "LIVE" });
+          assert.equal(completeCalls, 1);
+          assert.equal(extractCalls, 2);
+        },
+      );
+
+      it(
+        `${name} async phase-two seed extraction retries null delegated seeds`,
+        async () => {
+          let completeCalls = 0;
+          let extractCalls = 0;
+          const inner: Parser<"async", string, string> = {
+            mode: "async",
+            $valueType: [] as readonly string[],
+            $stateType: [] as readonly string[],
+            priority: 0,
+            usage: [],
+            leadingNames: new Set<string>(),
+            acceptingAnyToken: false,
+            initialState: "seed",
+            parse(context) {
+              return Promise.resolve({
+                success: true as const,
+                next: context,
+                consumed: [],
+              });
+            },
+            complete() {
+              completeCalls++;
+              return Promise.resolve({
+                success: false as const,
+                error: message`Missing value.`,
+              });
+            },
+            suggest: async function* () {},
+            getDocFragments() {
+              return { fragments: [] };
+            },
+          };
+          Object.defineProperty(inner, extractPhase2SeedKey, {
+            value(state: string | object) {
+              extractCalls++;
+              return Promise.resolve(
+                typeof state === "string"
+                  ? { value: state.toUpperCase() }
+                  : null,
+              );
+            },
+          });
+          const parser = wrap(inner);
+          const outerState = injectAnnotations(["live"] as [string], {
+            [
+              Symbol.for(
+                `@test/issue-594/${name}/async-phase2-null-retry`,
+              )
+            ]: true,
+          });
+
+          const seed = await extractPhase2Seed(parser, outerState);
+
+          assert.deepEqual(seed, { value: "LIVE" });
+          assert.equal(completeCalls, 1);
+          assert.equal(extractCalls, 2);
+        },
+      );
+
+      it(
+        `${name} phase-two seed extraction normalizes nested annotation wrappers`,
+        () => {
+          const marker = Symbol.for(
+            `@test/issue-594/${name}/phase2-normalize`,
+          );
+          const inner: Parser<
+            "sync",
+            { readonly nested: unknown },
+            string
+          > = {
+            mode: "sync",
+            $valueType: [] as readonly { readonly nested: unknown }[],
+            $stateType: [] as readonly string[],
+            priority: 0,
+            usage: [],
+            leadingNames: new Set<string>(),
+            acceptingAnyToken: false,
+            initialState: "seed",
+            parse(context) {
+              return {
+                success: true as const,
+                next: context,
+                consumed: [],
+              };
+            },
+            complete() {
+              return {
+                success: true as const,
+                value: {
+                  nested: injectAnnotations("value", { [marker]: "inner" }),
+                },
+              };
+            },
+            suggest() {
+              return [];
+            },
+            getDocFragments() {
+              return { fragments: [] };
+            },
+          };
+          const parser = wrap(inner);
+          const outerState = injectAnnotations(["live"] as [string], {
+            [marker]: "outer",
+          });
+
+          const seed = extractPhase2Seed(parser, outerState);
+
+          assert.deepEqual(seed, { value: { nested: "value" } });
+        },
+      );
+
+      it(
+        `${name} async phase-two seed extraction normalizes nested annotation wrappers`,
+        async () => {
+          const marker = Symbol.for(
+            `@test/issue-594/${name}/async-phase2-normalize`,
+          );
+          const inner: Parser<
+            "async",
+            { readonly nested: unknown },
+            string
+          > = {
+            mode: "async",
+            $valueType: [] as readonly { readonly nested: unknown }[],
+            $stateType: [] as readonly string[],
+            priority: 0,
+            usage: [],
+            leadingNames: new Set<string>(),
+            acceptingAnyToken: false,
+            initialState: "seed",
+            parse(context) {
+              return Promise.resolve({
+                success: true as const,
+                next: context,
+                consumed: [],
+              });
+            },
+            complete() {
+              return Promise.resolve({
+                success: true as const,
+                value: {
+                  nested: injectAnnotations("value", { [marker]: "inner" }),
+                },
+              });
+            },
+            suggest: async function* () {},
+            getDocFragments() {
+              return { fragments: [] };
+            },
+          };
+          const parser = wrap(inner);
+          const outerState = injectAnnotations(["live"] as [string], {
+            [marker]: "outer",
+          });
+
+          const seed = await extractPhase2Seed(parser, outerState);
+
+          assert.deepEqual(seed, { value: { nested: "value" } });
+        },
+      );
+
+      it(
         `${name} phase-two seed extraction retries the extractor without retrying failed completion`,
         () => {
           let completeCalls = 0;
@@ -10653,6 +10871,35 @@ describe("validateValue forwarding through modifiers (#414)", () => {
       }
     });
 
+    it("honors function options.errors.tooFew in validateValue", () => {
+      const parser = multiple(option("-x", string()), {
+        min: 3,
+        errors: {
+          tooFew: (min, actual) =>
+            message`too few: ${text(String(min))}/${text(String(actual))}.`,
+        },
+      });
+      const result = parser.validateValue!(["a"]);
+      assert.ok(result && typeof result === "object" && "success" in result);
+      assert.ok(!result.success);
+      if (!result.success) {
+        assert.equal(formatMessage(result.error), "too few: 3/1.");
+      }
+    });
+
+    it("honors static options.errors.tooMany in validateValue", () => {
+      const parser = multiple(option("-x", string()), {
+        max: 2,
+        errors: { tooMany: message`custom too-many.` },
+      });
+      const result = parser.validateValue!(["a", "b", "c"]);
+      assert.ok(result && typeof result === "object" && "success" in result);
+      assert.ok(!result.success);
+      if (!result.success) {
+        assert.equal(formatMessage(result.error), "custom too-many.");
+      }
+    });
+
     it("honors options.errors.tooMany in validateValue", () => {
       const parser = multiple(option("-x", string()), {
         max: 2,
@@ -10907,6 +11154,133 @@ describe("validateValue forwarding through modifiers (#414)", () => {
       const min1Result = min1.validateValue!([]);
       assert.ok(min1Result && "success" in min1Result);
       assert.ok(!min1Result.success);
+    });
+
+    it("forwards shouldDeferCompletion from the inner parser", () => {
+      const seenStates: unknown[] = [];
+      const inner: Parser<"sync", string, string> = {
+        mode: "sync",
+        $valueType: [] as readonly string[],
+        $stateType: [] as readonly string[],
+        priority: 0,
+        usage: [],
+        leadingNames: new Set<string>(),
+        acceptingAnyToken: false,
+        initialState: "seed",
+        parse(context) {
+          return {
+            success: true as const,
+            next: context,
+            consumed: ["--name", "alice"],
+          };
+        },
+        complete(state) {
+          return { success: true as const, value: state };
+        },
+        shouldDeferCompletion(state) {
+          seenStates.push(state);
+          return state === "deferred";
+        },
+        suggest() {
+          return [];
+        },
+        getDocFragments() {
+          return { fragments: [] };
+        },
+      };
+      const parser = nonEmpty(inner);
+
+      assert.ok(parser.shouldDeferCompletion?.("deferred"));
+      assert.deepEqual(seenStates, ["deferred"]);
+    });
+
+    it("forwards placeholders lazily from the inner parser", () => {
+      const parser = nonEmpty(option("--name", string()));
+
+      assert.equal(parser.placeholder, "");
+    });
+
+    it("uses inner runtime suggestion nodes when available", () => {
+      const nodePath = ["profile", "name"] as const;
+      const inner: Parser<"sync", string, string> = {
+        mode: "sync",
+        $valueType: [] as readonly string[],
+        $stateType: [] as readonly string[],
+        priority: 0,
+        usage: [],
+        leadingNames: new Set<string>(),
+        acceptingAnyToken: false,
+        initialState: "seed",
+        parse(context) {
+          return {
+            success: true as const,
+            next: context,
+            consumed: ["--name", "alice"],
+          };
+        },
+        complete(state) {
+          return { success: true as const, value: state };
+        },
+        suggest() {
+          return [];
+        },
+        getDocFragments() {
+          return { fragments: [] };
+        },
+        getSuggestRuntimeNodes(state, path) {
+          return [{ path: [...path, "inner"], parser: inner, state }];
+        },
+      };
+      const parser = nonEmpty(inner);
+
+      assert.deepEqual(parser.getSuggestRuntimeNodes?.("live", nodePath), [
+        { path: ["profile", "name", "inner"], parser: inner, state: "live" },
+      ]);
+    });
+
+    it("exposes dependency source runtime suggestion nodes", () => {
+      const sourceId = Symbol("nonempty-source");
+      const inner: Parser<"sync", string, string> = {
+        mode: "sync",
+        $valueType: [] as readonly string[],
+        $stateType: [] as readonly string[],
+        priority: 0,
+        usage: [],
+        leadingNames: new Set<string>(),
+        acceptingAnyToken: false,
+        initialState: "seed",
+        parse(context) {
+          return {
+            success: true as const,
+            next: context,
+            consumed: ["--name", "alice"],
+          };
+        },
+        complete(state) {
+          return { success: true as const, value: state };
+        },
+        suggest() {
+          return [];
+        },
+        getDocFragments() {
+          return { fragments: [] };
+        },
+        dependencyMetadata: {
+          source: {
+            kind: "source" as const,
+            sourceId,
+            preservesSourceValue: true,
+            extractSourceValue() {
+              return undefined;
+            },
+          },
+        },
+      };
+      const parser = nonEmpty(inner);
+
+      assert.deepEqual(parser.getSuggestRuntimeNodes?.("live", ["name"]), [
+        { path: ["name"], parser: inner, state: "live" },
+      ]);
     });
   });
 

--- a/packages/core/src/modifiers.test.ts
+++ b/packages/core/src/modifiers.test.ts
@@ -7035,7 +7035,7 @@ describe("branch coverage: modifiers edge cases", () => {
 
     assert.ok(result.success);
     if (!result.success) return;
-    assert.equal(result.provisional, true);
+    assert.ok(result.provisional);
     assert.deepEqual(result.next.state, state);
     assert.deepEqual(result.consumed, ["--same"]);
   });
@@ -7082,7 +7082,7 @@ describe("branch coverage: modifiers edge cases", () => {
 
     assert.ok(result.success);
     if (!result.success) return;
-    assert.equal(result.provisional, true);
+    assert.ok(result.provisional);
     assert.deepEqual(result.next.state, state);
     assert.deepEqual(result.consumed, ["--same"]);
   });
@@ -9788,8 +9788,10 @@ describe(
       it(
         `${name} phase-two seed extraction retries null delegated seeds`,
         () => {
-          let completeCalls = 0;
-          let extractCalls = 0;
+          const marker = Symbol.for(
+            `@test/issue-594/${name}/phase2-null-retry`,
+          );
+          const extractedStates: unknown[] = [];
           const inner: Parser<"sync", string, string> = {
             mode: "sync",
             $valueType: [] as readonly string[],
@@ -9807,7 +9809,6 @@ describe(
               };
             },
             complete() {
-              completeCalls++;
               return {
                 success: false as const,
                 error: message`Missing value.`,
@@ -9822,7 +9823,7 @@ describe(
           };
           Object.defineProperty(inner, extractPhase2SeedKey, {
             value(state: string | object) {
-              extractCalls++;
+              extractedStates.push(state);
               return typeof state === "string"
                 ? { value: state.toUpperCase() }
                 : null;
@@ -9830,22 +9831,28 @@ describe(
           });
           const parser = wrap(inner);
           const outerState = injectAnnotations(["live"] as [string], {
-            [Symbol.for(`@test/issue-594/${name}/phase2-null-retry`)]: true,
+            [marker]: true,
           });
 
           const seed = extractPhase2Seed(parser, outerState);
 
           assert.deepEqual(seed, { value: "LIVE" });
-          assert.equal(completeCalls, 1);
-          assert.equal(extractCalls, 2);
+          assert.ok(
+            extractedStates.some((state) =>
+              getAnnotations(state)?.[marker] === true
+            ),
+          );
+          assert.ok(extractedStates.includes("live"));
         },
       );
 
       it(
         `${name} async phase-two seed extraction retries null delegated seeds`,
         async () => {
-          let completeCalls = 0;
-          let extractCalls = 0;
+          const marker = Symbol.for(
+            `@test/issue-594/${name}/async-phase2-null-retry`,
+          );
+          const extractedStates: unknown[] = [];
           const inner: Parser<"async", string, string> = {
             mode: "async",
             $valueType: [] as readonly string[],
@@ -9863,7 +9870,6 @@ describe(
               });
             },
             complete() {
-              completeCalls++;
               return Promise.resolve({
                 success: false as const,
                 error: message`Missing value.`,
@@ -9876,7 +9882,7 @@ describe(
           };
           Object.defineProperty(inner, extractPhase2SeedKey, {
             value(state: string | object) {
-              extractCalls++;
+              extractedStates.push(state);
               return Promise.resolve(
                 typeof state === "string"
                   ? { value: state.toUpperCase() }
@@ -9886,18 +9892,18 @@ describe(
           });
           const parser = wrap(inner);
           const outerState = injectAnnotations(["live"] as [string], {
-            [
-              Symbol.for(
-                `@test/issue-594/${name}/async-phase2-null-retry`,
-              )
-            ]: true,
+            [marker]: true,
           });
 
           const seed = await extractPhase2Seed(parser, outerState);
 
           assert.deepEqual(seed, { value: "LIVE" });
-          assert.equal(completeCalls, 1);
-          assert.equal(extractCalls, 2);
+          assert.ok(
+            extractedStates.some((state) =>
+              getAnnotations(state)?.[marker] === true
+            ),
+          );
+          assert.ok(extractedStates.includes("live"));
         },
       );
 
@@ -10006,8 +10012,9 @@ describe(
       it(
         `${name} phase-two seed extraction retries the extractor without retrying failed completion`,
         () => {
-          let completeCalls = 0;
-          let extractCalls = 0;
+          const marker = Symbol.for(`@test/issue-594/${name}/phase2`);
+          const completedStates: unknown[] = [];
+          const extractedStates: unknown[] = [];
           const inner: Parser<"sync", string, string> = {
             mode: "sync",
             $valueType: [] as readonly string[],
@@ -10024,8 +10031,8 @@ describe(
                 consumed: [],
               };
             },
-            complete() {
-              completeCalls++;
+            complete(state) {
+              completedStates.push(state);
               return {
                 success: false as const,
                 error: message`Missing value.`,
@@ -10040,7 +10047,7 @@ describe(
           };
           Object.defineProperty(inner, extractPhase2SeedKey, {
             value(state: string | object) {
-              extractCalls++;
+              extractedStates.push(state);
               return typeof state === "string"
                 ? { value: { inner: state } }
                 : null;
@@ -10048,23 +10055,28 @@ describe(
           });
           const parser = wrap(inner);
           const outerState = injectAnnotations(["live"] as [string], {
-            [Symbol.for(`@test/issue-594/${name}/phase2`)]: true,
+            [marker]: true,
           });
 
           const seed = completeOrExtractPhase2Seed(parser, outerState);
 
-          assert.equal(completeCalls, 2);
-          assert.equal(extractCalls, 2);
           assert.deepEqual(seed, {
             value: { inner: "live" },
           });
+          assert.ok(
+            completedStates.some((state) =>
+              getAnnotations(state)?.[marker] === true
+            ),
+          );
+          assert.ok(!completedStates.includes("live"));
+          assert.ok(extractedStates.includes("live"));
         },
       );
       it(
         `${name} phase-two seed extraction retries wrapped initial-state failures before the extractor`,
         () => {
-          let completeCalls = 0;
-          let extractCalls = 0;
+          let completedUnwrappedState = false;
+          let extracted = false;
           const inner: Parser<"sync", string, undefined> = {
             mode: "sync",
             $valueType: [] as readonly string[],
@@ -10082,7 +10094,7 @@ describe(
               };
             },
             complete(state) {
-              completeCalls++;
+              if (state === undefined) completedUnwrappedState = true;
               return state === undefined
                 ? { success: true as const, value: "resolved" }
                 : {
@@ -10099,7 +10111,7 @@ describe(
           };
           Object.defineProperty(inner, extractPhase2SeedKey, {
             value() {
-              extractCalls++;
+              extracted = true;
               return null;
             },
           });
@@ -10113,16 +10125,16 @@ describe(
           assert.deepEqual(seed, {
             value: "resolved",
           });
-          assert.equal(completeCalls, 2);
-          assert.equal(extractCalls, 0);
+          assert.ok(completedUnwrappedState);
+          assert.ok(!extracted);
         },
       );
 
       it(
         `${name} async phase-two seed extraction retries wrapped initial-state failures before the extractor`,
         async () => {
-          let completeCalls = 0;
-          let extractCalls = 0;
+          let completedUnwrappedState = false;
+          let extracted = false;
           const inner: Parser<"async", string, undefined> = {
             mode: "async",
             $valueType: [] as readonly string[],
@@ -10140,7 +10152,7 @@ describe(
               });
             },
             complete(state) {
-              completeCalls++;
+              if (state === undefined) completedUnwrappedState = true;
               return Promise.resolve(
                 state === undefined
                   ? { success: true as const, value: "resolved" }
@@ -10157,7 +10169,7 @@ describe(
           };
           Object.defineProperty(inner, extractPhase2SeedKey, {
             value() {
-              extractCalls++;
+              extracted = true;
               return Promise.resolve(null);
             },
           });
@@ -10171,8 +10183,8 @@ describe(
           assert.deepEqual(seed, {
             value: "resolved",
           });
-          assert.equal(completeCalls, 2);
-          assert.equal(extractCalls, 0);
+          assert.ok(completedUnwrappedState);
+          assert.ok(!extracted);
         },
       );
 
@@ -10654,7 +10666,7 @@ describe("multiple() phase-two seed extraction", () => {
       (result as { readonly value?: unknown }).value,
       ["", { ready: false }, { inner: "", stable: "kept" }],
     );
-    assert.equal((result as { readonly deferred?: unknown }).deferred, true);
+    assert.ok((result as { readonly deferred?: unknown }).deferred);
     assert.deepEqual(
       (result as { readonly deferredKeys?: unknown }).deferredKeys,
       new Map<PropertyKey, DeferredMap | null>([

--- a/packages/core/src/modifiers.test.ts
+++ b/packages/core/src/modifiers.test.ts
@@ -10234,6 +10234,58 @@ describe("acceptingAnyToken", () => {
 });
 
 describe("multiple() dependency source extraction", () => {
+  it("delegates raw non-array source states to the inner source", () => {
+    const sourceId = Symbol("mode");
+    const rawState = Symbol("raw");
+    const visited: unknown[] = [];
+    const inner: Parser<"sync", string, symbol | null> = {
+      mode: "sync" as const,
+      $valueType: [] as const,
+      $stateType: [] as const,
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(),
+      acceptingAnyToken: false,
+      initialState: null,
+      parse: () => ({
+        success: false as const,
+        consumed: 0,
+        error: message`No parse.`,
+      }),
+      complete: () => ({
+        success: false as const,
+        error: message`No completion.`,
+      }),
+      suggest: function* () {},
+      getDocFragments: () => ({ fragments: [] }),
+    };
+    Object.defineProperty(inner, "dependencyMetadata", {
+      value: {
+        source: {
+          kind: "source" as const,
+          sourceId,
+          preservesSourceValue: true,
+          extractSourceValue(state: unknown) {
+            visited.push(state);
+            return state === rawState
+              ? { success: true as const, value: "prod" }
+              : undefined;
+          },
+        },
+      },
+      configurable: true,
+      enumerable: false,
+    });
+    const parser = multiple(inner);
+
+    const result = parser.dependencyMetadata?.source?.extractSourceValue(
+      rawState,
+    );
+
+    assert.deepEqual(result, { success: true, value: "prod" });
+    assert.deepEqual(visited, [rawState]);
+  });
+
   it("keeps scanning when the newest async source is thenable", async () => {
     const sourceId = Symbol("mode");
     const earlier = Symbol("earlier");
@@ -10293,6 +10345,59 @@ describe("multiple() dependency source extraction", () => {
     ]);
     assert.deepEqual(result, { success: true, value: "prod" });
     assert.deepEqual(visited, [latest, earlier]);
+  });
+});
+
+describe("multiple() value helpers", () => {
+  it("returns an empty placeholder when the inner placeholder throws", () => {
+    const inner = option("--item", string());
+    Object.defineProperty(inner, "placeholder", {
+      get() {
+        throw new TypeError("Placeholder unavailable.");
+      },
+      configurable: true,
+    });
+    const parser = multiple(inner, { min: 2 });
+
+    assert.deepEqual(parser.placeholder, []);
+  });
+
+  it("keeps elements that fail inner normalization", () => {
+    const inner: Parser<"sync", string, string> = {
+      mode: "sync",
+      $valueType: [] as readonly string[],
+      $stateType: [] as readonly string[],
+      priority: 0,
+      usage: [],
+      leadingNames: new Set<string>(),
+      acceptingAnyToken: false,
+      initialState: "",
+      parse(context) {
+        return {
+          success: true as const,
+          next: context,
+          consumed: [],
+        };
+      },
+      complete(state) {
+        return { success: true as const, value: state };
+      },
+      suggest: function* () {},
+      getDocFragments: () => ({ fragments: [] }),
+      normalizeValue(value) {
+        if (value === "sentinel") {
+          throw new TypeError("Sentinel cannot be normalized.");
+        }
+        return value.toUpperCase();
+      },
+    };
+    const parser = multiple(inner);
+
+    assert.deepEqual(parser.normalizeValue?.(["dev", "sentinel", "prod"]), [
+      "DEV",
+      "sentinel",
+      "PROD",
+    ]);
   });
 });
 
@@ -10657,6 +10762,15 @@ describe("map() phase-two seed extraction", () => {
     );
   });
 
+  it("returns null when the inner parser has no phase-two seed", () => {
+    const parser = mapLocal(
+      createExtractOnlyParser(null),
+      (value) => value * 2,
+    );
+
+    assert.equal(completeOrExtractPhase2Seed(parser, 1), null);
+  });
+
   it("keeps deferred transform failures as placeholders", () => {
     const parser = mapLocal(
       createExtractOnlyParser({ value: 1, deferred: true }),
@@ -10687,6 +10801,111 @@ describe("map() phase-two seed extraction", () => {
     });
 
     assert.equal(parser.placeholder, undefined);
+  });
+
+  it("passes failed dependency replays through unchanged", () => {
+    const sourceId = Symbol("mode");
+    const inner: Parser<"sync", string, string> = {
+      mode: "sync",
+      $valueType: [] as readonly string[],
+      $stateType: [] as readonly string[],
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(),
+      acceptingAnyToken: false,
+      initialState: "",
+      parse(context) {
+        return {
+          success: true as const,
+          next: context,
+          consumed: [],
+        };
+      },
+      complete() {
+        return { success: false as const, error: message`Missing value.` };
+      },
+      *suggest() {},
+      getDocFragments() {
+        return { fragments: [] };
+      },
+    };
+    Object.defineProperty(inner, "dependencyMetadata", {
+      value: {
+        derived: {
+          kind: "derived" as const,
+          dependencyIds: [sourceId],
+          replayParse() {
+            return {
+              success: false as const,
+              error: message`Replay failed.`,
+            };
+          },
+        },
+      },
+      configurable: true,
+    });
+    const parser = mapLocal(inner, (value) => value.toUpperCase());
+
+    assert.deepEqual(
+      parser.dependencyMetadata?.derived?.replayParse("json", ["mode"]),
+      { success: false, error: message`Replay failed.` },
+    );
+  });
+
+  it("keeps deferred dependency replay transform failures as placeholders", () => {
+    const sourceId = Symbol("mode");
+    const inner: Parser<"sync", string, string> = {
+      mode: "sync",
+      $valueType: [] as readonly string[],
+      $stateType: [] as readonly string[],
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(),
+      acceptingAnyToken: false,
+      initialState: "",
+      parse(context) {
+        return {
+          success: true as const,
+          next: context,
+          consumed: [],
+        };
+      },
+      complete() {
+        return { success: false as const, error: message`Missing value.` };
+      },
+      *suggest() {},
+      getDocFragments() {
+        return { fragments: [] };
+      },
+    };
+    Object.defineProperty(inner, "dependencyMetadata", {
+      value: {
+        derived: {
+          kind: "derived" as const,
+          dependencyIds: [sourceId],
+          replayParse() {
+            return {
+              success: true as const,
+              value: "json",
+              deferred: true as const,
+            };
+          },
+        },
+      },
+      configurable: true,
+    });
+    const parser = mapLocal(inner, () => {
+      throw new TypeError("Cannot map deferred placeholder.");
+    });
+
+    assert.deepEqual(
+      parser.dependencyMetadata?.derived?.replayParse("json", ["mode"]),
+      {
+        success: true,
+        value: undefined,
+        deferred: true,
+      },
+    );
   });
 
   it("maps promise-like dependency replays", async () => {

--- a/packages/core/src/modifiers.test.ts
+++ b/packages/core/src/modifiers.test.ts
@@ -59,6 +59,7 @@ import {
 } from "@optique/core/primitives";
 import {
   choice,
+  type DeferredMap,
   domain,
   integer,
   macAddress,
@@ -9912,6 +9913,128 @@ describe("multiple() dependency source extraction", () => {
 });
 
 describe("multiple() phase-two seed extraction", () => {
+  const nestedDeferredKeys: DeferredMap = new Map<
+    PropertyKey,
+    DeferredMap | null
+  >(
+    [["inner", null]],
+  );
+
+  function createSyncDeferredItemParser(): Parser<"sync", unknown, string> {
+    return {
+      mode: "sync",
+      $valueType: [] as readonly unknown[],
+      $stateType: [] as readonly string[],
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(),
+      acceptingAnyToken: false,
+      initialState: "",
+      parse(context) {
+        return {
+          success: true as const,
+          next: context,
+          consumed: [],
+        };
+      },
+      complete(state) {
+        if (state === "partial") {
+          return {
+            success: true as const,
+            value: { inner: "", stable: "kept" },
+            deferred: true as const,
+            deferredKeys: nestedDeferredKeys,
+          };
+        }
+        return {
+          success: true as const,
+          value: state === "structured" ? { ready: false } : "",
+          deferred: true as const,
+        };
+      },
+      *suggest() {},
+      getDocFragments() {
+        return { fragments: [] };
+      },
+    };
+  }
+
+  function createAsyncDeferredItemParser(): Parser<"async", unknown, string> {
+    const syncParser = createSyncDeferredItemParser();
+    return {
+      mode: "async",
+      $valueType: [] as readonly unknown[],
+      $stateType: [] as readonly string[],
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(),
+      acceptingAnyToken: false,
+      initialState: "",
+      parse(context) {
+        return Promise.resolve(syncParser.parse(context));
+      },
+      complete(state, exec) {
+        return Promise.resolve(syncParser.complete(state, exec));
+      },
+      async *suggest(context, prefix) {
+        yield* syncParser.suggest(context, prefix);
+      },
+      getDocFragments() {
+        return { fragments: [] };
+      },
+    };
+  }
+
+  function assertDeferredItems(result: unknown): void {
+    assert.ok(result != null && typeof result === "object");
+    assert.ok(!("then" in result), "deferred result must be resolved");
+    assert.ok(!("success" in result) || result.success === true);
+    assert.deepEqual(
+      (result as { readonly value?: unknown }).value,
+      ["", { ready: false }, { inner: "", stable: "kept" }],
+    );
+    assert.equal((result as { readonly deferred?: unknown }).deferred, true);
+    assert.deepEqual(
+      (result as { readonly deferredKeys?: unknown }).deferredKeys,
+      new Map<PropertyKey, DeferredMap | null>([
+        [0, null],
+        [2, nestedDeferredKeys],
+      ]),
+    );
+  }
+
+  it("preserves deferred item metadata during sync completion", () => {
+    const parser = multipleLocal(createSyncDeferredItemParser());
+    assertDeferredItems(
+      parser.complete(["scalar", "structured", "partial"]),
+    );
+  });
+
+  it("preserves deferred item metadata during async completion", async () => {
+    const parser = multipleLocal(createAsyncDeferredItemParser());
+    assertDeferredItems(
+      await parser.complete(["scalar", "structured", "partial"]),
+    );
+  });
+
+  it("preserves deferred item metadata during sync seed extraction", () => {
+    const parser = multipleLocal(createSyncDeferredItemParser());
+    assertDeferredItems(
+      completeOrExtractPhase2Seed(parser, ["scalar", "structured", "partial"]),
+    );
+  });
+
+  it("preserves deferred item metadata during async seed extraction", async () => {
+    const parser = multipleLocal(createAsyncDeferredItemParser());
+    assertDeferredItems(
+      await completeOrExtractPhase2Seed(parser, [
+        "scalar",
+        "structured",
+        "partial",
+      ]),
+    );
+  });
+
   it("unwraps injected annotation wrappers before extracting item seeds", () => {
     const marker = Symbol.for("@test/multiple-phase-two-seed");
     const child: Parser<"sync", string, string> = {

--- a/packages/core/src/modifiers.test.ts
+++ b/packages/core/src/modifiers.test.ts
@@ -6855,6 +6855,172 @@ describe("branch coverage: modifiers edge cases", () => {
     assert.deepEqual(second.next.state, first.next.state);
   });
 
+  it("multiple: sync parse absorbs empty fresh-item failure for min zero", () => {
+    const inner: Parser<"sync", string, string> = {
+      mode: "sync",
+      $valueType: [] as readonly string[],
+      $stateType: [] as readonly string[],
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(),
+      acceptingAnyToken: false,
+      initialState: "initial",
+      parse() {
+        return {
+          success: false as const,
+          consumed: 0,
+          error: message`No more values.`,
+        };
+      },
+      complete: (state) => ({ success: true as const, value: state }),
+      suggest: function* () {},
+      getDocFragments: () => ({ fragments: [] }),
+    };
+    const parser = multiple(inner);
+
+    const result = parser.parse({
+      buffer: [],
+      state: ["open"],
+      optionsTerminated: false,
+      usage: parser.usage,
+    });
+
+    assert.ok(result.success);
+    if (!result.success) return;
+    assert.deepEqual(result.next.state, ["open"]);
+    assert.deepEqual(result.consumed, []);
+  });
+
+  it("multiple: async parse absorbs empty fresh-item failure for min zero", async () => {
+    const inner: Parser<"async", string, string> = {
+      mode: "async",
+      $valueType: [] as readonly string[],
+      $stateType: [] as readonly string[],
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(),
+      acceptingAnyToken: false,
+      initialState: "initial",
+      parse() {
+        return Promise.resolve({
+          success: false as const,
+          consumed: 0,
+          error: message`No more async values.`,
+        });
+      },
+      complete: (state) =>
+        Promise.resolve({ success: true as const, value: state }),
+      suggest: async function* () {},
+      getDocFragments: () => ({ fragments: [] }),
+    };
+    const parser = multiple(inner);
+
+    const result = await parser.parse({
+      buffer: [],
+      state: ["open"],
+      optionsTerminated: false,
+      usage: parser.usage,
+    });
+
+    assert.ok(result.success);
+    if (!result.success) return;
+    assert.deepEqual(result.next.state, ["open"]);
+    assert.deepEqual(result.consumed, []);
+  });
+
+  it("multiple: sync parse keeps item state when current item consumes in place", () => {
+    const inner: Parser<"sync", string, string> = {
+      mode: "sync",
+      $valueType: [] as readonly string[],
+      $stateType: [] as readonly string[],
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(["--same"]),
+      acceptingAnyToken: false,
+      initialState: "initial",
+      parse(context) {
+        if (context.buffer[0] !== "--same") {
+          return {
+            success: false as const,
+            consumed: 0,
+            error: message`No value.`,
+          };
+        }
+        return {
+          success: true as const,
+          next: { ...context, buffer: context.buffer.slice(1) },
+          consumed: ["--same"],
+          provisional: true as const,
+        };
+      },
+      complete: (state) => ({ success: true as const, value: state }),
+      suggest: function* () {},
+      getDocFragments: () => ({ fragments: [] }),
+    };
+    const parser = multiple(inner);
+    const state = ["open"] as const;
+
+    const result = parser.parse({
+      buffer: ["--same"],
+      state,
+      optionsTerminated: false,
+      usage: parser.usage,
+    });
+
+    assert.ok(result.success);
+    if (!result.success) return;
+    assert.equal(result.provisional, true);
+    assert.deepEqual(result.next.state, state);
+    assert.deepEqual(result.consumed, ["--same"]);
+  });
+
+  it("multiple: async parse keeps item state when current item consumes in place", async () => {
+    const inner: Parser<"async", string, string> = {
+      mode: "async",
+      $valueType: [] as readonly string[],
+      $stateType: [] as readonly string[],
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(["--same"]),
+      acceptingAnyToken: false,
+      initialState: "initial",
+      parse(context) {
+        if (context.buffer[0] !== "--same") {
+          return Promise.resolve({
+            success: false as const,
+            consumed: 0,
+            error: message`No async value.`,
+          });
+        }
+        return Promise.resolve({
+          success: true as const,
+          next: { ...context, buffer: context.buffer.slice(1) },
+          consumed: ["--same"],
+          provisional: true as const,
+        });
+      },
+      complete: (state) =>
+        Promise.resolve({ success: true as const, value: state }),
+      suggest: async function* () {},
+      getDocFragments: () => ({ fragments: [] }),
+    };
+    const parser = multiple(inner);
+    const state = ["open"] as const;
+
+    const result = await parser.parse({
+      buffer: ["--same"],
+      state,
+      optionsTerminated: false,
+      usage: parser.usage,
+    });
+
+    assert.ok(result.success);
+    if (!result.success) return;
+    assert.equal(result.provisional, true);
+    assert.deepEqual(result.next.state, state);
+    assert.deepEqual(result.consumed, ["--same"]);
+  });
+
   it("multiple: zero-consumption fresh object state does not add a slot", () => {
     const inner: Parser<
       "sync",
@@ -10088,6 +10254,97 @@ describe("withDefault() phase-two seed extraction", () => {
 
     assert.deepEqual(seed, { value: "fallback" });
   });
+
+  it("keeps sentinel defaults when the inner normalizer rejects them", () => {
+    const sourceId = Symbol("name");
+    const inner: Parser<"sync", string, string> = {
+      mode: "sync",
+      $valueType: [] as readonly string[],
+      $stateType: [] as readonly string[],
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(),
+      acceptingAnyToken: false,
+      initialState: "",
+      parse() {
+        return {
+          success: false as const,
+          consumed: 0,
+          error: message`No input.`,
+        };
+      },
+      complete(state) {
+        return { success: true as const, value: state };
+      },
+      suggest: function* () {},
+      getDocFragments: () => ({ fragments: [] }),
+      normalizeValue(value) {
+        if (value === "sentinel") {
+          throw new TypeError("Sentinel cannot be normalized.");
+        }
+        return value.toUpperCase();
+      },
+      dependencyMetadata: {
+        source: {
+          kind: "source" as const,
+          sourceId,
+          preservesSourceValue: true,
+          extractSourceValue: () => undefined,
+        },
+      },
+    };
+    const parser = withDefault(inner, "sentinel");
+
+    assert.equal(parser.normalizeValue?.("sentinel"), "sentinel");
+    assert.deepEqual(
+      parser.dependencyMetadata?.source?.getMissingSourceValue?.(),
+      { success: true, value: "sentinel" },
+    );
+  });
+
+  it("surfaces structured default errors through dependency metadata", () => {
+    const sourceId = Symbol("name");
+    const inner: Parser<"sync", string, string> = {
+      mode: "sync",
+      $valueType: [] as readonly string[],
+      $stateType: [] as readonly string[],
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(),
+      acceptingAnyToken: false,
+      initialState: "",
+      parse() {
+        return {
+          success: false as const,
+          consumed: 0,
+          error: message`No input.`,
+        };
+      },
+      complete(state) {
+        return { success: true as const, value: state };
+      },
+      suggest: function* () {},
+      getDocFragments: () => ({ fragments: [] }),
+      dependencyMetadata: {
+        source: {
+          kind: "source" as const,
+          sourceId,
+          preservesSourceValue: true,
+          extractSourceValue: () => undefined,
+        },
+      },
+    };
+    const parser = withDefault(inner, () => {
+      throw new WithDefaultError(message`Default is unavailable.`);
+    });
+
+    const result = parser.dependencyMetadata?.source?.getMissingSourceValue?.();
+
+    assert.deepEqual(result, {
+      success: false,
+      error: message`Default is unavailable.`,
+    });
+  });
 });
 
 describe("map() phase-two seed extraction", () => {
@@ -10157,6 +10414,77 @@ describe("map() phase-two seed extraction", () => {
         deferred: true,
       },
     );
+  });
+
+  it("returns undefined placeholder when a mapped placeholder throws", () => {
+    const inner = createExtractOnlyParser({ value: 1 });
+    Object.defineProperty(inner, "placeholder", {
+      get() {
+        return 1;
+      },
+      configurable: true,
+    });
+    const parser = mapLocal(inner, () => {
+      throw new TypeError("Placeholder transform failed.");
+    });
+
+    assert.equal(parser.placeholder, undefined);
+  });
+
+  it("maps promise-like dependency replays", async () => {
+    const sourceId = Symbol("mode");
+    const inner: Parser<"sync", string, string> = {
+      mode: "sync",
+      $valueType: [] as readonly string[],
+      $stateType: [] as readonly string[],
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(),
+      acceptingAnyToken: false,
+      initialState: "",
+      parse(context) {
+        return {
+          success: true as const,
+          next: context,
+          consumed: [],
+        };
+      },
+      complete() {
+        return { success: false as const, error: message`Missing value.` };
+      },
+      *suggest() {},
+      getDocFragments() {
+        return { fragments: [] };
+      },
+    };
+    Object.defineProperty(inner, "dependencyMetadata", {
+      value: {
+        derived: {
+          kind: "derived" as const,
+          dependencyIds: [sourceId],
+          replayParse() {
+            return createPromiseLike({
+              success: true as const,
+              value: "json",
+              deferred: true as const,
+            });
+          },
+        },
+      },
+      configurable: true,
+    });
+    const parser = mapLocal(inner, (value) => String(value).toUpperCase());
+
+    const result = await parser.dependencyMetadata?.derived?.replayParse(
+      "json",
+      ["mode"],
+    );
+
+    assert.deepEqual(result, {
+      success: true,
+      value: "JSON",
+      deferred: true,
+    });
   });
 });
 

--- a/packages/core/src/parser-coverage.test.ts
+++ b/packages/core/src/parser-coverage.test.ts
@@ -7,8 +7,10 @@ import {
   getDocPageAsync,
   getDocPageSync,
   parse,
+  parseAsync,
   type Parser,
   type ParserContext,
+  parseSync,
   suggest,
   suggestAsync,
   type Suggestion,
@@ -62,6 +64,180 @@ describe("parser.ts coverage branches", () => {
     assert.deepEqual(asyncSuggestions, [
       { kind: "literal", text: "async-suggestion" },
     ]);
+  });
+
+  it("preserves deferred completion metadata from sync parsers", () => {
+    const deferredKeys = new Map<PropertyKey, null>([["answer", null]]);
+    const parser: Parser<"sync", { readonly answer: string }, null> = {
+      $valueType: [] as readonly { readonly answer: string }[],
+      $stateType: [] as readonly null[],
+      mode: "sync",
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(),
+      acceptingAnyToken: false,
+      initialState: null,
+      parse(context) {
+        return {
+          success: true as const,
+          next: { ...context, buffer: [] },
+          consumed: [],
+        };
+      },
+      complete() {
+        return {
+          success: true as const,
+          value: { answer: "" },
+          deferred: true as const,
+          deferredKeys,
+        };
+      },
+      suggest() {
+        return [];
+      },
+      getDocFragments() {
+        return { fragments: [] };
+      },
+    };
+
+    const result = parseSync(parser, []);
+
+    assert.ok(result.success);
+    assert.ok(result.deferred);
+    assert.deepEqual(result.deferredKeys, deferredKeys);
+  });
+
+  it("preserves deferred completion metadata from async parsers", async () => {
+    const deferredKeys = new Map<PropertyKey, null>([["answer", null]]);
+    const parser: Parser<"async", { readonly answer: string }, null> = {
+      $valueType: [] as readonly { readonly answer: string }[],
+      $stateType: [] as readonly null[],
+      mode: "async",
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(),
+      acceptingAnyToken: false,
+      initialState: null,
+      parse(context) {
+        return Promise.resolve({
+          success: true as const,
+          next: { ...context, buffer: [] },
+          consumed: [],
+        });
+      },
+      complete() {
+        return Promise.resolve({
+          success: true as const,
+          value: { answer: "" },
+          deferred: true as const,
+          deferredKeys,
+        });
+      },
+      async *suggest() {},
+      getDocFragments() {
+        return { fragments: [] };
+      },
+    };
+
+    const result = await parseAsync(parser, []);
+
+    assert.ok(result.success);
+    assert.ok(result.deferred);
+    assert.deepEqual(result.deferredKeys, deferredKeys);
+  });
+
+  it("seeds dependency source values before sync suggestions", () => {
+    const sourceId = Symbol("sync-source");
+    let extractedState: unknown;
+    const parser: Parser<"sync", "ok", { readonly source: string }> = {
+      $valueType: [] as readonly "ok"[],
+      $stateType: [] as readonly { readonly source: string }[],
+      mode: "sync",
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(),
+      acceptingAnyToken: false,
+      initialState: { source: "dev" },
+      dependencyMetadata: {
+        source: {
+          kind: "source",
+          sourceId,
+          preservesSourceValue: true,
+          extractSourceValue(state) {
+            extractedState = state;
+            return { success: true as const, value: "dev" };
+          },
+        },
+      },
+      parse(context) {
+        return {
+          success: true as const,
+          next: { ...context, buffer: [] },
+          consumed: [],
+        };
+      },
+      complete() {
+        return { success: true as const, value: "ok" };
+      },
+      *suggest() {
+        yield { kind: "literal", text: "debug" };
+      },
+      getDocFragments() {
+        return { fragments: [] };
+      },
+    };
+
+    const result = suggestSync(parser, [""]);
+
+    assert.deepEqual(result, [{ kind: "literal", text: "debug" }]);
+    assert.deepEqual(extractedState, { source: "dev" });
+  });
+
+  it("seeds dependency source values before async suggestions", async () => {
+    const sourceId = Symbol("async-source");
+    let extractedState: unknown;
+    const parser: Parser<"async", "ok", { readonly source: string }> = {
+      $valueType: [] as readonly "ok"[],
+      $stateType: [] as readonly { readonly source: string }[],
+      mode: "async",
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(),
+      acceptingAnyToken: false,
+      initialState: { source: "prod" },
+      dependencyMetadata: {
+        source: {
+          kind: "source",
+          sourceId,
+          preservesSourceValue: true,
+          extractSourceValue(state) {
+            extractedState = state;
+            return Promise.resolve({ success: true as const, value: "prod" });
+          },
+        },
+      },
+      parse(context) {
+        return Promise.resolve({
+          success: true as const,
+          next: { ...context, buffer: [] },
+          consumed: [],
+        });
+      },
+      complete() {
+        return Promise.resolve({ success: true as const, value: "ok" });
+      },
+      async *suggest() {
+        yield { kind: "literal", text: "strict" };
+      },
+      getDocFragments() {
+        return { fragments: [] };
+      },
+    };
+
+    const result = await suggestAsync(parser, [""]);
+
+    assert.deepEqual(result, [{ kind: "literal", text: "strict" }]);
+    assert.deepEqual(extractedState, { source: "prod" });
   });
 
   it("injects annotations into suggestSync() and suggestAsync() states", async () => {

--- a/packages/core/src/primitives.test.ts
+++ b/packages/core/src/primitives.test.ts
@@ -2160,6 +2160,79 @@ describe("negatableFlag()", () => {
     }
   });
 
+  it("should support static custom errors for every error branch", () => {
+    const parser = negatableFlag({
+      positive: "--color",
+      negative: "--no-color",
+    }, {
+      errors: {
+        missing: message`static missing`,
+        optionsTerminated: message`static terminated`,
+        endOfInput: message`static empty`,
+        duplicate: message`static duplicate`,
+        conflict: message`static conflict`,
+        unexpectedValue: message`static unexpected`,
+        noMatch: message`static no match`,
+      },
+    });
+
+    const cases = [
+      parser.complete(undefined),
+      parser.parse({
+        buffer: ["--color"],
+        state: parser.initialState,
+        optionsTerminated: true,
+        usage: parser.usage,
+      }),
+      parser.parse({
+        buffer: [],
+        state: parser.initialState,
+        optionsTerminated: false,
+        usage: parser.usage,
+      }),
+      parser.parse({
+        buffer: ["--color"],
+        state: { value: true, token: "--color" },
+        optionsTerminated: false,
+        usage: parser.usage,
+      }),
+      parser.parse({
+        buffer: ["--no-color"],
+        state: { value: true, token: "--color" },
+        optionsTerminated: false,
+        usage: parser.usage,
+      }),
+      parser.parse({
+        buffer: ["--color=true"],
+        state: parser.initialState,
+        optionsTerminated: false,
+        usage: parser.usage,
+      }),
+      parser.parse({
+        buffer: ["--unknown"],
+        state: parser.initialState,
+        optionsTerminated: false,
+        usage: parser.usage,
+      }),
+    ] as const;
+
+    assert.deepEqual(
+      cases.map((result) => {
+        assert.ok(!result.success);
+        return result.success ? "" : formatMessage(result.error);
+      }),
+      [
+        "static missing",
+        "static terminated",
+        "static empty",
+        "static duplicate",
+        "static conflict",
+        "static unexpected",
+        "static no match",
+      ],
+    );
+  });
+
   it('should keep docs and suggestions for hidden: "usage"', () => {
     const parser = negatableFlag({
       positive: "--color",

--- a/packages/core/src/primitives.test.ts
+++ b/packages/core/src/primitives.test.ts
@@ -755,6 +755,24 @@ describe("option", () => {
       }]);
     });
 
+    it("should suggest plus-prefixed async option names", async () => {
+      const parser = option("+log", asyncFileSuggestingParser());
+
+      const suggestions: Suggestion[] = [];
+      for await (
+        const suggestion of parser.suggest({
+          buffer: [],
+          state: parser.initialState,
+          usage: parser.usage,
+          optionsTerminated: false,
+        }, "+")
+      ) {
+        suggestions.push(suggestion);
+      }
+
+      assert.deepEqual(suggestions, [{ kind: "literal", text: "+log" }]);
+    });
+
     it("should not suggest async option names while completing a value", async () => {
       const asyncModeParser: ValueParser<"async", string> = {
         mode: "async",
@@ -1470,6 +1488,21 @@ describe("flag", () => {
       if (!result.success) {
         assertErrorIncludes(result.error, "Some parse error");
       }
+    });
+  });
+
+  describe("suggestions", () => {
+    it("should suggest plus-prefixed flag names", () => {
+      const parser = flag("+debug");
+
+      const suggestions = Array.from(parser.suggest({
+        buffer: [],
+        state: parser.initialState,
+        usage: parser.usage,
+        optionsTerminated: false,
+      }, "+"));
+
+      assert.deepEqual(suggestions, [{ kind: "literal", text: "+debug" }]);
     });
   });
 

--- a/packages/core/src/primitives.test.ts
+++ b/packages/core/src/primitives.test.ts
@@ -7972,6 +7972,115 @@ describe("validateValue on primitives (#414)", () => {
       );
       assert.ok(!numberResult.success);
     });
+
+    it("normalizes fallback values through the value parser when available", () => {
+      const valueParser: ValueParser<"sync", string> = {
+        mode: "sync",
+        metavar: "VALUE",
+        placeholder: "example",
+        parse: (input) => ({ success: true, value: input.toLowerCase() }),
+        format: (value) => value,
+        normalize: (value) => value.toLowerCase(),
+      };
+      const parser = option("-x", valueParser);
+      assert.equal(typeof parser.normalizeValue, "function");
+      if (typeof parser.normalizeValue === "function") {
+        assert.equal(parser.normalizeValue("Example.COM"), "example.com");
+      }
+    });
+
+    it("preserves fallback values when normalization throws", () => {
+      const sentinel = { value: "raw" };
+      const valueParser: ValueParser<"sync", typeof sentinel> = {
+        mode: "sync",
+        metavar: "VALUE",
+        placeholder: sentinel,
+        parse: () => ({ success: true, value: sentinel }),
+        format: () => "raw",
+        normalize: () => {
+          throw new TypeError("Cannot normalize sentinel.");
+        },
+      };
+      const parser = option("-x", valueParser);
+
+      assert.equal(typeof parser.normalizeValue, "function");
+      if (typeof parser.normalizeValue === "function") {
+        assert.equal(parser.normalizeValue(sentinel), sentinel);
+      }
+    });
+
+    it("accepts fallback values unchanged when format throws", () => {
+      const sentinel = { value: "raw" };
+      const valueParser: ValueParser<"sync", typeof sentinel> = {
+        mode: "sync",
+        metavar: "VALUE",
+        placeholder: sentinel,
+        parse: () => ({ success: true, value: sentinel }),
+        format: () => {
+          throw new TypeError("Cannot format sentinel.");
+        },
+      };
+      const parser = option("-x", valueParser);
+
+      const result = parser.validateValue!(sentinel);
+      assert.ok(result && typeof result === "object" && "success" in result);
+      assert.ok(result.success);
+      if (result.success) assert.equal(result.value, sentinel);
+    });
+
+    it("accepts fallback values unchanged when format returns a non-string", () => {
+      const valueParser: ValueParser<"sync", number> = {
+        mode: "sync",
+        metavar: "VALUE",
+        placeholder: 0,
+        parse: () => ({ success: false, error: message`should not parse.` }),
+        format: () => 123 as never,
+      };
+      const parser = option("-x", valueParser);
+
+      const result = parser.validateValue!(42);
+      assert.ok(result && typeof result === "object" && "success" in result);
+      assert.ok(result.success);
+      if (result.success) assert.equal(result.value, 42);
+    });
+
+    it("exposes undefined placeholder when the value parser placeholder throws", () => {
+      const valueParser: ValueParser<"sync", string> = {
+        mode: "sync",
+        metavar: "VALUE",
+        get placeholder(): string {
+          throw new TypeError("No placeholder.");
+        },
+        parse: (input) => ({ success: true, value: input }),
+        format: (value) => value,
+      };
+      const parser = option("-x", valueParser);
+
+      assert.equal(parser.placeholder, undefined);
+    });
+
+    it("validates async fallback values through async value parsers", async () => {
+      const valueParser: ValueParser<"async", string> = {
+        mode: "async",
+        metavar: "VALUE",
+        placeholder: "ok",
+        parse: (input) =>
+          Promise.resolve(
+            input === "ok"
+              ? { success: true, value: input }
+              : { success: false, error: message`Expected ok.` },
+          ),
+        format: (value) => value,
+      };
+      const parser = option("-x", valueParser);
+
+      const valid = await parser.validateValue!("ok");
+      assert.ok(valid.success);
+      if (valid.success) assert.equal(valid.value, "ok");
+
+      const invalid = await parser.validateValue!("bad");
+      assert.ok(!invalid.success);
+    });
   });
 
   describe("negatableFlag()", () => {

--- a/packages/core/src/primitives.ts
+++ b/packages/core/src/primitives.ts
@@ -533,7 +533,7 @@ function* suggestOptionSync<T>(
     if (
       !expectingValue &&
       (prefix.startsWith("--") || prefix.startsWith("-") ||
-        prefix.startsWith("/"))
+        prefix.startsWith("/") || prefix.startsWith("+"))
     ) {
       for (const optionName of optionNames) {
         if (optionName.startsWith(prefix)) {
@@ -563,7 +563,7 @@ function* suggestOptionSync<T>(
         context.buffer.length === 0 &&
         (context.exec?.path?.length ?? 0) === 0 &&
         !(prefix.startsWith("--") || prefix.startsWith("-") ||
-          prefix.startsWith("/"))
+          prefix.startsWith("/") || prefix.startsWith("+"))
       ) {
         shouldSuggestValues = true;
       }
@@ -713,7 +713,7 @@ async function* suggestOptionAsync<T>(
     if (
       !expectingValue &&
       (prefix.startsWith("--") || prefix.startsWith("-") ||
-        prefix.startsWith("/"))
+        prefix.startsWith("/") || prefix.startsWith("+"))
     ) {
       for (const optionName of optionNames) {
         if (optionName.startsWith(prefix)) {
@@ -743,7 +743,7 @@ async function* suggestOptionAsync<T>(
         context.buffer.length === 0 &&
         (context.exec?.path?.length ?? 0) === 0 &&
         !(prefix.startsWith("--") || prefix.startsWith("-") ||
-          prefix.startsWith("/"))
+          prefix.startsWith("/") || prefix.startsWith("+"))
       ) {
         shouldSuggestValues = true;
       }
@@ -1815,7 +1815,7 @@ export function flag(
       // If the prefix looks like an option prefix, suggest matching option names
       if (
         prefix.startsWith("--") || prefix.startsWith("-") ||
-        prefix.startsWith("/")
+        prefix.startsWith("/") || prefix.startsWith("+")
       ) {
         for (const optionName of optionNames) {
           if (optionName.startsWith(prefix)) {

--- a/packages/core/src/usage.test.ts
+++ b/packages/core/src/usage.test.ts
@@ -1107,6 +1107,29 @@ describe("expandCommands option", () => {
     );
   });
 
+  it("should expand branches that start with optional leaf terms", () => {
+    const usage: Usage = [
+      {
+        type: "exclusive",
+        terms: [
+          [{ type: "optional", terms: [{ type: "command", name: "init" }] }],
+          [{
+            type: "optional",
+            terms: [{ type: "option", names: ["--verbose"] }],
+          }],
+          [{
+            type: "optional",
+            terms: [{ type: "argument", metavar: "FILE" }],
+          }],
+        ],
+      },
+    ];
+
+    const result = formatUsage("tool", usage, { expandCommands: true });
+
+    assert.equal(result, "tool [init]\ntool [--verbose]\ntool [FILE]");
+  });
+
   it("should exclude hidden commands from expanded usage lines", () => {
     // Regression test for hidden commands appearing in usage lines
     // When a command has hidden: true, it should not appear in the
@@ -1750,6 +1773,12 @@ describe("formatUsageTerm", () => {
       const term: UsageTerm = { type: "ellipsis" };
       const result = formatUsageTerm(term);
       assert.equal(result, "...");
+    });
+
+    it("should dim ellipsis usage terms when colors are enabled", () => {
+      const term: UsageTerm = { type: "ellipsis" };
+      const result = formatUsageTerm(term, { colors: true });
+      assert.equal(result, "\x1b[2m...\x1b[0m");
     });
   });
 
@@ -2430,6 +2459,45 @@ describe("normalizeUsage", () => {
       const result = normalizeUsage([
         { type: "argument", metavar: "" } as never,
       ]);
+      assert.deepEqual(result, []);
+    });
+
+    it("should strip exclusive branches that normalize to malformed leaves", () => {
+      const result = normalizeUsage([
+        {
+          type: "exclusive",
+          terms: [
+            [{ type: "argument", metavar: "" } as never],
+            [],
+          ],
+        },
+      ]);
+
+      assert.deepEqual(result, [{ type: "exclusive", terms: [[]] }]);
+    });
+
+    it("should strip nested malformed exclusive branches", () => {
+      const result = normalizeUsage([
+        {
+          type: "exclusive",
+          terms: [
+            [{
+              type: "optional",
+              terms: [{ type: "argument", metavar: "" } as never],
+            }],
+            [{
+              type: "multiple",
+              terms: [{ type: "command", name: "" } as never],
+              min: 0,
+            }],
+            [{
+              type: "exclusive",
+              terms: [[{ type: "option", names: [] as never }]],
+            }],
+          ],
+        },
+      ]);
+
       assert.deepEqual(result, []);
     });
 
@@ -3304,6 +3372,11 @@ describe("mergeHidden special cases", () => {
     assert.equal(mergeHidden("help", "doc"), "help");
     assert.equal(mergeHidden("usage", "help"), "help");
     assert.equal(mergeHidden("doc", "help"), "help");
+  });
+
+  it("should treat false as an absent restriction", () => {
+    assert.equal(mergeHidden(false, "usage"), "usage");
+    assert.equal(mergeHidden("doc", false), "doc");
   });
 
   it('should not hide suggestions when merging into "help"', () => {

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -15011,6 +15011,140 @@ describe("branch coverage regressions", () => {
     assert.ok(!functionParser.parse("80").success);
   });
 
+  it("covers portRange placeholders and static range errors", () => {
+    assert.deepEqual(portRange().placeholder, { start: 1, end: 1 });
+    assert.deepEqual(portRange({ type: "bigint" }).placeholder, {
+      start: 1n,
+      end: 1n,
+    });
+
+    const numberParser = portRange({
+      errors: { invalidRange: message`number range is reversed` },
+    });
+    const numberResult = numberParser.parse("9000-8000");
+    assert.ok(!numberResult.success);
+    assert.deepEqual(numberResult.error, [
+      { type: "text", text: "number range is reversed" },
+    ]);
+
+    const bigintParser = portRange({
+      type: "bigint",
+      errors: { invalidRange: message`bigint range is reversed` },
+    });
+    const bigintResult = bigintParser.parse("9000-8000");
+    assert.ok(!bigintResult.success);
+    assert.deepEqual(bigintResult.error, [
+      { type: "text", text: "bigint range is reversed" },
+    ]);
+  });
+
+  it("covers socketAddress placeholders and callback format errors", () => {
+    assert.deepEqual(socketAddress({ host: { type: "ip" } }).placeholder, {
+      host: "0.0.0.0",
+      port: 1,
+    });
+    assert.deepEqual(socketAddress({ defaultPort: 443 }).placeholder, {
+      host: "localhost",
+      port: 443,
+    });
+
+    const invalidNumericPort = socketAddress({
+      separator: "-",
+      defaultPort: 80,
+      errors: {
+        invalidFormat: (input) => message`bad endpoint: ${input}`,
+      },
+    });
+    const portResult = invalidNumericPort.parse("db-70000");
+    assert.ok(!portResult.success);
+    assert.deepEqual(portResult.error, [
+      { type: "text", text: "bad endpoint: " },
+      { type: "value", value: "db-70000" },
+    ]);
+
+    const invalidIpSplit = socketAddress({
+      separator: "-",
+      defaultPort: 80,
+      host: { type: "both", ip: { allowPrivate: false } },
+      errors: {
+        invalidFormat: (input) => message`invalid endpoint: ${input}`,
+      },
+    });
+    const ipResult = invalidIpSplit.parse("192.168.0.1-80");
+    assert.ok(!ipResult.success);
+    assert.deepEqual(ipResult.error, [
+      { type: "text", text: "invalid endpoint: " },
+      { type: "value", value: "192.168.0.1-80" },
+    ]);
+  });
+
+  it("covers IPv6 callback errors for address policy failures", () => {
+    const invalid = ipv6({
+      errors: {
+        invalidIpv6: (input) => message`bad IPv6: ${input}`,
+      },
+    }).parse("not-ipv6");
+    assert.ok(!invalid.success);
+    assert.deepEqual(invalid.error, [
+      { type: "text", text: "bad IPv6: " },
+      { type: "value", value: "not-ipv6" },
+    ]);
+
+    const cases = [
+      {
+        parser: ipv6({
+          allowZero: false,
+          errors: { zeroNotAllowed: (value) => message`zero: ${value}` },
+        }),
+        input: "::",
+        label: "zero",
+      },
+      {
+        parser: ipv6({
+          allowLoopback: false,
+          errors: { loopbackNotAllowed: (value) => message`loop: ${value}` },
+        }),
+        input: "::1",
+        label: "loop",
+      },
+      {
+        parser: ipv6({
+          allowLinkLocal: false,
+          errors: { linkLocalNotAllowed: (value) => message`link: ${value}` },
+        }),
+        input: "fe80::1",
+        label: "link",
+      },
+      {
+        parser: ipv6({
+          allowUniqueLocal: false,
+          errors: {
+            uniqueLocalNotAllowed: (value) => message`unique: ${value}`,
+          },
+        }),
+        input: "fc00::1",
+        label: "unique",
+      },
+      {
+        parser: ipv6({
+          allowMulticast: false,
+          errors: { multicastNotAllowed: (value) => message`multi: ${value}` },
+        }),
+        input: "ff00::1",
+        label: "multi",
+      },
+    ] as const;
+
+    for (const { parser, input, label } of cases) {
+      const result = parser.parse(input);
+      assert.ok(!result.success);
+      assert.deepEqual(result.error, [
+        { type: "text", text: `${label}: ` },
+        { type: "value", value: parser.normalize!(input) },
+      ]);
+    }
+  });
+
   it("covers ip invalidIP function branch when both sub-parsers are generic", () => {
     const parser = ip({
       errors: {
@@ -15020,6 +15154,117 @@ describe("branch coverage regressions", () => {
 
     const result = parser.parse("not-an-ip-literal");
     assert.ok(!result.success);
+    if (!result.success) {
+      assert.equal(
+        formatMessage(result.error),
+        'invalid ip via callback: "not-an-ip-literal"',
+      );
+    }
+  });
+
+  it("covers IPv4-mapped IP restriction callbacks", () => {
+    const cases = [
+      {
+        input: "::ffff:127.0.0.1",
+        ipv4: { allowLoopback: false },
+        errors: {
+          loopbackNotAllowed: (addr: string) =>
+            message`mapped loopback ${text(addr)}`,
+        },
+        expected: "mapped loopback ::ffff:7f00:1",
+      },
+      {
+        input: "::ffff:169.254.1.1",
+        ipv4: { allowLinkLocal: false },
+        errors: {
+          linkLocalNotAllowed: (addr: string) =>
+            message`mapped link-local ${text(addr)}`,
+        },
+        expected: "mapped link-local ::ffff:a9fe:101",
+      },
+      {
+        input: "::ffff:224.0.0.1",
+        ipv4: { allowMulticast: false },
+        errors: {
+          multicastNotAllowed: (addr: string) =>
+            message`mapped multicast ${text(addr)}`,
+        },
+        expected: "mapped multicast ::ffff:e000:1",
+      },
+      {
+        input: "::ffff:255.255.255.255",
+        ipv4: { allowBroadcast: false },
+        errors: {
+          broadcastNotAllowed: (addr: string) =>
+            message`mapped broadcast ${text(addr)}`,
+        },
+        expected: "mapped broadcast ::ffff:ffff:ffff",
+      },
+      {
+        input: "::ffff:0.0.0.0",
+        ipv4: { allowZero: false },
+        errors: {
+          zeroNotAllowed: (addr: string) => message`mapped zero ${text(addr)}`,
+        },
+        expected: "mapped zero ::ffff:0:0",
+      },
+    ] as const;
+
+    for (const { input, ipv4: ipv4Options, errors, expected } of cases) {
+      const result = ip({ ipv4: ipv4Options, errors }).parse(input);
+      assert.ok(!result.success);
+      if (!result.success) {
+        assert.equal(formatMessage(result.error), expected);
+      }
+    }
+  });
+
+  it("covers CIDR placeholders and parser-specific fallback paths", () => {
+    assert.deepEqual(cidr({ version: 6 }).placeholder, {
+      address: "::",
+      prefix: 0,
+      version: 6,
+    });
+    assert.deepEqual(cidr({ minPrefix: 64 }).placeholder, {
+      address: "::",
+      prefix: 64,
+      version: 6,
+    });
+    assert.deepEqual(cidr({ version: 4, minPrefix: 24 }).placeholder, {
+      address: "0.0.0.0",
+      prefix: 24,
+      version: 4,
+    });
+
+    const invalidPrefix = cidr({
+      errors: {
+        invalidCidr: (input) => message`bad cidr ${text(input)}`,
+      },
+    }).parse("192.0.2.0/+24");
+    assert.ok(!invalidPrefix.success);
+    if (!invalidPrefix.success) {
+      assert.equal(
+        formatMessage(invalidPrefix.error),
+        "bad cidr 192.0.2.0/+24",
+      );
+    }
+
+    const prefixCallback = cidr({
+      ipv4: { allowPrivate: false },
+      errors: {
+        invalidPrefix: (prefix, version) =>
+          message`bad prefix ${text(prefix.toString())} for version ${
+            text(version.toString())
+          }`,
+      },
+    }).parse("192.168.0.0/33");
+    assert.ok(!prefixCallback.success);
+    if (!prefixCallback.success) {
+      assert.equal(
+        formatMessage(prefixCallback.error),
+        "bad prefix 33 for version 4",
+      );
+    }
   });
 });
 
@@ -15191,6 +15436,14 @@ describe("ValueParser.normalize()", () => {
     assert.equal(v6.normalize!("0:0:0:0:0:0:0:1"), "0:0:0:0:0:0:0:1");
   });
 
+  it("ipv6().format() and normalize() preserve non-string sentinels", () => {
+    const v6 = ipv6();
+    assert.equal(v6.format({ kind: "auto" } as never), "IPV6");
+    assert.deepEqual(v6.normalize!({ kind: "auto" } as never), {
+      kind: "auto",
+    });
+  });
+
   it("ip().normalize() compresses IPv6 addresses", () => {
     const ipParser = ip();
     assert.equal(
@@ -15198,6 +15451,27 @@ describe("ValueParser.normalize()", () => {
       "2001:db8::1",
     );
     assert.equal(ipParser.normalize!("192.0.2.1"), "192.0.2.1");
+  });
+
+  it("ip().format() and normalize() preserve non-string sentinels", () => {
+    const ipParser = ip();
+    assert.equal(ipParser.format({ kind: "auto" } as never), "IP");
+    assert.deepEqual(ipParser.normalize!({ kind: "auto" } as never), {
+      kind: "auto",
+    });
+  });
+
+  it("ip().format() and normalize() preserve values when validation throws", () => {
+    const ipParser = ip({
+      errors: {
+        invalidIP: () => {
+          throw new TypeError("bad ip callback.");
+        },
+      },
+    });
+
+    assert.equal(ipParser.format("not-an-ip"), "not-an-ip");
+    assert.equal(ipParser.normalize!("not-an-ip"), "not-an-ip");
   });
 
   it("cidr().normalize() compresses IPv6 CIDR addresses", () => {
@@ -15212,6 +15486,36 @@ describe("ValueParser.normalize()", () => {
       prefix: 32,
       version: 6,
     });
+  });
+
+  it("cidr().format() and normalize() preserve invalid sentinels", () => {
+    const cidrParser = cidr();
+    assert.equal(cidrParser.format({ kind: "auto" } as never), "CIDR");
+    assert.deepEqual(cidrParser.normalize!({ kind: "auto" } as never), {
+      kind: "auto",
+    });
+
+    const versionMismatch = { address: "192.0.2.0", prefix: 24, version: 6 };
+    assert.equal(cidrParser.format(versionMismatch as never), "192.0.2.0/24");
+    assert.deepEqual(cidrParser.normalize!(versionMismatch as never), {
+      address: "192.0.2.0",
+      prefix: 24,
+      version: 6,
+    });
+  });
+
+  it("cidr().format() and normalize() preserve values when validation throws", () => {
+    const cidrParser = cidr({
+      errors: {
+        invalidCidr: () => {
+          throw new TypeError("bad cidr callback.");
+        },
+      },
+    });
+    const invalid = { address: "not-an-ip", prefix: 24, version: 4 } as const;
+
+    assert.equal(cidrParser.format(invalid), "not-an-ip/24");
+    assert.deepEqual(cidrParser.normalize!(invalid), invalid);
   });
 });
 

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -1544,6 +1544,17 @@ describe("choice", () => {
       }
     });
 
+    it("should accept equivalent scientific notation for numeric choices", () => {
+      const parser = choice([1e21]);
+
+      const result = parser.parse("1.0e+21");
+
+      assert.ok(result.success);
+      if (result.success) {
+        assert.equal(result.value, 1e21);
+      }
+    });
+
     it("should allow exact duplicate choices with caseInsensitive", () => {
       const parser = choice(["json", "json", "yaml"], {
         caseInsensitive: true,
@@ -11259,6 +11270,42 @@ describe("socketAddress()", () => {
       ]);
     });
 
+    it("should keep IP-shaped split errors over earlier generic host errors", () => {
+      const parser = socketAddress({
+        requirePort: true,
+        host: {
+          type: "both",
+          ip: { allowPrivate: false },
+        },
+      });
+
+      const result = parser.parse("192.168.1.1:abc:80");
+      assert.ok(!result.success);
+      assert.deepStrictEqual(result.error, [
+        { type: "value", value: "192.168.1.1" },
+        { type: "text", text: " is a private IP address." },
+      ]);
+    });
+
+    it("should prefer custom invalidFormat for invalid trailing hosts", () => {
+      const parser = socketAddress({
+        defaultPort: 80,
+        host: {
+          type: "both",
+          ip: { allowPrivate: false },
+        },
+        errors: {
+          invalidFormat: message`Custom trailing host error`,
+        },
+      });
+
+      const result = parser.parse("192.168.1.1:");
+      assert.ok(!result.success);
+      assert.deepStrictEqual(result.error, [
+        { type: "text", text: "Custom trailing host error" },
+      ]);
+    });
+
     it("should return socket-level format error for non-numeric port suffix", () => {
       // "abc" does not match the /^[0-9]+$/ gate, so port() is
       // never consulted.  The generic format error is the correct
@@ -11695,6 +11742,24 @@ describe("macAddress()", () => {
     it("should return custom metavar", () => {
       const parser = macAddress({ metavar: "MAC_ADDR" });
       assert.strictEqual(parser.metavar, "MAC_ADDR");
+    });
+  });
+
+  describe("placeholder", () => {
+    it("should reflect the selected output separator", () => {
+      assert.strictEqual(macAddress().placeholder, "00:00:00:00:00:00");
+      assert.strictEqual(
+        macAddress({ separator: "." }).placeholder,
+        "0000.0000.0000",
+      );
+      assert.strictEqual(
+        macAddress({ separator: "none" }).placeholder,
+        "000000000000",
+      );
+      assert.strictEqual(
+        macAddress({ separator: "none", outputSeparator: "-" }).placeholder,
+        "00-00-00-00-00-00",
+      );
     });
   });
 
@@ -14026,6 +14091,50 @@ describe("cidr()", () => {
         { type: "text", text: "." },
       ]);
     });
+
+    it("should use custom prefixBelowMinimum over restriction error", () => {
+      const parser = cidr({
+        ipv4: { allowPrivate: false },
+        minPrefix: 16,
+        errors: {
+          prefixBelowMinimum: (actual, minimum) =>
+            message`prefix ${text(String(actual))} below ${
+              text(String(minimum))
+            }.`,
+        },
+      });
+      const result = parser.parse("192.168.0.0/8");
+      assert.ok(!result.success);
+      assert.deepStrictEqual(result.error, [
+        { type: "text", text: "prefix " },
+        { type: "text", text: "8" },
+        { type: "text", text: " below " },
+        { type: "text", text: "16" },
+        { type: "text", text: "." },
+      ]);
+    });
+
+    it("should use custom prefixAboveMaximum over restriction error", () => {
+      const parser = cidr({
+        ipv4: { allowLoopback: false },
+        maxPrefix: 24,
+        errors: {
+          prefixAboveMaximum: (actual, maximum) =>
+            message`prefix ${text(String(actual))} above ${
+              text(String(maximum))
+            }.`,
+        },
+      });
+      const result = parser.parse("127.0.0.0/32");
+      assert.ok(!result.success);
+      assert.deepStrictEqual(result.error, [
+        { type: "text", text: "prefix " },
+        { type: "text", text: "32" },
+        { type: "text", text: " above " },
+        { type: "text", text: "24" },
+        { type: "text", text: "." },
+      ]);
+    });
   });
 
   describe("IPv4-mapped IPv6 CIDR restrictions", () => {
@@ -15390,6 +15499,36 @@ describe("ValueParser.normalize()", () => {
       },
     });
     assert.equal(throwing.format("not-a-mac"), "not-a-mac");
+  });
+
+  it("macAddress().format() and normalize() avoid recursive validation", () => {
+    const formatParser = macAddress({
+      errors: {
+        invalidMacAddress: (input) =>
+          message`invalid after ${text(formatParser.format(input))}`,
+      },
+    });
+    assert.equal(formatParser.format("not-a-mac"), "not-a-mac");
+
+    const normalizeParser = macAddress({
+      errors: {
+        invalidMacAddress: (input) =>
+          message`invalid after ${text(normalizeParser.normalize!(input))}`,
+      },
+    });
+    assert.equal(normalizeParser.normalize!("not-a-mac"), "not-a-mac");
+  });
+
+  it("macAddress().normalize() preserves values when validation throws", () => {
+    const throwing = macAddress({
+      errors: {
+        invalidMacAddress: () => {
+          throw new TypeError("bad mac callback.");
+        },
+      },
+    });
+
+    assert.equal(throwing.normalize!("not-a-mac"), "not-a-mac");
   });
 
   it("domain().normalize() applies lowercase when configured", () => {

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -14867,6 +14867,22 @@ describe("branch coverage regressions", () => {
     }
   });
 
+  it("accepts equivalent scientific notation for numeric choices", () => {
+    const parser = choice([1e21, -0]);
+
+    const exponential = parser.parse("1e21");
+    assert.ok(exponential.success);
+    if (exponential.success) {
+      assert.equal(exponential.value, 1e21);
+    }
+
+    const negativeZero = parser.parse("-0");
+    assert.ok(negativeZero.success);
+    if (negativeZero.success) {
+      assert.ok(Object.is(negativeZero.value, -0));
+    }
+  });
+
   it("covers static custom invalidChoice for numeric choice parser", () => {
     const parser = choice([1, 2, 3], {
       errors: {
@@ -14917,6 +14933,49 @@ describe("branch coverage regressions", () => {
 
     assert.ok(!parser.parse("9").success);
     assert.ok(!parser.parse("21").success);
+  });
+
+  it("rejects invalid UUID allowedVersions values by value type", () => {
+    assert.throws(
+      () => uuid({ allowedVersions: [Symbol("version")] as never }),
+      {
+        name: "TypeError",
+        message:
+          'Expected every element of allowedVersions to be an integer, but got value "Symbol(version)" of type "symbol".',
+      },
+    );
+    assert.throws(
+      () => uuid({ allowedVersions: [[4]] as never }),
+      {
+        name: "TypeError",
+        message:
+          'Expected every element of allowedVersions to be an integer, but got value "4" of type "array".',
+      },
+    );
+  });
+
+  it("uses UUID version policy errors for otherwise well-formed UUIDs", () => {
+    const strictParser = uuid({
+      errors: {
+        disallowedVersion: (version, allowedVersions) =>
+          message`version ${text(String(version))} not in ${
+            text(allowedVersions.join(","))
+          }`,
+      },
+    });
+    const strictResult = strictParser.parse(
+      "550e8400-e29b-91d4-a716-446655440000",
+    );
+
+    assert.ok(!strictResult.success);
+    if (!strictResult.success) {
+      assert.deepEqual(strictResult.error, [
+        { type: "text", text: "version " },
+        { type: "text", text: "9" },
+        { type: "text", text: " not in " },
+        { type: "text", text: "1,2,3,4,5,6,7,8" },
+      ]);
+    }
   });
 
   it("covers port number static and function error branches", () => {
@@ -15074,6 +15133,20 @@ describe("ValueParser.normalize()", () => {
     assert.equal(mac.format("local"), "local");
   });
 
+  it("macAddress().format() falls back for non-string and throwing validation", () => {
+    const basic = macAddress();
+    assert.equal(basic.format(42 as never), "MAC");
+
+    const throwing = macAddress({
+      errors: {
+        invalidMacAddress: () => {
+          throw new TypeError("bad mac callback.");
+        },
+      },
+    });
+    assert.equal(throwing.format("not-a-mac"), "not-a-mac");
+  });
+
   it("domain().normalize() applies lowercase when configured", () => {
     const dom = domain({ lowercase: true });
     assert.equal(dom.normalize!("Example.COM"), "example.com");
@@ -15088,6 +15161,21 @@ describe("ValueParser.normalize()", () => {
   it("domain() has no normalize when lowercase is false", () => {
     const dom = domain();
     assert.equal(dom.normalize, undefined);
+  });
+
+  it("domain().format() falls back for non-string and throwing validation", () => {
+    const basic = domain({ lowercase: true });
+    assert.equal(basic.format(42 as never), "DOMAIN");
+
+    const throwing = domain({
+      lowercase: true,
+      errors: {
+        invalidDomain: () => {
+          throw new TypeError("bad domain callback.");
+        },
+      },
+    });
+    assert.equal(throwing.format("not a domain"), "not a domain");
   });
 
   it("ipv6().normalize() compresses non-canonical addresses", () => {
@@ -15205,6 +15293,17 @@ describe("checkEnumOption", () => {
       {
         name: "TypeError",
         message: 'Expected foo to be one of "a", "b", "c", but got number: 42.',
+      },
+    );
+  });
+
+  it("should render symbol values in TypeError messages", () => {
+    assert.throws(
+      () => checkEnumOption({ foo: Symbol("x") }, "foo", allowed),
+      {
+        name: "TypeError",
+        message:
+          'Expected foo to be one of "a", "b", "c", but got symbol: Symbol(x).',
       },
     );
   });

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -4947,64 +4947,6 @@ export function macAddress(
     return formatted.join(sep);
   }
 
-  // Normalizes a MAC address string by splitting on the detected separator,
-  // padding octets, and re-joining with the configured separator and case.
-  // Returns the value unchanged if it does not have the expected 6-octet
-  // structure (e.g., a string sentinel like "local").
-  // Shared by both format() and normalize().
-  function normalizeMac(value: string): string {
-    // Guard against sentinel defaults of incompatible runtime type
-    // (e.g., { kind: "local" } cast as string via withDefault).
-    // Fall back to metavar for help-text display.
-    if (typeof value !== "string") return metavar;
-    let octets: string[];
-    let detectedSep: ":" | "-" | "." | "none";
-    if (value.includes(":")) {
-      octets = value.split(":");
-      detectedSep = ":";
-    } else if (value.includes("-")) {
-      octets = value.split("-");
-      detectedSep = "-";
-    } else if (value.includes(".")) {
-      // Cisco format: exactly 3 groups of 4 hex digits
-      const groups = value.split(".");
-      if (
-        groups.length !== 3 ||
-        !groups.every((g) => /^[0-9a-fA-F]{4}$/.test(g))
-      ) {
-        return value;
-      }
-      octets = groups.flatMap((g) => [g.slice(0, 2), g.slice(2)]);
-      detectedSep = ".";
-    } else {
-      // No separator: require exactly 12 hex chars (matching parse's noneRegex)
-      if (value.length !== 12) return value;
-      octets = [];
-      for (let i = 0; i < value.length; i += 2) {
-        octets.push(value.slice(i, i + 2));
-      }
-      detectedSep = "none";
-    }
-    // Guard: a valid MAC has exactly 6 hex octets.  If not, the value is
-    // not a MAC address (e.g., a sentinel default) — return it unchanged.
-    if (
-      octets.length !== 6 ||
-      !octets.every((o) => /^[0-9a-fA-F]{1,2}$/.test(o))
-    ) {
-      return value;
-    }
-    octets = octets.map((o) => o.padStart(2, "0"));
-    let sep: ":" | "-" | "." | "none";
-    if (outputSeparator != null) {
-      sep = outputSeparator;
-    } else if (separator !== "any") {
-      sep = separator;
-    } else {
-      sep = detectedSep;
-    }
-    return joinOctets(octets, sep);
-  }
-
   const parserObj: ValueParser<"sync", string> = {
     mode: "sync",
     metavar,
@@ -5096,7 +5038,9 @@ export function macAddress(
       const finalSeparator = outputSeparator ?? inputSeparator ?? ":";
       return { success: true, value: joinOctets(octets, finalSeparator) };
     },
-    format: normalizeMac, // overridden below
+    format(value: string): string {
+      return value;
+    },
   };
   // Both format and normalize use the full parse() pipeline so that
   // values parse() would reject are returned unchanged.  This keeps

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -4924,8 +4924,8 @@ export function macAddress(
   const noneRegex = /^([0-9a-fA-F]{12})$/;
 
   // Shared formatting logic: applies case conversion and joins octets with
-  // the given separator.  Used by both parse() and format() to guarantee
-  // consistent normalization.
+  // the given separator.  Used by parse() to guarantee consistent
+  // normalization.
   function joinOctets(
     octets: readonly string[],
     sep: ":" | "-" | "." | "none",
@@ -4945,6 +4945,20 @@ export function macAddress(
     }
     if (sep === "none") return formatted.join("");
     return formatted.join(sep);
+  }
+
+  let macParsing = false;
+  function normalizeMacValue(value: string, fallback: string): string {
+    if (macParsing) return value;
+    macParsing = true;
+    try {
+      const result = parserObj.parse(value);
+      return result.success ? result.value : fallback;
+    } catch {
+      return fallback;
+    } finally {
+      macParsing = false;
+    }
   }
 
   const parserObj: ValueParser<"sync", string> = {
@@ -5039,50 +5053,14 @@ export function macAddress(
       return { success: true, value: joinOctets(octets, finalSeparator) };
     },
     format(value: string): string {
-      return value;
+      if (typeof value !== "string") return metavar;
+      return normalizeMacValue(value, value);
+    },
+    normalize(value: string): string {
+      if (typeof value !== "string") return value;
+      return normalizeMacValue(value, value);
     },
   };
-  // Both format and normalize use the full parse() pipeline so that
-  // values parse() would reject are returned unchanged.  This keeps
-  // help text consistent with the runtime default.
-  // A recursion guard prevents stack overflow when custom error callbacks
-  // call format()/normalize() on the same parser.
-  const macParser = parserObj;
-  let macParsing = false;
-  Object.defineProperty(parserObj, "format", {
-    value(v: string): string {
-      if (typeof v !== "string") return metavar;
-      if (macParsing) return v;
-      macParsing = true;
-      try {
-        const result = macParser.parse(v);
-        return result.success ? result.value : v;
-      } catch {
-        return v;
-      } finally {
-        macParsing = false;
-      }
-    },
-    configurable: true,
-    enumerable: true,
-  });
-  Object.defineProperty(parserObj, "normalize", {
-    value(v: string): string {
-      if (typeof v !== "string") return v;
-      if (macParsing) return v;
-      macParsing = true;
-      try {
-        const result = macParser.parse(v);
-        return result.success ? result.value : v;
-      } catch {
-        return v;
-      } finally {
-        macParsing = false;
-      }
-    },
-    configurable: true,
-    enumerable: true,
-  });
   return parserObj;
 }
 

--- a/packages/env/src/index.test.ts
+++ b/packages/env/src/index.test.ts
@@ -2651,6 +2651,104 @@ describe("bindEnv() with dependency sources", () => {
     );
   });
 
+  it("reports non-string env source values during source extraction", () => {
+    const envContext = createEnvContext({
+      prefix: "APP_",
+      source: (key) => ({ APP_MODE: ["prod"] as never })[key],
+    });
+    const parser = bindEnv(option("--mode", mode), {
+      context: envContext,
+      key: "MODE",
+      parser: choice(["dev", "prod"] as const),
+    });
+    const state = injectAnnotations(
+      parser.initialState,
+      envContext.getAnnotations() as Record<symbol, unknown>,
+    );
+
+    const result = parser.dependencyMetadata?.source?.extractSourceValue(state);
+
+    assert.ok(result != null && "success" in result);
+    assert.ok(!result.success);
+    if (!result.success) {
+      assert.match(
+        formatMessage(result.error),
+        /Environment variable .*APP_MODE.* must be a string, but got: .*array/,
+      );
+    }
+  });
+
+  it("validates default source values through preserving inner parsers", () => {
+    const sourceId = Symbol("mode");
+    const innerParser = {
+      mode: "sync" as const,
+      $valueType: [] as readonly ("dev" | "prod")[],
+      $stateType: [] as readonly undefined[],
+      priority: 0,
+      usage: [],
+      leadingNames: new Set<string>(),
+      acceptingAnyToken: false,
+      initialState: undefined,
+      parse() {
+        return {
+          success: false as const,
+          consumed: 0,
+          error: message`No CLI value.`,
+        };
+      },
+      complete() {
+        return { success: false as const, error: message`No value.` };
+      },
+      suggest() {
+        return [];
+      },
+      getDocFragments() {
+        return { fragments: [] };
+      },
+      validateValue(value: "dev" | "prod") {
+        return value === "dev" || value === "prod"
+          ? { success: true as const, value }
+          : {
+            success: false as const,
+            error: message`Invalid mode default.`,
+          };
+      },
+      dependencyMetadata: {
+        source: {
+          kind: "source" as const,
+          sourceId,
+          preservesSourceValue: true,
+          extractSourceValue() {
+            return undefined;
+          },
+        },
+      },
+    } satisfies Parser<"sync", "dev" | "prod", undefined> & {
+      readonly dependencyMetadata: {
+        readonly source: {
+          readonly kind: "source";
+          readonly sourceId: typeof sourceId;
+          readonly preservesSourceValue: true;
+          readonly extractSourceValue: () => undefined;
+        };
+      };
+    };
+    const parser = bindEnv(innerParser, {
+      context: createEnvContext({ source: () => undefined }),
+      key: "MODE",
+      parser: choice(["dev", "prod", "test"] as const),
+      default: "test" as never,
+    });
+
+    const result = parser.dependencyMetadata?.source?.getMissingSourceValue?.();
+
+    assert.ok(result != null && "success" in result);
+    assert.ok(!result.success);
+    if (!result.success) {
+      assert.equal(formatMessage(result.error), "Invalid mode default.");
+    }
+  });
+
   it("propagates env value as dependency to derived parser (suggest)", () => {
     const { parser, annotations } = createParser(
       (key) => ({ APP_MODE: "prod" })[key],

--- a/packages/env/src/index.test.ts
+++ b/packages/env/src/index.test.ts
@@ -1057,6 +1057,36 @@ describe("bindEnv()", () => {
       assert.ok(!extracted.success);
     });
 
+    it("reports dependency-source env parser failures before inner validation", () => {
+      const context = createEnvContext({
+        source: (key) => ({ PORT: "eighty" })[key],
+      });
+      const source = dependency(integer({ min: 1024 }));
+      const portParser = bindEnv(option("--port", source), {
+        context,
+        key: "PORT",
+        parser: integer(),
+      });
+      const annotations = context.getAnnotations();
+      if (annotations instanceof Promise) {
+        throw new TypeError("Expected synchronous annotations.");
+      }
+      const parseResult = portParser.parse({
+        buffer: [],
+        state: injectAnnotations(portParser.initialState, annotations),
+        optionsTerminated: false,
+        usage: portParser.usage,
+      });
+      assert.ok(parseResult.success);
+
+      const extracted = portParser.dependencyMetadata?.source
+        ?.extractSourceValue(parseResult.next.state);
+
+      assert.ok(extracted != null && !(extracted instanceof Promise));
+      assert.ok(!extracted.success);
+      assert.match(formatMessage(extracted.error), /Expected a valid integer/u);
+    });
+
     it("validates dependency-source defaults through inner parser", () => {
       const context = createEnvContext({
         source: () => undefined,
@@ -2329,6 +2359,46 @@ describe("bindEnv()", () => {
         formatMessage(extracted.error),
         'Environment variable `PORT` must be a string, but got: "array".',
       );
+    });
+
+    it("reports non-string dependency source env value types", () => {
+      const cases = [
+        [null, "null"],
+        [8080, "number"],
+        [["8080"], "array"],
+      ] as const;
+
+      for (const [rawValue, typeName] of cases) {
+        const context = createEnvContext({
+          source: () => rawValue as never,
+        });
+        const source = dependency(integer());
+        const parser = bindEnv(option("--port", source), {
+          context,
+          key: "PORT",
+          parser: integer(),
+        });
+        const parseResult = parser.parse({
+          buffer: [],
+          state: injectAnnotations(
+            parser.initialState,
+            getSyncAnnotations(context),
+          ),
+          optionsTerminated: false,
+          usage: parser.usage,
+        });
+        assert.ok(parseResult.success);
+
+        const extracted = parser.dependencyMetadata?.source
+          ?.extractSourceValue(parseResult.next.state);
+
+        assert.ok(extracted != null && !(extracted instanceof Promise));
+        assert.ok(!extracted.success);
+        assert.equal(
+          formatMessage(extracted.error),
+          `Environment variable \`PORT\` must be a string, but got: "${typeName}".`,
+        );
+      }
     });
   });
 

--- a/packages/env/src/index.test.ts
+++ b/packages/env/src/index.test.ts
@@ -3040,6 +3040,185 @@ describe("bindEnv() with dependency sources", () => {
     assert.equal(completeCalls, 0);
   });
 
+  it("exposes bindEnv defaults as missing source values without validation hooks", () => {
+    const sourceId = Symbol("mode-default");
+    const innerParser = {
+      mode: "sync" as const,
+      $valueType: [] as const,
+      $stateType: [] as const,
+      priority: 0,
+      usage: [],
+      leadingNames: new Set<string>(),
+      acceptingAnyToken: false,
+      initialState: undefined,
+      parse(context) {
+        return {
+          success: false as const,
+          consumed: 0,
+          error: message`No CLI value.`,
+          next: context,
+        };
+      },
+      complete() {
+        return { success: false as const, error: message`No value.` };
+      },
+      suggest() {
+        return [];
+      },
+      getDocFragments() {
+        return { fragments: [] };
+      },
+      dependencyMetadata: {
+        source: {
+          kind: "source" as const,
+          sourceId,
+          preservesSourceValue: true,
+          extractSourceValue() {
+            return undefined;
+          },
+        },
+      },
+    } satisfies Parser<"sync", "dev" | "prod", undefined> & {
+      readonly dependencyMetadata: {
+        readonly source: {
+          readonly kind: "source";
+          readonly sourceId: typeof sourceId;
+          readonly preservesSourceValue: true;
+          readonly extractSourceValue: () => undefined;
+        };
+      };
+    };
+    const parser = bindEnv(innerParser, {
+      context: createEnvContext({ source: () => undefined }),
+      key: "MODE",
+      parser: choice(["dev", "prod"] as const),
+      default: "prod" as const,
+    });
+
+    const missing = parser.dependencyMetadata?.source
+      ?.getMissingSourceValue?.();
+
+    assert.deepEqual(missing, { success: true, value: "prod" });
+  });
+
+  it("delegates non-preserving source extraction for raw inner states", () => {
+    const sourceId = Symbol("mapped-mode");
+    const rawState = { selected: "prod" as const };
+    const innerParser = {
+      mode: "sync" as const,
+      $valueType: [] as const,
+      $stateType: [] as const,
+      priority: 0,
+      usage: [],
+      leadingNames: new Set<string>(),
+      acceptingAnyToken: false,
+      initialState: rawState,
+      parse(context) {
+        return {
+          success: true as const,
+          next: context,
+          consumed: [],
+        };
+      },
+      complete() {
+        return { success: true as const, value: "production" as const };
+      },
+      suggest() {
+        return [];
+      },
+      getDocFragments() {
+        return { fragments: [] };
+      },
+      dependencyMetadata: {
+        source: {
+          kind: "source" as const,
+          sourceId,
+          preservesSourceValue: false,
+          extractSourceValue(state: unknown) {
+            return state === rawState
+              ? { success: true as const, value: "production" as const }
+              : undefined;
+          },
+        },
+      },
+    } satisfies Parser<"sync", "production", typeof rawState> & {
+      readonly dependencyMetadata: {
+        readonly source: {
+          readonly kind: "source";
+          readonly sourceId: typeof sourceId;
+          readonly preservesSourceValue: false;
+          readonly extractSourceValue: (
+            state: unknown,
+          ) => ValueParserResult<unknown> | undefined;
+        };
+      };
+    };
+    const parser = bindEnv(innerParser, {
+      context: createEnvContext({ source: () => undefined }),
+      key: "MODE",
+      parser: choice(["development", "production"] as const),
+    });
+
+    const extracted = parser.dependencyMetadata?.source?.extractSourceValue(
+      rawState,
+    );
+
+    assert.deepEqual(extracted, { success: true, value: "production" });
+  });
+
+  it("uses async defaults unchanged when the inner parser has no validator", async () => {
+    const innerParser = {
+      mode: "async" as const,
+      $valueType: [] as const,
+      $stateType: [] as const,
+      priority: 0,
+      usage: [],
+      leadingNames: new Set<string>(),
+      acceptingAnyToken: false,
+      initialState: undefined,
+      parse(context) {
+        return Promise.resolve({
+          success: false as const,
+          consumed: 0,
+          error: message`No CLI value.`,
+          next: context,
+        });
+      },
+      complete() {
+        return Promise.resolve({
+          success: false as const,
+          error: message`No value.`,
+        });
+      },
+      suggest() {
+        return {
+          async *[Symbol.asyncIterator]() {
+            yield* [];
+          },
+        };
+      },
+      getDocFragments() {
+        return { fragments: [] };
+      },
+    } satisfies Parser<"async", "dev" | "prod", undefined>;
+    const envContext = createEnvContext({ source: () => undefined });
+    const parser = bindEnv(innerParser, {
+      context: envContext,
+      key: "MODE",
+      parser: asyncChoice(["dev", "prod"] as const),
+      default: "prod" as const,
+    });
+
+    const result = await parse(parser, [], {
+      annotations: getSyncAnnotations(envContext),
+    });
+
+    assert.ok(result.success);
+    if (result.success) {
+      assert.equal(result.value, "prod");
+    }
+  });
+
   it("preserves outer annotations when no-CLI fallback delegates source extraction", () => {
     const configContext = createConfigContext<
       { readonly mode?: "dev" | "prod" }

--- a/packages/env/src/index.test.ts
+++ b/packages/env/src/index.test.ts
@@ -2237,6 +2237,46 @@ describe("bindEnv()", () => {
       );
     });
 
+    it("reports null EnvSource values with their concrete type", () => {
+      const context = createEnvContext({
+        source: () => null as never,
+      });
+      const parser = bindEnv(option("--name", string()), {
+        context,
+        key: "NAME",
+        parser: string(),
+      });
+
+      const result = parse(parser, [], {
+        annotations: getSyncAnnotations(context),
+      });
+      assert.ok(!result.success);
+      assert.equal(
+        formatMessage(result.error),
+        'Environment variable `NAME` must be a string, but got: "null".',
+      );
+    });
+
+    it("reports array EnvSource values with their concrete type", () => {
+      const context = createEnvContext({
+        source: () => ["alice"] as never,
+      });
+      const parser = bindEnv(option("--name", string()), {
+        context,
+        key: "NAME",
+        parser: string(),
+      });
+
+      const result = parse(parser, [], {
+        annotations: getSyncAnnotations(context),
+      });
+      assert.ok(!result.success);
+      assert.equal(
+        formatMessage(result.error),
+        'Environment variable `NAME` must be a string, but got: "array".',
+      );
+    });
+
     it("fails when EnvSource returns a Promise", () => {
       const context = createEnvContext({
         source: () => Promise.resolve("alice") as never,
@@ -2259,6 +2299,35 @@ describe("bindEnv()", () => {
       assert.match(
         errorText,
         /must be a string, but got: /u,
+      );
+    });
+
+    it("validates non-string dependency source env values before extraction", () => {
+      const context = createEnvContext({
+        source: () => ["8080"] as never,
+      });
+      const source = dependency(integer());
+      const parser = bindEnv(option("--port", source), {
+        context,
+        key: "PORT",
+        parser: integer(),
+      });
+      const annotations = getSyncAnnotations(context);
+      const parseResult = parser.parse({
+        buffer: [],
+        state: injectAnnotations(parser.initialState, annotations),
+        optionsTerminated: false,
+        usage: parser.usage,
+      });
+      assert.ok(parseResult.success);
+
+      const extracted = parser.dependencyMetadata?.source
+        ?.extractSourceValue(parseResult.next.state);
+      assert.ok(extracted != null && !(extracted instanceof Promise));
+      assert.ok(!extracted.success);
+      assert.equal(
+        formatMessage(extracted.error),
+        'Environment variable `PORT` must be a string, but got: "array".',
       );
     });
   });

--- a/packages/git/src/index.test.ts
+++ b/packages/git/src/index.test.ts
@@ -265,6 +265,24 @@ describe("git parsers", () => {
       }
     });
 
+    it("should list available tags in the default missing-tag error", async () => {
+      const testRepoDir = await createTestRepoWithBranchesAndTags();
+      try {
+        const parser = gitTag({ dir: testRepoDir });
+        const result = await parser.parse("v9.9.9");
+
+        assert.ok(!result.success);
+        if (!result.success) {
+          const text = formatMessage(result.error);
+          assert.match(text, /Tag "v9\.9\.9" does not exist/);
+          assert.match(text, /Available tags:/);
+          assert.match(text, /v1\.0\.0/);
+        }
+      } finally {
+        await cleanupTestRepo(testRepoDir);
+      }
+    });
+
     it("should parse tags with prerelease versions", async () => {
       const testRepoDir = await createTestRepoWithBranchesAndTags();
       try {
@@ -497,6 +515,47 @@ describe("git parsers", () => {
           const msg = formatMessage(result.error);
           assert.match(msg, /Remote branch/);
           assert.match(msg, /nonexistent/);
+        }
+      } finally {
+        await cleanupTestRepo(testRepoDir);
+      }
+    });
+
+    it("should list available remote branches in the default error", async () => {
+      const testRepoDir = await createTestRepo();
+      try {
+        await isomorphicGit.addRemote({
+          fs,
+          dir: testRepoDir,
+          remote: "origin",
+          url: "https://example.com/repo.git",
+          force: true,
+        });
+        const head = await isomorphicGit.resolveRef({
+          fs,
+          dir: testRepoDir,
+          ref: "HEAD",
+        });
+        await fs.mkdir(join(testRepoDir, ".git", "refs", "remotes", "origin"), {
+          recursive: true,
+        });
+        await fs.writeFile(
+          join(testRepoDir, ".git", "refs", "remotes", "origin", "main"),
+          `${head}\n`,
+        );
+
+        const parser = gitRemoteBranch("origin", { dir: testRepoDir });
+        const result = await parser.parse("release");
+
+        assert.ok(!result.success);
+        if (!result.success) {
+          const text = formatMessage(result.error);
+          assert.match(
+            text,
+            /Remote branch "release" does not exist on remote "origin"/,
+          );
+          assert.match(text, /Available branches:/);
+          assert.match(text, /main/);
         }
       } finally {
         await cleanupTestRepo(testRepoDir);

--- a/packages/git/src/index.test.ts
+++ b/packages/git/src/index.test.ts
@@ -399,6 +399,32 @@ describe("git parsers", () => {
       }
     });
 
+    it("should list available remotes in the default error", async () => {
+      const testRepoDir = await createTestRepo();
+      try {
+        await isomorphicGit.addRemote({
+          fs,
+          dir: testRepoDir,
+          remote: "origin",
+          url: "https://example.com/repo.git",
+          force: true,
+        });
+
+        const parser = gitRemote({ dir: testRepoDir });
+        const result = await parser.parse("upstream");
+
+        assert.ok(!result.success);
+        if (!result.success) {
+          assert.equal(
+            formatMessage(result.error),
+            'Remote "upstream" does not exist. Available remotes: "origin"',
+          );
+        }
+      } finally {
+        await cleanupTestRepo(testRepoDir);
+      }
+    });
+
     it("should have async mode", () => {
       const parser = gitRemote({ dir: "/tmp/dummy" });
       assert.equal(parser.mode, "async");
@@ -490,6 +516,32 @@ describe("git parsers", () => {
           assert.ok(
             !msg.includes("Remote branch"),
             "Should not say 'Remote branch' when the remote itself is missing",
+          );
+        }
+      } finally {
+        await cleanupTestRepo(testRepoDir);
+      }
+    });
+
+    it("should list available remotes when a remote branch remote is missing", async () => {
+      const testRepoDir = await createTestRepo();
+      try {
+        await isomorphicGit.addRemote({
+          fs,
+          dir: testRepoDir,
+          remote: "origin",
+          url: "https://example.com/repo.git",
+          force: true,
+        });
+
+        const parser = gitRemoteBranch("upstream", { dir: testRepoDir });
+        const result = await parser.parse("main");
+
+        assert.ok(!result.success);
+        if (!result.success) {
+          assert.equal(
+            formatMessage(result.error),
+            'Remote "upstream" does not exist. Available remotes: "origin"',
           );
         }
       } finally {
@@ -1234,6 +1286,40 @@ describe("git parsers", () => {
           mainSuggestions.length,
           1,
           "Should suggest 'main' only once",
+        );
+      } finally {
+        await cleanupTestRepo(testRepoDir);
+      }
+    });
+
+    it("should not suggest duplicate refs when a branch matches a short commit", async () => {
+      const testRepoDir = await createTestRepo();
+      try {
+        const oid = await isomorphicGit.resolveRef({
+          fs,
+          dir: testRepoDir,
+          ref: "main",
+        });
+        const shortOid = oid.slice(0, 7);
+        await isomorphicGit.branch({
+          fs,
+          dir: testRepoDir,
+          ref: shortOid,
+        });
+
+        const parser = gitRef({ dir: testRepoDir });
+        const suggestions: Suggestion[] = [];
+        for await (const s of parser.suggest!(shortOid)) {
+          suggestions.push(s);
+        }
+
+        assert.deepEqual(
+          suggestions
+            .filter((s): s is { kind: "literal"; text: string } =>
+              s.kind === "literal" && s.text === shortOid
+            )
+            .map((s) => s.text),
+          [shortOid],
         );
       } finally {
         await cleanupTestRepo(testRepoDir);

--- a/packages/inquirer/src/index.test.ts
+++ b/packages/inquirer/src/index.test.ts
@@ -1196,6 +1196,128 @@ describe("prompt()", () => {
   });
 
   describe("consumed-token detection", () => {
+    it("marks object placeholders as fully deferred", async () => {
+      const marker = Symbol.for("@test/inquirer/object-placeholder");
+      const inner:
+        & Parser<
+          "sync",
+          { readonly name: string; readonly meta: { readonly id: string } },
+          { readonly ready: boolean }
+        >
+        & {
+          readonly placeholder: {
+            readonly name: string;
+            readonly meta: { readonly id: string };
+          };
+        } = {
+          mode: "sync",
+          $valueType: [] as readonly {
+            readonly name: string;
+            readonly meta: { readonly id: string };
+          }[],
+          $stateType: [] as readonly { readonly ready: boolean }[],
+          priority: 0,
+          usage: [],
+          leadingNames: new Set(),
+          acceptingAnyToken: false,
+          initialState: { ready: true },
+          placeholder: { name: "", meta: { id: "" } },
+          parse(context) {
+            return {
+              success: true as const,
+              next: context,
+              consumed: [],
+            };
+          },
+          complete(state) {
+            assert.equal(getAnnotations(state)?.[marker], "seen");
+            return { success: true as const, value: undefined as never };
+          },
+          shouldDeferCompletion(state) {
+            assert.equal(getAnnotations(state)?.[marker], "seen");
+            return true;
+          },
+          *suggest() {},
+          getDocFragments() {
+            return { fragments: [] };
+          },
+        };
+      const parser = prompt(inner, {
+        type: "input",
+        message: "profile?",
+      } as never);
+      const state = injectAnnotations(parser.initialState, {
+        [marker]: "seen",
+      });
+
+      const result = await parser.complete(state);
+
+      assert.ok(result.success);
+      if (!result.success) return;
+      assert.deepEqual(result.value, { name: "", meta: { id: "" } });
+      assert.equal(result.deferred, true);
+      assert.deepEqual(
+        result.deferredKeys,
+        new Map<PropertyKey, null>([
+          ["name", null],
+          ["meta", null],
+        ]),
+      );
+    });
+
+    it("marks array placeholders as deferred without touching length", async () => {
+      const inner: Parser<"sync", readonly string[], undefined> & {
+        readonly placeholder: readonly string[];
+      } = {
+        mode: "sync",
+        $valueType: [] as readonly (readonly string[])[],
+        $stateType: [] as readonly undefined[],
+        priority: 0,
+        usage: [],
+        leadingNames: new Set(),
+        acceptingAnyToken: false,
+        initialState: undefined,
+        placeholder: ["alpha", "beta"],
+        parse(context) {
+          return {
+            success: true as const,
+            next: context,
+            consumed: [],
+          };
+        },
+        complete() {
+          return { success: true as const, value: undefined as never };
+        },
+        shouldDeferCompletion() {
+          return true;
+        },
+        *suggest() {},
+        getDocFragments() {
+          return { fragments: [] };
+        },
+      };
+      const parser = prompt(inner, {
+        type: "checkbox",
+        message: "tags?",
+        choices: [],
+      });
+
+      const result = await parser.complete(parser.initialState);
+
+      assert.ok(result.success);
+      if (!result.success) return;
+      assert.deepEqual(result.value, ["alpha", "beta"]);
+      assert.equal(result.deferred, true);
+      assert.deepEqual(
+        result.deferredKeys,
+        new Map<PropertyKey, null>([
+          ["0", null],
+          ["1", null],
+        ]),
+      );
+      assert.equal(result.deferredKeys?.has("length"), false);
+    });
+
     it("only marks hasCliValue when inner parser consumed tokens", async () => {
       // A mock parser that always succeeds with consumed: [] (like bindConfig
       // or withDefault returning a value without consuming CLI tokens).

--- a/packages/inquirer/src/index.test.ts
+++ b/packages/inquirer/src/index.test.ts
@@ -1318,6 +1318,57 @@ describe("prompt()", () => {
       assert.equal(result.deferredKeys?.has("length"), false);
     });
 
+    it("treats throwing placeholders as absent while deferring prompt", async () => {
+      const inner: Parser<"sync", string | undefined, undefined> & {
+        readonly placeholder: string;
+      } = {
+        mode: "sync",
+        $valueType: [] as readonly (string | undefined)[],
+        $stateType: [] as readonly undefined[],
+        priority: 0,
+        usage: [],
+        leadingNames: new Set(),
+        acceptingAnyToken: false,
+        initialState: undefined,
+        get placeholder(): string {
+          throw new TypeError("Placeholder is unavailable.");
+        },
+        parse(context) {
+          return {
+            success: true as const,
+            next: context,
+            consumed: [],
+          };
+        },
+        complete() {
+          return { success: true as const, value: undefined };
+        },
+        shouldDeferCompletion() {
+          return true;
+        },
+        *suggest() {},
+        getDocFragments() {
+          return { fragments: [] };
+        },
+      };
+      const parser = prompt(inner, {
+        type: "input",
+        message: "name?",
+      });
+
+      const result = await parser.complete(parser.initialState);
+
+      assert.ok(result.success);
+      if (!result.success) return;
+      assert.equal(result.value, undefined);
+      assert.ok(result.deferred);
+      assert.equal(
+        (parser as typeof parser & { readonly placeholder?: string })
+          .placeholder,
+        undefined,
+      );
+    });
+
     it("only marks hasCliValue when inner parser consumed tokens", async () => {
       // A mock parser that always succeeds with consumed: [] (like bindConfig
       // or withDefault returning a value without consuming CLI tokens).
@@ -1396,6 +1447,19 @@ describe("prompt()", () => {
       assert.deepEqual(nodes[0]?.path, ["prompt"]);
       assert.equal(nodes[0]?.parser, inner);
       assert.equal(nodes[0]?.state, "cli-state");
+
+      const initialNodes = wrapped.getSuggestRuntimeNodes?.(
+        wrapped.initialState as Parameters<
+          NonNullable<typeof wrapped.getSuggestRuntimeNodes>
+        >[0],
+        ["initial"],
+      );
+      assert.ok(initialNodes != null);
+      if (initialNodes == null) return;
+      assert.equal(initialNodes.length, 1);
+      assert.deepEqual(initialNodes[0]?.path, ["initial"]);
+      assert.equal(initialNodes[0]?.parser, inner);
+      assert.equal(initialNodes[0]?.state, "initial");
     });
 
     it("preserves delegated suggest nodes for source wrappers", async () => {
@@ -3478,6 +3542,44 @@ describe("prompt()", () => {
   });
 
   describe("internal branch coverage", { concurrency: false }, () => {
+    it("forwards inner value normalization through prompt()", () => {
+      const inner: Parser<"sync", string, undefined> = {
+        mode: "sync",
+        $valueType: [] as readonly string[],
+        $stateType: [] as readonly undefined[],
+        priority: 0,
+        usage: [],
+        leadingNames: new Set(),
+        acceptingAnyToken: false,
+        initialState: undefined,
+        parse(context) {
+          return {
+            success: true as const,
+            next: context,
+            consumed: [],
+          };
+        },
+        complete() {
+          return { success: true as const, value: "value" };
+        },
+        normalizeValue(value) {
+          return value.trim().toLowerCase();
+        },
+        *suggest() {},
+        getDocFragments() {
+          return { fragments: [] };
+        },
+      };
+
+      const parser = prompt(inner, {
+        type: "input",
+        message: "name?",
+      });
+
+      assert.equal(typeof parser.normalizeValue, "function");
+      assert.equal(parser.normalizeValue?.("  ALICE  "), "alice");
+    });
+
     it("covers async parse/suggest/complete branches with wrapped states", async () => {
       let docDefault: unknown;
       const inner: Parser<"async", string, { readonly token?: string }> = {
@@ -5306,6 +5408,65 @@ describe("prompt() with dependency sources", () => {
       assert.deepEqual(extracted, { success: true, value: "prod" });
     },
   );
+
+  it("delegates source extraction for raw inner states", async () => {
+    const sourceId = Symbol("raw-prompt-source");
+    const inner: Parser<"sync", string, { readonly value?: string }> = {
+      mode: "sync",
+      $valueType: [] as readonly string[],
+      $stateType: [] as readonly { readonly value?: string }[],
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(),
+      acceptingAnyToken: false,
+      initialState: {},
+      parse(context) {
+        return {
+          success: true as const,
+          next: context,
+          consumed: [],
+        };
+      },
+      complete(state) {
+        return {
+          success: true as const,
+          value: state.value ?? "fallback",
+        };
+      },
+      *suggest() {},
+      getDocFragments() {
+        return { fragments: [] };
+      },
+      dependencyMetadata: {
+        source: {
+          kind: "source",
+          sourceId,
+          preservesSourceValue: true,
+          extractSourceValue(state) {
+            return state != null &&
+                typeof state === "object" &&
+                "value" in state &&
+                typeof state.value === "string"
+              ? { success: true as const, value: state.value }
+              : undefined;
+          },
+        },
+      },
+    };
+    const parser = prompt(inner, {
+      type: "input",
+      message: "mode?",
+    });
+
+    assert.ok(
+      parser.dependencyMetadata?.source != null,
+      "Expected source metadata.",
+    );
+    const extracted = await parser.dependencyMetadata.source
+      .extractSourceValue({ value: "prod" });
+
+    assert.deepEqual(extracted, { success: true, value: "prod" });
+  });
 
   describe("shared-buffer wrapper contracts", () => {
     for (const kind of ["tuple", "concat"] as const) {

--- a/packages/logtape/src/index.test.ts
+++ b/packages/logtape/src/index.test.ts
@@ -890,6 +890,23 @@ describe("createConsoleSink()", () => {
     );
   });
 
+  it("should fall back when object stream stringifies to undefined", () => {
+    const stream = {
+      toJSON() {
+        return undefined;
+      },
+    };
+
+    assert.throws(
+      () => createConsoleSink({ stream: stream as never }),
+      {
+        name: "TypeError",
+        message:
+          'Invalid stream: expected "stdout" or "stderr", got [object Object].',
+      },
+    );
+  });
+
   it("should throw TypeError for cyclic object stream (JSON.stringify throws)", () => {
     // When JSON.stringify throws (cyclic object), the catch block falls back
     // to String(value) = "[object Object]" (lines 238–240 in output.ts).

--- a/packages/temporal/src/index.test.ts
+++ b/packages/temporal/src/index.test.ts
@@ -29,6 +29,43 @@ if (usingPolyfill) {
   globalThis.Temporal = polyfill.Temporal;
 }
 
+function throwingTemporalType<
+  T extends { readonly from: (...args: never[]) => unknown },
+>(
+  originalType: T,
+): T {
+  const clone = Object.create(originalType) as T;
+  Object.defineProperty(clone, "from", {
+    value() {
+      throw new RangeError("placeholder unavailable.");
+    },
+    configurable: true,
+  });
+  return clone;
+}
+
+function canShadowTemporalConstructors(): boolean {
+  const originalTemporal = globalThis.Temporal;
+  if (originalTemporal == null) return false;
+  try {
+    Object.defineProperty(globalThis, "Temporal", {
+      value: {
+        ...originalTemporal,
+        Instant: throwingTemporalType(originalTemporal.Instant),
+      },
+      configurable: true,
+    });
+    return instant().placeholder === undefined;
+  } catch {
+    return false;
+  } finally {
+    Object.defineProperty(globalThis, "Temporal", {
+      value: originalTemporal,
+      configurable: true,
+    });
+  }
+}
+
 describe("instant", () => {
   const parser = instant();
 
@@ -1631,5 +1668,45 @@ describe("placeholder values", () => {
     assert.ok(p instanceof Temporal.PlainMonthDay);
     assert.equal(p.monthCode, "M01");
     assert.equal(p.day, 1);
+  });
+
+  const canShadowTemporal = canShadowTemporalConstructors();
+  it("placeholder getters fall back to undefined when Temporal.from throws", {
+    skip: !canShadowTemporal,
+  }, () => {
+    if (!canShadowTemporal) return;
+
+    const originalTemporal = globalThis.Temporal;
+
+    try {
+      Object.defineProperty(globalThis, "Temporal", {
+        value: {
+          ...originalTemporal,
+          Instant: throwingTemporalType(originalTemporal.Instant),
+          Duration: throwingTemporalType(originalTemporal.Duration),
+          ZonedDateTime: throwingTemporalType(originalTemporal.ZonedDateTime),
+          PlainDate: throwingTemporalType(originalTemporal.PlainDate),
+          PlainTime: throwingTemporalType(originalTemporal.PlainTime),
+          PlainDateTime: throwingTemporalType(originalTemporal.PlainDateTime),
+          PlainYearMonth: throwingTemporalType(originalTemporal.PlainYearMonth),
+          PlainMonthDay: throwingTemporalType(originalTemporal.PlainMonthDay),
+        },
+        configurable: true,
+      });
+
+      assert.equal(instant().placeholder, undefined);
+      assert.equal(duration().placeholder, undefined);
+      assert.equal(zonedDateTime().placeholder, undefined);
+      assert.equal(plainDate().placeholder, undefined);
+      assert.equal(plainTime().placeholder, undefined);
+      assert.equal(plainDateTime().placeholder, undefined);
+      assert.equal(plainYearMonth().placeholder, undefined);
+      assert.equal(plainMonthDay().placeholder, undefined);
+    } finally {
+      Object.defineProperty(globalThis, "Temporal", {
+        value: originalTemporal,
+        configurable: true,
+      });
+    }
   });
 });

--- a/packages/valibot/src/index.test.ts
+++ b/packages/valibot/src/index.test.ts
@@ -932,6 +932,35 @@ describe("valibot()", () => {
       assert.equal(parser.choices, undefined);
       assert.equal(parser.suggest, undefined);
     });
+
+    it("should not expose choices from malformed internal choice metadata", () => {
+      const malformedPicklist = valibot({
+        type: "picklist",
+        options: "not-array",
+      } as never, { placeholder: "" });
+      assert.equal(malformedPicklist.metavar, "CHOICE");
+      assert.equal(malformedPicklist.choices, undefined);
+      assert.equal(malformedPicklist.suggest, undefined);
+
+      const malformedUnionOptions = valibot({
+        type: "union",
+        options: "not-array",
+      } as never, { placeholder: "" });
+      assert.equal(malformedUnionOptions.metavar, "VALUE");
+      assert.equal(malformedUnionOptions.choices, undefined);
+      assert.equal(malformedUnionOptions.suggest, undefined);
+
+      const malformedUnionMember = valibot({
+        type: "union",
+        options: [
+          { type: "literal", literal: "dev" },
+          "prod",
+        ],
+      } as never, { placeholder: "" });
+      assert.equal(malformedUnionMember.metavar, "VALUE");
+      assert.equal(malformedUnionMember.choices, undefined);
+      assert.equal(malformedUnionMember.suggest, undefined);
+    });
   });
 
   describe("async schema rejection", () => {

--- a/packages/valibot/src/index.test.ts
+++ b/packages/valibot/src/index.test.ts
@@ -1334,6 +1334,46 @@ describe("valibot()", () => {
       assert.ok(result.success);
     });
 
+    it("should not reject union with v.pipe(v.any(), safe-transform) arm", () => {
+      const asyncInner = v.pipeAsync(
+        v.string(),
+        // deno-lint-ignore require-await
+        v.checkAsync(async (val) => val === "ok", "not ok"),
+      );
+      const asyncSchema = v.union([
+        v.pipe(v.any(), v.toLowerCase() as never),
+        asyncInner,
+      ] as never);
+      const parser = valibot(asyncSchema as never, {
+        placeholder: "" as never,
+      });
+      const result = parser.parse("HELLO");
+      assert.ok(result.success);
+      if (result.success) {
+        assert.equal(result.value, "hello");
+      }
+    });
+
+    it("should not reject union with v.pipe(v.string(), safe-transform) arm", () => {
+      const asyncInner = v.pipeAsync(
+        v.string(),
+        // deno-lint-ignore require-await
+        v.checkAsync(async (val) => val === "ok", "not ok"),
+      );
+      const asyncSchema = v.union([
+        v.pipe(v.string(), v.toUpperCase()),
+        asyncInner,
+      ] as never);
+      const parser = valibot(asyncSchema as never, {
+        placeholder: "" as never,
+      });
+      const result = parser.parse("hello");
+      assert.ok(result.success);
+      if (result.success) {
+        assert.equal(result.value, "HELLO");
+      }
+    });
+
     it("should not reject union with nested schema in string pipe catch-all", () => {
       const asyncInner = v.pipeAsync(
         v.string(),
@@ -1366,6 +1406,77 @@ describe("valibot()", () => {
         v.pipe(v.string(), v.email()),
         asyncInner,
       ] as never);
+      assert.throws(
+        () => valibot(asyncSchema as never, { placeholder: "" as never }),
+        expectedError,
+      );
+    });
+
+    it("should reject async map members after transform", () => {
+      const asyncInner = v.pipeAsync(
+        v.string(),
+        // deno-lint-ignore require-await
+        v.checkAsync(async (val) => val === "ok", "not ok"),
+      );
+      const asyncKeySchema = v.pipe(
+        v.string(),
+        v.transform(() => new Map()),
+        v.map(asyncInner as never, v.string()),
+      );
+      assert.throws(
+        () => valibot(asyncKeySchema as never, { placeholder: "" as never }),
+        expectedError,
+      );
+
+      const asyncValueSchema = v.pipe(
+        v.string(),
+        v.transform(() => new Map()),
+        v.map(v.string(), asyncInner as never),
+      );
+      assert.throws(
+        () => valibot(asyncValueSchema as never, { placeholder: "" as never }),
+        expectedError,
+      );
+    });
+
+    it("should reject async rest schemas after transform", () => {
+      const asyncRest = v.pipeAsync(
+        v.string(),
+        // deno-lint-ignore require-await
+        v.checkAsync(async (val) => val === "ok", "not ok"),
+      );
+      const objectSchema = v.pipe(
+        v.string(),
+        v.transform(() => ({ extra: "ok" })) as never,
+        v.objectWithRest({}, asyncRest as never) as never,
+      );
+      assert.throws(
+        () => valibot(objectSchema as never, { placeholder: "" as never }),
+        expectedError,
+      );
+
+      const tupleSchema = v.pipe(
+        v.string(),
+        v.transform(() => ["ok"]) as never,
+        v.tupleWithRest([], asyncRest as never) as never,
+      );
+      assert.throws(
+        () => valibot(tupleSchema as never, { placeholder: "" as never }),
+        expectedError,
+      );
+    });
+
+    it("should propagate type-changing nested pipe schemas to later containers", () => {
+      const asyncInner = v.pipeAsync(
+        v.string(),
+        // deno-lint-ignore require-await
+        v.checkAsync(async (val) => val === "ok", "not ok"),
+      );
+      const asyncSchema = v.pipe(
+        v.string(),
+        v.pipe(v.string(), v.transform(JSON.parse)) as never,
+        v.object({ value: asyncInner } as never),
+      );
       assert.throws(
         () => valibot(asyncSchema as never, { placeholder: "" as never }),
         expectedError,

--- a/packages/zod/src/index.test.ts
+++ b/packages/zod/src/index.test.ts
@@ -1678,6 +1678,79 @@ describe("Zod internal compatibility branches", () => {
       assert.equal(formatMessage(result.error), '"Validation failed"');
     }
   });
+
+  it("should suppress boolean choices through legacy effect wrappers", () => {
+    const booleanSchema = fakeZodSchema<boolean>(
+      { typeName: "ZodBoolean" },
+      (input) =>
+        typeof input === "boolean"
+          ? { success: true, data: input }
+          : zodFailure("Expected boolean."),
+    );
+    const preprocessParser = zod(
+      fakeZodSchema<boolean>(
+        {
+          typeName: "ZodEffects",
+          effect: { type: "preprocess" },
+          schema: booleanSchema,
+        },
+        () => ({ success: true, data: false }),
+      ),
+      { placeholder: false },
+    );
+    assert.equal(preprocessParser.metavar, "VALUE");
+    assert.equal(preprocessParser.choices, undefined);
+    assert.equal(preprocessParser.suggest, undefined);
+
+    const cases = [
+      fakeZodSchema<boolean>(
+        { typeName: "ZodEffects", schema: booleanSchema },
+        () => ({ success: true, data: false }),
+      ),
+      fakeZodSchema<boolean>(
+        { typeName: "ZodCatch", innerType: booleanSchema },
+        () => ({ success: true, data: false }),
+      ),
+    ];
+
+    for (const schema of cases) {
+      const parser = zod(schema, { placeholder: false });
+      assert.equal(parser.metavar, "BOOLEAN");
+      assert.equal(parser.choices, undefined);
+      assert.equal(parser.suggest, undefined);
+    }
+  });
+
+  it("should infer booleans through legacy branded and pipeline wrappers", () => {
+    const booleanSchema = fakeZodSchema<boolean>(
+      { typeName: "ZodBoolean" },
+      (input) =>
+        typeof input === "boolean"
+          ? { success: true, data: input }
+          : zodFailure("Expected boolean."),
+    );
+    const cases = [
+      fakeZodSchema<boolean>(
+        { typeName: "ZodBranded", type: booleanSchema },
+        () => ({ success: true, data: true }),
+      ),
+      fakeZodSchema<boolean>(
+        { typeName: "ZodPipeline", innerType: booleanSchema },
+        () => ({ success: true, data: true }),
+      ),
+      fakeZodSchema<boolean>(
+        { typeName: "pipeline", innerType: booleanSchema },
+        () => ({ success: true, data: true }),
+      ),
+    ];
+
+    for (const schema of cases) {
+      const parser = zod(schema, { placeholder: false });
+      assert.equal(parser.metavar, "BOOLEAN");
+      assert.equal(parser.choices, undefined);
+      assert.equal(parser.suggest, undefined);
+    }
+  });
 });
 
 // Helpers

--- a/packages/zod/src/index.test.ts
+++ b/packages/zod/src/index.test.ts
@@ -1,4 +1,4 @@
-import { message } from "@optique/core/message";
+import { formatMessage, message } from "@optique/core/message";
 import { zod } from "@optique/zod";
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
@@ -1542,3 +1542,171 @@ describe("parse() — non-async errors are re-thrown", () => {
     );
   });
 });
+
+describe("Zod internal compatibility branches", () => {
+  it("should detect legacy async parse error messages", () => {
+    const messages = [
+      "Async refinement encountered during synchronous parse operation. Use .parseAsync instead.",
+      "Asynchronous transform encountered during synchronous parse operation. Use .parseAsync instead.",
+      "Synchronous parse encountered promise.",
+    ];
+
+    for (const asyncMessage of messages) {
+      const parser = zod(
+        fakeZodSchema<string>({ typeName: "ZodString" }, () => {
+          throw new Error(asyncMessage);
+        }),
+        { placeholder: "" },
+      );
+
+      assert.throws(
+        () => parser.parse("value"),
+        {
+          name: "TypeError",
+          message:
+            "Async Zod schemas (e.g., async refinements) are not supported by zod(). Use synchronous schemas instead.",
+        },
+      );
+    }
+  });
+
+  it("should infer choices from Zod v3 enum internals", () => {
+    const parser = zod(
+      fakeZodSchema<string>(
+        { typeName: "ZodEnum", values: ["debug", "info"] },
+        (input) => (
+          input === "debug" || input === "info"
+            ? { success: true, data: input }
+            : zodFailure("Invalid enum value.")
+        ),
+      ),
+      { placeholder: "debug" },
+    );
+
+    assert.deepEqual(parser.choices, ["debug", "info"]);
+    assert.deepEqual([...parser.suggest?.("i") ?? []], [
+      { kind: "literal", text: "info" },
+    ]);
+  });
+
+  it("should infer choices from Zod v3 native enum internals", () => {
+    const parser = zod(
+      fakeZodSchema<string>(
+        { typeName: "ZodNativeEnum", values: { Debug: "debug", Info: "info" } },
+        (input) => (
+          input === "debug" || input === "info"
+            ? { success: true, data: input }
+            : zodFailure("Invalid native enum value.")
+        ),
+      ),
+      { placeholder: "debug" },
+    );
+
+    assert.deepEqual(parser.choices, ["debug", "info"]);
+  });
+
+  it("should infer choices from legacy literal and union internals", () => {
+    const prod = fakeZodSchema<string>(
+      { typeName: "ZodLiteral", value: "prod" },
+      (input) =>
+        input === "prod"
+          ? { success: true, data: "prod" }
+          : zodFailure("Invalid literal value."),
+    );
+    const dev = fakeZodSchema<string>(
+      { typeName: "ZodLiteral", values: ["dev"] },
+      (input) =>
+        input === "dev"
+          ? { success: true, data: "dev" }
+          : zodFailure("Invalid literal value."),
+    );
+    const parser = zod(
+      fakeZodSchema<string>(
+        { typeName: "ZodUnion", options: [prod, dev] },
+        (input) =>
+          input === "prod" || input === "dev"
+            ? { success: true, data: input }
+            : zodFailure("Invalid union value."),
+      ),
+      { placeholder: "prod" },
+    );
+
+    assert.deepEqual(parser.choices, ["prod", "dev"]);
+  });
+
+  it("should reject non-string legacy choice internals", () => {
+    const numericNativeEnum = zod(
+      fakeZodSchema<number>(
+        { typeName: "ZodNativeEnum", values: { A: 0, 0: "A" } },
+        () => zodFailure("Invalid native enum value."),
+      ),
+      { placeholder: 0 },
+    );
+    const numericLiteral = zod(
+      fakeZodSchema<number>(
+        { typeName: "ZodLiteral", values: [1] },
+        () => zodFailure("Invalid literal value."),
+      ),
+      { placeholder: 1 },
+    );
+    const malformedUnion = zod(
+      fakeZodSchema<string>(
+        { typeName: "ZodUnion", options: "not-array" },
+        () => zodFailure("Invalid union value."),
+      ),
+      { placeholder: "" },
+    );
+
+    assert.equal(numericNativeEnum.choices, undefined);
+    assert.equal(numericLiteral.choices, undefined);
+    assert.equal(malformedUnion.choices, undefined);
+  });
+
+  it("should use default validation message when a fake schema has no issues", () => {
+    const parser = zod(
+      fakeZodSchema<string>(
+        { typeName: "ZodString" },
+        () => ({ success: false, error: new z.ZodError([]) }),
+      ),
+      { placeholder: "" },
+    );
+
+    const result = parser.parse("bad");
+
+    assert.ok(!result.success);
+    if (!result.success) {
+      assert.equal(formatMessage(result.error), '"Validation failed"');
+    }
+  });
+});
+
+// Helpers
+
+type FakeZodResult<T> =
+  | { readonly success: true; readonly data: T }
+  | { readonly success: false; readonly error: z.ZodError };
+
+function fakeZodSchema<T>(
+  def: Record<string, unknown>,
+  safeParse: (input: unknown) => FakeZodResult<T>,
+): z.Schema<T> {
+  const schema = {} as z.Schema<T>;
+  return new Proxy(schema, {
+    get(target, key, receiver): unknown {
+      if (key === "_def") return def;
+      if (key === "safeParse") return safeParse;
+      return Reflect.get(target, key, receiver);
+    },
+  });
+}
+
+function zodFailure(message: string): FakeZodResult<never> {
+  return {
+    success: false,
+    error: new z.ZodError([{
+      code: "custom",
+      message,
+      path: [],
+    }]),
+  };
+}


### PR DESCRIPTION
This PR raises the official `mise coverage` result to the target 95% line and branch coverage threshold, with focused tests across *packages/core*, *packages/env*, *packages/config*, *packages/inquirer*, *packages/git*, *packages/temporal*, *packages/valibot*, *packages/zod*, *packages/logtape*, and the *examples/gitique* example.

Most of the new coverage is in parser edge cases: replay behavior, fallback metadata, dependency replay, deferred parser state, completion probes, source extraction, and value parser normalization. The goal was not to pin implementation details, but to cover the behaviors that could break user-facing parsing, completion, or fallback flows.

While adding completion coverage, this found and fixed a shell completion bug in *packages/core/src/facade.ts*. Configured help and version options such as `--help`, `--version`, aliases, slash-prefixed names, and plus-prefixed names are now suggested at the root option position. Completion payloads such as `build --help ""` and `build --version ""` are still treated as completion context, not as active help/version requests.

This also fixes plus-prefixed option completion in *packages/core/src/primitives.ts*, so parser options and flags like `+debug` are recognized as option-prefix completions. The regression coverage lives in *packages/core/src/facade.test.ts* and *packages/core/src/primitives.test.ts*. The changelog entry is in *CHANGES.md*.

## Testing

- `mise coverage`
- `mise check && mise test:deno && CI=true mise test:node && CI=true mise test:bun`

## Coverage result

- Official processed `mise coverage` table: branch 95.0%, line 95.0%