### PR TITLE
`fileSize()` value parser for human-readable data sizes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -55,10 +55,20 @@ To be released.
     Documentation and the negatable Boolean options pattern example now show
     the new primitive.  [[#801], [#802]]
 
+ -  Added `fileSize()` value parser for parsing human-readable data size
+    strings such as `"10MB"` or `"1.5GiB"` into byte counts.  Supports
+    both SI units (`KB`, `MB`, `GB`, …) and IEC units (`KiB`, `MiB`,
+    `GiB`, …), case-insensitive input, optional negative values via
+    `allowNegative`, a configurable `defaultUnit` for bare numbers, and
+    a `siAsBinary` mode that interprets SI suffixes as powers of 1 024
+    (matching the common but technically incorrect convention where
+    1 KB = 1 024 bytes).  [[#807]]
+
 [#801]: https://github.com/dahlia/optique/issues/801
 [#802]: https://github.com/dahlia/optique/pull/802
 [#803]: https://github.com/dahlia/optique/issues/803
 [#805]: https://github.com/dahlia/optique/pull/805
+[#807]: https://github.com/dahlia/optique/issues/807
 
 ### @optique/env
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -59,10 +59,13 @@ To be released.
     strings such as `"10MB"` or `"1.5GiB"` into byte counts.  Supports
     both SI units (`KB`, `MB`, `GB`, …) and IEC units (`KiB`, `MiB`,
     `GiB`, …), case-insensitive input, optional negative values via
-    `allowNegative`, a configurable `defaultUnit` for bare numbers, and
-    a `siAsBinary` mode that interprets SI suffixes as powers of 1 024
+    `allowNegative`, a configurable `defaultUnit` for bare numbers, a
+    `siAsBinary` mode that interprets SI suffixes as powers of 1 024
     (matching the common but technically incorrect convention where
-    1 KB = 1 024 bytes).  [[#807]]
+    1 KB = 1 024 bytes), and a `type: "bigint"` mode that returns
+    `bigint` instead of `number`, enabling exact representation of
+    byte counts beyond `Number.MAX_SAFE_INTEGER` (including EB/EiB
+    values).  [[#807]]
 
 [#801]: https://github.com/dahlia/optique/issues/801
 [#802]: https://github.com/dahlia/optique/pull/802

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -65,13 +65,14 @@ To be released.
     1 KB = 1 024 bytes), and a `type: "bigint"` mode that returns
     `bigint` instead of `number`, enabling exact representation of
     byte counts beyond `Number.MAX_SAFE_INTEGER` (including EB/EiB
-    values).  [[#807]]
+    values).  [[#807], [#814]]
 
 [#801]: https://github.com/dahlia/optique/issues/801
 [#802]: https://github.com/dahlia/optique/pull/802
 [#803]: https://github.com/dahlia/optique/issues/803
 [#805]: https://github.com/dahlia/optique/pull/805
 [#807]: https://github.com/dahlia/optique/issues/807
+[#814]: https://github.com/dahlia/optique/pull/814
 
 ### @optique/env
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,5 +1,6 @@
 import { transformerTwoslash } from "@shikijs/vitepress-twoslash";
 import deflist from "markdown-it-deflist";
+import footnote from "markdown-it-footnote";
 import process from "node:process";
 import { ModuleKind, ModuleResolutionKind, ScriptTarget } from "typescript";
 import { defineConfig } from "vitepress";
@@ -211,6 +212,7 @@ export default defineConfig({
     ],
     config(md) {
       md.use(deflist);
+      md.use(footnote);
       md.use(groupIconMdPlugin);
     },
   },

--- a/docs/concepts/valueparsers.md
+++ b/docs/concepts/valueparsers.md
@@ -33,7 +33,7 @@ with Optique's type system.
 | `string()`                       | *@optique/core*     | `string`                       | Any string, with optional pattern validation        |
 | `integer()`                      | *@optique/core*     | `number` or `bigint`           | Integer with range validation                       |
 | `float()`                        | *@optique/core*     | `number`                       | Floating-point number                               |
-| `fileSize()`                     | *@optique/core*     | `number`                       | Human-readable data size (bytes)                    |
+| `fileSize()`                     | *@optique/core*     | `number` or `bigint`           | Human-readable data size (bytes)                    |
 | `choice()`                       | *@optique/core*     | string or number literal union | Enumerated values                                   |
 | `url()`                          | *@optique/core*     | `URL`                          | URL with protocol filtering                         |
 | `locale()`                       | *@optique/core*     | `Intl.Locale`                  | BCP 47 locale identifier                            |
@@ -280,12 +280,11 @@ Unit suffixes are matched case-insensitively: `"1kb"`, `"1KB"`, and `"1Kb"`
 are all treated as 1 000 bytes.  Optional whitespace between the number and
 unit is also accepted (`"1 MB"`).
 
-[^filesize-safe]: Because `fileSize()` returns a JavaScript `number`, the result
-                  must be a safe integer (≤ `Number.MAX_SAFE_INTEGER` ≈ 9 ×
-                  10^15). In practice this means values in the `EB`/`EiB` range
-                  and values above roughly 9 PB or 8 PiB are rejected. If you
-                  need to handle sizes this large, use the `string()` parser
-                  with manual conversion.
+[^filesize-safe]: In `number` mode (the default), the result must be a safe
+                  integer (≤ `Number.MAX_SAFE_INTEGER` ≈ 9 × 10^15). Values in
+                  the `EB`/`EiB` range and values above roughly 9 PB or 8 PiB
+                  are therefore rejected. Use `type: "bigint"` to lift this
+                  restriction — see the [bigint mode](#bigint-mode) section.
 
 ### Default unit
 
@@ -325,6 +324,24 @@ const legacySize = fileSize({ siAsBinary: true });
 
 IEC suffixes (`KiB`, `MiB`, …) are unaffected by this option and always
 use powers of 1 024.
+
+### Bigint mode {#bigint-mode}
+
+By default, `fileSize()` returns `number`, which cannot represent byte counts
+above roughly 9 PB exactly.  Pass `type: "bigint"` to get a `bigint` result
+instead — this lifts the safe-integer restriction and makes `EB`/`EiB` values
+usable:
+
+~~~~ typescript twoslash
+import { fileSize } from "@optique/core/valueparser";
+// ---cut-before---
+const diskLimit = fileSize({ type: "bigint" });
+// "1EB" → 1_000_000_000_000_000_000n
+// "1EiB" → 1_152_921_504_606_846_976n
+~~~~
+
+All options (`allowNegative`, `defaultUnit`, `siAsBinary`, `metavar`) work
+the same way in bigint mode.
 
 ### Error messages
 

--- a/docs/concepts/valueparsers.md
+++ b/docs/concepts/valueparsers.md
@@ -33,6 +33,7 @@ with Optique's type system.
 | `string()`                       | *@optique/core*     | `string`                       | Any string, with optional pattern validation        |
 | `integer()`                      | *@optique/core*     | `number` or `bigint`           | Integer with range validation                       |
 | `float()`                        | *@optique/core*     | `number`                       | Floating-point number                               |
+| `fileSize()`                     | *@optique/core*     | `number`                       | Human-readable data size (bytes)                    |
 | `choice()`                       | *@optique/core*     | string or number literal union | Enumerated values                                   |
 | `url()`                          | *@optique/core*     | `URL`                          | URL with protocol filtering                         |
 | `locale()`                       | *@optique/core*     | `Intl.Locale`                  | BCP 47 locale identifier                            |
@@ -238,6 +239,107 @@ const value = float({
 
 The parser uses `"NUMBER"` as its default metavar and provides clear error
 messages for invalid formats and out-of-range values.
+
+
+`fileSize()` parser
+-------------------
+
+*This API is available since Optique 1.1.0.*
+
+The `fileSize()` parser converts human-readable data size strings into a
+`number` representing the equivalent byte count.  It is useful for CLI tools
+that accept storage limits, upload caps, log rotation thresholds, or similar
+size values.
+
+~~~~ typescript twoslash
+import { fileSize } from "@optique/core/valueparser";
+
+// Parses "10MB", "1.5GiB", "512B", etc. → number (bytes)
+const maxUpload = fileSize();
+
+// Custom metavar shown in help text
+const cacheSize = fileSize({ metavar: "SIZE" });
+~~~~
+
+### Supported units
+
+The parser accepts both SI (decimal) and IEC (binary) unit suffixes,
+matched case-insensitively:
+
+| Unit | Bytes (SI/default)     | Unit | Bytes (IEC)           |
+| ---- | ---------------------- | ---- | --------------------- |
+| B    | 1                      |      |                       |
+| KB   | 1 000                  | KiB  | 1 024                 |
+| MB   | 1 000 000              | MiB  | 1 048 576             |
+| GB   | 1 000 000 000          | GiB  | 1 073 741 824         |
+| TB   | 1 000 000 000 000      | TiB  | 1 099 511 627 776     |
+| PB   | 10^15                  | PiB  | 2^50                  |
+| EB   | 10^18 [^filesize-safe] | EiB  | 2^60 [^filesize-safe] |
+
+Unit suffixes are matched case-insensitively: `"1kb"`, `"1KB"`, and `"1Kb"`
+are all treated as 1 000 bytes.  Optional whitespace between the number and
+unit is also accepted (`"1 MB"`).
+
+[^filesize-safe]: Because `fileSize()` returns a JavaScript `number`, the result
+                  must be a safe integer (≤ `Number.MAX_SAFE_INTEGER` ≈ 9 ×
+                  10^15). In practice this means values in the `EB`/`EiB` range
+                  and values above roughly 9 PB or 8 PiB are rejected. If you
+                  need to handle sizes this large, use the `string()` parser
+                  with manual conversion.
+
+### Default unit
+
+When a bare number is provided without a unit, `fileSize()` rejects it by
+default.  Use the `defaultUnit` option to assume a unit in that case:
+
+~~~~ typescript twoslash
+import { fileSize } from "@optique/core/valueparser";
+// ---cut-before---
+// "100" → 100 000 000 bytes; "100MB" → still 100 000 000 bytes
+const parser = fileSize({ defaultUnit: "MB" });
+~~~~
+
+### Allowing negative values
+
+By default, negative values are rejected.  Pass `allowNegative: true` to
+accept them:
+
+~~~~ typescript twoslash
+import { fileSize } from "@optique/core/valueparser";
+// ---cut-before---
+const delta = fileSize({ allowNegative: true });
+~~~~
+
+### SI-as-binary mode
+
+Some tools use `KB`, `MB`, `GB` etc. to mean powers of 1 024 rather than
+1 000 — a widespread but technically incorrect convention.  Enable
+`siAsBinary: true` to match that behaviour:
+
+~~~~ typescript twoslash
+import { fileSize } from "@optique/core/valueparser";
+// ---cut-before---
+// "1KB" → 1 024 bytes instead of 1 000
+const legacySize = fileSize({ siAsBinary: true });
+~~~~
+
+IEC suffixes (`KiB`, `MiB`, …) are unaffected by this option and always
+use powers of 1 024.
+
+### Error messages
+
+~~~~ bash
+$ myapp --max-upload "abc"
+Error: Expected a file size like 10MB or 1.5GiB, but got abc.
+
+$ myapp --max-upload "100"
+Error: Expected a file size like 10MB or 1.5GiB, but got 100.
+
+$ myapp --max-upload "-1MB"
+Error: Expected a non-negative file size, but got -1MB.
+~~~~
+
+The parser uses `"SIZE"` as its default metavar.
 
 
 `choice()` parser

--- a/docs/concepts/valueparsers.md
+++ b/docs/concepts/valueparsers.md
@@ -284,7 +284,7 @@ unit is also accepted (`"1 MB"`).
                   integer (≤ `Number.MAX_SAFE_INTEGER` ≈ 9 × 10^15). Values in
                   the `EB`/`EiB` range and values above roughly 9 PB or 8 PiB
                   are therefore rejected. Use `type: "bigint"` to lift this
-                  restriction — see the [bigint mode](#bigint-mode) section.
+                  restriction—see the [bigint mode](#bigint-mode) section.
 
 ### Default unit
 

--- a/docs/concepts/valueparsers.md
+++ b/docs/concepts/valueparsers.md
@@ -325,7 +325,7 @@ const legacySize = fileSize({ siAsBinary: true });
 IEC suffixes (`KiB`, `MiB`, …) are unaffected by this option and always
 use powers of 1 024.
 
-### Bigint mode {#bigint-mode}
+### Bigint mode
 
 By default, `fileSize()` returns `number`, which cannot represent byte counts
 above roughly 9 PB exactly.  Pass `type: "bigint"` to get a `bigint` result

--- a/docs/package.json
+++ b/docs/package.json
@@ -16,6 +16,7 @@
     "@types/node": "catalog:",
     "arktype": "^2.1.29",
     "markdown-it-deflist": "^3.0.0",
+    "markdown-it-footnote": "^4.0.0",
     "typescript": "catalog:",
     "valibot": "catalog:",
     "vitepress": "^2.0.0-alpha.15",

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -16448,11 +16448,24 @@ describe("fileSize() — bigint mode", () => {
   });
 
   describe("option validation", () => {
+    it("throws TypeError for invalid type", () => {
+      assert.throws(
+        // @ts-ignore intentionally invalid
+        () => fileSize({ type: "bytes" }),
+        (e: unknown) =>
+          e instanceof TypeError &&
+          e.message ===
+            'Expected type to be "number" or "bigint", but got: bytes.',
+      );
+    });
+
     it("throws TypeError for empty metavar", () => {
       assert.throws(
         // @ts-ignore intentionally invalid
         () => fileSize({ type: "bigint", metavar: "" }),
-        TypeError,
+        (e: unknown) =>
+          e instanceof TypeError &&
+          e.message === "Expected a non-empty string.",
       );
     });
 
@@ -16460,7 +16473,10 @@ describe("fileSize() — bigint mode", () => {
       assert.throws(
         // @ts-ignore intentionally invalid
         () => fileSize({ type: "bigint", allowNegative: "yes" }),
-        TypeError,
+        (e: unknown) =>
+          e instanceof TypeError &&
+          e.message ===
+            "Expected allowNegative to be a boolean, but got string: yes.",
       );
     });
 
@@ -16468,7 +16484,10 @@ describe("fileSize() — bigint mode", () => {
       assert.throws(
         // @ts-ignore intentionally invalid
         () => fileSize({ type: "bigint", siAsBinary: 1 }),
-        TypeError,
+        (e: unknown) =>
+          e instanceof TypeError &&
+          e.message ===
+            "Expected siAsBinary to be a boolean, but got number: 1.",
       );
     });
 
@@ -16476,7 +16495,12 @@ describe("fileSize() — bigint mode", () => {
       assert.throws(
         // @ts-ignore intentionally invalid
         () => fileSize({ type: "bigint", defaultUnit: "XB" }),
-        TypeError,
+        (e: unknown) =>
+          e instanceof TypeError &&
+          e.message ===
+            'Expected defaultUnit to be one of "B", "KB", "MB", "GB", ' +
+              '"TB", "PB", "EB", "KiB", "MiB", "GiB", "TiB", "PiB", ' +
+              '"EiB", but got string: "XB".',
       );
     });
   });

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -16037,6 +16037,36 @@ describe("fileSize()", () => {
       const r = fileSize().parse("0.99999999999999999B");
       assert.ok(!r.success);
     });
+
+    it("rejects byte counts exceeding Number.MAX_SAFE_INTEGER for any unit", () => {
+      const parser = fileSize();
+      fc.assert(
+        fc.property(
+          fc.bigInt({
+            min: BigInt(Number.MAX_SAFE_INTEGER) + 1n,
+            max: 100_000_000_000_000_000_000n,
+          }),
+          (n) => !parser.parse(`${n}B`).success,
+        ),
+        propertyParameters,
+      );
+    });
+  });
+
+  describe("type discriminator", () => {
+    it("type: 'number' explicit returns number", () => {
+      const parser = fileSize({ type: "number" });
+      const r = parser.parse("1MB");
+      assert.ok(r.success);
+      if (r.success) {
+        assert.equal(typeof r.value, "number");
+        assert.equal(r.value, 1_000_000);
+      }
+    });
+
+    it("type: 'number' explicit has same placeholder as default", () => {
+      assert.equal(fileSize({ type: "number" }).placeholder, 0);
+    });
   });
 
   describe("metavar", () => {
@@ -16122,6 +16152,61 @@ describe("fileSize()", () => {
         );
         if (result.success) assert.equal(result.value, bytes);
       }
+    });
+
+    it("round-trips any non-negative safe integer via fast-check", () => {
+      const parser = fileSize();
+      fc.assert(
+        fc.property(
+          fc.integer({ min: 0, max: Number.MAX_SAFE_INTEGER }),
+          (bytes) => {
+            const formatted = parser.format(bytes);
+            const r = parser.parse(formatted);
+            return r.success && r.value === bytes;
+          },
+        ),
+        propertyParameters,
+      );
+    });
+
+    it("round-trips negative values with allowNegative via fast-check", () => {
+      const parser = fileSize({ allowNegative: true });
+      fc.assert(
+        fc.property(
+          fc.integer({ min: -Number.MAX_SAFE_INTEGER, max: -1 }),
+          (bytes) => {
+            const formatted = parser.format(bytes);
+            const r = parser.parse(formatted);
+            return r.success && r.value === bytes;
+          },
+        ),
+        propertyParameters,
+      );
+    });
+
+    it("parse(n × unit) gives n × multiplier for any integer n", () => {
+      const units: readonly [string, number][] = [
+        ["B", 1],
+        ["KB", 1_000],
+        ["MB", 1_000_000],
+        ["GB", 1_000_000_000],
+        ["KiB", 1_024],
+        ["MiB", 1_048_576],
+        ["GiB", 1_073_741_824],
+      ];
+      const parser = fileSize();
+      fc.assert(
+        fc.property(
+          fc.constantFrom(...units),
+          fc.nat({ max: 9_000 }),
+          ([unit, multiplier], n) => {
+            const bytes = n * multiplier;
+            const r = parser.parse(`${n}${unit}`);
+            return r.success && r.value === bytes;
+          },
+        ),
+        propertyParameters,
+      );
     });
   });
 
@@ -16325,6 +16410,89 @@ describe("fileSize() — bigint mode", () => {
       assert.ok(r.success);
       if (r.success) assert.equal(r.value, 1_152_921_504_606_846_976n);
     });
+
+    it("round-trips with siAsBinary: true", () => {
+      const parser = fileSize({ type: "bigint", siAsBinary: true });
+      for (
+        const bytes of [
+          0n,
+          512n,
+          1_024n,
+          1_048_576n,
+          1_073_741_824n,
+          1_152_921_504_606_846_976n,
+        ]
+      ) {
+        const formatted = parser.format(bytes);
+        const result = parser.parse(formatted);
+        assert.ok(
+          result.success,
+          `format(${bytes}) = ${formatted} did not parse`,
+        );
+        if (result.success) assert.equal(result.value, bytes);
+      }
+    });
+  });
+
+  describe("metavar", () => {
+    it("defaults to SIZE", () => {
+      assert.equal(fileSize({ type: "bigint" }).metavar, "SIZE");
+    });
+
+    it("uses custom metavar", () => {
+      assert.equal(
+        fileSize({ type: "bigint", metavar: "BYTES" }).metavar,
+        "BYTES",
+      );
+    });
+  });
+
+  describe("option validation", () => {
+    it("throws TypeError for empty metavar", () => {
+      assert.throws(
+        // @ts-ignore intentionally invalid
+        () => fileSize({ type: "bigint", metavar: "" }),
+        TypeError,
+      );
+    });
+
+    it("throws TypeError for non-boolean allowNegative", () => {
+      assert.throws(
+        // @ts-ignore intentionally invalid
+        () => fileSize({ type: "bigint", allowNegative: "yes" }),
+        TypeError,
+      );
+    });
+
+    it("throws TypeError for non-boolean siAsBinary", () => {
+      assert.throws(
+        // @ts-ignore intentionally invalid
+        () => fileSize({ type: "bigint", siAsBinary: 1 }),
+        TypeError,
+      );
+    });
+
+    it("throws TypeError for invalid defaultUnit", () => {
+      assert.throws(
+        // @ts-ignore intentionally invalid
+        () => fileSize({ type: "bigint", defaultUnit: "XB" }),
+        TypeError,
+      );
+    });
+  });
+
+  describe("optional whitespace between number and unit", () => {
+    it("parses '1 EB' with a space", () => {
+      const r = bigintParser.parse("1 EB");
+      assert.ok(r.success);
+      if (r.success) assert.equal(r.value, 1_000_000_000_000_000_000n);
+    });
+
+    it("parses '1  EiB' with multiple spaces", () => {
+      const r = bigintParser.parse("1  EiB");
+      assert.ok(r.success);
+      if (r.success) assert.equal(r.value, 1_152_921_504_606_846_976n);
+    });
   });
 
   describe("placeholder", () => {
@@ -16376,6 +16544,17 @@ describe("fileSize() — bigint mode", () => {
       assert.equal(bigintParser.format(0n), "0B");
     });
 
+    it("formats 1_500_000_000_000_000_000n (1.5EB) as 1.5EB", () => {
+      assert.equal(bigintParser.format(1_500_000_000_000_000_000n), "1.5EB");
+    });
+
+    it("formats negative values (allowNegative: true)", () => {
+      const parser = fileSize({ type: "bigint", allowNegative: true });
+      assert.equal(parser.format(-1_000_000_000n), "-1GB");
+      assert.equal(parser.format(-1_073_741_824n), "-1GiB");
+      assert.equal(parser.format(-1_000_000_000_000_000_000n), "-1EB");
+    });
+
     it("round-trips representative values", () => {
       const values = [
         0n,
@@ -16393,6 +16572,44 @@ describe("fileSize() — bigint mode", () => {
         if (result.success) assert.equal(result.value, v);
       }
     });
+
+    it("round-trips any non-negative bigint up to 1000 EB via fast-check", () => {
+      const maxBytes = 1_000n * 1_000_000_000_000_000_000n;
+      fc.assert(
+        fc.property(
+          fc.bigInt({ min: 0n, max: maxBytes }),
+          (bytes) => {
+            const formatted = bigintParser.format(bytes);
+            const r = bigintParser.parse(formatted);
+            return r.success && r.value === bytes;
+          },
+        ),
+        propertyParameters,
+      );
+    });
+
+    it("parse(n × unit) gives n × multiplier for any integer n", () => {
+      const units: readonly [string, bigint][] = [
+        ["B", 1n],
+        ["KB", 1_000n],
+        ["MB", 1_000_000n],
+        ["EB", 1_000_000_000_000_000_000n],
+        ["KiB", 1_024n],
+        ["EiB", 1_152_921_504_606_846_976n],
+      ];
+      fc.assert(
+        fc.property(
+          fc.constantFrom(...units),
+          fc.bigInt({ min: 1n, max: 999n }),
+          ([unit, multiplier], n) => {
+            const bytes = n * multiplier;
+            const r = bigintParser.parse(`${n}${unit}`);
+            return r.success && r.value === bytes;
+          },
+        ),
+        propertyParameters,
+      );
+    });
   });
 
   describe("error cases", () => {
@@ -16403,10 +16620,53 @@ describe("fileSize() — bigint mode", () => {
     it("rejects unknown unit", () => {
       assert.ok(!bigintParser.parse("100XB").success);
     });
+
+    it("rejects empty string", () => {
+      assert.ok(!bigintParser.parse("").success);
+    });
+
+    it("rejects float64-precision rounding input (1.0000000000000001B)", () => {
+      assert.ok(!bigintParser.parse("1.0000000000000001B").success);
+    });
   });
 
   describe("custom error messages", () => {
-    it("negativeNotAllowed receives bigint argument", () => {
+    it("uses static invalidFormat error message", () => {
+      const customError = message`Bad size: ${"example"}`;
+      const parser = fileSize({
+        type: "bigint",
+        errors: { invalidFormat: customError },
+      });
+      const r = parser.parse("bad");
+      assert.ok(!r.success);
+      if (!r.success) assert.deepEqual(r.error, customError);
+    });
+
+    it("uses function invalidFormat error message", () => {
+      const parser = fileSize({
+        type: "bigint",
+        errors: { invalidFormat: (input) => message`Not a size: ${input}` },
+      });
+      const r = parser.parse("bad");
+      assert.ok(!r.success);
+      if (!r.success) {
+        const expected = message`Not a size: ${"bad"}`;
+        assert.deepEqual(r.error, expected);
+      }
+    });
+
+    it("uses static negativeNotAllowed error message", () => {
+      const customError = message`No negatives!`;
+      const parser = fileSize({
+        type: "bigint",
+        errors: { negativeNotAllowed: customError },
+      });
+      const r = parser.parse("-1EB");
+      assert.ok(!r.success);
+      if (!r.success) assert.deepEqual(r.error, customError);
+    });
+
+    it("negativeNotAllowed function receives bigint argument", () => {
       let received: bigint | undefined;
       const parser = fileSize({
         type: "bigint",

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -6,6 +6,7 @@ import {
   domain,
   email,
   fileSize,
+  type FileSizeOptionsBigInt,
   float,
   hostname,
   integer,
@@ -16170,6 +16171,254 @@ describe("fileSize()", () => {
         } not allowed`;
         assert.deepEqual(r.error, expected);
       }
+    });
+  });
+});
+
+describe("fileSize() — bigint mode", () => {
+  const bigintParser = fileSize({ type: "bigint" });
+
+  describe("type inference", () => {
+    it("returns bigint values", () => {
+      const r = bigintParser.parse("512B");
+      assert.ok(r.success);
+      if (r.success) assert.equal(typeof r.value, "bigint");
+    });
+
+    it("accepts FileSizeOptionsBigInt type", () => {
+      const opts: FileSizeOptionsBigInt = { type: "bigint" };
+      const parser = fileSize(opts);
+      assert.ok(isValueParser(parser));
+    });
+  });
+
+  describe("SI units", () => {
+    it("parses 512B → 512n", () => {
+      const r = bigintParser.parse("512B");
+      assert.ok(r.success);
+      if (r.success) assert.equal(r.value, 512n);
+    });
+
+    it("parses 1KB → 1000n", () => {
+      const r = bigintParser.parse("1KB");
+      assert.ok(r.success);
+      if (r.success) assert.equal(r.value, 1_000n);
+    });
+
+    it("parses 1MB → 1_000_000n", () => {
+      const r = bigintParser.parse("1MB");
+      assert.ok(r.success);
+      if (r.success) assert.equal(r.value, 1_000_000n);
+    });
+
+    it("parses 1GB → 1_000_000_000n", () => {
+      const r = bigintParser.parse("1GB");
+      assert.ok(r.success);
+      if (r.success) assert.equal(r.value, 1_000_000_000n);
+    });
+  });
+
+  describe("IEC units", () => {
+    it("parses 1KiB → 1024n", () => {
+      const r = bigintParser.parse("1KiB");
+      assert.ok(r.success);
+      if (r.success) assert.equal(r.value, 1_024n);
+    });
+
+    it("parses 1GiB → 1_073_741_824n", () => {
+      const r = bigintParser.parse("1GiB");
+      assert.ok(r.success);
+      if (r.success) assert.equal(r.value, 1_073_741_824n);
+    });
+  });
+
+  describe("large values (beyond Number.MAX_SAFE_INTEGER)", () => {
+    it("parses 1EB → 1_000_000_000_000_000_000n", () => {
+      const r = bigintParser.parse("1EB");
+      assert.ok(r.success);
+      if (r.success) {
+        assert.equal(r.value, 1_000_000_000_000_000_000n);
+        assert.equal(typeof r.value, "bigint");
+      }
+    });
+
+    it("parses 1EiB → 1_152_921_504_606_846_976n", () => {
+      const r = bigintParser.parse("1EiB");
+      assert.ok(r.success);
+      if (r.success) assert.equal(r.value, 1_152_921_504_606_846_976n);
+    });
+
+    it("parses 100EB", () => {
+      const r = bigintParser.parse("100EB");
+      assert.ok(r.success);
+      if (r.success) assert.equal(r.value, 100_000_000_000_000_000_000n);
+    });
+  });
+
+  describe("floating-point inputs", () => {
+    it("parses 1.5GB → 1_500_000_000n", () => {
+      const r = bigintParser.parse("1.5GB");
+      assert.ok(r.success);
+      if (r.success) assert.equal(r.value, 1_500_000_000n);
+    });
+
+    it("parses 1.5EiB → 1_729_382_256_910_270_464n", () => {
+      const r = bigintParser.parse("1.5EiB");
+      assert.ok(r.success);
+      if (r.success) assert.equal(r.value, 1_729_382_256_910_270_464n);
+    });
+  });
+
+  describe("case-insensitive units", () => {
+    it("parses 1KIB → 1024n", () => {
+      const r = bigintParser.parse("1KIB");
+      assert.ok(r.success);
+      if (r.success) assert.equal(r.value, 1_024n);
+    });
+
+    it("parses 1eb → 1_000_000_000_000_000_000n", () => {
+      const r = bigintParser.parse("1eb");
+      assert.ok(r.success);
+      if (r.success) assert.equal(r.value, 1_000_000_000_000_000_000n);
+    });
+  });
+
+  describe("defaultUnit option", () => {
+    it("uses defaultUnit when no unit is in input", () => {
+      const parser = fileSize({ type: "bigint", defaultUnit: "MB" });
+      const r = parser.parse("100");
+      assert.ok(r.success);
+      if (r.success) assert.equal(r.value, 100_000_000n);
+    });
+
+    it("rejects bare number when defaultUnit is absent", () => {
+      const r = bigintParser.parse("100");
+      assert.ok(!r.success);
+    });
+  });
+
+  describe("allowNegative option", () => {
+    it("rejects negative by default", () => {
+      const r = bigintParser.parse("-1MB");
+      assert.ok(!r.success);
+    });
+
+    it("allows negative when allowNegative is true", () => {
+      const parser = fileSize({ type: "bigint", allowNegative: true });
+      const r = parser.parse("-1EB");
+      assert.ok(r.success);
+      if (r.success) assert.equal(r.value, -1_000_000_000_000_000_000n);
+    });
+  });
+
+  describe("siAsBinary option", () => {
+    it("treats KB as 1024n when siAsBinary is true", () => {
+      const parser = fileSize({ type: "bigint", siAsBinary: true });
+      const r = parser.parse("1KB");
+      assert.ok(r.success);
+      if (r.success) assert.equal(r.value, 1_024n);
+    });
+
+    it("treats EB as 1024^6 when siAsBinary is true", () => {
+      const parser = fileSize({ type: "bigint", siAsBinary: true });
+      const r = parser.parse("1EB");
+      assert.ok(r.success);
+      if (r.success) assert.equal(r.value, 1_152_921_504_606_846_976n);
+    });
+  });
+
+  describe("placeholder", () => {
+    it("defaults to 0n", () => {
+      assert.equal(bigintParser.placeholder, 0n);
+    });
+
+    it("uses custom placeholder", () => {
+      const parser = fileSize({ type: "bigint", placeholder: 1024n });
+      assert.equal(parser.placeholder, 1024n);
+    });
+  });
+
+  describe("format()", () => {
+    it("formats 512n as 512B", () => {
+      assert.equal(bigintParser.format(512n), "512B");
+    });
+
+    it("formats 1_000n as 1KB", () => {
+      assert.equal(bigintParser.format(1_000n), "1KB");
+    });
+
+    it("formats 1_073_741_824n (1GiB) as 1GiB", () => {
+      assert.equal(bigintParser.format(1_073_741_824n), "1GiB");
+    });
+
+    it("formats 1_000_000_000_000_000_000n (1EB) as 1EB", () => {
+      assert.equal(
+        bigintParser.format(1_000_000_000_000_000_000n),
+        "1EB",
+      );
+    });
+
+    it("formats 1_152_921_504_606_846_976n (1EiB) as 1EiB", () => {
+      assert.equal(
+        bigintParser.format(1_152_921_504_606_846_976n),
+        "1EiB",
+      );
+    });
+
+    it("formats 1_729_382_256_910_270_464n (1.5EiB) as 1.5EiB", () => {
+      assert.equal(
+        bigintParser.format(1_729_382_256_910_270_464n),
+        "1.5EiB",
+      );
+    });
+
+    it("formats 0n as 0B", () => {
+      assert.equal(bigintParser.format(0n), "0B");
+    });
+
+    it("round-trips representative values", () => {
+      const values = [
+        0n,
+        512n,
+        1_000n,
+        1_024n,
+        1_073_741_824n,
+        1_000_000_000_000_000_000n,
+        1_152_921_504_606_846_976n,
+      ];
+      for (const v of values) {
+        const formatted = bigintParser.format(v);
+        const result = bigintParser.parse(formatted);
+        assert.ok(result.success, `format(${v}) = ${formatted} did not parse`);
+        if (result.success) assert.equal(result.value, v);
+      }
+    });
+  });
+
+  describe("error cases", () => {
+    it("rejects fractional byte values (0.1B)", () => {
+      assert.ok(!bigintParser.parse("0.1B").success);
+    });
+
+    it("rejects unknown unit", () => {
+      assert.ok(!bigintParser.parse("100XB").success);
+    });
+  });
+
+  describe("custom error messages", () => {
+    it("negativeNotAllowed receives bigint argument", () => {
+      let received: bigint | undefined;
+      const parser = fileSize({
+        type: "bigint",
+        errors: {
+          negativeNotAllowed: (value) => {
+            received = value;
+            return message`Negative: ${String(value)}`;
+          },
+        },
+      });
+      parser.parse("-1EB");
+      assert.equal(received, -1_000_000_000_000_000_000n);
     });
   });
 });

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -5,6 +5,7 @@ import {
   cidr,
   domain,
   email,
+  fileSize,
   float,
   hostname,
   integer,
@@ -15749,6 +15750,427 @@ describe("checkEnumOption", () => {
           'Expected foo to be one of "a", "b", "c", but got symbol: Symbol(x).',
       },
     );
+  });
+});
+
+describe("fileSize()", () => {
+  describe("basic byte parsing", () => {
+    it("parses bare bytes with B suffix", () => {
+      const parser = fileSize();
+      const r = parser.parse("512B");
+      assert.ok(r.success);
+      if (r.success) assert.equal(r.value, 512);
+    });
+
+    it("parses zero bytes", () => {
+      const parser = fileSize();
+      const r = parser.parse("0B");
+      assert.ok(r.success);
+      if (r.success) assert.equal(r.value, 0);
+    });
+  });
+
+  describe("SI units (powers of 1000)", () => {
+    it("parses 1KB as 1000", () => {
+      const r = fileSize().parse("1KB");
+      assert.ok(r.success);
+      if (r.success) assert.equal(r.value, 1_000);
+    });
+
+    it("parses 1MB as 1_000_000", () => {
+      const r = fileSize().parse("1MB");
+      assert.ok(r.success);
+      if (r.success) assert.equal(r.value, 1_000_000);
+    });
+
+    it("parses 1GB as 1_000_000_000", () => {
+      const r = fileSize().parse("1GB");
+      assert.ok(r.success);
+      if (r.success) assert.equal(r.value, 1_000_000_000);
+    });
+
+    it("parses 1TB as 1_000_000_000_000", () => {
+      const r = fileSize().parse("1TB");
+      assert.ok(r.success);
+      if (r.success) assert.equal(r.value, 1_000_000_000_000);
+    });
+
+    it("parses 1PB as 1_000_000_000_000_000", () => {
+      const r = fileSize().parse("1PB");
+      assert.ok(r.success);
+      if (r.success) assert.equal(r.value, 1_000_000_000_000_000);
+    });
+  });
+
+  describe("IEC units (powers of 1024)", () => {
+    it("parses 1KiB as 1024", () => {
+      const r = fileSize().parse("1KiB");
+      assert.ok(r.success);
+      if (r.success) assert.equal(r.value, 1_024);
+    });
+
+    it("parses 1MiB as 1_048_576", () => {
+      const r = fileSize().parse("1MiB");
+      assert.ok(r.success);
+      if (r.success) assert.equal(r.value, 1_048_576);
+    });
+
+    it("parses 1GiB as 1_073_741_824", () => {
+      const r = fileSize().parse("1GiB");
+      assert.ok(r.success);
+      if (r.success) assert.equal(r.value, 1_073_741_824);
+    });
+
+    it("parses 1TiB as 1_099_511_627_776", () => {
+      const r = fileSize().parse("1TiB");
+      assert.ok(r.success);
+      if (r.success) assert.equal(r.value, 1_099_511_627_776);
+    });
+
+    it("parses 1PiB as 1_125_899_906_842_624", () => {
+      const r = fileSize().parse("1PiB");
+      assert.ok(r.success);
+      if (r.success) assert.equal(r.value, 1_125_899_906_842_624);
+    });
+  });
+
+  describe("floating-point values", () => {
+    it("parses 1.5MB as 1_500_000", () => {
+      const r = fileSize().parse("1.5MB");
+      assert.ok(r.success);
+      if (r.success) assert.equal(r.value, 1_500_000);
+    });
+
+    it("parses 1.5GiB as 1_610_612_736", () => {
+      const r = fileSize().parse("1.5GiB");
+      assert.ok(r.success);
+      if (r.success) assert.equal(r.value, 1_610_612_736);
+    });
+
+    it("parses .5KB as 500", () => {
+      const r = fileSize().parse(".5KB");
+      assert.ok(r.success);
+      if (r.success) assert.equal(r.value, 500);
+    });
+  });
+
+  describe("case-insensitive units", () => {
+    it("parses lowercase kb as KB", () => {
+      const r = fileSize().parse("1kb");
+      assert.ok(r.success);
+      if (r.success) assert.equal(r.value, 1_000);
+    });
+
+    it("parses uppercase KIB as KiB", () => {
+      const r = fileSize().parse("1KIB");
+      assert.ok(r.success);
+      if (r.success) assert.equal(r.value, 1_024);
+    });
+
+    it("parses mixed case Gib as GiB", () => {
+      const r = fileSize().parse("1Gib");
+      assert.ok(r.success);
+      if (r.success) assert.equal(r.value, 1_073_741_824);
+    });
+
+    it("parses mixed case Mb as MB", () => {
+      const r = fileSize().parse("2Mb");
+      assert.ok(r.success);
+      if (r.success) assert.equal(r.value, 2_000_000);
+    });
+  });
+
+  describe("optional whitespace between number and unit", () => {
+    it("parses '1 MB' with a space", () => {
+      const r = fileSize().parse("1 MB");
+      assert.ok(r.success);
+      if (r.success) assert.equal(r.value, 1_000_000);
+    });
+
+    it("parses '1  KiB' with multiple spaces", () => {
+      const r = fileSize().parse("1  KiB");
+      assert.ok(r.success);
+      if (r.success) assert.equal(r.value, 1_024);
+    });
+  });
+
+  describe("defaultUnit option", () => {
+    it("uses defaultUnit when no unit is in input", () => {
+      const parser = fileSize({ defaultUnit: "MB" });
+      const r = parser.parse("100");
+      assert.ok(r.success);
+      if (r.success) assert.equal(r.value, 100_000_000);
+    });
+
+    it("uses defaultUnit B to treat bare number as bytes", () => {
+      const parser = fileSize({ defaultUnit: "B" });
+      const r = parser.parse("1024");
+      assert.ok(r.success);
+      if (r.success) assert.equal(r.value, 1_024);
+    });
+
+    it("ignores defaultUnit when unit is present in input", () => {
+      const parser = fileSize({ defaultUnit: "MB" });
+      const r = parser.parse("1KB");
+      assert.ok(r.success);
+      if (r.success) assert.equal(r.value, 1_000);
+    });
+
+    it("rejects bare number when defaultUnit is absent", () => {
+      const r = fileSize().parse("100");
+      assert.ok(!r.success);
+    });
+  });
+
+  describe("negative values", () => {
+    it("rejects negative values by default", () => {
+      const r = fileSize().parse("-100B");
+      assert.ok(!r.success);
+    });
+
+    it("allows negative values when allowNegative is true", () => {
+      const parser = fileSize({ allowNegative: true });
+      const r = parser.parse("-1MB");
+      assert.ok(r.success);
+      if (r.success) assert.equal(r.value, -1_000_000);
+    });
+
+    it("allows negative IEC values when allowNegative is true", () => {
+      const parser = fileSize({ allowNegative: true });
+      const r = parser.parse("-1GiB");
+      assert.ok(r.success);
+      if (r.success) assert.equal(r.value, -1_073_741_824);
+    });
+  });
+
+  describe("siAsBinary option", () => {
+    it("treats KB as 1000 by default (siAsBinary: false)", () => {
+      const r = fileSize().parse("1KB");
+      assert.ok(r.success);
+      if (r.success) assert.equal(r.value, 1_000);
+    });
+
+    it("treats KB as 1024 when siAsBinary is true", () => {
+      const parser = fileSize({ siAsBinary: true });
+      const r = parser.parse("1KB");
+      assert.ok(r.success);
+      if (r.success) assert.equal(r.value, 1_024);
+    });
+
+    it("treats MB as 1_000_000 by default", () => {
+      const r = fileSize().parse("1MB");
+      assert.ok(r.success);
+      if (r.success) assert.equal(r.value, 1_000_000);
+    });
+
+    it("treats MB as 1_048_576 when siAsBinary is true", () => {
+      const parser = fileSize({ siAsBinary: true });
+      const r = parser.parse("1MB");
+      assert.ok(r.success);
+      if (r.success) assert.equal(r.value, 1_048_576);
+    });
+
+    it("treats GB as 1_000_000_000 by default", () => {
+      const r = fileSize().parse("1GB");
+      assert.ok(r.success);
+      if (r.success) assert.equal(r.value, 1_000_000_000);
+    });
+
+    it("treats GB as 1_073_741_824 when siAsBinary is true", () => {
+      const parser = fileSize({ siAsBinary: true });
+      const r = parser.parse("1GB");
+      assert.ok(r.success);
+      if (r.success) assert.equal(r.value, 1_073_741_824);
+    });
+
+    it("does not affect IEC units when siAsBinary is true", () => {
+      const parser = fileSize({ siAsBinary: true });
+      const r = parser.parse("1KiB");
+      assert.ok(r.success);
+      if (r.success) assert.equal(r.value, 1_024);
+    });
+  });
+
+  describe("error cases", () => {
+    it("rejects unknown unit", () => {
+      const r = fileSize().parse("100XB");
+      assert.ok(!r.success);
+    });
+
+    it("rejects pure text", () => {
+      const r = fileSize().parse("abc");
+      assert.ok(!r.success);
+    });
+
+    it("rejects empty string", () => {
+      const r = fileSize().parse("");
+      assert.ok(!r.success);
+    });
+
+    it("rejects number with leading plus and no unit (no defaultUnit)", () => {
+      const r = fileSize().parse("+100");
+      assert.ok(!r.success);
+    });
+
+    it("rejects fractional byte values (0.1B)", () => {
+      const r = fileSize().parse("0.1B");
+      assert.ok(!r.success);
+    });
+
+    it("rejects fractional byte values (1.5B)", () => {
+      const r = fileSize().parse("1.5B");
+      assert.ok(!r.success);
+    });
+
+    it("rejects values beyond Number.MAX_SAFE_INTEGER", () => {
+      const r = fileSize().parse(`${Number.MAX_SAFE_INTEGER + 1}B`);
+      assert.ok(!r.success);
+    });
+
+    it("rejects input whose float64 conversion silently rounds to integer (1.0000000000000001B)", () => {
+      const r = fileSize().parse("1.0000000000000001B");
+      assert.ok(!r.success);
+    });
+
+    it("rejects input whose float64 conversion silently rounds near MAX_SAFE_INTEGER (0.99999999999999999B)", () => {
+      const r = fileSize().parse("0.99999999999999999B");
+      assert.ok(!r.success);
+    });
+  });
+
+  describe("metavar", () => {
+    it("defaults to SIZE", () => {
+      assert.equal(fileSize().metavar, "SIZE");
+    });
+
+    it("uses custom metavar", () => {
+      assert.equal(fileSize({ metavar: "BYTES" }).metavar, "BYTES");
+    });
+  });
+
+  describe("placeholder", () => {
+    it("defaults to 0", () => {
+      assert.equal(fileSize().placeholder, 0);
+    });
+
+    it("uses custom placeholder", () => {
+      assert.equal(fileSize({ placeholder: 1024 }).placeholder, 1024);
+    });
+  });
+
+  describe("format()", () => {
+    it("formats 512 as 512B", () => {
+      assert.equal(fileSize().format(512), "512B");
+    });
+
+    it("formats 1000 as 1KB", () => {
+      assert.equal(fileSize().format(1_000), "1KB");
+    });
+
+    it("formats 1_000_000 as 1MB", () => {
+      assert.equal(fileSize().format(1_000_000), "1MB");
+    });
+
+    it("formats 1_000_000_000 as 1GB", () => {
+      assert.equal(fileSize().format(1_000_000_000), "1GB");
+    });
+
+    it("formats 1_073_741_824 (1 GiB) as 1GiB", () => {
+      assert.equal(fileSize().format(1_073_741_824), "1GiB");
+    });
+
+    it("formats 1_500_000 as 1.5MB", () => {
+      assert.equal(fileSize().format(1_500_000), "1.5MB");
+    });
+
+    it("formats 1_572_864 (1.5 MiB) as 1.5MiB", () => {
+      assert.equal(fileSize().format(1_572_864), "1.5MiB");
+    });
+
+    it("formats 0 as 0B", () => {
+      assert.equal(fileSize().format(0), "0B");
+    });
+
+    it("formats 1KB as 1KB when siAsBinary is true", () => {
+      assert.equal(fileSize({ siAsBinary: true }).format(1_024), "1KB");
+    });
+
+    it("round-trips representative byte values through format and parse", () => {
+      const parser = fileSize();
+      for (
+        const bytes of [0, 512, 1000, 1024, 1_500_000, 1_048_576, 1_073_741_824]
+      ) {
+        const formatted = parser.format(bytes);
+        const result = parser.parse(formatted);
+        assert.ok(
+          result.success,
+          `format(${bytes}) = ${formatted} did not parse`,
+        );
+        if (result.success) assert.equal(result.value, bytes);
+      }
+    });
+
+    it("round-trips with siAsBinary: true", () => {
+      const parser = fileSize({ siAsBinary: true });
+      for (const bytes of [0, 512, 1_024, 1_048_576, 1_073_741_824]) {
+        const formatted = parser.format(bytes);
+        const result = parser.parse(formatted);
+        assert.ok(
+          result.success,
+          `format(${bytes}) = ${formatted} did not parse`,
+        );
+        if (result.success) assert.equal(result.value, bytes);
+      }
+    });
+  });
+
+  describe("custom error messages", () => {
+    it("uses static invalidFormat error message", () => {
+      const customError = message`Bad size: ${"example"}`;
+      const parser = fileSize({ errors: { invalidFormat: customError } });
+      const r = parser.parse("bad");
+      assert.ok(!r.success);
+      if (!r.success) assert.deepEqual(r.error, customError);
+    });
+
+    it("uses function invalidFormat error message", () => {
+      const parser = fileSize({
+        errors: {
+          invalidFormat: (input) => message`Not a size: ${input}`,
+        },
+      });
+      const r = parser.parse("bad");
+      assert.ok(!r.success);
+      if (!r.success) {
+        const expected = message`Not a size: ${"bad"}`;
+        assert.deepEqual(r.error, expected);
+      }
+    });
+
+    it("uses static negativeNotAllowed error message", () => {
+      const customError = message`No negatives!`;
+      const parser = fileSize({ errors: { negativeNotAllowed: customError } });
+      const r = parser.parse("-1MB");
+      assert.ok(!r.success);
+      if (!r.success) assert.deepEqual(r.error, customError);
+    });
+
+    it("uses function negativeNotAllowed error message", () => {
+      const parser = fileSize({
+        errors: {
+          negativeNotAllowed: (value) =>
+            message`Negative size ${text(String(value))} not allowed`,
+        },
+      });
+      const r = parser.parse("-1MB");
+      assert.ok(!r.success);
+      if (!r.success) {
+        const expected = message`Negative size ${
+          text(String(-1_000_000))
+        } not allowed`;
+        assert.deepEqual(r.error, expected);
+      }
+    });
   });
 });
 

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -1443,6 +1443,341 @@ export function float(options: FloatOptions = {}): ValueParser<"sync", number> {
 }
 
 /**
+ * A canonical file size unit string.  SI units use powers of 1 000 by
+ * default; IEC units always use powers of 1 024.
+ * @since 1.1.0
+ */
+export type FileSizeUnit =
+  | "B"
+  | "KB"
+  | "MB"
+  | "GB"
+  | "TB"
+  | "PB"
+  | "EB"
+  | "KiB"
+  | "MiB"
+  | "GiB"
+  | "TiB"
+  | "PiB"
+  | "EiB";
+
+/**
+ * Options for creating a {@link fileSize} parser.
+ * @since 1.1.0
+ */
+export interface FileSizeOptions {
+  /**
+   * The metavariable name for this parser.  Used in help messages to
+   * indicate what kind of value this parser expects.
+   * @default `"SIZE"`
+   */
+  readonly metavar?: NonEmptyString;
+
+  /**
+   * If `true`, negative byte values are accepted.  Most size-related CLI
+   * options do not accept negative values, so this defaults to `false`.
+   * @default `false`
+   */
+  readonly allowNegative?: boolean;
+
+  /**
+   * The unit to assume when the input contains only a number with no unit
+   * suffix (e.g., `"100"` with `defaultUnit: "MB"` → 100 000 000 bytes).
+   * When this option is absent, a bare number without a unit is rejected.
+   */
+  readonly defaultUnit?: FileSizeUnit;
+
+  /**
+   * When `true`, SI suffixes (`KB`, `MB`, `GB`, …) are interpreted as
+   * binary powers of 1 024 rather than decimal powers of 1 000.  This
+   * matches a widespread but technically incorrect convention where
+   * "1 KB" means 1 024 bytes.  IEC suffixes (`KiB`, `MiB`, …) are
+   * unaffected by this option.
+   *
+   * @default `false`
+   * @since 1.1.0
+   */
+  readonly siAsBinary?: boolean;
+
+  /**
+   * A custom placeholder value used during deferred prompt resolution.
+   * @default `0`
+   * @since 1.1.0
+   */
+  readonly placeholder?: number;
+
+  /**
+   * Custom error messages for file size parsing failures.
+   * @since 1.1.0
+   */
+  readonly errors?: {
+    /**
+     * Custom error message when the input is not a valid file size string.
+     * Can be a static message or a function that receives the raw input.
+     */
+    readonly invalidFormat?: Message | ((input: string) => Message);
+
+    /**
+     * Custom error message when a negative value is provided but
+     * {@link FileSizeOptions.allowNegative} is `false`.
+     * Can be a static message or a function that receives the byte value.
+     */
+    readonly negativeNotAllowed?: Message | ((value: number) => Message);
+  };
+}
+
+// Multipliers for SI units (powers of 1 000)
+const SI_MULTIPLIERS: Readonly<Record<string, number>> = {
+  b: 1,
+  kb: 1_000,
+  mb: 1_000_000,
+  gb: 1_000_000_000,
+  tb: 1_000_000_000_000,
+  pb: 1_000_000_000_000_000,
+  eb: 1_000_000_000_000_000_000,
+};
+
+// Multipliers for IEC units (powers of 1 024) — also overrides SI when
+// siAsBinary is true, making e.g. "kb" → 1 024.
+const IEC_MULTIPLIERS: Readonly<Record<string, number>> = {
+  b: 1,
+  kb: 1_024,
+  mb: 1_024 ** 2,
+  gb: 1_024 ** 3,
+  tb: 1_024 ** 4,
+  pb: 1_024 ** 5,
+  eb: 1_024 ** 6,
+  kib: 1_024,
+  mib: 1_024 ** 2,
+  gib: 1_024 ** 3,
+  tib: 1_024 ** 4,
+  pib: 1_024 ** 5,
+  eib: 1_024 ** 6,
+};
+
+// IEC-only keys for normal mode (unit strings that always use powers of 1 024)
+const IEC_ONLY_MULTIPLIERS: Readonly<Record<string, number>> = {
+  kib: 1_024,
+  mib: 1_024 ** 2,
+  gib: 1_024 ** 3,
+  tib: 1_024 ** 4,
+  pib: 1_024 ** 5,
+  eib: 1_024 ** 6,
+};
+
+const FILE_SIZE_REGEX = /^([+-]?(?:\d+\.?\d*|\d*\.\d+))\s*([a-zA-Z]*)$/;
+
+/**
+ * Checks whether `v` has at most two decimal places (within floating-point
+ * tolerance) and lies in the range [1, 1000).
+ */
+function isCleanUnit(v: number): boolean {
+  if (v < 1 || v >= 1000) return false;
+  const rounded = Math.round(v * 100) / 100;
+  return Math.abs(rounded - v) < 1e-9 * Math.max(1, Math.abs(v));
+}
+
+/**
+ * Formats `bytes` using the most readable unit from the given ordered list.
+ * Falls back to `"${bytes}B"`.
+ */
+function formatWithUnits(
+  bytes: number,
+  units: readonly [string, number][],
+): string {
+  if (bytes === 0) return "0B";
+  const absBytes = Math.abs(bytes);
+  for (const [unit, size] of units) {
+    const v = bytes / size;
+    if (absBytes >= size && isCleanUnit(Math.abs(v))) {
+      const rounded = Math.round(v * 100) / 100;
+      return `${rounded}${unit}`;
+    }
+  }
+  return `${bytes}B`;
+}
+
+// Format order for default mode: IEC first (prefer binary for exact powers of
+// 1 024), then SI.
+const FORMAT_UNITS_DEFAULT: readonly [string, number][] = [
+  ["EiB", 1_024 ** 6],
+  ["PiB", 1_024 ** 5],
+  ["TiB", 1_024 ** 4],
+  ["GiB", 1_024 ** 3],
+  ["MiB", 1_024 ** 2],
+  ["KiB", 1_024],
+  ["EB", 1_000_000_000_000_000_000],
+  ["PB", 1_000_000_000_000_000],
+  ["TB", 1_000_000_000_000],
+  ["GB", 1_000_000_000],
+  ["MB", 1_000_000],
+  ["KB", 1_000],
+];
+
+// Format order for siAsBinary mode: SI suffixes come first (they are the
+// user's preferred convention), using binary multipliers.
+const FORMAT_UNITS_SI_AS_BINARY: readonly [string, number][] = [
+  ["EB", 1_024 ** 6],
+  ["PB", 1_024 ** 5],
+  ["TB", 1_024 ** 4],
+  ["GB", 1_024 ** 3],
+  ["MB", 1_024 ** 2],
+  ["KB", 1_024],
+];
+
+/**
+ * Parses `numStr` as a decimal rational and multiplies by `multiplier`,
+ * returning the exact integer result as a safe `number`, or `null` when the
+ * result would be fractional or outside `Number.MAX_SAFE_INTEGER`.
+ *
+ * All arithmetic is performed with `bigint` to avoid float64 precision loss
+ * (e.g. `"1.0000000000000001"` must not silently round to `1`).
+ */
+function parseExactBytes(
+  numStr: string,
+  multiplier: number,
+): number | null {
+  const negative = numStr.startsWith("-");
+  const absStr = numStr.startsWith("+") || numStr.startsWith("-")
+    ? numStr.slice(1)
+    : numStr;
+  const dotIdx = absStr.indexOf(".");
+  const intPart = dotIdx < 0 ? absStr : absStr.slice(0, dotIdx);
+  const fracPart = dotIdx < 0 ? "" : absStr.slice(dotIdx + 1);
+  // Remove leading zeros to avoid BigInt parsing issues, but keep at least "0"
+  const numeratorStr = ((intPart || "0") + fracPart).replace(/^0+/, "") || "0";
+  const numerator = BigInt(numeratorStr) * (negative ? -1n : 1n);
+  const denominator = 10n ** BigInt(fracPart.length);
+  // All our multipliers are exact integers representable as float64.
+  const mBig = BigInt(multiplier);
+  const bytesNumerator = numerator * mBig;
+  if (bytesNumerator % denominator !== 0n) return null;
+  const bytes = bytesNumerator / denominator;
+  const maxSafe = BigInt(Number.MAX_SAFE_INTEGER);
+  if (bytes < -maxSafe || bytes > maxSafe) return null;
+  return Number(bytes);
+}
+
+const FILE_SIZE_UNITS: readonly FileSizeUnit[] = [
+  "B",
+  "KB",
+  "MB",
+  "GB",
+  "TB",
+  "PB",
+  "EB",
+  "KiB",
+  "MiB",
+  "GiB",
+  "TiB",
+  "PiB",
+  "EiB",
+];
+
+/**
+ * Creates a {@link ValueParser} for human-readable file/data size strings such
+ * as `"10MB"`, `"1.5GiB"`, or `"512B"`.  The parsed value is a `number`
+ * representing the equivalent byte count.
+ *
+ * Supported units:
+ *
+ * | Unit | Bytes (default) |
+ * |------|----------------|
+ * | B    | 1              |
+ * | KB   | 1 000          |
+ * | MB   | 1 000 000      |
+ * | GB   | 1 000 000 000  |
+ * | KiB  | 1 024          |
+ * | MiB  | 1 048 576      |
+ * | GiB  | 1 073 741 824  |
+ * | …    | …              |
+ *
+ * Unit suffixes are matched case-insensitively, so `"1kb"`, `"1KB"`, and
+ * `"1Kb"` are all equivalent.
+ *
+ * @param options Configuration options for the file size parser.
+ * @returns A {@link ValueParser} that parses file size strings into byte
+ *          counts.
+ * @throws {TypeError} If {@link FileSizeOptions.metavar} is an empty string,
+ *   if {@link FileSizeOptions.allowNegative} or
+ *   {@link FileSizeOptions.siAsBinary} is not a boolean, or if
+ *   {@link FileSizeOptions.defaultUnit} is not a valid
+ *   {@link FileSizeUnit}.
+ * @since 1.1.0
+ */
+export function fileSize(
+  options: FileSizeOptions = {},
+): ValueParser<"sync", number> {
+  const metavar = options.metavar ?? "SIZE";
+  ensureNonEmptyString(metavar);
+  checkBooleanOption(options, "allowNegative");
+  checkBooleanOption(options, "siAsBinary");
+  checkEnumOption(options, "defaultUnit", FILE_SIZE_UNITS);
+  const siAsBinary = options.siAsBinary ?? false;
+  const multiplierMap = siAsBinary ? IEC_MULTIPLIERS : {
+    ...SI_MULTIPLIERS,
+    ...IEC_ONLY_MULTIPLIERS,
+  };
+  const formatUnits = siAsBinary
+    ? FORMAT_UNITS_SI_AS_BINARY
+    : FORMAT_UNITS_DEFAULT;
+
+  function invalidFormatError(input: string): ValueParserResult<number> {
+    return {
+      success: false,
+      error: options.errors?.invalidFormat
+        ? (typeof options.errors.invalidFormat === "function"
+          ? options.errors.invalidFormat(input)
+          : options.errors.invalidFormat)
+        : message`Expected a file size like ${"10MB"} or ${"1.5GiB"}, but got ${input}.`,
+    };
+  }
+
+  return {
+    mode: "sync",
+    metavar,
+    placeholder: options.placeholder ?? 0,
+    parse(input: string): ValueParserResult<number> {
+      const match = FILE_SIZE_REGEX.exec(input.trim());
+      if (match == null) return invalidFormatError(input);
+
+      const numStr = match[1];
+      const unitStr = match[2].toLowerCase();
+
+      let multiplier: number;
+      if (unitStr === "") {
+        if (options.defaultUnit == null) return invalidFormatError(input);
+        multiplier = multiplierMap[options.defaultUnit.toLowerCase()];
+      } else {
+        const m = multiplierMap[unitStr];
+        if (m == null) return invalidFormatError(input);
+        multiplier = m;
+      }
+
+      const bytes = parseExactBytes(numStr, multiplier);
+      if (bytes == null) return invalidFormatError(input);
+
+      if (!(options.allowNegative ?? false) && bytes < 0) {
+        return {
+          success: false,
+          error: options.errors?.negativeNotAllowed
+            ? (typeof options.errors.negativeNotAllowed === "function"
+              ? options.errors.negativeNotAllowed(bytes)
+              : options.errors.negativeNotAllowed)
+            : message`Expected a non-negative file size, but got ${input}.`,
+        };
+      }
+
+      return { success: true, value: bytes };
+    },
+    format(value: number): string {
+      return formatWithUnits(value, formatUnits);
+    },
+  };
+}
+
+/**
  * The set of URL schemes that are considered "special" by the WHATWG URL
  * Standard.  These schemes always use the `://` authority syntax.
  * Non-special schemes use only `:` (e.g., `mailto:`, `urn:`).

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -1918,14 +1918,25 @@ export function fileSize(
  * @param options Configuration options for the file size parser.
  * @returns A {@link ValueParser} that parses file size strings into byte
  *          counts.
- * @throws {TypeError} If `metavar` is an empty string, if `allowNegative` or
- *   `siAsBinary` is not a boolean, or if `defaultUnit` is not a valid
- *   {@link FileSizeUnit}.
+ * @throws {TypeError} If `type` is neither `"number"` nor `"bigint"`, if
+ *   `metavar` is an empty string, if `allowNegative` or `siAsBinary` is not
+ *   a boolean, or if `defaultUnit` is not a valid {@link FileSizeUnit}.
  * @since 1.1.0
  */
 export function fileSize(
   options: FileSizeOptionsNumber | FileSizeOptionsBigInt = {},
 ): ValueParser<"sync", number> | ValueParser<"sync", bigint> {
+  if (
+    options.type !== undefined &&
+    options.type !== "number" &&
+    options.type !== "bigint"
+  ) {
+    throw new TypeError(
+      `Expected type to be "number" or "bigint", but got: ${
+        String(options.type)
+      }.`,
+    );
+  }
   const metavar = options.metavar ?? "SIZE";
   ensureNonEmptyString(metavar);
   checkBooleanOption(options, "allowNegative");

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -1647,18 +1647,12 @@ const IEC_ONLY_MULTIPLIERS: Readonly<Record<string, number>> = {
 const FILE_SIZE_REGEX = /^([+-]?(?:\d+\.?\d*|\d*\.\d+))\s*([a-zA-Z]*)$/;
 
 /**
- * Checks whether `v` has at most two decimal places (within floating-point
- * tolerance) and lies in the range [1, 1000).
- */
-function isCleanUnit(v: number): boolean {
-  if (v < 1 || v >= 1000) return false;
-  const rounded = Math.round(v * 100) / 100;
-  return Math.abs(rounded - v) < 1e-9 * Math.max(1, Math.abs(v));
-}
-
-/**
  * Formats `bytes` using the most readable unit from the given ordered list.
  * Falls back to `"${bytes}B"`.
+ *
+ * A unit is chosen only when the formatted value round-trips exactly: the
+ * rounded quotient must lie in [1, 1000) and `rounded * size === bytes` must
+ * hold in float64 arithmetic.  This guarantees `parse(format(x)) === x`.
  */
 function formatWithUnits(
   bytes: number,
@@ -1667,9 +1661,11 @@ function formatWithUnits(
   if (bytes === 0) return "0B";
   const absBytes = Math.abs(bytes);
   for (const [unit, size] of units) {
+    if (absBytes < size) continue;
     const v = bytes / size;
-    if (absBytes >= size && isCleanUnit(Math.abs(v))) {
-      const rounded = Math.round(v * 100) / 100;
+    const rounded = Math.round(v * 100) / 100;
+    const absRounded = Math.abs(rounded);
+    if (absRounded >= 1 && absRounded < 1000 && rounded * size === bytes) {
       return `${rounded}${unit}`;
     }
   }

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -1463,10 +1463,16 @@ export type FileSizeUnit =
   | "EiB";
 
 /**
- * Options for creating a {@link fileSize} parser.
+ * Options for creating a {@link fileSize} parser that returns `number`.
  * @since 1.1.0
  */
-export interface FileSizeOptions {
+export interface FileSizeOptionsNumber {
+  /**
+   * The return type.  Defaults to `"number"`.
+   * @default `"number"`
+   */
+  readonly type?: "number";
+
   /**
    * The metavariable name for this parser.  Used in help messages to
    * indicate what kind of value this parser expects.
@@ -1520,12 +1526,84 @@ export interface FileSizeOptions {
 
     /**
      * Custom error message when a negative value is provided but
-     * {@link FileSizeOptions.allowNegative} is `false`.
+     * {@link FileSizeOptionsNumber.allowNegative} is `false`.
      * Can be a static message or a function that receives the byte value.
      */
     readonly negativeNotAllowed?: Message | ((value: number) => Message);
   };
 }
+
+/**
+ * Options for creating a {@link fileSize} parser that returns `bigint`.
+ * Use this when byte counts may exceed `Number.MAX_SAFE_INTEGER` (roughly
+ * 9 PB), for example when working with EB/EiB-range values.
+ * @since 1.1.0
+ */
+export interface FileSizeOptionsBigInt {
+  /**
+   * Must be set to `"bigint"` to select bigint output.
+   */
+  readonly type: "bigint";
+
+  /**
+   * The metavariable name for this parser.  Used in help messages to
+   * indicate what kind of value this parser expects.
+   * @default `"SIZE"`
+   */
+  readonly metavar?: NonEmptyString;
+
+  /**
+   * If `true`, negative byte values are accepted.
+   * @default `false`
+   */
+  readonly allowNegative?: boolean;
+
+  /**
+   * The unit to assume when the input contains only a number with no unit
+   * suffix.  When absent, a bare number is rejected.
+   */
+  readonly defaultUnit?: FileSizeUnit;
+
+  /**
+   * When `true`, SI suffixes (`KB`, `MB`, `GB`, …) are interpreted as
+   * binary powers of 1 024 rather than decimal powers of 1 000.
+   * @default `false`
+   * @since 1.1.0
+   */
+  readonly siAsBinary?: boolean;
+
+  /**
+   * A custom placeholder value used during deferred prompt resolution.
+   * @default `0n`
+   * @since 1.1.0
+   */
+  readonly placeholder?: bigint;
+
+  /**
+   * Custom error messages for file size parsing failures.
+   * @since 1.1.0
+   */
+  readonly errors?: {
+    /**
+     * Custom error message when the input is not a valid file size string.
+     * Can be a static message or a function that receives the raw input.
+     */
+    readonly invalidFormat?: Message | ((input: string) => Message);
+
+    /**
+     * Custom error message when a negative value is provided but
+     * {@link FileSizeOptionsBigInt.allowNegative} is `false`.
+     * Can be a static message or a function that receives the byte value.
+     */
+    readonly negativeNotAllowed?: Message | ((value: bigint) => Message);
+  };
+}
+
+/**
+ * Options for creating a {@link fileSize} parser.
+ * @since 1.1.0
+ */
+export type FileSizeOptions = FileSizeOptionsNumber | FileSizeOptionsBigInt;
 
 // Multipliers for SI units (powers of 1 000)
 const SI_MULTIPLIERS: Readonly<Record<string, number>> = {
@@ -1626,6 +1704,128 @@ const FORMAT_UNITS_SI_AS_BINARY: readonly [string, number][] = [
   ["KB", 1_024],
 ];
 
+// Bigint multiplier maps — mirrors of the number maps above
+const BIGINT_SI_MULTIPLIERS: Readonly<Record<string, bigint>> = {
+  b: 1n,
+  kb: 1_000n,
+  mb: 1_000_000n,
+  gb: 1_000_000_000n,
+  tb: 1_000_000_000_000n,
+  pb: 1_000_000_000_000_000n,
+  eb: 1_000_000_000_000_000_000n,
+};
+
+const BIGINT_IEC_MULTIPLIERS: Readonly<Record<string, bigint>> = {
+  b: 1n,
+  kb: 1_024n,
+  mb: 1_024n ** 2n,
+  gb: 1_024n ** 3n,
+  tb: 1_024n ** 4n,
+  pb: 1_024n ** 5n,
+  eb: 1_024n ** 6n,
+  kib: 1_024n,
+  mib: 1_024n ** 2n,
+  gib: 1_024n ** 3n,
+  tib: 1_024n ** 4n,
+  pib: 1_024n ** 5n,
+  eib: 1_024n ** 6n,
+};
+
+const BIGINT_IEC_ONLY_MULTIPLIERS: Readonly<Record<string, bigint>> = {
+  kib: 1_024n,
+  mib: 1_024n ** 2n,
+  gib: 1_024n ** 3n,
+  tib: 1_024n ** 4n,
+  pib: 1_024n ** 5n,
+  eib: 1_024n ** 6n,
+};
+
+// Bigint format unit lists
+const BIGINT_FORMAT_UNITS_DEFAULT: readonly [string, bigint][] = [
+  ["EiB", 1_024n ** 6n],
+  ["PiB", 1_024n ** 5n],
+  ["TiB", 1_024n ** 4n],
+  ["GiB", 1_024n ** 3n],
+  ["MiB", 1_024n ** 2n],
+  ["KiB", 1_024n],
+  ["EB", 1_000_000_000_000_000_000n],
+  ["PB", 1_000_000_000_000_000n],
+  ["TB", 1_000_000_000_000n],
+  ["GB", 1_000_000_000n],
+  ["MB", 1_000_000n],
+  ["KB", 1_000n],
+];
+
+const BIGINT_FORMAT_UNITS_SI_AS_BINARY: readonly [string, bigint][] = [
+  ["EB", 1_024n ** 6n],
+  ["PB", 1_024n ** 5n],
+  ["TB", 1_024n ** 4n],
+  ["GB", 1_024n ** 3n],
+  ["MB", 1_024n ** 2n],
+  ["KB", 1_024n],
+];
+
+/**
+ * Formats a bigint byte count using the most readable unit.  Falls back to
+ * `"${value}B"`.  Tries exact integers, then 1 and 2 decimal places.
+ */
+function formatBigIntBytes(
+  value: bigint,
+  units: readonly [string, bigint][],
+): string {
+  if (value === 0n) return "0B";
+  const absValue = value < 0n ? -value : value;
+  for (const [unit, size] of units) {
+    if (absValue < size) continue;
+    // Exact integer
+    if (value % size === 0n) {
+      const v = value / size;
+      const absV = v < 0n ? -v : v;
+      if (absV >= 1n && absV < 1000n) return `${v}${unit}`;
+    }
+    // Up to 2 decimal places
+    const v100 = value * 100n;
+    if (v100 % size === 0n) {
+      const q = v100 / size;
+      const absQ = q < 0n ? -q : q;
+      if (absQ >= 100n && absQ < 100_000n) {
+        const intPart = q / 100n;
+        const decPart = absQ % 100n;
+        if (decPart % 10n === 0n) {
+          return `${intPart}.${decPart / 10n}${unit}`;
+        }
+        return `${intPart}.${String(decPart).padStart(2, "0")}${unit}`;
+      }
+    }
+  }
+  return `${value}B`;
+}
+
+/**
+ * Core computation: parses `numStr` as a decimal rational, multiplies by
+ * `mBig`, and returns the exact integer result as a `bigint`, or `null` when
+ * the result would be fractional.  The safe-integer range check is NOT applied
+ * here; callers add it as needed.
+ */
+function parseExactBytesRaw(
+  numStr: string,
+  mBig: bigint,
+): bigint | null {
+  const negative = numStr.startsWith("-");
+  const absStr = numStr.startsWith("+") || numStr.startsWith("-")
+    ? numStr.slice(1)
+    : numStr;
+  const dotIdx = absStr.indexOf(".");
+  const intPart = dotIdx < 0 ? absStr : absStr.slice(0, dotIdx);
+  const fracPart = dotIdx < 0 ? "" : absStr.slice(dotIdx + 1);
+  const numeratorStr = ((intPart || "0") + fracPart).replace(/^0+/, "") || "0";
+  const numerator = BigInt(numeratorStr) * (negative ? -1n : 1n);
+  const denominator = 10n ** BigInt(fracPart.length);
+  const bytesNumerator = numerator * mBig;
+  if (bytesNumerator % denominator !== 0n) return null;
+  return bytesNumerator / denominator;
+}
+
 /**
  * Parses `numStr` as a decimal rational and multiplies by `multiplier`,
  * returning the exact integer result as a safe `number`, or `null` when the
@@ -1638,22 +1838,8 @@ function parseExactBytes(
   numStr: string,
   multiplier: number,
 ): number | null {
-  const negative = numStr.startsWith("-");
-  const absStr = numStr.startsWith("+") || numStr.startsWith("-")
-    ? numStr.slice(1)
-    : numStr;
-  const dotIdx = absStr.indexOf(".");
-  const intPart = dotIdx < 0 ? absStr : absStr.slice(0, dotIdx);
-  const fracPart = dotIdx < 0 ? "" : absStr.slice(dotIdx + 1);
-  // Remove leading zeros to avoid BigInt parsing issues, but keep at least "0"
-  const numeratorStr = ((intPart || "0") + fracPart).replace(/^0+/, "") || "0";
-  const numerator = BigInt(numeratorStr) * (negative ? -1n : 1n);
-  const denominator = 10n ** BigInt(fracPart.length);
-  // All our multipliers are exact integers representable as float64.
-  const mBig = BigInt(multiplier);
-  const bytesNumerator = numerator * mBig;
-  if (bytesNumerator % denominator !== 0n) return null;
-  const bytes = bytesNumerator / denominator;
+  const bytes = parseExactBytesRaw(numStr, BigInt(multiplier));
+  if (bytes == null) return null;
   const maxSafe = BigInt(Number.MAX_SAFE_INTEGER);
   if (bytes < -maxSafe || bytes > maxSafe) return null;
   return Number(bytes);
@@ -1676,9 +1862,46 @@ const FILE_SIZE_UNITS: readonly FileSizeUnit[] = [
 ];
 
 /**
+ * Creates a {@link ValueParser} for human-readable file/data size strings
+ * that returns a `number` byte count.
+ *
+ * @param options Configuration options for the file size parser.
+ * @returns A {@link ValueParser} that parses file size strings into `number`
+ *          byte counts.
+ * @throws {TypeError} If {@link FileSizeOptionsNumber.metavar} is an empty
+ *   string, if {@link FileSizeOptionsNumber.allowNegative} or
+ *   {@link FileSizeOptionsNumber.siAsBinary} is not a boolean, or if
+ *   {@link FileSizeOptionsNumber.defaultUnit} is not a valid
+ *   {@link FileSizeUnit}.
+ * @since 1.1.0
+ */
+export function fileSize(
+  options?: FileSizeOptionsNumber,
+): ValueParser<"sync", number>;
+
+/**
+ * Creates a {@link ValueParser} for human-readable file/data size strings
+ * that returns a `bigint` byte count.  Use this when byte counts may exceed
+ * `Number.MAX_SAFE_INTEGER` (~9 PB), for example with EB/EiB-range values.
+ *
+ * @param options Configuration options for the file size parser.
+ * @returns A {@link ValueParser} that parses file size strings into `bigint`
+ *          byte counts.
+ * @throws {TypeError} If {@link FileSizeOptionsBigInt.metavar} is an empty
+ *   string, if {@link FileSizeOptionsBigInt.allowNegative} or
+ *   {@link FileSizeOptionsBigInt.siAsBinary} is not a boolean, or if
+ *   {@link FileSizeOptionsBigInt.defaultUnit} is not a valid
+ *   {@link FileSizeUnit}.
+ * @since 1.1.0
+ */
+export function fileSize(
+  options: FileSizeOptionsBigInt,
+): ValueParser<"sync", bigint>;
+
+/**
  * Creates a {@link ValueParser} for human-readable file/data size strings such
- * as `"10MB"`, `"1.5GiB"`, or `"512B"`.  The parsed value is a `number`
- * representing the equivalent byte count.
+ * as `"10MB"`, `"1.5GiB"`, or `"512B"`.  The parsed value is a `number` or
+ * `bigint` representing the equivalent byte count.
  *
  * Supported units:
  *
@@ -1699,31 +1922,22 @@ const FILE_SIZE_UNITS: readonly FileSizeUnit[] = [
  * @param options Configuration options for the file size parser.
  * @returns A {@link ValueParser} that parses file size strings into byte
  *          counts.
- * @throws {TypeError} If {@link FileSizeOptions.metavar} is an empty string,
- *   if {@link FileSizeOptions.allowNegative} or
- *   {@link FileSizeOptions.siAsBinary} is not a boolean, or if
- *   {@link FileSizeOptions.defaultUnit} is not a valid
+ * @throws {TypeError} If `metavar` is an empty string, if `allowNegative` or
+ *   `siAsBinary` is not a boolean, or if `defaultUnit` is not a valid
  *   {@link FileSizeUnit}.
  * @since 1.1.0
  */
 export function fileSize(
-  options: FileSizeOptions = {},
-): ValueParser<"sync", number> {
+  options: FileSizeOptionsNumber | FileSizeOptionsBigInt = {},
+): ValueParser<"sync", number> | ValueParser<"sync", bigint> {
   const metavar = options.metavar ?? "SIZE";
   ensureNonEmptyString(metavar);
   checkBooleanOption(options, "allowNegative");
   checkBooleanOption(options, "siAsBinary");
   checkEnumOption(options, "defaultUnit", FILE_SIZE_UNITS);
   const siAsBinary = options.siAsBinary ?? false;
-  const multiplierMap = siAsBinary ? IEC_MULTIPLIERS : {
-    ...SI_MULTIPLIERS,
-    ...IEC_ONLY_MULTIPLIERS,
-  };
-  const formatUnits = siAsBinary
-    ? FORMAT_UNITS_SI_AS_BINARY
-    : FORMAT_UNITS_DEFAULT;
 
-  function invalidFormatError(input: string): ValueParserResult<number> {
+  function invalidFormatError(input: string): ValueParserResult<never> {
     return {
       success: false,
       error: options.errors?.invalidFormat
@@ -1734,6 +1948,72 @@ export function fileSize(
     };
   }
 
+  // bigint branch
+  if (options.type === "bigint") {
+    const bigintMultiplierMap: Readonly<Record<string, bigint>> = siAsBinary
+      ? BIGINT_IEC_MULTIPLIERS
+      : {
+        ...BIGINT_SI_MULTIPLIERS,
+        ...BIGINT_IEC_ONLY_MULTIPLIERS,
+      };
+    const bigintFormatUnits = siAsBinary
+      ? BIGINT_FORMAT_UNITS_SI_AS_BINARY
+      : BIGINT_FORMAT_UNITS_DEFAULT;
+    const numberFormatUnits = siAsBinary
+      ? FORMAT_UNITS_SI_AS_BINARY
+      : FORMAT_UNITS_DEFAULT;
+
+    return {
+      mode: "sync",
+      metavar,
+      placeholder: options.placeholder ?? 0n,
+      parse(input: string): ValueParserResult<bigint> {
+        const match = FILE_SIZE_REGEX.exec(input.trim());
+        if (match == null) return invalidFormatError(input);
+        const numStr = match[1];
+        const unitStr = match[2].toLowerCase();
+        let mBig: bigint;
+        if (unitStr === "") {
+          if (options.defaultUnit == null) return invalidFormatError(input);
+          mBig = bigintMultiplierMap[options.defaultUnit.toLowerCase()];
+        } else {
+          const m = bigintMultiplierMap[unitStr];
+          if (m == null) return invalidFormatError(input);
+          mBig = m;
+        }
+        const bytes = parseExactBytesRaw(numStr, mBig);
+        if (bytes == null) return invalidFormatError(input);
+        if (!(options.allowNegative ?? false) && bytes < 0n) {
+          return {
+            success: false,
+            error: options.errors?.negativeNotAllowed
+              ? (typeof options.errors.negativeNotAllowed === "function"
+                ? options.errors.negativeNotAllowed(bytes)
+                : options.errors.negativeNotAllowed)
+              : message`Expected a non-negative file size, but got ${input}.`,
+          };
+        }
+        return { success: true, value: bytes };
+      },
+      format(value: bigint): string {
+        const maxSafe = BigInt(Number.MAX_SAFE_INTEGER);
+        if (value >= -maxSafe && value <= maxSafe) {
+          return formatWithUnits(Number(value), numberFormatUnits);
+        }
+        return formatBigIntBytes(value, bigintFormatUnits);
+      },
+    };
+  }
+
+  // number branch (default)
+  const multiplierMap = siAsBinary ? IEC_MULTIPLIERS : {
+    ...SI_MULTIPLIERS,
+    ...IEC_ONLY_MULTIPLIERS,
+  };
+  const formatUnits = siAsBinary
+    ? FORMAT_UNITS_SI_AS_BINARY
+    : FORMAT_UNITS_DEFAULT;
+
   return {
     mode: "sync",
     metavar,
@@ -1741,10 +2021,8 @@ export function fileSize(
     parse(input: string): ValueParserResult<number> {
       const match = FILE_SIZE_REGEX.exec(input.trim());
       if (match == null) return invalidFormatError(input);
-
       const numStr = match[1];
       const unitStr = match[2].toLowerCase();
-
       let multiplier: number;
       if (unitStr === "") {
         if (options.defaultUnit == null) return invalidFormatError(input);
@@ -1754,10 +2032,8 @@ export function fileSize(
         if (m == null) return invalidFormatError(input);
         multiplier = m;
       }
-
       const bytes = parseExactBytes(numStr, multiplier);
       if (bytes == null) return invalidFormatError(input);
-
       if (!(options.allowNegative ?? false) && bytes < 0) {
         return {
           success: false,
@@ -1768,7 +2044,6 @@ export function fileSize(
             : message`Expected a non-negative file size, but got ${input}.`,
         };
       }
-
       return { success: true, value: bytes };
     },
     format(value: number): string {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,9 @@ importers:
       markdown-it-deflist:
         specifier: ^3.0.0
         version: 3.0.0
+      markdown-it-footnote:
+        specifier: ^4.0.0
+        version: 4.0.0
       typescript:
         specifier: 'catalog:'
         version: 5.8.3
@@ -1858,6 +1861,9 @@ packages:
 
   markdown-it-deflist@3.0.0:
     resolution: {integrity: sha512-OxPmQ/keJZwbubjiQWOvKLHwpV2wZ5I3Smc81OjhwbfJsjdRrvD5aLTQxmZzzePeO0kbGzAo3Krk4QLgA8PWLg==}
+
+  markdown-it-footnote@4.0.0:
+    resolution: {integrity: sha512-WYJ7urf+khJYl3DqofQpYfEYkZKbmXmwxQV8c8mO/hGIhgZ1wOe7R4HLFNwqx7TjILbnC98fuyeSsin19JdFcQ==}
 
   markdown-it@14.1.0:
     resolution: {integrity: sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==}
@@ -3720,6 +3726,8 @@ snapshots:
   mark.js@8.11.1: {}
 
   markdown-it-deflist@3.0.0: {}
+
+  markdown-it-footnote@4.0.0: {}
 
   markdown-it@14.1.0:
     dependencies:


### PR DESCRIPTION
Closes #807.

## What this adds

`fileSize()` is a new value parser in *@optique/core* that converts strings like `"10MB"`, `"1.5GiB"`, or `"512B"` into byte counts. Without it, developers using `string()` had to handle unit conversion and error messages themselves.

The parser returns `number` by default and `bigint` when `type: "bigint"` is set, following the `integer()` option shape.

## Options

- `allowNegative`, defaulting to `false`, accepts negative sizes.
- `defaultUnit` supplies the unit for bare numbers.
- `siAsBinary`, defaulting to `false`, treats `KB`, `MB`, `GB`, and other SI suffixes as powers of 1,024, matching the widespread but technically incorrect convention.
- `type: "bigint"` avoids the safe-integer limit for very large values.

## Units

Both SI (powers of 1,000: KB, MB, GB, TB, PB, EB) and IEC (powers of 1,024: KiB, MiB, GiB, TiB, PiB, EiB) suffixes are accepted, matched case-insensitively. Optional whitespace between the number and suffix is allowed.

In `number` mode, results must be safe integers, so EB/EiB values and anything above roughly 9 PB are rejected. `type: "bigint"` does not apply the safe-integer check.

## Implementation notes

Parsing uses bigint arithmetic internally even in `number` mode, avoiding the float64 precision loss that would otherwise cause inputs like `"1.0000000000000001B"` to silently round to 1.

`format()` chooses an exact unit when it can, preferring IEC for exact binary multiples and then SI. It only uses a unit when the rounded quotient multiplies back to the original byte count exactly in float64, a property the tests verify with fast-check over the full `[0, MAX_SAFE_INTEGER]` range for `number` mode and up to 1,000 EB for `bigint` mode.

## Changes

- *packages/core/src/valueparser.ts*: `FileSizeUnit`, `FileSizeOptionsNumber`, `FileSizeOptionsBigInt`, `FileSizeOptions`, `fileSize()`
- *packages/core/src/valueparser.test.ts*: tests covering parsing, formatting, bigint mode, safe-integer boundaries, option validation, and fast-check round-trip properties
- *docs/concepts/valueparsers.md*: parser catalog entry, `fileSize()` section with a unit table, options, bigint mode, and error message examples
- *CHANGES.md*: 1.1.0 entry
- *docs/package.json* / *docs/.vitepress/config.mts*: `markdown-it-footnote` added for the footnote in the unit table