### PR TITLE
`color()` value parser

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -67,12 +67,23 @@ To be released.
     byte counts beyond `Number.MAX_SAFE_INTEGER` (including EB/EiB
     values).  [[#807], [#814]]
 
+ -  Added `color()` value parser for parsing CSS color strings into a
+    structured `Color` object with `r`, `g`, `b` (0–255), and `a` (0–1)
+    fields.  Supports hex notation (`#rgb`, `#rrggbb`, `#rgba`,
+    `#rrggbbaa`), RGB/RGBA functional notation, HSL/HSLA functional
+    notation, and all 148 CSS Level 4 named colors (including
+    `transparent` and `rebeccapurple`).  The `formats` option restricts
+    accepted input notations.  The `format()` method always outputs
+    canonical lowercase hex.  [[#810], [#815]]
+
 [#801]: https://github.com/dahlia/optique/issues/801
 [#802]: https://github.com/dahlia/optique/pull/802
 [#803]: https://github.com/dahlia/optique/issues/803
 [#805]: https://github.com/dahlia/optique/pull/805
 [#807]: https://github.com/dahlia/optique/issues/807
+[#810]: https://github.com/dahlia/optique/issues/810
 [#814]: https://github.com/dahlia/optique/pull/814
+[#815]: https://github.com/dahlia/optique/pull/815
 
 ### @optique/env
 

--- a/docs/concepts/valueparsers.md
+++ b/docs/concepts/valueparsers.md
@@ -34,6 +34,7 @@ with Optique's type system.
 | `integer()`                      | *@optique/core*     | `number` or `bigint`           | Integer with range validation                       |
 | `float()`                        | *@optique/core*     | `number`                       | Floating-point number                               |
 | `fileSize()`                     | *@optique/core*     | `number` or `bigint`           | Human-readable data size (bytes)                    |
+| `color()`                        | *@optique/core*     | `Color`                        | CSS color (hex, rgb, hsl, or named)                 |
 | `choice()`                       | *@optique/core*     | string or number literal union | Enumerated values                                   |
 | `url()`                          | *@optique/core*     | `URL`                          | URL with protocol filtering                         |
 | `locale()`                       | *@optique/core*     | `Intl.Locale`                  | BCP 47 locale identifier                            |
@@ -357,6 +358,100 @@ Error: Expected a non-negative file size, but got -1MB.
 ~~~~
 
 The parser uses `"SIZE"` as its default metavar.
+
+
+`color()` parser
+----------------
+
+*This API is available since Optique 1.1.0.*
+
+The `color()` parser converts CSS color strings into a structured `Color`
+object with normalized `r`, `g`, `b`, and `a` fields.  It is useful for CLI
+tools that accept theme colors, background colors, or any other color
+configuration from users.
+
+~~~~ typescript twoslash
+import { color } from "@optique/core/valueparser";
+
+// Accepts any CSS color notation
+const background = color();
+
+// Custom metavar shown in help text
+const fg = color({ metavar: "FG_COLOR" });
+~~~~
+
+### Supported formats
+
+The parser accepts four CSS color notations by default:
+
+| Format  | Examples                                       |
+| ------- | ---------------------------------------------- |
+| `hex`   | `#f00`, `#ff0000`, `#f00f`, `#ff0000ff`        |
+| `rgb`   | `rgb(255, 0, 0)`, `rgba(255, 0, 0, 0.5)`       |
+| `hsl`   | `hsl(0, 100%, 50%)`, `hsla(0, 100%, 50%, 0.5)` |
+| `named` | `red`, `rebeccapurple`, `transparent`, …       |
+
+Hex digits are matched case-insensitively.  The `rgb` and `hsl` function
+names are also case-insensitive.  Named colors are matched
+case-insensitively as well.
+
+### Return type
+
+The returned `Color` object has four fields:
+
+ -  `r`, `g`, `b` — red, green, and blue channels as integers in the range
+    0–255
+ -  `a` — alpha channel as a float in the range 0–1, where 1 is fully opaque
+    and 0 is fully transparent
+
+~~~~ typescript twoslash
+import { color, type Color } from "@optique/core/valueparser";
+// ---cut-before---
+const result = color().parse("#ff8000");
+if (result.success) {
+  const c: Color = result.value;
+  // c.r === 255, c.g === 128, c.b === 0, c.a === 1
+}
+~~~~
+
+### Restricting accepted formats
+
+Use the `formats` option to limit which notations are accepted:
+
+~~~~ typescript twoslash
+import { color } from "@optique/core/valueparser";
+// ---cut-before---
+// Only hex notation
+const hexOnly = color({ formats: ["hex"] });
+
+// Hex and named colors
+const hexOrNamed = color({ formats: ["hex", "named"] });
+~~~~
+
+### Named colors
+
+The parser recognizes all 148 CSS Level 4 named colors, including
+`transparent` (which has alpha 0) and `rebeccapurple`.  Named color lookup
+is case-insensitive, so `"Red"`, `"RED"`, and `"red"` all parse to the same
+value.
+
+When shell completion is active, named colors are suggested based on the
+current prefix.
+
+### `format()` output
+
+The `format()` method always outputs canonical lowercase hex: `#rrggbb`
+when alpha is 1, or `#rrggbbaa` when alpha is less than 1.  This means
+`format()` output can always be re-parsed with `formats: ["hex"]`.
+
+### Error messages
+
+~~~~ bash
+$ myapp --bg "notacolor"
+Error: Expected a CSS color like #ff0000, rgb(255, 0, 0), or red, but got notacolor.
+~~~~
+
+The parser uses `"COLOR"` as its default metavar.
 
 
 `choice()` parser

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -17320,6 +17320,58 @@ describe("color()", () => {
         RangeError,
       );
     });
+
+    it("formats as rgb() when hex is not in formats", () => {
+      const parser = color({ formats: ["rgb"] });
+      assert.equal(
+        parser.format({ r: 255, g: 0, b: 0, a: 1 }),
+        "rgb(255, 0, 0)",
+      );
+    });
+
+    it("formats as rgba() with alpha when hex is not in formats", () => {
+      const parser = color({ formats: ["rgb"] });
+      const formatted = parser.format({ r: 255, g: 0, b: 0, a: 128 / 255 });
+      assert.ok(formatted.startsWith("rgba(255, 0, 0,"), formatted);
+      const r = parser.parse(formatted);
+      assert.ok(r.success);
+    });
+
+    it("formats as hsl() when only hsl is in formats", () => {
+      const parser = color({ formats: ["hsl"] });
+      const formatted = parser.format({ r: 255, g: 0, b: 0, a: 1 });
+      assert.equal(formatted, "hsl(0, 100%, 50%)");
+      assert.ok(parser.parse(formatted).success);
+    });
+
+    it("formats as named color when only named is in formats and a match exists", () => {
+      const parser = color({ formats: ["named"] });
+      assert.equal(parser.format({ r: 255, g: 0, b: 0, a: 1 }), "red");
+    });
+  });
+
+  describe("normalize()", () => {
+    it("quantizes non-integer alpha to 8-bit precision", () => {
+      const normalized = color().normalize!({ r: 0, g: 0, b: 0, a: 0.5 });
+      assert.equal(normalized.a, 128 / 255);
+    });
+
+    it("leaves already-quantized alpha unchanged", () => {
+      const original: Color = { r: 0, g: 0, b: 0, a: 128 / 255 };
+      const normalized = color().normalize!(original);
+      assert.strictEqual(normalized, original);
+    });
+
+    it("leaves opaque colors with a === 1 unchanged", () => {
+      const original: Color = { r: 255, g: 0, b: 0, a: 1 };
+      const normalized = color().normalize!(original);
+      assert.strictEqual(normalized, original);
+    });
+
+    it("returns invalid Color unchanged without throwing", () => {
+      const invalid = { r: 300, g: 0, b: 0, a: 1 } as Color;
+      assert.deepEqual(color().normalize!(invalid), invalid);
+    });
   });
 
   describe("error messages", () => {

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -3,6 +3,8 @@ import {
   checkEnumOption,
   choice,
   cidr,
+  type Color,
+  color,
   domain,
   email,
   fileSize,
@@ -24,7 +26,13 @@ import {
   url,
   uuid,
 } from "@optique/core/valueparser";
-import { formatMessage, message, text, values } from "@optique/core/message";
+import {
+  formatMessage,
+  message,
+  type MessageTerm,
+  text,
+  values,
+} from "@optique/core/message";
 import assert from "node:assert/strict";
 import * as fc from "fast-check";
 import { describe, it } from "node:test";
@@ -16703,6 +16711,588 @@ describe("fileSize() — bigint mode", () => {
       });
       parser.parse("-1EB");
       assert.equal(received, -1_000_000_000_000_000_000n);
+    });
+  });
+});
+
+describe("color()", () => {
+  describe("constructor", () => {
+    it("default metavar is COLOR", () => {
+      const parser = color();
+      assert.equal(parser.metavar, "COLOR");
+    });
+
+    it("accepts custom metavar", () => {
+      const parser = color({ metavar: "FG" });
+      assert.equal(parser.metavar, "FG");
+    });
+
+    it("throws TypeError for empty metavar", () => {
+      assert.throws(() => color({ metavar: "" as NonEmptyString }), TypeError);
+    });
+
+    it("mode is sync", () => {
+      assert.equal(color().mode, "sync");
+    });
+
+    it("default placeholder is opaque black", () => {
+      assert.deepEqual(color().placeholder, { r: 0, g: 0, b: 0, a: 1 });
+    });
+
+    it("accepts custom placeholder", () => {
+      const p: Color = { r: 255, g: 0, b: 0, a: 1 };
+      assert.deepEqual(color({ placeholder: p }).placeholder, p);
+    });
+
+    it("throws TypeError for invalid format in formats array", () => {
+      assert.throws(
+        () => color({ formats: ["hex", "invalid" as never] }),
+        TypeError,
+      );
+    });
+
+    it("accepts empty formats array", () => {
+      const parser = color({ formats: [] });
+      const r = parser.parse("#ff0000");
+      assert.ok(!r.success);
+    });
+  });
+
+  describe("hex format", () => {
+    it("parses 6-digit lowercase #rrggbb", () => {
+      const r = color().parse("#ff8000");
+      assert.ok(r.success);
+      if (r.success) assert.deepEqual(r.value, { r: 255, g: 128, b: 0, a: 1 });
+    });
+
+    it("parses 6-digit uppercase #RRGGBB", () => {
+      const r = color().parse("#FF8000");
+      assert.ok(r.success);
+      if (r.success) assert.deepEqual(r.value, { r: 255, g: 128, b: 0, a: 1 });
+    });
+
+    it("parses 3-digit shorthand #rgb", () => {
+      const r = color().parse("#f80");
+      assert.ok(r.success);
+      if (r.success) assert.deepEqual(r.value, { r: 255, g: 136, b: 0, a: 1 });
+    });
+
+    it("parses 8-digit #rrggbbaa", () => {
+      const r = color().parse("#ff000080");
+      assert.ok(r.success);
+      if (r.success) {
+        assert.equal(r.value.r, 255);
+        assert.equal(r.value.g, 0);
+        assert.equal(r.value.b, 0);
+        assert.ok(Math.abs(r.value.a - 128 / 255) < 1e-9);
+      }
+    });
+
+    it("parses 4-digit shorthand #rgba", () => {
+      const r = color().parse("#f00f");
+      assert.ok(r.success);
+      if (r.success) {
+        assert.equal(r.value.r, 255);
+        assert.equal(r.value.g, 0);
+        assert.equal(r.value.b, 0);
+        assert.equal(r.value.a, 1);
+      }
+    });
+
+    it("parses #000000 as black", () => {
+      const r = color().parse("#000000");
+      assert.ok(r.success);
+      if (r.success) assert.deepEqual(r.value, { r: 0, g: 0, b: 0, a: 1 });
+    });
+
+    it("parses #ffffff as white", () => {
+      const r = color().parse("#ffffff");
+      assert.ok(r.success);
+      if (r.success) {
+        assert.deepEqual(r.value, { r: 255, g: 255, b: 255, a: 1 });
+      }
+    });
+
+    it("rejects #gg0000 — invalid hex digit", () => {
+      const r = color().parse("#gg0000");
+      assert.ok(!r.success);
+    });
+
+    it("rejects 5-digit hex", () => {
+      const r = color().parse("#ff000");
+      assert.ok(!r.success);
+    });
+
+    it("rejects 7-digit hex", () => {
+      const r = color().parse("#ff00000");
+      assert.ok(!r.success);
+    });
+
+    it("trims leading/trailing whitespace", () => {
+      const r = color().parse("  #ff0000  ");
+      assert.ok(r.success);
+    });
+
+    it("round-trip: parse(format(x)) for opaque hex color", () => {
+      fc.assert(
+        fc.property(
+          fc.integer({ min: 0, max: 255 }),
+          fc.integer({ min: 0, max: 255 }),
+          fc.integer({ min: 0, max: 255 }),
+          (r, g, b) => {
+            const parser = color();
+            const original: Color = { r, g, b, a: 1 };
+            const formatted = parser.format(original);
+            const result = parser.parse(formatted);
+            if (!result.success) return false;
+            return (
+              result.value.r === r &&
+              result.value.g === g &&
+              result.value.b === b &&
+              result.value.a === 1
+            );
+          },
+        ),
+        propertyParameters,
+      );
+    });
+  });
+
+  describe("rgb/rgba format", () => {
+    it("parses rgb(255, 0, 0) as red", () => {
+      const r = color().parse("rgb(255, 0, 0)");
+      assert.ok(r.success);
+      if (r.success) assert.deepEqual(r.value, { r: 255, g: 0, b: 0, a: 1 });
+    });
+
+    it("parses rgb(0, 0, 0) as black", () => {
+      const r = color().parse("rgb(0, 0, 0)");
+      assert.ok(r.success);
+      if (r.success) assert.deepEqual(r.value, { r: 0, g: 0, b: 0, a: 1 });
+    });
+
+    it("parses rgba(255, 128, 0, 0.5)", () => {
+      const r = color().parse("rgba(255, 128, 0, 0.5)");
+      assert.ok(r.success);
+      if (r.success) {
+        assert.equal(r.value.r, 255);
+        assert.equal(r.value.g, 128);
+        assert.equal(r.value.b, 0);
+        assert.equal(r.value.a, 0.5);
+      }
+    });
+
+    it("parses rgba(0, 0, 0, 0) as fully transparent", () => {
+      const r = color().parse("rgba(0, 0, 0, 0)");
+      assert.ok(r.success);
+      if (r.success) assert.deepEqual(r.value, { r: 0, g: 0, b: 0, a: 0 });
+    });
+
+    it("rejects rgb(256, 0, 0) — r > 255", () => {
+      const r = color().parse("rgb(256, 0, 0)");
+      assert.ok(!r.success);
+    });
+
+    it("rejects rgba(0, 0, 0, 1.5) — alpha > 1", () => {
+      const r = color().parse("rgba(0, 0, 0, 1.5)");
+      assert.ok(!r.success);
+    });
+
+    it("rejects rgba(0, 0, 0, -0.1) — alpha < 0", () => {
+      const r = color().parse("rgba(0, 0, 0, -0.1)");
+      assert.ok(!r.success);
+    });
+
+    it("accepts extra whitespace: rgb( 255 , 0 , 0 )", () => {
+      const r = color().parse("rgb( 255 , 0 , 0 )");
+      assert.ok(r.success);
+    });
+
+    it("case-insensitive: RGB(255, 0, 0)", () => {
+      const r = color().parse("RGB(255, 0, 0)");
+      assert.ok(r.success);
+    });
+
+    it("case-insensitive: RGBA(255, 0, 0, 1)", () => {
+      const r = color().parse("RGBA(255, 0, 0, 1)");
+      assert.ok(r.success);
+    });
+  });
+
+  describe("hsl/hsla format", () => {
+    it("parses hsl(0, 100%, 50%) as red", () => {
+      const r = color().parse("hsl(0, 100%, 50%)");
+      assert.ok(r.success);
+      if (r.success) assert.deepEqual(r.value, { r: 255, g: 0, b: 0, a: 1 });
+    });
+
+    it("parses hsl(120, 100%, 50%) as lime", () => {
+      const r = color().parse("hsl(120, 100%, 50%)");
+      assert.ok(r.success);
+      if (r.success) assert.deepEqual(r.value, { r: 0, g: 255, b: 0, a: 1 });
+    });
+
+    it("parses hsl(240, 100%, 50%) as blue", () => {
+      const r = color().parse("hsl(240, 100%, 50%)");
+      assert.ok(r.success);
+      if (r.success) assert.deepEqual(r.value, { r: 0, g: 0, b: 255, a: 1 });
+    });
+
+    it("parses hsl(0, 0%, 0%) as black", () => {
+      const r = color().parse("hsl(0, 0%, 0%)");
+      assert.ok(r.success);
+      if (r.success) assert.deepEqual(r.value, { r: 0, g: 0, b: 0, a: 1 });
+    });
+
+    it("parses hsl(0, 0%, 100%) as white", () => {
+      const r = color().parse("hsl(0, 0%, 100%)");
+      assert.ok(r.success);
+      if (r.success) {
+        assert.deepEqual(r.value, { r: 255, g: 255, b: 255, a: 1 });
+      }
+    });
+
+    it("parses hsla(120, 100%, 50%, 0.5)", () => {
+      const r = color().parse("hsla(120, 100%, 50%, 0.5)");
+      assert.ok(r.success);
+      if (r.success) {
+        assert.equal(r.value.r, 0);
+        assert.equal(r.value.g, 255);
+        assert.equal(r.value.b, 0);
+        assert.equal(r.value.a, 0.5);
+      }
+    });
+
+    it("accepts hsl(360, 100%, 50%) — hue wraps to 0", () => {
+      const r = color().parse("hsl(360, 100%, 50%)");
+      assert.ok(r.success);
+      if (r.success) assert.deepEqual(r.value, { r: 255, g: 0, b: 0, a: 1 });
+    });
+
+    it("rejects hsl(361, 100%, 50%) — hue > 360", () => {
+      const r = color().parse("hsl(361, 100%, 50%)");
+      assert.ok(!r.success);
+    });
+
+    it("rejects hsl(-1, 100%, 50%) — hue < 0", () => {
+      const r = color().parse("hsl(-1, 100%, 50%)");
+      assert.ok(!r.success);
+    });
+
+    it("rejects hsl(0, 101%, 50%) — saturation > 100%", () => {
+      const r = color().parse("hsl(0, 101%, 50%)");
+      assert.ok(!r.success);
+    });
+
+    it("rejects hsl(0, 100%, 101%) — lightness > 100%", () => {
+      const r = color().parse("hsl(0, 100%, 101%)");
+      assert.ok(!r.success);
+    });
+
+    it("rejects hsla(0, 100%, 50%, 1.1) — alpha > 1", () => {
+      const r = color().parse("hsla(0, 100%, 50%, 1.1)");
+      assert.ok(!r.success);
+    });
+
+    it("case-insensitive: HSL(0, 100%, 50%)", () => {
+      const r = color().parse("HSL(0, 100%, 50%)");
+      assert.ok(r.success);
+    });
+
+    it("case-insensitive: HSLA(0, 100%, 50%, 1)", () => {
+      const r = color().parse("HSLA(0, 100%, 50%, 1)");
+      assert.ok(r.success);
+    });
+  });
+
+  describe("named colors", () => {
+    it("parses 'red'", () => {
+      const r = color().parse("red");
+      assert.ok(r.success);
+      if (r.success) assert.deepEqual(r.value, { r: 255, g: 0, b: 0, a: 1 });
+    });
+
+    it("parses 'green' as #008000", () => {
+      const r = color().parse("green");
+      assert.ok(r.success);
+      if (r.success) assert.deepEqual(r.value, { r: 0, g: 128, b: 0, a: 1 });
+    });
+
+    it("parses 'blue'", () => {
+      const r = color().parse("blue");
+      assert.ok(r.success);
+      if (r.success) assert.deepEqual(r.value, { r: 0, g: 0, b: 255, a: 1 });
+    });
+
+    it("parses 'white'", () => {
+      const r = color().parse("white");
+      assert.ok(r.success);
+      if (r.success) {
+        assert.deepEqual(r.value, { r: 255, g: 255, b: 255, a: 1 });
+      }
+    });
+
+    it("parses 'black'", () => {
+      const r = color().parse("black");
+      assert.ok(r.success);
+      if (r.success) assert.deepEqual(r.value, { r: 0, g: 0, b: 0, a: 1 });
+    });
+
+    it("parses 'transparent' as fully transparent black", () => {
+      const r = color().parse("transparent");
+      assert.ok(r.success);
+      if (r.success) assert.deepEqual(r.value, { r: 0, g: 0, b: 0, a: 0 });
+    });
+
+    it("parses 'rebeccapurple' (#663399)", () => {
+      const r = color().parse("rebeccapurple");
+      assert.ok(r.success);
+      if (r.success) {
+        assert.equal(r.value.r, 102);
+        assert.equal(r.value.g, 51);
+        assert.equal(r.value.b, 153);
+        assert.equal(r.value.a, 1);
+      }
+    });
+
+    it("case-insensitive: 'RED', 'Red', 'rEd'", () => {
+      const red = { r: 255, g: 0, b: 0, a: 1 };
+      for (const name of ["RED", "Red", "rEd"]) {
+        const r = color().parse(name);
+        assert.ok(r.success, `Expected ${name} to parse`);
+        if (r.success) assert.deepEqual(r.value, red);
+      }
+    });
+
+    it("'aqua' and 'cyan' are the same color", () => {
+      const a = color().parse("aqua");
+      const c = color().parse("cyan");
+      assert.ok(a.success && c.success);
+      if (a.success && c.success) assert.deepEqual(a.value, c.value);
+    });
+
+    it("'fuchsia' and 'magenta' are the same color", () => {
+      const a = color().parse("fuchsia");
+      const b = color().parse("magenta");
+      assert.ok(a.success && b.success);
+      if (a.success && b.success) assert.deepEqual(a.value, b.value);
+    });
+
+    it("'gray' and 'grey' are the same color", () => {
+      const a = color().parse("gray");
+      const b = color().parse("grey");
+      assert.ok(a.success && b.success);
+      if (a.success && b.success) assert.deepEqual(a.value, b.value);
+    });
+
+    it("rejects unknown name 'notacolor'", () => {
+      const r = color().parse("notacolor");
+      assert.ok(!r.success);
+    });
+
+    it("rejects empty string", () => {
+      const r = color().parse("");
+      assert.ok(!r.success);
+    });
+  });
+
+  describe("formats option", () => {
+    it("formats: ['hex'] accepts hex", () => {
+      const r = color({ formats: ["hex"] }).parse("#ff0000");
+      assert.ok(r.success);
+    });
+
+    it("formats: ['hex'] rejects rgb", () => {
+      const r = color({ formats: ["hex"] }).parse("rgb(255, 0, 0)");
+      assert.ok(!r.success);
+    });
+
+    it("formats: ['hex'] rejects hsl", () => {
+      const r = color({ formats: ["hex"] }).parse("hsl(0, 100%, 50%)");
+      assert.ok(!r.success);
+    });
+
+    it("formats: ['hex'] rejects named", () => {
+      const r = color({ formats: ["hex"] }).parse("red");
+      assert.ok(!r.success);
+    });
+
+    it("formats: ['rgb'] accepts rgb", () => {
+      const r = color({ formats: ["rgb"] }).parse("rgb(255, 0, 0)");
+      assert.ok(r.success);
+    });
+
+    it("formats: ['rgb'] rejects hex", () => {
+      const r = color({ formats: ["rgb"] }).parse("#ff0000");
+      assert.ok(!r.success);
+    });
+
+    it("formats: ['hsl'] accepts hsl", () => {
+      const r = color({ formats: ["hsl"] }).parse("hsl(0, 100%, 50%)");
+      assert.ok(r.success);
+    });
+
+    it("formats: ['hsl'] rejects hex", () => {
+      const r = color({ formats: ["hsl"] }).parse("#ff0000");
+      assert.ok(!r.success);
+    });
+
+    it("formats: ['named'] accepts named colors", () => {
+      const r = color({ formats: ["named"] }).parse("red");
+      assert.ok(r.success);
+    });
+
+    it("formats: ['named'] rejects hex", () => {
+      const r = color({ formats: ["named"] }).parse("#ff0000");
+      assert.ok(!r.success);
+    });
+
+    it("formats: ['hex', 'named'] accepts hex and named", () => {
+      assert.ok(color({ formats: ["hex", "named"] }).parse("#ff0000").success);
+      assert.ok(color({ formats: ["hex", "named"] }).parse("red").success);
+    });
+
+    it("formats: ['hex', 'named'] rejects rgb and hsl", () => {
+      assert.ok(
+        !color({ formats: ["hex", "named"] }).parse("rgb(255, 0, 0)").success,
+      );
+      assert.ok(
+        !color({ formats: ["hex", "named"] }).parse("hsl(0, 100%, 50%)")
+          .success,
+      );
+    });
+  });
+
+  describe("format()", () => {
+    it("formats opaque color as #rrggbb", () => {
+      assert.equal(
+        color().format({ r: 255, g: 0, b: 0, a: 1 }),
+        "#ff0000",
+      );
+    });
+
+    it("formats #000000", () => {
+      assert.equal(
+        color().format({ r: 0, g: 0, b: 0, a: 1 }),
+        "#000000",
+      );
+    });
+
+    it("formats #ffffff", () => {
+      assert.equal(
+        color().format({ r: 255, g: 255, b: 255, a: 1 }),
+        "#ffffff",
+      );
+    });
+
+    it("formats transparent as #00000000", () => {
+      assert.equal(
+        color().format({ r: 0, g: 0, b: 0, a: 0 }),
+        "#00000000",
+      );
+    });
+
+    it("formats 50% alpha as #rrggbb80", () => {
+      const formatted = color().format({ r: 255, g: 0, b: 0, a: 0.5 });
+      assert.equal(formatted, "#ff000080");
+    });
+
+    it("property: parse(format(x)) round-trips for integer r/g/b", () => {
+      fc.assert(
+        fc.property(
+          fc.integer({ min: 0, max: 255 }),
+          fc.integer({ min: 0, max: 255 }),
+          fc.integer({ min: 0, max: 255 }),
+          (r, g, b) => {
+            const parser = color();
+            const original: Color = { r, g, b, a: 1 };
+            const result = parser.parse(parser.format(original));
+            return result.success &&
+              result.value.r === r &&
+              result.value.g === g &&
+              result.value.b === b &&
+              result.value.a === 1;
+          },
+        ),
+        propertyParameters,
+      );
+    });
+  });
+
+  describe("error messages", () => {
+    it("default error message on invalid input mentions the input", () => {
+      const r = color().parse("notacolor");
+      assert.ok(!r.success);
+      if (!r.success) {
+        const mentionsInput = r.error.some(
+          (t: MessageTerm) => t.type === "value" && t.value === "notacolor",
+        );
+        assert.ok(mentionsInput, "Error should mention input");
+      }
+    });
+
+    it("uses static invalidFormat error message", () => {
+      const customError = message`Must be a valid color.`;
+      const parser = color({ errors: { invalidFormat: customError } });
+      const r = parser.parse("notacolor");
+      assert.ok(!r.success);
+      if (!r.success) assert.deepEqual(r.error, customError);
+    });
+
+    it("uses function invalidFormat receiving raw input", () => {
+      let received: string | undefined;
+      const parser = color({
+        errors: {
+          invalidFormat: (input: string) => {
+            received = input;
+            return message`Bad color: ${input}`;
+          },
+        },
+      });
+      parser.parse("  notacolor  ");
+      assert.equal(received, "  notacolor  ");
+    });
+  });
+
+  describe("suggest()", () => {
+    it("suggests named colors matching prefix", () => {
+      const suggestions = [...color().suggest!("re")]
+        .filter((s) => s.kind === "literal")
+        .map((s) => s.kind === "literal" ? s.text : "");
+      assert.ok(suggestions.includes("red"), "should include 'red'");
+      assert.ok(
+        suggestions.includes("rebeccapurple"),
+        "should include 'rebeccapurple'",
+      );
+    });
+
+    it("suggest prefix 're' does not include 'blue'", () => {
+      const suggestions = [...color().suggest!("re")]
+        .filter((s) => s.kind === "literal")
+        .map((s) => s.kind === "literal" ? s.text : "");
+      assert.ok(!suggestions.includes("blue"));
+    });
+
+    it("no suggestions when formats excludes named", () => {
+      const suggestions = [...color({ formats: ["hex"] }).suggest!("re")];
+      assert.deepEqual(suggestions, []);
+    });
+
+    it("case-insensitive prefix: 'RE' matches named colors", () => {
+      const suggestions = [...color().suggest!("RE")]
+        .filter((s) => s.kind === "literal")
+        .map((s) => s.kind === "literal" ? s.text : "");
+      assert.ok(suggestions.includes("red"));
+    });
+
+    it("empty prefix yields all named colors", () => {
+      const suggestions = [...color().suggest!("")];
+      assert.ok(suggestions.length > 100, "should have many named colors");
+    });
+
+    it("no suggestions for unmatched prefix", () => {
+      const suggestions = [...color().suggest!("zzz")];
+      assert.deepEqual(suggestions, []);
     });
   });
 });

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -17163,6 +17163,46 @@ describe("color()", () => {
     });
   });
 
+  describe("NaN/malformed input rejection", () => {
+    it("rejects rgba with dot-only alpha: rgba(0,0,0,.)", () => {
+      assert.ok(!color().parse("rgba(0,0,0,.)").success);
+    });
+
+    it("rejects rgba with double-dot alpha: rgba(0,0,0,1..)", () => {
+      assert.ok(!color().parse("rgba(0,0,0,1..)").success);
+    });
+
+    it("accepts rgba with leading-dot alpha: rgba(0,0,0,.5)", () => {
+      const r = color().parse("rgba(0,0,0,.5)");
+      assert.ok(r.success);
+      if (r.success) assert.equal(r.value.a, 0.5);
+    });
+
+    it("rejects hsl with dot-only hue: hsl(.,50%,50%)", () => {
+      assert.ok(!color().parse("hsl(.,50%,50%)").success);
+    });
+
+    it("rejects hsl with double-dot hue: hsl(1..,50%,50%)", () => {
+      assert.ok(!color().parse("hsl(1..,50%,50%)").success);
+    });
+
+    it("rejects hsl with dot-only saturation: hsl(0,.%,50%)", () => {
+      assert.ok(!color().parse("hsl(0,.%,50%)").success);
+    });
+  });
+
+  describe("named color immutability", () => {
+    it("returns a fresh object each time for named colors", () => {
+      const r1 = color().parse("red");
+      const r2 = color().parse("red");
+      assert.ok(r1.success && r2.success);
+      if (r1.success && r2.success) {
+        assert.notStrictEqual(r1.value, r2.value);
+        assert.deepEqual(r1.value, r2.value);
+      }
+    });
+  });
+
   describe("format()", () => {
     it("formats opaque color as #rrggbb", () => {
       assert.equal(
@@ -17215,6 +17255,48 @@ describe("color()", () => {
           },
         ),
         propertyParameters,
+      );
+    });
+
+    it("throws RangeError for r > 255", () => {
+      assert.throws(
+        () => color().format({ r: 300, g: 0, b: 0, a: 1 }),
+        RangeError,
+      );
+    });
+
+    it("throws RangeError for a > 1", () => {
+      assert.throws(
+        () => color().format({ r: 0, g: 0, b: 0, a: 1.5 }),
+        RangeError,
+      );
+    });
+
+    it("throws RangeError for NaN in a field", () => {
+      assert.throws(
+        () => color().format({ r: 0, g: 0, b: 0, a: Number.NaN }),
+        RangeError,
+      );
+    });
+
+    it("throws RangeError for fractional r", () => {
+      assert.throws(
+        () => color().format({ r: 0.5, g: 0, b: 0, a: 1 }),
+        RangeError,
+      );
+    });
+
+    it("throws RangeError for fractional g", () => {
+      assert.throws(
+        () => color().format({ r: 0, g: 128.7, b: 0, a: 1 }),
+        RangeError,
+      );
+    });
+
+    it("throws RangeError for fractional b", () => {
+      assert.throws(
+        () => color().format({ r: 0, g: 0, b: 0.1, a: 1 }),
+        RangeError,
       );
     });
   });

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -16963,18 +16963,18 @@ describe("color()", () => {
       }
     });
 
-    it("accepts hsl(360, 100%, 50%) — hue wraps to 0", () => {
+    it("accepts hsl(360, 100%, 50%) — hue wraps to same as 0°", () => {
       const r = color().parse("hsl(360, 100%, 50%)");
       assert.ok(r.success);
       if (r.success) assert.deepEqual(r.value, { r: 255, g: 0, b: 0, a: 1 });
     });
 
-    it("rejects hsl(361, 100%, 50%) — hue > 360", () => {
+    it("accepts hsl(361, 100%, 50%) — out-of-range hue wraps", () => {
       const r = color().parse("hsl(361, 100%, 50%)");
-      assert.ok(!r.success);
+      assert.ok(r.success);
     });
 
-    it("rejects hsl(-1, 100%, 50%) — hue < 0", () => {
+    it("rejects hsl(-1, 100%, 50%) — negative hue not matched by input pattern", () => {
       const r = color().parse("hsl(-1, 100%, 50%)");
       assert.ok(!r.success);
     });

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -16886,7 +16886,7 @@ describe("color()", () => {
         assert.equal(r.value.r, 255);
         assert.equal(r.value.g, 128);
         assert.equal(r.value.b, 0);
-        assert.equal(r.value.a, 0.5);
+        assert.equal(r.value.a, 128 / 255); // quantized to 8-bit
       }
     });
 
@@ -16967,7 +16967,7 @@ describe("color()", () => {
         assert.equal(r.value.r, 0);
         assert.equal(r.value.g, 255);
         assert.equal(r.value.b, 0);
-        assert.equal(r.value.a, 0.5);
+        assert.equal(r.value.a, 128 / 255); // quantized to 8-bit
       }
     });
 
@@ -17184,7 +17184,7 @@ describe("color()", () => {
     it("accepts rgba with leading-dot alpha: rgba(0,0,0,.5)", () => {
       const r = color().parse("rgba(0,0,0,.5)");
       assert.ok(r.success);
-      if (r.success) assert.equal(r.value.a, 0.5);
+      if (r.success) assert.equal(r.value.a, 128 / 255); // quantized to 8-bit
     });
 
     it("rejects hsl with dot-only hue: hsl(.,50%,50%)", () => {

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -17348,6 +17348,23 @@ describe("color()", () => {
       const parser = color({ formats: ["named"] });
       assert.equal(parser.format({ r: 255, g: 0, b: 0, a: 1 }), "red");
     });
+
+    it("throws RangeError for named-only parser when no name matches", () => {
+      assert.throws(
+        () =>
+          color({ formats: ["named"] }).format({ r: 128, g: 64, b: 32, a: 1 }),
+        RangeError,
+      );
+    });
+
+    it("hsl format() round-trips near-black color {r:0,g:0,b:1}", () => {
+      const parser = color({ formats: ["hsl"] });
+      const original: Color = { r: 0, g: 0, b: 1, a: 1 };
+      const formatted = parser.format(original);
+      const result = parser.parse(formatted);
+      assert.ok(result.success, `Expected success but got: ${formatted}`);
+      if (result.success) assert.deepEqual(result.value, original);
+    });
   });
 
   describe("normalize()", () => {

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -16728,7 +16728,12 @@ describe("color()", () => {
     });
 
     it("throws TypeError for empty metavar", () => {
-      assert.throws(() => color({ metavar: "" as NonEmptyString }), TypeError);
+      assert.throws(
+        () => color({ metavar: "" as NonEmptyString }),
+        (e: unknown) =>
+          e instanceof TypeError &&
+          e.message === "Expected a non-empty string.",
+      );
     });
 
     it("mode is sync", () => {
@@ -16747,7 +16752,10 @@ describe("color()", () => {
     it("throws TypeError for invalid format in formats array", () => {
       assert.throws(
         () => color({ formats: ["hex", "invalid" as never] }),
-        TypeError,
+        (e: unknown) =>
+          e instanceof TypeError &&
+          e.message ===
+            `Expected formats to contain only "hex", "rgb", "hsl", "named", but got: "invalid".`,
       );
     });
 
@@ -17369,7 +17377,7 @@ describe("color()", () => {
 
     it("empty prefix yields all named colors", () => {
       const suggestions = [...color().suggest!("")];
-      assert.ok(suggestions.length > 100, "should have many named colors");
+      assert.equal(suggestions.length, 149);
     });
 
     it("no suggestions for unmatched prefix", () => {

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -16982,9 +16982,10 @@ describe("color()", () => {
       assert.ok(r.success);
     });
 
-    it("rejects hsl(-1, 100%, 50%) — negative hue not matched by input pattern", () => {
-      const r = color().parse("hsl(-1, 100%, 50%)");
-      assert.ok(!r.success);
+    it("accepts hsl(-120, 100%, 50%) — negative hue wraps to 240°", () => {
+      const r = color().parse("hsl(-120, 100%, 50%)");
+      assert.ok(r.success);
+      if (r.success) assert.deepEqual(r.value, { r: 0, g: 0, b: 255, a: 1 });
     });
 
     it("rejects hsl(0, 101%, 50%) — saturation > 100%", () => {

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -17103,6 +17103,18 @@ describe("color()", () => {
       const r = color().parse("");
       assert.ok(!r.success);
     });
+
+    it("rejects prototype-inherited keys like 'constructor'", () => {
+      assert.ok(!color().parse("constructor").success);
+    });
+
+    it("rejects prototype-inherited keys like 'toString'", () => {
+      assert.ok(!color().parse("toString").success);
+    });
+
+    it("rejects '__proto__'", () => {
+      assert.ok(!color().parse("__proto__").success);
+    });
   });
 
   describe("formats option", () => {

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -2059,6 +2059,395 @@ export function fileSize(
   };
 }
 
+// https://www.w3.org/TR/css-color-4/#named-colors
+const CSS_NAMED_COLORS: Readonly<Record<string, Color>> = {
+  aliceblue: { r: 240, g: 248, b: 255, a: 1 },
+  antiquewhite: { r: 250, g: 235, b: 215, a: 1 },
+  aqua: { r: 0, g: 255, b: 255, a: 1 },
+  aquamarine: { r: 127, g: 255, b: 212, a: 1 },
+  azure: { r: 240, g: 255, b: 255, a: 1 },
+  beige: { r: 245, g: 245, b: 220, a: 1 },
+  bisque: { r: 255, g: 228, b: 196, a: 1 },
+  black: { r: 0, g: 0, b: 0, a: 1 },
+  blanchedalmond: { r: 255, g: 235, b: 205, a: 1 },
+  blue: { r: 0, g: 0, b: 255, a: 1 },
+  blueviolet: { r: 138, g: 43, b: 226, a: 1 },
+  brown: { r: 165, g: 42, b: 42, a: 1 },
+  burlywood: { r: 222, g: 184, b: 135, a: 1 },
+  cadetblue: { r: 95, g: 158, b: 160, a: 1 },
+  chartreuse: { r: 127, g: 255, b: 0, a: 1 },
+  chocolate: { r: 210, g: 105, b: 30, a: 1 },
+  coral: { r: 255, g: 127, b: 80, a: 1 },
+  cornflowerblue: { r: 100, g: 149, b: 237, a: 1 },
+  cornsilk: { r: 255, g: 248, b: 220, a: 1 },
+  crimson: { r: 220, g: 20, b: 60, a: 1 },
+  cyan: { r: 0, g: 255, b: 255, a: 1 },
+  darkblue: { r: 0, g: 0, b: 139, a: 1 },
+  darkcyan: { r: 0, g: 139, b: 139, a: 1 },
+  darkgoldenrod: { r: 184, g: 134, b: 11, a: 1 },
+  darkgray: { r: 169, g: 169, b: 169, a: 1 },
+  darkgreen: { r: 0, g: 100, b: 0, a: 1 },
+  darkgrey: { r: 169, g: 169, b: 169, a: 1 },
+  darkkhaki: { r: 189, g: 183, b: 107, a: 1 },
+  darkmagenta: { r: 139, g: 0, b: 139, a: 1 },
+  darkolivegreen: { r: 85, g: 107, b: 47, a: 1 },
+  darkorange: { r: 255, g: 140, b: 0, a: 1 },
+  darkorchid: { r: 153, g: 50, b: 204, a: 1 },
+  darkred: { r: 139, g: 0, b: 0, a: 1 },
+  darksalmon: { r: 233, g: 150, b: 122, a: 1 },
+  darkseagreen: { r: 143, g: 188, b: 143, a: 1 },
+  darkslateblue: { r: 72, g: 61, b: 139, a: 1 },
+  darkslategray: { r: 47, g: 79, b: 79, a: 1 },
+  darkslategrey: { r: 47, g: 79, b: 79, a: 1 },
+  darkturquoise: { r: 0, g: 206, b: 209, a: 1 },
+  darkviolet: { r: 148, g: 0, b: 211, a: 1 },
+  deeppink: { r: 255, g: 20, b: 147, a: 1 },
+  deepskyblue: { r: 0, g: 191, b: 255, a: 1 },
+  dimgray: { r: 105, g: 105, b: 105, a: 1 },
+  dimgrey: { r: 105, g: 105, b: 105, a: 1 },
+  dodgerblue: { r: 30, g: 144, b: 255, a: 1 },
+  firebrick: { r: 178, g: 34, b: 34, a: 1 },
+  floralwhite: { r: 255, g: 250, b: 240, a: 1 },
+  forestgreen: { r: 34, g: 139, b: 34, a: 1 },
+  fuchsia: { r: 255, g: 0, b: 255, a: 1 },
+  gainsboro: { r: 220, g: 220, b: 220, a: 1 },
+  ghostwhite: { r: 248, g: 248, b: 255, a: 1 },
+  gold: { r: 255, g: 215, b: 0, a: 1 },
+  goldenrod: { r: 218, g: 165, b: 32, a: 1 },
+  gray: { r: 128, g: 128, b: 128, a: 1 },
+  green: { r: 0, g: 128, b: 0, a: 1 },
+  greenyellow: { r: 173, g: 255, b: 47, a: 1 },
+  grey: { r: 128, g: 128, b: 128, a: 1 },
+  honeydew: { r: 240, g: 255, b: 240, a: 1 },
+  hotpink: { r: 255, g: 105, b: 180, a: 1 },
+  indianred: { r: 205, g: 92, b: 92, a: 1 },
+  indigo: { r: 75, g: 0, b: 130, a: 1 },
+  ivory: { r: 255, g: 255, b: 240, a: 1 },
+  khaki: { r: 240, g: 230, b: 140, a: 1 },
+  lavender: { r: 230, g: 230, b: 250, a: 1 },
+  lavenderblush: { r: 255, g: 240, b: 245, a: 1 },
+  lawngreen: { r: 124, g: 252, b: 0, a: 1 },
+  lemonchiffon: { r: 255, g: 250, b: 205, a: 1 },
+  lightblue: { r: 173, g: 216, b: 230, a: 1 },
+  lightcoral: { r: 240, g: 128, b: 128, a: 1 },
+  lightcyan: { r: 224, g: 255, b: 255, a: 1 },
+  lightgoldenrodyellow: { r: 250, g: 250, b: 210, a: 1 },
+  lightgray: { r: 211, g: 211, b: 211, a: 1 },
+  lightgreen: { r: 144, g: 238, b: 144, a: 1 },
+  lightgrey: { r: 211, g: 211, b: 211, a: 1 },
+  lightpink: { r: 255, g: 182, b: 193, a: 1 },
+  lightsalmon: { r: 255, g: 160, b: 122, a: 1 },
+  lightseagreen: { r: 32, g: 178, b: 170, a: 1 },
+  lightskyblue: { r: 135, g: 206, b: 250, a: 1 },
+  lightslategray: { r: 119, g: 136, b: 153, a: 1 },
+  lightslategrey: { r: 119, g: 136, b: 153, a: 1 },
+  lightsteelblue: { r: 176, g: 196, b: 222, a: 1 },
+  lightyellow: { r: 255, g: 255, b: 224, a: 1 },
+  lime: { r: 0, g: 255, b: 0, a: 1 },
+  limegreen: { r: 50, g: 205, b: 50, a: 1 },
+  linen: { r: 250, g: 240, b: 230, a: 1 },
+  magenta: { r: 255, g: 0, b: 255, a: 1 },
+  maroon: { r: 128, g: 0, b: 0, a: 1 },
+  mediumaquamarine: { r: 102, g: 205, b: 170, a: 1 },
+  mediumblue: { r: 0, g: 0, b: 205, a: 1 },
+  mediumorchid: { r: 186, g: 85, b: 211, a: 1 },
+  mediumpurple: { r: 147, g: 112, b: 219, a: 1 },
+  mediumseagreen: { r: 60, g: 179, b: 113, a: 1 },
+  mediumslateblue: { r: 123, g: 104, b: 238, a: 1 },
+  mediumspringgreen: { r: 0, g: 250, b: 154, a: 1 },
+  mediumturquoise: { r: 72, g: 209, b: 204, a: 1 },
+  mediumvioletred: { r: 199, g: 21, b: 133, a: 1 },
+  midnightblue: { r: 25, g: 25, b: 112, a: 1 },
+  mintcream: { r: 245, g: 255, b: 250, a: 1 },
+  mistyrose: { r: 255, g: 228, b: 225, a: 1 },
+  moccasin: { r: 255, g: 228, b: 181, a: 1 },
+  navajowhite: { r: 255, g: 222, b: 173, a: 1 },
+  navy: { r: 0, g: 0, b: 128, a: 1 },
+  oldlace: { r: 253, g: 245, b: 230, a: 1 },
+  olive: { r: 128, g: 128, b: 0, a: 1 },
+  olivedrab: { r: 107, g: 142, b: 35, a: 1 },
+  orange: { r: 255, g: 165, b: 0, a: 1 },
+  orangered: { r: 255, g: 69, b: 0, a: 1 },
+  orchid: { r: 218, g: 112, b: 214, a: 1 },
+  palegoldenrod: { r: 238, g: 232, b: 170, a: 1 },
+  palegreen: { r: 152, g: 251, b: 152, a: 1 },
+  paleturquoise: { r: 175, g: 238, b: 238, a: 1 },
+  palevioletred: { r: 219, g: 112, b: 147, a: 1 },
+  papayawhip: { r: 255, g: 239, b: 213, a: 1 },
+  peachpuff: { r: 255, g: 218, b: 185, a: 1 },
+  peru: { r: 205, g: 133, b: 63, a: 1 },
+  pink: { r: 255, g: 192, b: 203, a: 1 },
+  plum: { r: 221, g: 160, b: 221, a: 1 },
+  powderblue: { r: 176, g: 224, b: 230, a: 1 },
+  purple: { r: 128, g: 0, b: 128, a: 1 },
+  rebeccapurple: { r: 102, g: 51, b: 153, a: 1 },
+  red: { r: 255, g: 0, b: 0, a: 1 },
+  rosybrown: { r: 188, g: 143, b: 143, a: 1 },
+  royalblue: { r: 65, g: 105, b: 225, a: 1 },
+  saddlebrown: { r: 139, g: 69, b: 19, a: 1 },
+  salmon: { r: 250, g: 128, b: 114, a: 1 },
+  sandybrown: { r: 244, g: 164, b: 96, a: 1 },
+  seagreen: { r: 46, g: 139, b: 87, a: 1 },
+  seashell: { r: 255, g: 245, b: 238, a: 1 },
+  sienna: { r: 160, g: 82, b: 45, a: 1 },
+  silver: { r: 192, g: 192, b: 192, a: 1 },
+  skyblue: { r: 135, g: 206, b: 235, a: 1 },
+  slateblue: { r: 106, g: 90, b: 205, a: 1 },
+  slategray: { r: 112, g: 128, b: 144, a: 1 },
+  slategrey: { r: 112, g: 128, b: 144, a: 1 },
+  snow: { r: 255, g: 250, b: 250, a: 1 },
+  springgreen: { r: 0, g: 255, b: 127, a: 1 },
+  steelblue: { r: 70, g: 130, b: 180, a: 1 },
+  tan: { r: 210, g: 180, b: 140, a: 1 },
+  teal: { r: 0, g: 128, b: 128, a: 1 },
+  thistle: { r: 216, g: 191, b: 216, a: 1 },
+  tomato: { r: 255, g: 99, b: 71, a: 1 },
+  transparent: { r: 0, g: 0, b: 0, a: 0 },
+  turquoise: { r: 64, g: 224, b: 208, a: 1 },
+  violet: { r: 238, g: 130, b: 238, a: 1 },
+  wheat: { r: 245, g: 222, b: 179, a: 1 },
+  white: { r: 255, g: 255, b: 255, a: 1 },
+  whitesmoke: { r: 245, g: 245, b: 245, a: 1 },
+  yellow: { r: 255, g: 255, b: 0, a: 1 },
+  yellowgreen: { r: 154, g: 205, b: 50, a: 1 },
+};
+
+function hslToRgb(
+  h: number,
+  s: number,
+  l: number,
+): [number, number, number] {
+  h = ((h % 360) + 360) % 360;
+  const a = s * Math.min(l, 1 - l);
+  const f = (n: number): number => {
+    const k = (n + h / 30) % 12;
+    return l - a * Math.max(-1, Math.min(k - 3, 9 - k, 1));
+  };
+  return [
+    Math.round(f(0) * 255),
+    Math.round(f(8) * 255),
+    Math.round(f(4) * 255),
+  ];
+}
+
+const COLOR_HEX_SHORT_REGEX =
+  /^#([0-9a-fA-F])([0-9a-fA-F])([0-9a-fA-F])([0-9a-fA-F])?$/;
+const COLOR_HEX_LONG_REGEX =
+  /^#([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})?$/;
+const COLOR_RGB_REGEX =
+  /^rgba?\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*(?:,\s*([\d.]+))?\s*\)$/i;
+const COLOR_HSL_REGEX =
+  /^hsla?\(\s*([\d.]+)\s*,\s*([\d.]+)%\s*,\s*([\d.]+)%\s*(?:,\s*([\d.]+))?\s*\)$/i;
+
+const VALID_COLOR_FORMATS = ["hex", "rgb", "hsl", "named"] as const;
+
+/**
+ * A structured CSS color value with normalized RGBA components.
+ * @since 1.1.0
+ */
+export interface Color {
+  /** Red channel, 0–255. */
+  readonly r: number;
+  /** Green channel, 0–255. */
+  readonly g: number;
+  /** Blue channel, 0–255. */
+  readonly b: number;
+  /** Alpha channel, 0–1 (1 = fully opaque). */
+  readonly a: number;
+}
+
+/**
+ * The CSS color notation a {@link color} parser accepts.
+ * @since 1.1.0
+ */
+export type ColorFormat = "hex" | "rgb" | "hsl" | "named";
+
+/**
+ * Options for creating a {@link color} value parser.
+ * @since 1.1.0
+ */
+export interface ColorOptions {
+  /**
+   * The metavariable name for this parser.  Used in help messages to
+   * indicate what kind of value this parser expects.
+   * @default `"COLOR"`
+   */
+  readonly metavar?: NonEmptyString;
+
+  /**
+   * Restricts which CSS color notations are accepted.  Defaults to all
+   * four notations: `"hex"`, `"rgb"`, `"hsl"`, and `"named"`.
+   * @default all formats
+   */
+  readonly formats?: readonly ColorFormat[];
+
+  /**
+   * A custom placeholder value used during deferred prompt resolution.
+   * @default `{ r: 0, g: 0, b: 0, a: 1 }`
+   * @since 1.1.0
+   */
+  readonly placeholder?: Color;
+
+  /**
+   * Custom error messages for color parsing failures.
+   * @since 1.1.0
+   */
+  readonly errors?: {
+    /**
+     * Custom error message when the input is not a valid CSS color string.
+     * Can be a static message or a function that receives the raw input.
+     */
+    readonly invalidFormat?: Message | ((input: string) => Message);
+  };
+}
+
+/**
+ * Creates a value parser that accepts CSS color strings and returns a
+ * structured {@link Color} object with normalized RGBA components.
+ *
+ * Supported input notations by default:
+ * - Hex: `#rgb`, `#rrggbb`, `#rgba`, `#rrggbbaa`
+ * - RGB: `rgb(r, g, b)`, `rgba(r, g, b, a)`
+ * - HSL: `hsl(h, s%, l%)`, `hsla(h, s%, l%, a)`
+ * - Named: all 148 CSS Level 4 named colors (e.g., `red`, `rebeccapurple`)
+ *
+ * The `format()` method always outputs canonical lowercase hex
+ * (`#rrggbb` when fully opaque, `#rrggbbaa` otherwise).
+ *
+ * @param options Configuration options for the parser.
+ * @returns A sync value parser producing {@link Color} objects.
+ * @throws {TypeError} If {@link ColorOptions.metavar} is an empty string, or
+ *   if {@link ColorOptions.formats} contains an invalid format name.
+ * @since 1.1.0
+ */
+export function color(options: ColorOptions = {}): ValueParser<"sync", Color> {
+  const metavar = options.metavar ?? "COLOR";
+  ensureNonEmptyString(metavar);
+
+  if (options.formats !== undefined) {
+    for (const fmt of options.formats) {
+      if (!(VALID_COLOR_FORMATS as readonly string[]).includes(fmt)) {
+        throw new TypeError(
+          `Expected formats to contain only ${
+            VALID_COLOR_FORMATS.map((v) => JSON.stringify(v)).join(", ")
+          }, but got: ${JSON.stringify(fmt)}.`,
+        );
+      }
+    }
+  }
+
+  const allowedFormats = options.formats ?? VALID_COLOR_FORMATS;
+  const allowHex = allowedFormats.includes("hex");
+  const allowRgb = allowedFormats.includes("rgb");
+  const allowHsl = allowedFormats.includes("hsl");
+  const allowNamed = allowedFormats.includes("named");
+
+  const defaultPlaceholder: Color = { r: 0, g: 0, b: 0, a: 1 };
+
+  function invalidFormatError(input: string): ValueParserResult<Color> {
+    return {
+      success: false,
+      error: options.errors?.invalidFormat
+        ? (typeof options.errors.invalidFormat === "function"
+          ? options.errors.invalidFormat(input)
+          : options.errors.invalidFormat)
+        : message`Expected a CSS color like ${"#ff0000"}, ${"rgb(255, 0, 0)"}, or ${"red"}, but got ${input}.`,
+    };
+  }
+
+  return {
+    mode: "sync",
+    metavar,
+    placeholder: options.placeholder ?? defaultPlaceholder,
+
+    parse(input: string): ValueParserResult<Color> {
+      const trimmed = input.trim();
+
+      if (allowHex) {
+        let m = COLOR_HEX_LONG_REGEX.exec(trimmed);
+        if (m != null) {
+          const r = parseInt(m[1], 16);
+          const g = parseInt(m[2], 16);
+          const b = parseInt(m[3], 16);
+          const a = m[4] !== undefined ? parseInt(m[4], 16) / 255 : 1;
+          return { success: true, value: { r, g, b, a } };
+        }
+        m = COLOR_HEX_SHORT_REGEX.exec(trimmed);
+        if (m != null) {
+          const r = parseInt(m[1] + m[1], 16);
+          const g = parseInt(m[2] + m[2], 16);
+          const b = parseInt(m[3] + m[3], 16);
+          const a = m[4] !== undefined ? parseInt(m[4] + m[4], 16) / 255 : 1;
+          return { success: true, value: { r, g, b, a } };
+        }
+      }
+
+      if (allowRgb) {
+        const m = COLOR_RGB_REGEX.exec(trimmed);
+        if (m != null) {
+          const r = parseInt(m[1], 10);
+          const g = parseInt(m[2], 10);
+          const b = parseInt(m[3], 10);
+          const a = m[4] !== undefined ? parseFloat(m[4]) : 1;
+          if (r > 255 || g > 255 || b > 255 || a < 0 || a > 1) {
+            return invalidFormatError(input);
+          }
+          return { success: true, value: { r, g, b, a } };
+        }
+      }
+
+      if (allowHsl) {
+        const m = COLOR_HSL_REGEX.exec(trimmed);
+        if (m != null) {
+          const h = parseFloat(m[1]);
+          const s = parseFloat(m[2]);
+          const l = parseFloat(m[3]);
+          const a = m[4] !== undefined ? parseFloat(m[4]) : 1;
+          if (
+            h < 0 || h > 360 || s < 0 || s > 100 || l < 0 || l > 100 ||
+            a < 0 || a > 1
+          ) {
+            return invalidFormatError(input);
+          }
+          const [r, g, b] = hslToRgb(h, s / 100, l / 100);
+          return { success: true, value: { r, g, b, a } };
+        }
+      }
+
+      if (allowNamed) {
+        const named = CSS_NAMED_COLORS[trimmed.toLowerCase()];
+        if (named !== undefined) {
+          return { success: true, value: named };
+        }
+      }
+
+      return invalidFormatError(input);
+    },
+
+    format(value: Color): string {
+      const r = Math.round(value.r).toString(16).padStart(2, "0");
+      const g = Math.round(value.g).toString(16).padStart(2, "0");
+      const b = Math.round(value.b).toString(16).padStart(2, "0");
+      if (value.a === 1) {
+        return `#${r}${g}${b}`;
+      }
+      const a = Math.round(value.a * 255).toString(16).padStart(2, "0");
+      return `#${r}${g}${b}${a}`;
+    },
+
+    *suggest(prefix: string): Iterable<Suggestion> {
+      if (allowNamed) {
+        const lowerPrefix = prefix.toLowerCase();
+        for (const name of Object.keys(CSS_NAMED_COLORS)) {
+          if (name.startsWith(lowerPrefix)) {
+            yield { kind: "literal", text: name };
+          }
+        }
+      }
+    },
+  };
+}
+
 /**
  * The set of URL schemes that are considered "special" by the WHATWG URL
  * Standard.  These schemes always use the `://` authority syntax.

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -2234,10 +2234,17 @@ const COLOR_HEX_SHORT_REGEX =
   /^#([0-9a-fA-F])([0-9a-fA-F])([0-9a-fA-F])([0-9a-fA-F])?$/;
 const COLOR_HEX_LONG_REGEX =
   /^#([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})?$/;
-const COLOR_RGB_REGEX =
-  /^rgba?\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*(?:,\s*([\d.]+))?\s*\)$/i;
-const COLOR_HSL_REGEX =
-  /^hsla?\(\s*([\d.]+)\s*,\s*([\d.]+)%\s*,\s*([\d.]+)%\s*(?:,\s*([\d.]+))?\s*\)$/i;
+const COLOR_NUM_PATTERN = "(?:\\d+(?:\\.\\d*)?|\\d*\\.\\d+)";
+const COLOR_RGB_REGEX = new RegExp(
+  `^rgba?\\(\\s*(\\d{1,3})\\s*,\\s*(\\d{1,3})\\s*,\\s*(\\d{1,3})` +
+    `\\s*(?:,\\s*(${COLOR_NUM_PATTERN}))?\\s*\\)$`,
+  "i",
+);
+const COLOR_HSL_REGEX = new RegExp(
+  `^hsla?\\(\\s*(${COLOR_NUM_PATTERN})\\s*,\\s*(${COLOR_NUM_PATTERN})%` +
+    `\\s*,\\s*(${COLOR_NUM_PATTERN})%\\s*(?:,\\s*(${COLOR_NUM_PATTERN}))?\\s*\\)$`,
+  "i",
+);
 
 const VALID_COLOR_FORMATS = ["hex", "rgb", "hsl", "named"] as const;
 
@@ -2389,7 +2396,10 @@ export function color(options: ColorOptions = {}): ValueParser<"sync", Color> {
           const g = parseInt(m[2], 10);
           const b = parseInt(m[3], 10);
           const a = m[4] !== undefined ? parseFloat(m[4]) : 1;
-          if (r > 255 || g > 255 || b > 255 || a < 0 || a > 1) {
+          if (
+            r > 255 || g > 255 || b > 255 ||
+            !Number.isFinite(a) || a < 0 || a > 1
+          ) {
             return invalidFormatError(input);
           }
           return { success: true, value: { r, g, b, a } };
@@ -2404,8 +2414,10 @@ export function color(options: ColorOptions = {}): ValueParser<"sync", Color> {
           const l = parseFloat(m[3]);
           const a = m[4] !== undefined ? parseFloat(m[4]) : 1;
           if (
-            h < 0 || h > 360 || s < 0 || s > 100 || l < 0 || l > 100 ||
-            a < 0 || a > 1
+            !Number.isFinite(h) || h < 0 || h > 360 ||
+            !Number.isFinite(s) || s < 0 || s > 100 ||
+            !Number.isFinite(l) || l < 0 || l > 100 ||
+            !Number.isFinite(a) || a < 0 || a > 1
           ) {
             return invalidFormatError(input);
           }
@@ -2417,7 +2429,7 @@ export function color(options: ColorOptions = {}): ValueParser<"sync", Color> {
       if (allowNamed) {
         const named = CSS_NAMED_COLORS[trimmed.toLowerCase()];
         if (named !== undefined) {
-          return { success: true, value: named };
+          return { success: true, value: { ...named } };
         }
       }
 
@@ -2425,14 +2437,25 @@ export function color(options: ColorOptions = {}): ValueParser<"sync", Color> {
     },
 
     format(value: Color): string {
-      const r = Math.round(value.r).toString(16).padStart(2, "0");
-      const g = Math.round(value.g).toString(16).padStart(2, "0");
-      const b = Math.round(value.b).toString(16).padStart(2, "0");
-      if (value.a === 1) {
-        return `#${r}${g}${b}`;
+      const { r, g, b, a } = value;
+      if (
+        !Number.isInteger(r) || r < 0 || r > 255 ||
+        !Number.isInteger(g) || g < 0 || g > 255 ||
+        !Number.isInteger(b) || b < 0 || b > 255 ||
+        !Number.isFinite(a) || a < 0 || a > 1
+      ) {
+        throw new RangeError(
+          `Color components out of range: r=${r}, g=${g}, b=${b}, a=${a}.`,
+        );
       }
-      const a = Math.round(value.a * 255).toString(16).padStart(2, "0");
-      return `#${r}${g}${b}${a}`;
+      const rh = Math.round(r).toString(16).padStart(2, "0");
+      const gh = Math.round(g).toString(16).padStart(2, "0");
+      const bh = Math.round(b).toString(16).padStart(2, "0");
+      if (a === 1) {
+        return `#${rh}${gh}${bh}`;
+      }
+      const ah = Math.round(a * 255).toString(16).padStart(2, "0");
+      return `#${rh}${gh}${bh}${ah}`;
     },
 
     *suggest(prefix: string): Iterable<Suggestion> {

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -2448,7 +2448,7 @@ export function color(options: ColorOptions = {}): ValueParser<"sync", Color> {
 
       if (allowNamed) {
         const key = trimmed.toLowerCase();
-        if (key in CSS_NAMED_COLORS) {
+        if (Object.hasOwn(CSS_NAMED_COLORS, key)) {
           return { success: true, value: { ...CSS_NAMED_COLORS[key] } };
         }
       }

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -2212,6 +2212,8 @@ const CSS_NAMED_COLORS: Readonly<Record<string, Color>> = {
   yellowgreen: { r: 154, g: 205, b: 50, a: 1 },
 };
 
+const CSS_NAMED_COLOR_KEYS: readonly string[] = Object.keys(CSS_NAMED_COLORS);
+
 function hslToRgb(
   h: number,
   s: number,
@@ -2325,6 +2327,9 @@ export interface ColorOptions {
  * @returns A sync value parser producing {@link Color} objects.
  * @throws {TypeError} If {@link ColorOptions.metavar} is an empty string, or
  *   if {@link ColorOptions.formats} contains an invalid format name.
+ * @throws {RangeError} If {@link ValueParser.format} is called with a
+ *   {@link Color} whose `r`, `g`, or `b` channel is not an integer in
+ *   0–255, or whose `a` channel is not a finite number in 0–1.
  * @since 1.1.0
  */
 export function color(options: ColorOptions = {}): ValueParser<"sync", Color> {
@@ -2461,7 +2466,7 @@ export function color(options: ColorOptions = {}): ValueParser<"sync", Color> {
     *suggest(prefix: string): Iterable<Suggestion> {
       if (allowNamed) {
         const lowerPrefix = prefix.toLowerCase();
-        for (const name of Object.keys(CSS_NAMED_COLORS)) {
+        for (const name of CSS_NAMED_COLOR_KEYS) {
           if (name.startsWith(lowerPrefix)) {
             yield { kind: "literal", text: name };
           }

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -2357,6 +2357,13 @@ export function color(options: ColorOptions = {}): ValueParser<"sync", Color> {
 
   const defaultPlaceholder: Color = { r: 0, g: 0, b: 0, a: 1 };
 
+  const formatExamples: readonly string[] = [
+    ...(allowHex ? ["#ff0000"] : []),
+    ...(allowRgb ? ["rgb(255, 0, 0)"] : []),
+    ...(allowHsl ? ["hsl(0, 100%, 50%)"] : []),
+    ...(allowNamed ? ["red"] : []),
+  ];
+
   function invalidFormatError(input: string): ValueParserResult<Color> {
     return {
       success: false,
@@ -2364,7 +2371,12 @@ export function color(options: ColorOptions = {}): ValueParser<"sync", Color> {
         ? (typeof options.errors.invalidFormat === "function"
           ? options.errors.invalidFormat(input)
           : options.errors.invalidFormat)
-        : message`Expected a CSS color like ${"#ff0000"}, ${"rgb(255, 0, 0)"}, or ${"red"}, but got ${input}.`,
+        : message`Expected a CSS color like ${
+          valueSet(formatExamples, {
+            fallback: "a valid color",
+            type: "disjunction",
+          })
+        }, but got ${input}.`,
     };
   }
 
@@ -2433,9 +2445,9 @@ export function color(options: ColorOptions = {}): ValueParser<"sync", Color> {
       }
 
       if (allowNamed) {
-        const named = CSS_NAMED_COLORS[trimmed.toLowerCase()];
-        if (named !== undefined) {
-          return { success: true, value: { ...named } };
+        const key = trimmed.toLowerCase();
+        if (key in CSS_NAMED_COLORS) {
+          return { success: true, value: { ...CSS_NAMED_COLORS[key] } };
         }
       }
 

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -2413,13 +2413,14 @@ export function color(options: ColorOptions = {}): ValueParser<"sync", Color> {
           const r = parseInt(m[1], 10);
           const g = parseInt(m[2], 10);
           const b = parseInt(m[3], 10);
-          const a = m[4] !== undefined ? parseFloat(m[4]) : 1;
+          const aRaw = m[4] !== undefined ? parseFloat(m[4]) : 1;
           if (
             r > 255 || g > 255 || b > 255 ||
-            !Number.isFinite(a) || a < 0 || a > 1
+            !Number.isFinite(aRaw) || aRaw < 0 || aRaw > 1
           ) {
             return invalidFormatError(input);
           }
+          const a = Math.round(aRaw * 255) / 255;
           return { success: true, value: { r, g, b, a } };
         }
       }
@@ -2430,16 +2431,17 @@ export function color(options: ColorOptions = {}): ValueParser<"sync", Color> {
           const h = parseFloat(m[1]);
           const s = parseFloat(m[2]);
           const l = parseFloat(m[3]);
-          const a = m[4] !== undefined ? parseFloat(m[4]) : 1;
+          const aRaw = m[4] !== undefined ? parseFloat(m[4]) : 1;
           if (
             !Number.isFinite(h) ||
             !Number.isFinite(s) || s < 0 || s > 100 ||
             !Number.isFinite(l) || l < 0 || l > 100 ||
-            !Number.isFinite(a) || a < 0 || a > 1
+            !Number.isFinite(aRaw) || aRaw < 0 || aRaw > 1
           ) {
             return invalidFormatError(input);
           }
           const [r, g, b] = hslToRgb(h, s / 100, l / 100);
+          const a = Math.round(aRaw * 255) / 255;
           return { success: true, value: { r, g, b, a } };
         }
       }

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -2414,7 +2414,7 @@ export function color(options: ColorOptions = {}): ValueParser<"sync", Color> {
           const l = parseFloat(m[3]);
           const a = m[4] !== undefined ? parseFloat(m[4]) : 1;
           if (
-            !Number.isFinite(h) || h < 0 || h > 360 ||
+            !Number.isFinite(h) ||
             !Number.isFinite(s) || s < 0 || s > 100 ||
             !Number.isFinite(l) || l < 0 || l > 100 ||
             !Number.isFinite(a) || a < 0 || a > 1

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -2237,13 +2237,14 @@ const COLOR_HEX_SHORT_REGEX =
 const COLOR_HEX_LONG_REGEX =
   /^#([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})?$/;
 const COLOR_NUM_PATTERN = "(?:\\d+(?:\\.\\d*)?|\\d*\\.\\d+)";
+const COLOR_HUE_PATTERN = `(?:-?${COLOR_NUM_PATTERN})`;
 const COLOR_RGB_REGEX = new RegExp(
   `^rgba?\\(\\s*(\\d{1,3})\\s*,\\s*(\\d{1,3})\\s*,\\s*(\\d{1,3})` +
     `\\s*(?:,\\s*(${COLOR_NUM_PATTERN}))?\\s*\\)$`,
   "i",
 );
 const COLOR_HSL_REGEX = new RegExp(
-  `^hsla?\\(\\s*(${COLOR_NUM_PATTERN})\\s*,\\s*(${COLOR_NUM_PATTERN})%` +
+  `^hsla?\\(\\s*(${COLOR_HUE_PATTERN})\\s*,\\s*(${COLOR_NUM_PATTERN})%` +
     `\\s*,\\s*(${COLOR_NUM_PATTERN})%\\s*(?:,\\s*(${COLOR_NUM_PATTERN}))?\\s*\\)$`,
   "i",
 );

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -2232,6 +2232,31 @@ function hslToRgb(
   ];
 }
 
+function rgbToHsl(
+  r: number,
+  g: number,
+  b: number,
+): [number, number, number] {
+  const rn = r / 255, gn = g / 255, bn = b / 255;
+  const max = Math.max(rn, gn, bn);
+  const min = Math.min(rn, gn, bn);
+  const l = (max + min) / 2;
+  if (max === min) {
+    return [0, 0, Math.round(l * 100)];
+  }
+  const d = max - min;
+  const s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+  let h: number;
+  if (max === rn) {
+    h = ((gn - bn) / d + (gn < bn ? 6 : 0)) / 6;
+  } else if (max === gn) {
+    h = ((bn - rn) / d + 2) / 6;
+  } else {
+    h = ((rn - gn) / d + 4) / 6;
+  }
+  return [Math.round(h * 360), Math.round(s * 100), Math.round(l * 100)];
+}
+
 const COLOR_HEX_SHORT_REGEX =
   /^#([0-9a-fA-F])([0-9a-fA-F])([0-9a-fA-F])([0-9a-fA-F])?$/;
 const COLOR_HEX_LONG_REGEX =
@@ -2468,14 +2493,49 @@ export function color(options: ColorOptions = {}): ValueParser<"sync", Color> {
           `Color components out of range: r=${r}, g=${g}, b=${b}, a=${a}.`,
         );
       }
+      const aStr = parseFloat(a.toFixed(4));
+      if (allowHex) {
+        const rh = r.toString(16).padStart(2, "0");
+        const gh = g.toString(16).padStart(2, "0");
+        const bh = b.toString(16).padStart(2, "0");
+        if (a === 1) return `#${rh}${gh}${bh}`;
+        const ah = Math.round(a * 255).toString(16).padStart(2, "0");
+        return `#${rh}${gh}${bh}${ah}`;
+      }
+      if (allowRgb) {
+        return a === 1
+          ? `rgb(${r}, ${g}, ${b})`
+          : `rgba(${r}, ${g}, ${b}, ${aStr})`;
+      }
+      if (allowHsl) {
+        const [h, s, l] = rgbToHsl(r, g, b);
+        return a === 1
+          ? `hsl(${h}, ${s}%, ${l}%)`
+          : `hsla(${h}, ${s}%, ${l}%, ${aStr})`;
+      }
+      // named-only: try reverse lookup, fall back to hex
+      for (const [name, c] of Object.entries(CSS_NAMED_COLORS)) {
+        if (c.r === r && c.g === g && c.b === b && c.a === a) return name;
+      }
       const rh = r.toString(16).padStart(2, "0");
       const gh = g.toString(16).padStart(2, "0");
       const bh = b.toString(16).padStart(2, "0");
-      if (a === 1) {
-        return `#${rh}${gh}${bh}`;
-      }
+      if (a === 1) return `#${rh}${gh}${bh}`;
       const ah = Math.round(a * 255).toString(16).padStart(2, "0");
       return `#${rh}${gh}${bh}${ah}`;
+    },
+
+    normalize(value: Color): Color {
+      if (
+        !Number.isInteger(value.r) || value.r < 0 || value.r > 255 ||
+        !Number.isInteger(value.g) || value.g < 0 || value.g > 255 ||
+        !Number.isInteger(value.b) || value.b < 0 || value.b > 255 ||
+        !Number.isFinite(value.a) || value.a < 0 || value.a > 1
+      ) {
+        return value;
+      }
+      const a = Math.round(value.a * 255) / 255;
+      return a === value.a ? value : { ...value, a };
     },
 
     *suggest(prefix: string): Iterable<Suggestion> {

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -2468,9 +2468,9 @@ export function color(options: ColorOptions = {}): ValueParser<"sync", Color> {
           `Color components out of range: r=${r}, g=${g}, b=${b}, a=${a}.`,
         );
       }
-      const rh = Math.round(r).toString(16).padStart(2, "0");
-      const gh = Math.round(g).toString(16).padStart(2, "0");
-      const bh = Math.round(b).toString(16).padStart(2, "0");
+      const rh = r.toString(16).padStart(2, "0");
+      const gh = g.toString(16).padStart(2, "0");
+      const bh = b.toString(16).padStart(2, "0");
       if (a === 1) {
         return `#${rh}${gh}${bh}`;
       }

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -2242,7 +2242,7 @@ function rgbToHsl(
   const min = Math.min(rn, gn, bn);
   const l = (max + min) / 2;
   if (max === min) {
-    return [0, 0, Math.round(l * 100)];
+    return [0, 0, l * 100];
   }
   const d = max - min;
   const s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
@@ -2254,7 +2254,7 @@ function rgbToHsl(
   } else {
     h = ((rn - gn) / d + 4) / 6;
   }
-  return [Math.round(h * 360), Math.round(s * 100), Math.round(l * 100)];
+  return [h * 360, s * 100, l * 100];
 }
 
 const COLOR_HEX_SHORT_REGEX =
@@ -2509,20 +2509,20 @@ export function color(options: ColorOptions = {}): ValueParser<"sync", Color> {
       }
       if (allowHsl) {
         const [h, s, l] = rgbToHsl(r, g, b);
+        const hStr = parseFloat(h.toFixed(4));
+        const sStr = parseFloat(s.toFixed(4));
+        const lStr = parseFloat(l.toFixed(4));
         return a === 1
-          ? `hsl(${h}, ${s}%, ${l}%)`
-          : `hsla(${h}, ${s}%, ${l}%, ${aStr})`;
+          ? `hsl(${hStr}, ${sStr}%, ${lStr}%)`
+          : `hsla(${hStr}, ${sStr}%, ${lStr}%, ${aStr})`;
       }
-      // named-only: try reverse lookup, fall back to hex
+      // named-only: try reverse lookup
       for (const [name, c] of Object.entries(CSS_NAMED_COLORS)) {
         if (c.r === r && c.g === g && c.b === b && c.a === a) return name;
       }
-      const rh = r.toString(16).padStart(2, "0");
-      const gh = g.toString(16).padStart(2, "0");
-      const bh = b.toString(16).padStart(2, "0");
-      if (a === 1) return `#${rh}${gh}${bh}`;
-      const ah = Math.round(a * 255).toString(16).padStart(2, "0");
-      return `#${rh}${gh}${bh}${ah}`;
+      throw new RangeError(
+        `No CSS named color matches { r: ${r}, g: ${g}, b: ${b}, a: ${a} }.`,
+      );
     },
 
     normalize(value: Color): Color {


### PR DESCRIPTION
Adds a `color()` value parser to *@optique/core* that accepts CSS color strings and returns a typed `Color` object with `r`, `g`, `b` (0–255 integers) and `a` (0–1) fields.

The parser accepts four notations, all case-insensitive: hex (`#f00`, `#ff0000`, `#ff0000ff`), RGB/RGBA (`rgb(255, 0, 0)`, `rgba(255, 0, 0, 0.5)`), HSL/HSLA (`hsl(0, 100%, 50%)`), and all 148 CSS Level 4 named colors including `transparent` and `rebeccapurple`. The `formats` option restricts which notations are accepted. The `format()` method always outputs canonical lowercase hex, so `parse(format(x))` round-trips reliably. Named colors appear as shell completion suggestions via `suggest()`.

A Codex review caught three edge cases in the initial implementation. The RGB/HSL regexes used `[\d.]+` for numeric components, which matched strings like `.` and `1..`; `parseFloat` then returned `NaN` or silently truncated, bypassing the range checks. The pattern is now `(?:\d+(?:\.\d*)?|\d*\.\d+)`, with `Number.isFinite()` guards added after each `parseFloat()` call. Named color parsing was returning a reference to the shared lookup table entry rather than a copy, so a caller using a type cast could mutate it and affect every subsequent parse of that name. And `format()` accepted any `number` for each channel, meaning `{ r: 300, g: 0, b: 0, a: 1 }` silently formatted as `"#12c0000"` and `a: NaN` produced `"#000000NaN"`; the method now throws `RangeError` for non-integer r/g/b, out-of-range, or non-finite values.

Files changed: *packages/core/src/valueparser.ts*, *packages/core/src/valueparser.test.ts*, *docs/concepts/valueparsers.md*, *CHANGES.md*.

Closes #810.