### PR TITLE
`semVer()` value parser

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -76,14 +76,30 @@ To be released.
     accepted input notations.  The `format()` method always outputs
     canonical lowercase hex.  [[#810], [#815]]
 
+ -  Added `semVer()` value parser for [Semantic Versioning 2.0.0] strings.
+    The parser strictly validates that input conforms to the SemVer 2.0.0
+    specification (no leading zeros in numeric components, no empty
+    identifiers, only permitted characters in pre-release and build
+    metadata).  Returns either a `SemVerString` template-literal type
+    (default, accepts arbitrary valid SemVer numeric components) or a
+    structured `SemVer` object with `major`, `minor`, `patch`, and optional
+    `preRelease` and `metadata` fields via `type: "object"` (object mode
+    stores components as `number` and rejects values above
+    `Number.MAX_SAFE_INTEGER`).  An `allowPrefix` option accepts an optional
+    leading `v` character (e.g. `v1.2.3`); the prefix is always stripped
+    from the output.  [[#808], [#816]]
+
+[Semantic Versioning 2.0.0]: https://semver.org/
 [#801]: https://github.com/dahlia/optique/issues/801
 [#802]: https://github.com/dahlia/optique/pull/802
 [#803]: https://github.com/dahlia/optique/issues/803
 [#805]: https://github.com/dahlia/optique/pull/805
 [#807]: https://github.com/dahlia/optique/issues/807
+[#808]: https://github.com/dahlia/optique/issues/808
 [#810]: https://github.com/dahlia/optique/issues/810
 [#814]: https://github.com/dahlia/optique/pull/814
 [#815]: https://github.com/dahlia/optique/pull/815
+[#816]: https://github.com/dahlia/optique/pull/816
 
 ### @optique/env
 

--- a/docs/concepts/valueparsers.md
+++ b/docs/concepts/valueparsers.md
@@ -39,6 +39,7 @@ with Optique's type system.
 | `url()`                          | *@optique/core*     | `URL`                          | URL with protocol filtering                         |
 | `locale()`                       | *@optique/core*     | `Intl.Locale`                  | BCP 47 locale identifier                            |
 | `uuid()`                         | *@optique/core*     | `string`                       | UUID with RFC 9562 validation                       |
+| `semVer()`                       | *@optique/core*     | `SemVerString` or `SemVer`     | Semantic Versioning 2.0.0                           |
 | `port()`                         | *@optique/core*     | `number` or `bigint`           | TCP/UDP port number                                 |
 | `ipv4()`                         | *@optique/core*     | `string`                       | IPv4 address with restrictions                      |
 | `ipv6()`                         | *@optique/core*     | `string`                       | IPv6 address                                        |
@@ -822,6 +823,121 @@ processUuid("not-a-uuid");  // ✗ Type error
 
 The parser uses `"UUID"` as its default metavar and provides specific error
 messages for format violations, version mismatches, and variant violations.
+
+
+`semVer()` parser
+-----------------
+
+*This API is available since Optique 1.1.0.*
+
+The `semVer()` parser validates strings according to the
+[Semantic Versioning 2.0.0] specification.  It ensures that major, minor, and
+patch components are non-negative integers without leading zeros, and that
+pre-release and build metadata identifiers contain only permitted characters.
+
+~~~~ typescript twoslash
+import { semVer } from "@optique/core/valueparser";
+
+// String mode (default): returns a SemVerString template-literal type
+const version = semVer();
+
+// Object mode: returns a structured SemVer object
+const structuredVersion = semVer({ type: "object" });
+~~~~
+
+[Semantic Versioning 2.0.0]: https://semver.org/
+
+### String mode
+
+By default, `semVer()` returns a `SemVerString` template-literal type that
+covers all four valid forms of a SemVer string:
+
+~~~~ typescript twoslash
+import { semVer, type SemVerString } from "@optique/core/valueparser";
+
+const parser = semVer();
+
+const result = parser.parse("1.2.3-rc.1+build.42");
+if (result.success) {
+  const v: SemVerString = result.value;  // "1.2.3-rc.1+build.42"
+}
+~~~~
+
+The output is always the canonical form with no leading `v` prefix, even when
+the `v` prefix was accepted as input (see [V prefix](#v-prefix) below).
+
+### Object mode
+
+Pass `type: "object"` to receive a structured `SemVer` value with individual
+components:
+
+~~~~ typescript twoslash
+import { semVer, type SemVer } from "@optique/core/valueparser";
+
+const parser = semVer({ type: "object" });
+
+const result = parser.parse("2.0.0-alpha.1+build.42");
+if (result.success) {
+  const v: SemVer = result.value;
+  // v.major    → 2
+  // v.minor    → 0
+  // v.patch    → 0
+  // v.preRelease → "alpha.1"
+  // v.metadata   → "build.42"
+}
+~~~~
+
+The `preRelease` and `metadata` fields are absent (not `undefined`) when the
+input contains no pre-release or build metadata.
+
+> [!NOTE]
+> Object mode stores `major`, `minor`, and `patch` as JavaScript `number`
+> values, so it rejects inputs whose version components exceed
+> `Number.MAX_SAFE_INTEGER` (2⁵³ − 1 = 9,007,199,254,740,991).  In the
+> unlikely event that you need to handle version numbers of that magnitude,
+> use string mode instead.
+
+### V prefix
+
+By default the parser rejects a leading `v` character.  Set `allowPrefix: true`
+to accept the common `v1.2.3` convention:
+
+~~~~ typescript twoslash
+import { semVer } from "@optique/core/valueparser";
+
+const parser = semVer({ allowPrefix: true });
+
+const result = parser.parse("v1.2.3");
+if (result.success) {
+  console.log(result.value);  // "1.2.3" — prefix stripped from output
+}
+~~~~
+
+The `v` prefix is stripped from the output regardless of mode; the canonical
+form never includes it.
+
+### Error messages
+
+When input is not a valid SemVer 2.0.0 string, the parser returns an error:
+
+~~~~ bash
+$ myapp --version "1.02.0"
+Error: Expected a valid Semantic Versioning 2.0.0 string (e.g. 1.0.0), but got 1.02.0.
+~~~~
+
+Custom error messages can be provided as a static message or a function:
+
+~~~~ typescript twoslash
+import { semVer } from "@optique/core/valueparser";
+import { message } from "@optique/core/message";
+
+const parser = semVer({
+  errors: {
+    invalidSemVer: (input) =>
+      message`${input} is not a valid version string.`,
+  },
+});
+~~~~
 
 
 `port()` parser

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -17490,6 +17490,23 @@ describe("semVer()", () => {
       assert.throws(
         () => semVer({ metavar: "" as NonEmptyString }),
         TypeError,
+        "Expected a non-empty string.",
+      );
+    });
+
+    it("non-boolean allowPrefix throws TypeError", () => {
+      assert.throws(
+        () => semVer({ allowPrefix: "yes" as unknown as boolean }),
+        TypeError,
+        "Expected allowPrefix to be a boolean",
+      );
+    });
+
+    it("invalid type option throws TypeError", () => {
+      assert.throws(
+        () => semVer({ type: "number" as unknown as "string" }),
+        TypeError,
+        'Expected type to be one of "string", "object"',
       );
     });
 

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -21,6 +21,9 @@ import {
   type NonEmptyString,
   port,
   portRange,
+  type SemVer,
+  semVer,
+  type SemVerString,
   socketAddress,
   string,
   url,
@@ -17465,6 +17468,429 @@ describe("color()", () => {
     it("no suggestions for unmatched prefix", () => {
       const suggestions = [...color().suggest!("zzz")];
       assert.deepEqual(suggestions, []);
+    });
+  });
+});
+
+describe("semVer()", () => {
+  describe("constructor", () => {
+    it("default mode is sync", () => {
+      assert.equal(semVer().mode, "sync");
+    });
+
+    it("default metavar is SEMVER", () => {
+      assert.equal(semVer().metavar, "SEMVER");
+    });
+
+    it("custom metavar is respected", () => {
+      assert.equal(semVer({ metavar: "VERSION" }).metavar, "VERSION");
+    });
+
+    it("empty metavar throws TypeError", () => {
+      assert.throws(
+        () => semVer({ metavar: "" as NonEmptyString }),
+        TypeError,
+      );
+    });
+
+    it("placeholder for string mode is 0.0.0", () => {
+      assert.equal(semVer().placeholder, "0.0.0");
+    });
+
+    it("placeholder for object mode has major/minor/patch", () => {
+      assert.deepEqual(semVer({ type: "object" }).placeholder, {
+        major: 0,
+        minor: 0,
+        patch: 0,
+      });
+    });
+  });
+
+  describe("parse() — string mode (default)", () => {
+    it("parses a basic version", () => {
+      const result = semVer().parse("1.2.3");
+      assert.ok(result.success);
+      assert.equal(result.value, "1.2.3");
+    });
+
+    it("parses version with pre-release", () => {
+      const result = semVer().parse("1.0.0-alpha.1");
+      assert.ok(result.success);
+      assert.equal(result.value, "1.0.0-alpha.1");
+    });
+
+    it("parses version with build metadata", () => {
+      const result = semVer().parse("1.0.0+build.42");
+      assert.ok(result.success);
+      assert.equal(result.value, "1.0.0+build.42");
+    });
+
+    it("parses version with pre-release and build metadata", () => {
+      const result = semVer().parse("1.0.0-beta.2+exp.sha.5114f85");
+      assert.ok(result.success);
+      assert.equal(result.value, "1.0.0-beta.2+exp.sha.5114f85");
+    });
+
+    it("parses 0.0.0", () => {
+      const result = semVer().parse("0.0.0");
+      assert.ok(result.success);
+      assert.equal(result.value, "0.0.0");
+    });
+
+    it("rejects leading zeros in major", () => {
+      const result = semVer().parse("01.0.0");
+      assert.ok(!result.success);
+    });
+
+    it("rejects leading zeros in minor", () => {
+      const result = semVer().parse("1.02.0");
+      assert.ok(!result.success);
+    });
+
+    it("rejects leading zeros in patch", () => {
+      const result = semVer().parse("1.0.03");
+      assert.ok(!result.success);
+    });
+
+    it("rejects empty pre-release identifier", () => {
+      const result = semVer().parse("1.0.0-");
+      assert.ok(!result.success);
+    });
+
+    it("rejects empty build metadata identifier", () => {
+      const result = semVer().parse("1.0.0+");
+      assert.ok(!result.success);
+    });
+
+    it("rejects invalid characters in pre-release", () => {
+      const result = semVer().parse("1.0.0-alpha@1");
+      assert.ok(!result.success);
+    });
+
+    it("rejects arbitrary strings", () => {
+      const result = semVer().parse("not-a-version");
+      assert.ok(!result.success);
+    });
+
+    it("rejects two-part version", () => {
+      const result = semVer().parse("1.2");
+      assert.ok(!result.success);
+    });
+
+    it("rejects negative numbers", () => {
+      const result = semVer().parse("-1.0.0");
+      assert.ok(!result.success);
+    });
+
+    it("rejects v-prefixed input by default", () => {
+      const result = semVer().parse("v1.0.0");
+      assert.ok(!result.success);
+    });
+
+    it("rejects leading zeros in numeric pre-release identifier", () => {
+      const result = semVer().parse("1.0.0-01");
+      assert.ok(!result.success);
+    });
+  });
+
+  describe("parse() — numeric limits", () => {
+    it("accepts Number.MAX_SAFE_INTEGER as major", () => {
+      const result = semVer({ type: "object" }).parse(
+        `${Number.MAX_SAFE_INTEGER}.0.0`,
+      );
+      assert.ok(result.success);
+      assert.equal(result.value.major, Number.MAX_SAFE_INTEGER);
+    });
+
+    it("rejects components beyond Number.MAX_SAFE_INTEGER in object mode", () => {
+      const unsafe = "9007199254740993"; // MAX_SAFE_INTEGER + 2
+      const result = semVer({ type: "object" }).parse(`${unsafe}.0.0`);
+      assert.ok(!result.success);
+    });
+  });
+
+  describe("parse() — allowPrefix option", () => {
+    it("accepts v-prefixed input when allowPrefix: true", () => {
+      const result = semVer({ allowPrefix: true }).parse("v1.2.3");
+      assert.ok(result.success);
+    });
+
+    it("strips the v prefix from string mode output", () => {
+      const result = semVer({ allowPrefix: true }).parse("v1.2.3");
+      assert.ok(result.success);
+      assert.equal(result.value, "1.2.3");
+    });
+
+    it("still accepts non-prefixed input when allowPrefix: true", () => {
+      const result = semVer({ allowPrefix: true }).parse("1.2.3");
+      assert.ok(result.success);
+      assert.equal(result.value, "1.2.3");
+    });
+
+    it("rejects v-prefixed input when allowPrefix: false (explicit)", () => {
+      const result = semVer({ allowPrefix: false }).parse("v1.0.0");
+      assert.ok(!result.success);
+    });
+  });
+
+  describe("parse() — object mode", () => {
+    it("parses basic version into components", () => {
+      const result = semVer({ type: "object" }).parse("1.2.3");
+      assert.ok(result.success);
+      assert.deepEqual(result.value, { major: 1, minor: 2, patch: 3 });
+    });
+
+    it("parses version with pre-release", () => {
+      const result = semVer({ type: "object" }).parse("1.0.0-alpha.1");
+      assert.ok(result.success);
+      assert.deepEqual(result.value, {
+        major: 1,
+        minor: 0,
+        patch: 0,
+        preRelease: "alpha.1",
+      });
+    });
+
+    it("parses version with build metadata", () => {
+      const result = semVer({ type: "object" }).parse("1.0.0+build.42");
+      assert.ok(result.success);
+      assert.deepEqual(result.value, {
+        major: 1,
+        minor: 0,
+        patch: 0,
+        metadata: "build.42",
+      });
+    });
+
+    it("parses version with pre-release and metadata", () => {
+      const result = semVer({ type: "object" }).parse(
+        "2.3.4-rc.1+sha.abc123",
+      );
+      assert.ok(result.success);
+      assert.deepEqual(result.value, {
+        major: 2,
+        minor: 3,
+        patch: 4,
+        preRelease: "rc.1",
+        metadata: "sha.abc123",
+      });
+    });
+
+    it("strips v prefix from object mode output when allowPrefix: true", () => {
+      const result = semVer({ type: "object", allowPrefix: true }).parse(
+        "v3.0.0",
+      );
+      assert.ok(result.success);
+      assert.deepEqual(result.value, { major: 3, minor: 0, patch: 0 });
+    });
+
+    it("rejects invalid input in object mode", () => {
+      const result = semVer({ type: "object" }).parse("not-semver");
+      assert.ok(!result.success);
+    });
+  });
+
+  describe("format()", () => {
+    it("string mode returns the value as-is", () => {
+      const p = semVer();
+      assert.equal(p.format("1.2.3" as SemVerString), "1.2.3");
+    });
+
+    it("string mode with pre-release", () => {
+      const p = semVer();
+      assert.equal(
+        p.format("1.0.0-alpha.1" as SemVerString),
+        "1.0.0-alpha.1",
+      );
+    });
+
+    it("object mode formats major.minor.patch", () => {
+      const p = semVer({ type: "object" });
+      assert.equal(p.format({ major: 1, minor: 2, patch: 3 }), "1.2.3");
+    });
+
+    it("object mode includes pre-release", () => {
+      const p = semVer({ type: "object" });
+      assert.equal(
+        p.format({ major: 1, minor: 0, patch: 0, preRelease: "alpha.1" }),
+        "1.0.0-alpha.1",
+      );
+    });
+
+    it("object mode includes metadata", () => {
+      const p = semVer({ type: "object" });
+      assert.equal(
+        p.format({ major: 1, minor: 0, patch: 0, metadata: "build.42" }),
+        "1.0.0+build.42",
+      );
+    });
+
+    it("object mode includes pre-release and metadata", () => {
+      const p = semVer({ type: "object" });
+      assert.equal(
+        p.format({
+          major: 1,
+          minor: 0,
+          patch: 0,
+          preRelease: "rc.1",
+          metadata: "sha.abc",
+        }),
+        "1.0.0-rc.1+sha.abc",
+      );
+    });
+  });
+
+  describe("format() round-trip", () => {
+    it("string mode parse→format is identity", () => {
+      const p = semVer();
+      const versions = [
+        "1.0.0",
+        "0.0.1",
+        "10.20.30",
+        "1.0.0-alpha",
+        "1.0.0-alpha.1",
+        "1.0.0-0.3.7",
+        "1.0.0+build.1",
+        "1.0.0-beta+exp.sha",
+      ];
+      for (const v of versions) {
+        const result = p.parse(v);
+        assert.ok(result.success, `Expected ${v} to parse successfully`);
+        assert.equal(p.format(result.value), v);
+      }
+    });
+
+    it("object mode parse→format is identity", () => {
+      const p = semVer({ type: "object" });
+      const versions = [
+        "1.0.0",
+        "1.0.0-alpha.1",
+        "1.0.0+build.1",
+        "1.0.0-rc.1+sha.abc",
+      ];
+      for (const v of versions) {
+        const result = p.parse(v);
+        assert.ok(result.success, `Expected ${v} to parse successfully`);
+        assert.equal(p.format(result.value), v);
+      }
+    });
+
+    it("property-based round-trip for string mode", () => {
+      const p = semVer();
+      const semverArbitrary = fc
+        .tuple(
+          fc.nat({ max: 999 }),
+          fc.nat({ max: 999 }),
+          fc.nat({ max: 999 }),
+        )
+        .map(([ma, mi, pa]) => `${ma}.${mi}.${pa}`);
+      fc.assert(
+        fc.property(semverArbitrary, (v) => {
+          const result = p.parse(v);
+          assert.ok(result.success);
+          assert.equal(p.format(result.value), v);
+        }),
+        propertyParameters,
+      );
+    });
+  });
+
+  describe("error messages", () => {
+    it("default error message references the input", () => {
+      const result = semVer().parse("bad-version");
+      assert.ok(!result.success);
+      const msg = result.error;
+      const hasInput = msg.some(
+        (t) => t.type === "value" && t.value === "bad-version",
+      );
+      assert.ok(hasInput);
+    });
+
+    it("static custom error message", () => {
+      const customError = [text("Not a valid version.")] as const;
+      const p = semVer({
+        errors: { invalidSemVer: customError },
+      });
+      const result = p.parse("bad");
+      assert.ok(!result.success);
+      assert.deepEqual(result.error, customError);
+    });
+
+    it("function custom error message receives input", () => {
+      const p = semVer({
+        errors: {
+          invalidSemVer: (input) => message`Nope, "${input}" is not semver.`,
+        },
+      });
+      const result = p.parse("xyz");
+      assert.ok(!result.success);
+      const flat = formatMessage(result.error);
+      assert.ok(flat.includes("xyz"));
+    });
+  });
+
+  describe("suggest()", () => {
+    it("has a suggest function", () => {
+      assert.ok(typeof semVer().suggest === "function");
+    });
+
+    it("empty prefix returns non-empty suggestions", () => {
+      const suggestions = [...semVer().suggest!("")];
+      assert.ok(suggestions.length > 0);
+    });
+
+    it("all suggestions are kind=literal", () => {
+      const suggestions = [...semVer().suggest!("")];
+      assert.ok(suggestions.every((s) => s.kind === "literal"));
+    });
+
+    it("filters suggestions by prefix", () => {
+      const suggestions = [...semVer().suggest!("1.")];
+      assert.ok(
+        suggestions.every(
+          (s) => s.kind === "literal" && s.text.startsWith("1."),
+        ),
+      );
+    });
+
+    it("no suggestions for unmatched prefix", () => {
+      const suggestions = [...semVer().suggest!("zzz")];
+      assert.deepEqual(suggestions, []);
+    });
+
+    it("allowPrefix: true includes v-prefixed suggestions", () => {
+      const suggestions = [...semVer({ allowPrefix: true }).suggest!("v")];
+      assert.ok(suggestions.length > 0);
+      assert.ok(
+        suggestions.every(
+          (s) => s.kind === "literal" && s.text.startsWith("v"),
+        ),
+      );
+    });
+
+    it("allowPrefix: false does not include v-prefixed suggestions", () => {
+      const suggestions = [...semVer({ allowPrefix: false }).suggest!("v")];
+      assert.deepEqual(suggestions, []);
+    });
+  });
+
+  describe("type inference", () => {
+    it("string mode infers SemVerString", () => {
+      const p = semVer();
+      const result = p.parse("1.0.0");
+      if (result.success) {
+        const _v: SemVerString = result.value;
+        assert.ok(_v);
+      }
+    });
+
+    it("object mode infers SemVer", () => {
+      const p = semVer({ type: "object" });
+      const result = p.parse("1.0.0");
+      if (result.success) {
+        const _v: SemVer = result.value;
+        assert.ok(_v);
+      }
     });
   });
 });

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -17496,17 +17496,22 @@ describe("semVer()", () => {
 
     it("non-boolean allowPrefix throws TypeError", () => {
       assert.throws(
-        () => semVer({ allowPrefix: "yes" as unknown as boolean }),
-        TypeError,
-        "Expected allowPrefix to be a boolean",
+        () => semVer({ allowPrefix: "yes" as never }),
+        {
+          name: "TypeError",
+          message: "Expected allowPrefix to be a boolean, but got string: yes.",
+        },
       );
     });
 
     it("invalid type option throws TypeError", () => {
       assert.throws(
-        () => semVer({ type: "number" as unknown as "string" }),
-        TypeError,
-        'Expected type to be one of "string", "object"',
+        () => semVer({ type: "number" as never }),
+        {
+          name: "TypeError",
+          message:
+            'Expected type to be one of "string", "object", but got string: "number".',
+        },
       );
     });
 

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -8041,3 +8041,268 @@ export function cidr(
   });
   return cidrParserObj;
 }
+
+/**
+ * A normalized Semantic Versioning 2.0.0 string.
+ *
+ * Covers all four valid forms:
+ *  - `MAJOR.MINOR.PATCH`
+ *  - `MAJOR.MINOR.PATCH-preRelease`
+ *  - `MAJOR.MINOR.PATCH+metadata`
+ *  - `MAJOR.MINOR.PATCH-preRelease+metadata`
+ *
+ * Note: this type uses TypeScript template literals as a coarse structural
+ * hint.  The `${number}` slots accept any JavaScript number serialization
+ * (including negative numbers, decimals, and `Infinity`), so the type alone
+ * does not guarantee full SemVer 2.0.0 validity.  Full validation is
+ * enforced at parse time by {@link semVer}.  Only values returned by
+ * `semVer().parse()` are guaranteed to conform to the specification.
+ *
+ * @since 1.1.0
+ */
+export type SemVerString =
+  | `${number}.${number}.${number}`
+  | `${number}.${number}.${number}-${string}`
+  | `${number}.${number}.${number}+${string}`
+  | `${number}.${number}.${number}-${string}+${string}`;
+
+/**
+ * A parsed Semantic Versioning 2.0.0 value as a structured object.
+ *
+ * @since 1.1.0
+ */
+export interface SemVer {
+  /**
+   * The major version number.
+   *
+   * This field is a JavaScript `number`, so it is limited to
+   * {@link Number.MAX_SAFE_INTEGER} (2⁵³ − 1).  Inputs whose major
+   * component exceeds this value are rejected by {@link semVer} in object
+   * mode; use string mode to handle arbitrarily large version numbers.
+   */
+  readonly major: number;
+  /**
+   * The minor version number.
+   *
+   * Same safe-integer constraint as {@link major}.
+   */
+  readonly minor: number;
+  /**
+   * The patch version number.
+   *
+   * Same safe-integer constraint as {@link major}.
+   */
+  readonly patch: number;
+  /**
+   * The pre-release identifier (the part after `-`, before `+`), if present.
+   * Example: `"alpha.1"` for `1.0.0-alpha.1`.
+   */
+  readonly preRelease?: string;
+  /**
+   * The build metadata (the part after `+`), if present.
+   * Example: `"build.42"` for `1.0.0+build.42`.
+   */
+  readonly metadata?: string;
+}
+
+/** @internal */
+interface SemVerOptionsBase {
+  /**
+   * The metavariable name for this parser.  Used in help messages.
+   * @default `"SEMVER"`
+   */
+  readonly metavar?: NonEmptyString;
+  /**
+   * Whether to accept an optional leading `v` character (e.g. `v1.2.3`).
+   * The `v` prefix is stripped; output is always the canonical unprefixed form.
+   * @default false
+   */
+  readonly allowPrefix?: boolean;
+  /**
+   * Custom error messages for parse failures.
+   * @since 1.1.0
+   */
+  readonly errors?: {
+    /**
+     * Message when input is not a valid SemVer string.
+     * Can be a static message or a function receiving the rejected input.
+     */
+    readonly invalidSemVer?: Message | ((input: string) => Message);
+  };
+}
+
+/**
+ * Options for {@link semVer} in string mode (the default).
+ *
+ * @since 1.1.0
+ */
+export interface SemVerOptionsString extends SemVerOptionsBase {
+  /** Return a {@link SemVerString} template-literal type. */
+  readonly type?: "string";
+}
+
+/**
+ * Options for {@link semVer} in object mode.
+ *
+ * In object mode, version components are stored as JavaScript `number`
+ * values.  Components exceeding {@link Number.MAX_SAFE_INTEGER} (2⁵³ − 1)
+ * cannot be represented exactly and are therefore rejected with a parse
+ * error.  Use string mode (the default) if you need to handle version
+ * numbers of arbitrary magnitude.
+ *
+ * @since 1.1.0
+ */
+export interface SemVerOptionsObject extends SemVerOptionsBase {
+  /** Return a structured {@link SemVer} object. */
+  readonly type: "object";
+}
+
+// Official SemVer 2.0.0 regex with optional leading "v" prefix capture group.
+// Groups: prefix?, major, minor, patch, pre?, meta?
+const SEMVER_REGEX =
+  /^(?<prefix>v)?(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(?:-(?<pre>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?<meta>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
+
+const SEMVER_SUGGESTIONS: readonly string[] = Object.freeze([
+  "0.0.0",
+  "1.0.0",
+  "1.0.0-alpha",
+  "1.0.0-alpha.1",
+  "1.0.0+build.1",
+  "1.0.0-alpha.1+build.1",
+]);
+
+/**
+ * Creates a {@link ValueParser} for [Semantic Versioning 2.0.0] strings.
+ *
+ * In string mode (the default), the parser returns a {@link SemVerString}
+ * template-literal type.  String mode accepts any spec-valid SemVer input,
+ * including version components of arbitrary magnitude.
+ *
+ * In object mode (`type: "object"`), the parser returns a structured
+ * {@link SemVer} value with `major`, `minor`, `patch`, and optional
+ * `preRelease` and `metadata` fields.  Because the numeric components are
+ * stored as JavaScript `number`, object mode additionally rejects inputs
+ * whose major, minor, or patch value exceeds
+ * {@link Number.MAX_SAFE_INTEGER} (2⁵³ − 1).  Use string mode if you need
+ * to handle arbitrarily large version numbers.
+ *
+ * Both modes strictly enforce the SemVer 2.0.0 specification: no leading
+ * zeros in numeric components, no empty pre-release or build identifiers,
+ * and no invalid characters.
+ *
+ * [Semantic Versioning 2.0.0]: https://semver.org/
+ *
+ * @param options Configuration options.
+ * @returns A {@link ValueParser} that validates SemVer strings.
+ * @throws {TypeError} If {@link SemVerOptionsString.metavar} is an empty
+ *   string.
+ * @since 1.1.0
+ */
+export function semVer(
+  options?: SemVerOptionsString,
+): ValueParser<"sync", SemVerString>;
+/**
+ * Creates a {@link ValueParser} for [Semantic Versioning 2.0.0] strings,
+ * returning a structured {@link SemVer} object.
+ *
+ * [Semantic Versioning 2.0.0]: https://semver.org/
+ *
+ * @param options Configuration options with `type: "object"`.
+ * @returns A {@link ValueParser} that converts SemVer strings to {@link SemVer}
+ *   objects.
+ * @throws {TypeError} If {@link SemVerOptionsObject.metavar} is an empty
+ *   string.
+ * @since 1.1.0
+ */
+export function semVer(
+  options: SemVerOptionsObject,
+): ValueParser<"sync", SemVer>;
+export function semVer(
+  options: SemVerOptionsString | SemVerOptionsObject = {},
+): ValueParser<"sync", SemVerString> | ValueParser<"sync", SemVer> {
+  const metavar = options.metavar ?? "SEMVER";
+  ensureNonEmptyString(metavar);
+  checkBooleanOption(options, "allowPrefix");
+  const allowPrefix = options.allowPrefix ?? false;
+  const objectMode = options.type === "object";
+  const errorOption = options.errors?.invalidSemVer;
+
+  const suggestions: readonly string[] = allowPrefix
+    ? [...SEMVER_SUGGESTIONS, ...SEMVER_SUGGESTIONS.map((s) => `v${s}`)]
+    : SEMVER_SUGGESTIONS;
+
+  function makeError(input: string): ValueParserResult<never> {
+    return {
+      success: false,
+      error: errorOption
+        ? (typeof errorOption === "function" ? errorOption(input) : errorOption)
+        : message`Expected a valid Semantic Versioning 2.0.0 string (e.g. ${"1.0.0"}), but got ${input}.`,
+    };
+  }
+
+  if (objectMode) {
+    return {
+      mode: "sync",
+      metavar,
+      placeholder: { major: 0, minor: 0, patch: 0 },
+      parse(input: string): ValueParserResult<SemVer> {
+        const m = SEMVER_REGEX.exec(input);
+        if (m == null) return makeError(input);
+        if (!allowPrefix && m.groups!.prefix != null) return makeError(input);
+        const major = parseInt(m.groups!.major, 10);
+        const minor = parseInt(m.groups!.minor, 10);
+        const patch = parseInt(m.groups!.patch, 10);
+        if (
+          !Number.isSafeInteger(major) ||
+          !Number.isSafeInteger(minor) ||
+          !Number.isSafeInteger(patch)
+        ) {
+          return makeError(input);
+        }
+        const result: SemVer = {
+          major,
+          minor,
+          patch,
+          ...(m.groups!.pre != null ? { preRelease: m.groups!.pre } : {}),
+          ...(m.groups!.meta != null ? { metadata: m.groups!.meta } : {}),
+        };
+        return { success: true, value: result };
+      },
+      format(value: SemVer): string {
+        let s = `${value.major}.${value.minor}.${value.patch}`;
+        if (value.preRelease != null) s += `-${value.preRelease}`;
+        if (value.metadata != null) s += `+${value.metadata}`;
+        return s;
+      },
+      *suggest(prefix: string): Iterable<Suggestion> {
+        for (const s of suggestions) {
+          if (s.startsWith(prefix)) yield { kind: "literal", text: s };
+        }
+      },
+    };
+  }
+
+  return {
+    mode: "sync",
+    metavar,
+    placeholder: "0.0.0" as SemVerString,
+    parse(input: string): ValueParserResult<SemVerString> {
+      const m = SEMVER_REGEX.exec(input);
+      if (m == null) return makeError(input);
+      if (!allowPrefix && m.groups!.prefix != null) return makeError(input);
+      const canonical =
+        `${m.groups!.major}.${m.groups!.minor}.${m.groups!.patch}` +
+        (m.groups!.pre != null ? `-${m.groups!.pre}` : "") +
+        (m.groups!.meta != null ? `+${m.groups!.meta}` : "");
+      return { success: true, value: canonical as SemVerString };
+    },
+    format(value: SemVerString): string {
+      return value;
+    },
+    *suggest(prefix: string): Iterable<Suggestion> {
+      for (const s of suggestions) {
+        if (s.startsWith(prefix)) yield { kind: "literal", text: s };
+      }
+    },
+  };
+}

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -8194,8 +8194,11 @@ const SEMVER_SUGGESTIONS: readonly string[] = Object.freeze([
  *
  * @param options Configuration options.
  * @returns A {@link ValueParser} that validates SemVer strings.
- * @throws {TypeError} If {@link SemVerOptionsString.metavar} is an empty
- *   string.
+ * @throws {TypeError} If {@link SemVerOptionsBase.metavar} is an empty string.
+ * @throws {TypeError} If {@link SemVerOptionsBase.allowPrefix} is not a
+ *   boolean.
+ * @throws {TypeError} If {@link SemVerOptionsString.type} is not `"string"`,
+ *   `"object"`, or `undefined`.
  * @since 1.1.0
  */
 export function semVer(
@@ -8210,8 +8213,11 @@ export function semVer(
  * @param options Configuration options with `type: "object"`.
  * @returns A {@link ValueParser} that converts SemVer strings to {@link SemVer}
  *   objects.
- * @throws {TypeError} If {@link SemVerOptionsObject.metavar} is an empty
- *   string.
+ * @throws {TypeError} If {@link SemVerOptionsBase.metavar} is an empty string.
+ * @throws {TypeError} If {@link SemVerOptionsBase.allowPrefix} is not a
+ *   boolean.
+ * @throws {TypeError} If {@link SemVerOptionsObject.type} is not `"string"`,
+ *   `"object"`, or `undefined`.
  * @since 1.1.0
  */
 export function semVer(
@@ -8222,6 +8228,7 @@ export function semVer(
 ): ValueParser<"sync", SemVerString> | ValueParser<"sync", SemVer> {
   const metavar = options.metavar ?? "SEMVER";
   ensureNonEmptyString(metavar);
+  checkEnumOption(options, "type", ["string", "object"]);
   checkBooleanOption(options, "allowPrefix");
   const allowPrefix = options.allowPrefix ?? false;
   const objectMode = options.type === "object";

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -8171,6 +8171,11 @@ const SEMVER_SUGGESTIONS: readonly string[] = Object.freeze([
   "1.0.0-alpha.1+build.1",
 ]);
 
+const SEMVER_SUGGESTIONS_WITH_PREFIX: readonly string[] = Object.freeze([
+  ...SEMVER_SUGGESTIONS,
+  ...SEMVER_SUGGESTIONS.map((s) => `v${s}`),
+]);
+
 /**
  * Creates a {@link ValueParser} for [Semantic Versioning 2.0.0] strings.
  *
@@ -8234,8 +8239,8 @@ export function semVer(
   const objectMode = options.type === "object";
   const errorOption = options.errors?.invalidSemVer;
 
-  const suggestions: readonly string[] = allowPrefix
-    ? [...SEMVER_SUGGESTIONS, ...SEMVER_SUGGESTIONS.map((s) => `v${s}`)]
+  const suggestions = allowPrefix
+    ? SEMVER_SUGGESTIONS_WITH_PREFIX
     : SEMVER_SUGGESTIONS;
 
   function makeError(input: string): ValueParserResult<never> {


### PR DESCRIPTION
Adds a `semVer()` value parser to *@optique/core* that validates strings against the [Semantic Versioning 2.0.0](https://semver.org/) specification and returns either the validated version string or a structured object.

By default the parser returns a `SemVerString` template-literal type for `MAJOR.MINOR.PATCH`, with optional pre-release identifiers, build metadata, or both. Pass `type: "object"` to get a `SemVer` interface with discrete `major`, `minor`, `patch`, `preRelease`, and `metadata` fields. Both modes enforce the SemVer grammar, including leading-zero rules for numeric identifiers, non-empty pre-release and build identifiers, and the allowed character set. An `allowPrefix` option accepts the common `v`-prefixed convention (`v1.2.3`) and strips the prefix from the output. Custom error messages are supported via `errors.invalidSemVer`. Completion suggestions are available through `suggest()`.

Codex found two issues during review. In object mode, `parseInt()` can lose precision for numeric components above `Number.MAX_SAFE_INTEGER`, so a caller parsing `9007199254740993.0.0` would receive `{ major: 9007199254740992, ... }` and a round-trip through `format()` would produce a different string. The parser now rejects those inputs with a `Number.isSafeInteger()` check. String mode is unaffected because it does not convert the numeric components to `number`.

Codex also noted that the `SemVerString` template-literal type accepts structurally invalid values like `-1.0.0` and `Infinity.0.0`, because TypeScript's `${number}` is broader than SemVer's numeric grammar. I kept the template-literal type instead of replacing it with a branded string, and documented that it is only a coarse structural hint. Actual validity is enforced at parse time.

Files changed: *packages/core/src/valueparser.ts*, *packages/core/src/valueparser.test.ts*, *docs/concepts/valueparsers.md*, *CHANGES.md*.

Closes #808.