### PR TITLE
`json()` value parser for structured data blobs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -94,7 +94,7 @@ To be released.
     restricts the root type via the `rootType` option (`"string"`,
     `"number"`, `"boolean"`, `"null"`, `"object"`, or `"array"`), narrowing
     the TypeScript return type accordingly.  Also exports the `Json` type
-    representing any JSON-serializable value.  [[#811]]
+    representing any JSON-serializable value.  [[#811], [#817]]
 
 [Semantic Versioning 2.0.0]: https://semver.org/
 [#801]: https://github.com/dahlia/optique/issues/801
@@ -108,6 +108,7 @@ To be released.
 [#814]: https://github.com/dahlia/optique/pull/814
 [#815]: https://github.com/dahlia/optique/pull/815
 [#816]: https://github.com/dahlia/optique/pull/816
+[#817]: https://github.com/dahlia/optique/pull/817
 
 ### @optique/env
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -89,6 +89,13 @@ To be released.
     leading `v` character (e.g. `v1.2.3`); the prefix is always stripped
     from the output.  [[#808], [#816]]
 
+ -  Added `json()` value parser for accepting JSON-encoded strings from the
+    command line.  The parser validates well-formed JSON and optionally
+    restricts the root type via the `rootType` option (`"string"`,
+    `"number"`, `"boolean"`, `"null"`, `"object"`, or `"array"`), narrowing
+    the TypeScript return type accordingly.  Also exports the `Json` type
+    representing any JSON-serializable value.  [[#811]]
+
 [Semantic Versioning 2.0.0]: https://semver.org/
 [#801]: https://github.com/dahlia/optique/issues/801
 [#802]: https://github.com/dahlia/optique/pull/802
@@ -97,6 +104,7 @@ To be released.
 [#807]: https://github.com/dahlia/optique/issues/807
 [#808]: https://github.com/dahlia/optique/issues/808
 [#810]: https://github.com/dahlia/optique/issues/810
+[#811]: https://github.com/dahlia/optique/issues/811
 [#814]: https://github.com/dahlia/optique/pull/814
 [#815]: https://github.com/dahlia/optique/pull/815
 [#816]: https://github.com/dahlia/optique/pull/816

--- a/docs/concepts/valueparsers.md
+++ b/docs/concepts/valueparsers.md
@@ -36,6 +36,7 @@ with Optique's type system.
 | `fileSize()`                     | *@optique/core*     | `number` or `bigint`           | Human-readable data size (bytes)                    |
 | `color()`                        | *@optique/core*     | `Color`                        | CSS color (hex, rgb, hsl, or named)                 |
 | `choice()`                       | *@optique/core*     | string or number literal union | Enumerated values                                   |
+| `json()`                         | *@optique/core*     | `Json`                         | Any JSON value, with optional root type restriction |
 | `url()`                          | *@optique/core*     | `URL`                          | URL with protocol filtering                         |
 | `locale()`                       | *@optique/core*     | `Intl.Locale`                  | BCP 47 locale identifier                            |
 | `uuid()`                         | *@optique/core*     | `string`                       | UUID with RFC 9562 validation                       |
@@ -553,6 +554,109 @@ const depth = choice([8, 10, 12]);
 > option in your runner configuration.  See the
 > [choice display](./runners.md#choice-display) section in the runners guide
 > for details.
+
+
+`json()` parser
+---------------
+
+*This API is available since Optique 1.1.0.*
+
+The `json()` parser accepts any well-formed JSON string and returns the
+corresponding JavaScript value.  It is a lightweight way to accept structured
+data on the command line without pulling in a full schema library.
+
+~~~~ typescript twoslash
+import { json } from "@optique/core/valueparser";
+
+// Accept any JSON value
+const data = json();
+
+const result = data.parse('{"name":"Alice","age":30}');
+if (result.success) {
+  console.log(result.value); // { name: "Alice", age: 30 }
+}
+~~~~
+
+The return type is the exported `Json` union, which covers all
+JSON-serializable values:
+
+~~~~ typescript
+type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { readonly [property: string]: Json }
+  | readonly Json[];
+~~~~
+
+### Root type restriction
+
+Use the `rootType` option to restrict which JSON root type is accepted.
+When `rootType` is set, the TypeScript return type is narrowed accordingly:
+
+~~~~ typescript twoslash
+import { json, type Json } from "@optique/core/valueparser";
+
+// Only accept JSON objects — return type is { readonly [p: string]: Json }
+const objParser = json({ rootType: "object" });
+
+// Only accept JSON arrays — return type is readonly Json[]
+const arrParser = json({ rootType: "array" });
+
+// Only accept JSON strings — return type is string
+const strParser = json({ rootType: "string" });
+
+// Only accept JSON numbers — return type is number
+const numParser = json({ rootType: "number" });
+
+// Only accept JSON booleans — return type is boolean
+const boolParser = json({ rootType: "boolean" });
+
+// Only accept JSON null — return type is null
+const nullParser = json({ rootType: "null" });
+~~~~
+
+### Error messages
+
+The `json()` parser provides two customizable error messages.
+
+`invalidJson` fires when the input cannot be parsed as JSON at all:
+
+~~~~ bash
+$ myapp --config '{bad json}'
+Error: `JSON`: Not a valid JSON: Expected property name or '}' in JSON at position 1
+~~~~
+
+`invalidRootType` fires when the JSON is valid but the root type does not
+match `rootType`:
+
+~~~~ bash
+$ myapp --count '{"a":1}'
+Error: `JSON`: Expected JSON number, but got object.
+~~~~
+
+Both messages can be overridden with a static `Message` or a callback:
+
+~~~~ typescript twoslash
+import { json } from "@optique/core/valueparser";
+import { text } from "@optique/core/message";
+
+const parser = json({
+  rootType: "object",
+  errors: {
+    invalidJson: [text("Config must be a valid JSON string.")],
+    invalidRootType: (_value, expected) =>
+      [text(`Expected a JSON ${expected}.`)],
+  },
+});
+~~~~
+
+The parser uses `"JSON"` as its default metavar.
+
+> [!TIP]
+> For schema-validated JSON with complex shapes, consider the
+> *@optique/zod* or *@optique/valibot* integrations instead.
 
 
 `url()` parser

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -17937,8 +17937,10 @@ describe("json()", () => {
     it("empty metavar throws TypeError", () => {
       assert.throws(
         () => json({ metavar: "" as NonEmptyString }),
-        TypeError,
-        "Expected a non-empty string.",
+        {
+          name: "TypeError",
+          message: "Expected a non-empty string.",
+        },
       );
     });
 

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -17980,6 +17980,22 @@ describe("json()", () => {
         },
       );
     });
+
+    it("throws TypeError when placeholder is Infinity", () => {
+      assert.throws(() => json({ placeholder: Infinity }), {
+        name: "TypeError",
+        message:
+          "Expected placeholder to be a finite JSON number, but got Infinity.",
+      });
+    });
+
+    it("throws TypeError when placeholder is NaN", () => {
+      assert.throws(() => json({ placeholder: NaN }), {
+        name: "TypeError",
+        message:
+          "Expected placeholder to be a finite JSON number, but got NaN.",
+      });
+    });
   });
 
   describe("parse() without rootType", () => {
@@ -18065,6 +18081,29 @@ describe("json()", () => {
       assert.ok(!result.success);
       if (!result.success) {
         assert.deepEqual(result.error, [{ type: "text", text: "bad: {nope}" }]);
+      }
+    });
+
+    it("rejects overflowing numbers that parse as Infinity", () => {
+      const result = json().parse("1e309");
+      assert.ok(!result.success);
+      if (!result.success) {
+        assert.deepEqual(result.error, [
+          { type: "text", text: "Not a valid JSON: number out of range." },
+        ]);
+      }
+    });
+
+    it("uses invalidJson callback for out-of-range numbers", () => {
+      const parser = json({
+        errors: { invalidJson: (input) => [text(`overflow: ${input}`)] },
+      });
+      const result = parser.parse("1e309");
+      assert.ok(!result.success);
+      if (!result.success) {
+        assert.deepEqual(result.error, [
+          { type: "text", text: "overflow: 1e309" },
+        ]);
       }
     });
   });
@@ -18287,6 +18326,27 @@ describe("json()", () => {
 
     it("formats null", () => {
       assert.equal(json().format(null), "null");
+    });
+
+    it("throws TypeError for Infinity", () => {
+      assert.throws(() => json().format(Infinity), {
+        name: "TypeError",
+        message: "Expected a finite JSON number, but got Infinity.",
+      });
+    });
+
+    it("throws TypeError for -Infinity", () => {
+      assert.throws(() => json().format(-Infinity), {
+        name: "TypeError",
+        message: "Expected a finite JSON number, but got -Infinity.",
+      });
+    });
+
+    it("throws TypeError for NaN", () => {
+      assert.throws(() => json().format(NaN), {
+        name: "TypeError",
+        message: "Expected a finite JSON number, but got NaN.",
+      });
     });
   });
 

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -18019,6 +18019,24 @@ describe("json()", () => {
       if (result.success) assert.equal(result.value, "hello");
     });
 
+    it("parses a JSON string with escaped quotes", () => {
+      const result = json().parse('"hello \\"world\\""');
+      assert.ok(result.success);
+      if (result.success) assert.equal(result.value, 'hello "world"');
+    });
+
+    it("parses a JSON string with escape sequences", () => {
+      const result = json().parse('"line1\\nline2"');
+      assert.ok(result.success);
+      if (result.success) assert.equal(result.value, "line1\nline2");
+    });
+
+    it("parses a JSON string with Unicode escapes", () => {
+      const result = json().parse('"\\u00e9"');
+      assert.ok(result.success);
+      if (result.success) assert.equal(result.value, "é");
+    });
+
     it("parses a JSON number", () => {
       const result = json().parse("42");
       assert.ok(result.success);

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -16,6 +16,8 @@ import {
   ipv4,
   ipv6,
   isValueParser,
+  type Json,
+  json,
   locale,
   macAddress,
   type NonEmptyString,
@@ -17913,6 +17915,372 @@ describe("semVer()", () => {
         const _v: SemVer = result.value;
         assert.ok(_v);
       }
+    });
+  });
+});
+
+describe("json()", () => {
+  describe("constructor", () => {
+    it("default mode is sync", () => {
+      assert.equal(json().mode, "sync");
+    });
+
+    it("default metavar is JSON", () => {
+      assert.equal(json().metavar, "JSON");
+    });
+
+    it("custom metavar is respected", () => {
+      assert.equal(json({ metavar: "DATA" }).metavar, "DATA");
+    });
+
+    it("empty metavar throws TypeError", () => {
+      assert.throws(
+        () => json({ metavar: "" as NonEmptyString }),
+        TypeError,
+        "Expected a non-empty string.",
+      );
+    });
+  });
+
+  describe("parse() without rootType", () => {
+    it("parses a JSON object", () => {
+      const result = json().parse('{"a":1}');
+      assert.ok(result.success);
+      if (result.success) assert.deepEqual(result.value, { a: 1 });
+    });
+
+    it("parses a JSON array", () => {
+      const result = json().parse("[1,2,3]");
+      assert.ok(result.success);
+      if (result.success) assert.deepEqual(result.value, [1, 2, 3]);
+    });
+
+    it("parses a JSON string", () => {
+      const result = json().parse('"hello"');
+      assert.ok(result.success);
+      if (result.success) assert.equal(result.value, "hello");
+    });
+
+    it("parses a JSON number", () => {
+      const result = json().parse("42");
+      assert.ok(result.success);
+      if (result.success) assert.equal(result.value, 42);
+    });
+
+    it("parses a JSON boolean true", () => {
+      const result = json().parse("true");
+      assert.ok(result.success);
+      if (result.success) assert.equal(result.value, true);
+    });
+
+    it("parses a JSON boolean false", () => {
+      const result = json().parse("false");
+      assert.ok(result.success);
+      if (result.success) assert.equal(result.value, false);
+    });
+
+    it("parses JSON null", () => {
+      const result = json().parse("null");
+      assert.ok(result.success);
+      if (result.success) assert.equal(result.value, null);
+    });
+
+    it("parses nested JSON", () => {
+      const result = json().parse('{"a":[1,{"b":true}]}');
+      assert.ok(result.success);
+      if (result.success) {
+        assert.deepEqual(result.value, { a: [1, { b: true }] });
+      }
+    });
+
+    it("rejects malformed JSON with default error", () => {
+      const result = json().parse("{not json}");
+      assert.ok(!result.success);
+      if (!result.success) {
+        const msg = result.error;
+        assert.ok(
+          Array.isArray(msg) && msg[0].type === "text" &&
+            (msg[0].text as string).startsWith("Not a valid JSON:"),
+          `Expected error to start with "Not a valid JSON:", got: ${
+            JSON.stringify(msg)
+          }`,
+        );
+      }
+    });
+
+    it("rejects malformed JSON with static custom error", () => {
+      const parser = json({ errors: { invalidJson: [text("bad JSON")] } });
+      const result = parser.parse("{nope}");
+      assert.ok(!result.success);
+      if (!result.success) {
+        assert.deepEqual(result.error, [{ type: "text", text: "bad JSON" }]);
+      }
+    });
+
+    it("rejects malformed JSON with function custom error", () => {
+      const parser = json({
+        errors: { invalidJson: (input) => [text(`bad: ${input}`)] },
+      });
+      const result = parser.parse("{nope}");
+      assert.ok(!result.success);
+      if (!result.success) {
+        assert.deepEqual(result.error, [{ type: "text", text: "bad: {nope}" }]);
+      }
+    });
+  });
+
+  describe('parse() with rootType: "string"', () => {
+    it("accepts a JSON string", () => {
+      const result = json({ rootType: "string" }).parse('"hello"');
+      assert.ok(result.success);
+      if (result.success) {
+        const _v: string = result.value;
+        assert.equal(_v, "hello");
+      }
+    });
+
+    it("rejects a JSON number", () => {
+      const result = json({ rootType: "string" }).parse("42");
+      assert.ok(!result.success);
+    });
+
+    it("rejects a JSON object", () => {
+      const result = json({ rootType: "string" }).parse("{}");
+      assert.ok(!result.success);
+    });
+
+    it("rejects a JSON array", () => {
+      const result = json({ rootType: "string" }).parse("[]");
+      assert.ok(!result.success);
+    });
+
+    it("rejects JSON null", () => {
+      const result = json({ rootType: "string" }).parse("null");
+      assert.ok(!result.success);
+    });
+
+    it("default error for type mismatch", () => {
+      const result = json({ rootType: "string" }).parse("42");
+      assert.ok(!result.success);
+      if (!result.success) {
+        assert.deepEqual(result.error, [
+          { type: "text", text: "Expected JSON string, but got number." },
+        ]);
+      }
+    });
+  });
+
+  describe('parse() with rootType: "number"', () => {
+    it("accepts a JSON number", () => {
+      const result = json({ rootType: "number" }).parse("3.14");
+      assert.ok(result.success);
+      if (result.success) {
+        const _v: number = result.value;
+        assert.equal(_v, 3.14);
+      }
+    });
+
+    it("rejects a JSON string", () => {
+      assert.ok(!json({ rootType: "number" }).parse('"42"').success);
+    });
+
+    it("rejects a JSON object", () => {
+      assert.ok(!json({ rootType: "number" }).parse("{}").success);
+    });
+  });
+
+  describe('parse() with rootType: "boolean"', () => {
+    it("accepts true", () => {
+      const result = json({ rootType: "boolean" }).parse("true");
+      assert.ok(result.success);
+      if (result.success) {
+        const _v: boolean = result.value;
+        assert.equal(_v, true);
+      }
+    });
+
+    it("accepts false", () => {
+      const result = json({ rootType: "boolean" }).parse("false");
+      assert.ok(result.success);
+      if (result.success) assert.equal(result.value, false);
+    });
+
+    it("rejects a JSON number", () => {
+      assert.ok(!json({ rootType: "boolean" }).parse("1").success);
+    });
+  });
+
+  describe('parse() with rootType: "null"', () => {
+    it("accepts null", () => {
+      const result = json({ rootType: "null" }).parse("null");
+      assert.ok(result.success);
+      if (result.success) {
+        const _v: null = result.value;
+        assert.equal(_v, null);
+      }
+    });
+
+    it("rejects a JSON boolean", () => {
+      assert.ok(!json({ rootType: "null" }).parse("false").success);
+    });
+
+    it("rejects a JSON string", () => {
+      assert.ok(!json({ rootType: "null" }).parse('"null"').success);
+    });
+  });
+
+  describe('parse() with rootType: "object"', () => {
+    it("accepts a JSON object", () => {
+      const result = json({ rootType: "object" }).parse('{"x":1}');
+      assert.ok(result.success);
+      if (result.success) {
+        const _v: { readonly [p: string]: Json } = result.value;
+        assert.deepEqual(_v, { x: 1 });
+      }
+    });
+
+    it("rejects a JSON array", () => {
+      assert.ok(!json({ rootType: "object" }).parse("[1,2]").success);
+    });
+
+    it("rejects a JSON string", () => {
+      assert.ok(!json({ rootType: "object" }).parse('"hi"').success);
+    });
+
+    it("rejects JSON null", () => {
+      assert.ok(!json({ rootType: "object" }).parse("null").success);
+    });
+
+    it("default error for type mismatch", () => {
+      const result = json({ rootType: "object" }).parse("[1]");
+      assert.ok(!result.success);
+      if (!result.success) {
+        assert.deepEqual(result.error, [
+          { type: "text", text: "Expected JSON object, but got array." },
+        ]);
+      }
+    });
+  });
+
+  describe('parse() with rootType: "array"', () => {
+    it("accepts a JSON array", () => {
+      const result = json({ rootType: "array" }).parse("[1,2]");
+      assert.ok(result.success);
+      if (result.success) {
+        const _v: readonly Json[] = result.value;
+        assert.deepEqual(_v, [1, 2]);
+      }
+    });
+
+    it("rejects a JSON object", () => {
+      assert.ok(!json({ rootType: "array" }).parse("{}").success);
+    });
+
+    it("rejects a JSON number", () => {
+      assert.ok(!json({ rootType: "array" }).parse("42").success);
+    });
+
+    it("default error for type mismatch", () => {
+      const result = json({ rootType: "array" }).parse('{"a":1}');
+      assert.ok(!result.success);
+      if (!result.success) {
+        assert.deepEqual(result.error, [
+          { type: "text", text: "Expected JSON array, but got object." },
+        ]);
+      }
+    });
+  });
+
+  describe("custom invalidRootType error", () => {
+    it("static message error", () => {
+      const parser = json({
+        rootType: "string",
+        errors: { invalidRootType: [text("wrong type")] },
+      });
+      const result = parser.parse("42");
+      assert.ok(!result.success);
+      if (!result.success) {
+        assert.deepEqual(result.error, [{ type: "text", text: "wrong type" }]);
+      }
+    });
+
+    it("function error receives value and expected type", () => {
+      const parser = json({
+        rootType: "object",
+        errors: {
+          invalidRootType: (
+            value: Json,
+            expected: string,
+          ) => [text(`want ${expected}, got ${typeof value}`)],
+        },
+      });
+      const result = parser.parse("42");
+      assert.ok(!result.success);
+      if (!result.success) {
+        assert.deepEqual(result.error, [
+          { type: "text", text: "want object, got number" },
+        ]);
+      }
+    });
+  });
+
+  describe("format()", () => {
+    it("formats an object", () => {
+      assert.equal(json().format({ a: 1 }), '{"a":1}');
+    });
+
+    it("formats an array", () => {
+      assert.equal(json().format([1, 2, 3]), "[1,2,3]");
+    });
+
+    it("formats a string", () => {
+      assert.equal(json().format("hello"), '"hello"');
+    });
+
+    it("formats a number", () => {
+      assert.equal(json().format(42), "42");
+    });
+
+    it("formats a boolean", () => {
+      assert.equal(json().format(true), "true");
+    });
+
+    it("formats null", () => {
+      assert.equal(json().format(null), "null");
+    });
+  });
+
+  describe("placeholder", () => {
+    it("default placeholder is null (no rootType)", () => {
+      assert.equal(json().placeholder, null);
+    });
+
+    it("default placeholder for rootType: string is empty string", () => {
+      assert.equal(json({ rootType: "string" }).placeholder, "");
+    });
+
+    it("default placeholder for rootType: number is 0", () => {
+      assert.equal(json({ rootType: "number" }).placeholder, 0);
+    });
+
+    it("default placeholder for rootType: boolean is false", () => {
+      assert.equal(json({ rootType: "boolean" }).placeholder, false);
+    });
+
+    it("default placeholder for rootType: null is null", () => {
+      assert.equal(json({ rootType: "null" }).placeholder, null);
+    });
+
+    it("default placeholder for rootType: object is empty object", () => {
+      assert.deepEqual(json({ rootType: "object" }).placeholder, {});
+    });
+
+    it("default placeholder for rootType: array is empty array", () => {
+      assert.deepEqual(json({ rootType: "array" }).placeholder, []);
+    });
+
+    it("custom placeholder is respected", () => {
+      assert.equal(json({ placeholder: 123 }).placeholder, 123);
     });
   });
 });

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -17940,6 +17940,36 @@ describe("json()", () => {
         "Expected a non-empty string.",
       );
     });
+
+    it("accepts a pre-typed JsonOptions variable", () => {
+      const opts: import("@optique/core/valueparser").JsonOptions = {
+        rootType: "object",
+      };
+      const parser = json(opts);
+      const result = parser.parse('{"a":1}');
+      assert.ok(result.success);
+    });
+
+    it("throws TypeError when placeholder type mismatches rootType", () => {
+      assert.throws(
+        () =>
+          json({ rootType: "string", placeholder: 123 as unknown as string }),
+        {
+          name: "TypeError",
+          message: "Expected placeholder to be a JSON string, but got number.",
+        },
+      );
+    });
+
+    it("rootType: string accepts a typed string placeholder", () => {
+      const parser = json({ rootType: "string", placeholder: "default" });
+      assert.equal(parser.placeholder, "default");
+    });
+
+    it("rootType: number accepts a typed number placeholder", () => {
+      const parser = json({ rootType: "number", placeholder: -1 });
+      assert.equal(parser.placeholder, -1);
+    });
   });
 
   describe("parse() without rootType", () => {

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -18417,6 +18417,12 @@ describe("json()", () => {
         message: "Expected a finite JSON number, but got Infinity.",
       });
     });
+
+    it("terminates quickly for circular references", () => {
+      const circular: Record<string, unknown> = {};
+      circular.self = circular;
+      assert.throws(() => json().format(circular as Json), TypeError);
+    });
   });
 
   describe("placeholder", () => {

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -17968,6 +17968,18 @@ describe("json()", () => {
       const parser = json({ rootType: "number", placeholder: -1 });
       assert.equal(parser.placeholder, -1);
     });
+
+    it("invalid rootType throws TypeError at construction", () => {
+      assert.throws(
+        () => json({ rootType: "invalid" as never }),
+        {
+          name: "TypeError",
+          message:
+            'Expected rootType to be one of "string", "number", "boolean",' +
+            ' "null", "object", "array", but got string: "invalid".',
+        },
+      );
+    });
   });
 
   describe("parse() without rootType", () => {

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -18089,10 +18089,13 @@ describe("json()", () => {
       assert.ok(!result.success);
       if (!result.success) {
         const msg = result.error;
+        const prefix = "Not a valid JSON:";
+        const firstText = Array.isArray(msg) && msg[0]?.type === "text"
+          ? (msg[0].text as string)
+          : "";
         assert.ok(
-          Array.isArray(msg) && msg[0].type === "text" &&
-            (msg[0].text as string).startsWith("Not a valid JSON:"),
-          `Expected error to start with "Not a valid JSON:", got: ${
+          firstText.startsWith(prefix) && firstText.length > prefix.length,
+          `Expected error to start with "${prefix}" followed by SyntaxError detail, got: ${
             JSON.stringify(msg)
           }`,
         );

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -17987,7 +17987,7 @@ describe("json()", () => {
       assert.throws(() => json({ placeholder: Infinity }), {
         name: "TypeError",
         message:
-          "Expected placeholder to be a finite JSON number, but got Infinity.",
+          "Expected placeholder to contain only finite numbers, but found Infinity.",
       });
     });
 
@@ -17995,7 +17995,15 @@ describe("json()", () => {
       assert.throws(() => json({ placeholder: NaN }), {
         name: "TypeError",
         message:
-          "Expected placeholder to be a finite JSON number, but got NaN.",
+          "Expected placeholder to contain only finite numbers, but found NaN.",
+      });
+    });
+
+    it("throws TypeError when placeholder contains nested Infinity", () => {
+      assert.throws(() => json({ placeholder: { n: Infinity } }), {
+        name: "TypeError",
+        message:
+          "Expected placeholder to contain only finite numbers, but found Infinity.",
       });
     });
   });

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -18077,6 +18077,13 @@ describe("json()", () => {
       }
     });
 
+    it("handles very deeply nested arrays without stack overflow", () => {
+      const depth = 10_000;
+      const input = "[".repeat(depth) + "]".repeat(depth);
+      const result = json().parse(input);
+      assert.ok(result.success);
+    });
+
     it("rejects malformed JSON with default error", () => {
       const result = json().parse("{not json}");
       assert.ok(!result.success);

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -18,6 +18,7 @@ import {
   isValueParser,
   type Json,
   json,
+  type JsonOptions,
   locale,
   macAddress,
   type NonEmptyString,
@@ -17942,7 +17943,7 @@ describe("json()", () => {
     });
 
     it("accepts a pre-typed JsonOptions variable", () => {
-      const opts: import("@optique/core/valueparser").JsonOptions = {
+      const opts: JsonOptions = {
         rootType: "object",
       };
       const parser = json(opts);
@@ -17951,14 +17952,11 @@ describe("json()", () => {
     });
 
     it("throws TypeError when placeholder type mismatches rootType", () => {
-      assert.throws(
-        () =>
-          json({ rootType: "string", placeholder: 123 as unknown as string }),
-        {
-          name: "TypeError",
-          message: "Expected placeholder to be a JSON string, but got number.",
-        },
-      );
+      const opts: JsonOptions = { rootType: "string", placeholder: 123 };
+      assert.throws(() => json(opts), {
+        name: "TypeError",
+        message: "Expected placeholder to be a JSON string, but got number.",
+      });
     });
 
     it("rootType: string accepts a typed string placeholder", () => {

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -18106,6 +18106,26 @@ describe("json()", () => {
         ]);
       }
     });
+
+    it("rejects objects containing nested Infinity", () => {
+      const result = json().parse('{"n":1e309}');
+      assert.ok(!result.success);
+      if (!result.success) {
+        assert.deepEqual(result.error, [
+          { type: "text", text: "Not a valid JSON: number out of range." },
+        ]);
+      }
+    });
+
+    it("rejects arrays containing nested Infinity", () => {
+      const result = json().parse("[1e309]");
+      assert.ok(!result.success);
+    });
+
+    it("rejects deeply nested Infinity", () => {
+      const result = json().parse('{"a":{"b":[1e309]}}');
+      assert.ok(!result.success);
+    });
   });
 
   describe('parse() with rootType: "string"', () => {
@@ -18346,6 +18366,20 @@ describe("json()", () => {
       assert.throws(() => json().format(NaN), {
         name: "TypeError",
         message: "Expected a finite JSON number, but got NaN.",
+      });
+    });
+
+    it("throws TypeError for object containing Infinity", () => {
+      assert.throws(() => json().format({ n: Infinity }), {
+        name: "TypeError",
+        message: "Expected a finite JSON number, but got Infinity.",
+      });
+    });
+
+    it("throws TypeError for array containing Infinity", () => {
+      assert.throws(() => json().format([Infinity]), {
+        name: "TypeError",
+        message: "Expected a finite JSON number, but got Infinity.",
       });
     });
   });

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -8407,7 +8407,10 @@ export interface JsonOptions {
  * @since 1.1.0
  */
 export function json(
-  options: JsonOptions & { readonly rootType: "string" },
+  options: JsonOptions & {
+    readonly rootType: "string";
+    readonly placeholder?: string;
+  },
 ): ValueParser<"sync", string>;
 
 /**
@@ -8419,7 +8422,10 @@ export function json(
  * @since 1.1.0
  */
 export function json(
-  options: JsonOptions & { readonly rootType: "number" },
+  options: JsonOptions & {
+    readonly rootType: "number";
+    readonly placeholder?: number;
+  },
 ): ValueParser<"sync", number>;
 
 /**
@@ -8431,7 +8437,10 @@ export function json(
  * @since 1.1.0
  */
 export function json(
-  options: JsonOptions & { readonly rootType: "boolean" },
+  options: JsonOptions & {
+    readonly rootType: "boolean";
+    readonly placeholder?: boolean;
+  },
 ): ValueParser<"sync", boolean>;
 
 /**
@@ -8443,7 +8452,10 @@ export function json(
  * @since 1.1.0
  */
 export function json(
-  options: JsonOptions & { readonly rootType: "null" },
+  options: JsonOptions & {
+    readonly rootType: "null";
+    readonly placeholder?: null;
+  },
 ): ValueParser<"sync", null>;
 
 /**
@@ -8456,7 +8468,10 @@ export function json(
  * @since 1.1.0
  */
 export function json(
-  options: JsonOptions & { readonly rootType: "object" },
+  options: JsonOptions & {
+    readonly rootType: "object";
+    readonly placeholder?: { readonly [property: string]: Json };
+  },
 ): ValueParser<"sync", { readonly [property: string]: Json }>;
 
 /**
@@ -8468,20 +8483,24 @@ export function json(
  * @since 1.1.0
  */
 export function json(
-  options: JsonOptions & { readonly rootType: "array" },
+  options: JsonOptions & {
+    readonly rootType: "array";
+    readonly placeholder?: readonly Json[];
+  },
 ): ValueParser<"sync", readonly Json[]>;
 
 /**
  * Creates a {@link ValueParser} that parses JSON-encoded strings into any
  * {@link Json} value (object, array, string, number, boolean, or null).
  *
+ * Also accepts a pre-typed `JsonOptions` variable when the `rootType` is not
+ * known at compile time; the return type is the widened {@link Json} union.
+ *
  * @param options Optional configuration for the parser.
  * @returns A parser whose successful value is typed as {@link Json}.
  * @since 1.1.0
  */
-export function json(
-  options?: JsonOptions & { readonly rootType?: undefined },
-): ValueParser<"sync", Json>;
+export function json(options?: JsonOptions): ValueParser<"sync", Json>;
 
 /**
  * Creates a {@link ValueParser} for parsing JSON-encoded strings from the
@@ -8504,6 +8523,8 @@ export function json(
  * @returns A {@link ValueParser} that converts JSON-encoded strings to the
  *   appropriate JavaScript type.
  * @throws {TypeError} If `options.metavar` is provided but is an empty string.
+ * @throws {TypeError} If `options.placeholder` is provided with a `rootType`
+ *   but its JSON type does not match the `rootType`.
  * @since 1.1.0
  */
 export function json(options?: JsonOptions): ValueParser<"sync", Json> {
@@ -8512,6 +8533,15 @@ export function json(options?: JsonOptions): ValueParser<"sync", Json> {
   const rootType = options?.rootType;
   const invalidJsonError = options?.errors?.invalidJson;
   const invalidRootTypeError = options?.errors?.invalidRootType;
+
+  if (rootType != null && options?.placeholder !== undefined) {
+    const placeholderType = jsonTypeOf(options.placeholder);
+    if (placeholderType !== rootType) {
+      throw new TypeError(
+        `Expected placeholder to be a JSON ${rootType}, but got ${placeholderType}.`,
+      );
+    }
+  }
 
   const defaultPlaceholder: Json = rootType === "string"
     ? ""

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -8525,6 +8525,8 @@ export function json(options?: JsonOptions): ValueParser<"sync", Json>;
  * @throws {TypeError} If `options.metavar` is provided but is an empty string.
  * @throws {TypeError} If `options.rootType` is provided but is not one of the
  *   six allowed values.
+ * @throws {TypeError} If `options.placeholder` is a non-finite number
+ *   (`Infinity`, `-Infinity`, or `NaN`).
  * @throws {TypeError} If `options.placeholder` is provided with a `rootType`
  *   but its JSON type does not match the `rootType`.
  * @since 1.1.0
@@ -8544,11 +8546,20 @@ export function json(options?: JsonOptions): ValueParser<"sync", Json> {
   const invalidJsonError = options?.errors?.invalidJson;
   const invalidRootTypeError = options?.errors?.invalidRootType;
 
-  if (rootType != null && options?.placeholder !== undefined) {
-    const placeholderType = jsonTypeOf(options.placeholder);
-    if (placeholderType !== rootType) {
+  if (options?.placeholder !== undefined) {
+    const p = options.placeholder;
+    if (typeof p === "number" && !Number.isFinite(p)) {
       throw new TypeError(
-        `Expected placeholder to be a JSON ${rootType}, but got ${placeholderType}.`,
+        `Expected placeholder to be a finite JSON number, but got ${
+          String(p)
+        }.`,
+      );
+    }
+    if (rootType != null && jsonTypeOf(p) !== rootType) {
+      throw new TypeError(
+        `Expected placeholder to be a JSON ${rootType}, but got ${
+          jsonTypeOf(p)
+        }.`,
       );
     }
   }
@@ -8581,6 +8592,13 @@ export function json(options?: JsonOptions): ValueParser<"sync", Json> {
           : invalidJsonError ?? [text(`Not a valid JSON: ${err.message}`)];
         return { success: false, error };
       }
+      if (typeof value === "number" && !Number.isFinite(value)) {
+        const error: Message = invalidJsonError instanceof Function
+          ? invalidJsonError(input)
+          : invalidJsonError ??
+            [text(`Not a valid JSON: number out of range.`)];
+        return { success: false, error };
+      }
       if (rootType != null) {
         const actual = jsonTypeOf(value);
         if (actual !== rootType) {
@@ -8594,6 +8612,11 @@ export function json(options?: JsonOptions): ValueParser<"sync", Json> {
       return { success: true, value };
     },
     format(value: Json): string {
+      if (typeof value === "number" && !Number.isFinite(value)) {
+        throw new TypeError(
+          `Expected a finite JSON number, but got ${String(value)}.`,
+        );
+      }
       return JSON.stringify(value);
     },
   };

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -8529,6 +8529,8 @@ export function json(options?: JsonOptions): ValueParser<"sync", Json>;
  *   (`Infinity`, `-Infinity`, or `NaN`).
  * @throws {TypeError} If `options.placeholder` is provided with a `rootType`
  *   but its JSON type does not match the `rootType`.
+ * @throws {TypeError} If the returned parser's `format()` method is called
+ *   with a value that contains a non-finite number anywhere in its structure.
  * @since 1.1.0
  */
 export function json(options?: JsonOptions): ValueParser<"sync", Json> {
@@ -8592,7 +8594,8 @@ export function json(options?: JsonOptions): ValueParser<"sync", Json> {
           : invalidJsonError ?? [text(`Not a valid JSON: ${err.message}`)];
         return { success: false, error };
       }
-      if (typeof value === "number" && !Number.isFinite(value)) {
+      const nonFinite = findNonFiniteNumber(value);
+      if (nonFinite !== undefined) {
         const error: Message = invalidJsonError instanceof Function
           ? invalidJsonError(input)
           : invalidJsonError ??
@@ -8612,9 +8615,10 @@ export function json(options?: JsonOptions): ValueParser<"sync", Json> {
       return { success: true, value };
     },
     format(value: Json): string {
-      if (typeof value === "number" && !Number.isFinite(value)) {
+      const nonFinite = findNonFiniteNumber(value);
+      if (nonFinite !== undefined) {
         throw new TypeError(
-          `Expected a finite JSON number, but got ${String(value)}.`,
+          `Expected a finite JSON number, but got ${String(nonFinite)}.`,
         );
       }
       return JSON.stringify(value);
@@ -8626,4 +8630,27 @@ function jsonTypeOf(value: Json): string {
   if (value === null) return "null";
   if (Array.isArray(value)) return "array";
   return typeof value;
+}
+
+function findNonFiniteNumber(value: Json): number | undefined {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? undefined : value;
+  }
+  if (
+    value === null || typeof value === "string" || typeof value === "boolean"
+  ) {
+    return undefined;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const found = findNonFiniteNumber(item);
+      if (found !== undefined) return found;
+    }
+    return undefined;
+  }
+  for (const item of Object.values(value)) {
+    const found = findNonFiniteNumber(item);
+    if (found !== undefined) return found;
+  }
+  return undefined;
 }

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -8322,10 +8322,10 @@ export function semVer(
 /**
  * Any JSON-serializable value.
  *
- * This type covers all values that `JSON.stringify` can serialize without
- * error.  Note that certain JavaScript distinctions are not preserved
- * through serialization: for example, `-0` serializes as `"0"`, so a
- * round-trip through `format()` and `parse()` may return `0` instead.
+ * This type is a TypeScript approximation of JSON data values.  Note that
+ * certain JavaScript distinctions are not preserved through serialization:
+ * for example, `-0` serializes as `"0"`, so a round-trip through
+ * `format()` and `parse()` may return `0` instead.
  *
  * @since 1.1.0
  */

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -8318,3 +8318,249 @@ export function semVer(
     },
   };
 }
+
+/**
+ * Any JSON-serializable value.
+ *
+ * This type covers all values that can be round-tripped through
+ * `JSON.stringify` and `JSON.parse` without loss.
+ *
+ * @since 1.1.0
+ */
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { readonly [property: string]: Json }
+  | readonly Json[];
+
+/**
+ * Options for creating a {@link json} value parser.
+ *
+ * @since 1.1.0
+ */
+export interface JsonOptions {
+  /**
+   * The metavariable name for this parser.  This is used in help messages to
+   * indicate what kind of value this parser expects.  Usually a single
+   * word in uppercase, like `DATA` or `CONFIG`.
+   * @default `"JSON"`
+   */
+  readonly metavar?: NonEmptyString;
+
+  /**
+   * A custom placeholder value used during deferred prompt resolution.
+   * @default Depends on `rootType`: `null` when unset, `""` for `"string"`,
+   *   `0` for `"number"`, `false` for `"boolean"`, `null` for `"null"`,
+   *   `{}` for `"object"`, `[]` for `"array"`.
+   * @since 1.1.0
+   */
+  readonly placeholder?: Json;
+
+  /**
+   * Restricts the expected JSON root type.  When set, the parser rejects
+   * JSON values whose root type does not match and narrows the TypeScript
+   * return type accordingly.
+   *
+   * @since 1.1.0
+   */
+  readonly rootType?:
+    | "string"
+    | "number"
+    | "boolean"
+    | "null"
+    | "object"
+    | "array";
+
+  /**
+   * Custom error messages for JSON parsing failures.
+   *
+   * @since 1.1.0
+   */
+  readonly errors?: {
+    /**
+     * Custom error message when the input is not valid JSON.
+     * Can be a static message or a function that receives the raw input.
+     * @since 1.1.0
+     */
+    readonly invalidJson?: Message | ((input: string) => Message);
+
+    /**
+     * Custom error message when the parsed JSON value does not match the
+     * expected `rootType`.  Can be a static message or a function that
+     * receives the parsed value and the expected root type name.
+     * @since 1.1.0
+     */
+    readonly invalidRootType?:
+      | Message
+      | ((value: Json, expected: string) => Message);
+  };
+}
+
+/**
+ * Creates a {@link ValueParser} that parses JSON-encoded strings and returns
+ * a `string`.
+ *
+ * @param options Configuration options including `rootType: "string"`.
+ * @returns A parser whose successful value is typed as `string`.
+ * @since 1.1.0
+ */
+export function json(
+  options: JsonOptions & { readonly rootType: "string" },
+): ValueParser<"sync", string>;
+
+/**
+ * Creates a {@link ValueParser} that parses JSON-encoded strings and returns
+ * a `number`.
+ *
+ * @param options Configuration options including `rootType: "number"`.
+ * @returns A parser whose successful value is typed as `number`.
+ * @since 1.1.0
+ */
+export function json(
+  options: JsonOptions & { readonly rootType: "number" },
+): ValueParser<"sync", number>;
+
+/**
+ * Creates a {@link ValueParser} that parses JSON-encoded strings and returns
+ * a `boolean`.
+ *
+ * @param options Configuration options including `rootType: "boolean"`.
+ * @returns A parser whose successful value is typed as `boolean`.
+ * @since 1.1.0
+ */
+export function json(
+  options: JsonOptions & { readonly rootType: "boolean" },
+): ValueParser<"sync", boolean>;
+
+/**
+ * Creates a {@link ValueParser} that parses JSON-encoded strings and returns
+ * `null`.
+ *
+ * @param options Configuration options including `rootType: "null"`.
+ * @returns A parser whose successful value is typed as `null`.
+ * @since 1.1.0
+ */
+export function json(
+  options: JsonOptions & { readonly rootType: "null" },
+): ValueParser<"sync", null>;
+
+/**
+ * Creates a {@link ValueParser} that parses JSON-encoded strings and returns
+ * a plain JSON object.
+ *
+ * @param options Configuration options including `rootType: "object"`.
+ * @returns A parser whose successful value is typed as
+ *   `{ readonly [property: string]: Json }`.
+ * @since 1.1.0
+ */
+export function json(
+  options: JsonOptions & { readonly rootType: "object" },
+): ValueParser<"sync", { readonly [property: string]: Json }>;
+
+/**
+ * Creates a {@link ValueParser} that parses JSON-encoded strings and returns
+ * a JSON array.
+ *
+ * @param options Configuration options including `rootType: "array"`.
+ * @returns A parser whose successful value is typed as `readonly Json[]`.
+ * @since 1.1.0
+ */
+export function json(
+  options: JsonOptions & { readonly rootType: "array" },
+): ValueParser<"sync", readonly Json[]>;
+
+/**
+ * Creates a {@link ValueParser} that parses JSON-encoded strings into any
+ * {@link Json} value (object, array, string, number, boolean, or null).
+ *
+ * @param options Optional configuration for the parser.
+ * @returns A parser whose successful value is typed as {@link Json}.
+ * @since 1.1.0
+ */
+export function json(
+  options?: JsonOptions & { readonly rootType?: undefined },
+): ValueParser<"sync", Json>;
+
+/**
+ * Creates a {@link ValueParser} for parsing JSON-encoded strings from the
+ * command line.
+ *
+ * The parser accepts any well-formed JSON string by default.  Use the
+ * `rootType` option to restrict which JSON root type is accepted and to
+ * narrow the TypeScript return type accordingly.
+ *
+ * @example
+ * ```typescript
+ * // Accept any JSON value
+ * const anyJson = json();
+ *
+ * // Accept only JSON objects (return type narrowed)
+ * const objJson = json({ rootType: "object" });
+ * ```
+ *
+ * @param options Optional configuration for the parser.
+ * @returns A {@link ValueParser} that converts JSON-encoded strings to the
+ *   appropriate JavaScript type.
+ * @throws {TypeError} If `options.metavar` is provided but is an empty string.
+ * @since 1.1.0
+ */
+export function json(options?: JsonOptions): ValueParser<"sync", Json> {
+  const metavar = options?.metavar ?? "JSON";
+  ensureNonEmptyString(metavar);
+  const rootType = options?.rootType;
+  const invalidJsonError = options?.errors?.invalidJson;
+  const invalidRootTypeError = options?.errors?.invalidRootType;
+
+  const defaultPlaceholder: Json = rootType === "string"
+    ? ""
+    : rootType === "number"
+    ? 0
+    : rootType === "boolean"
+    ? false
+    : rootType === "object"
+    ? {}
+    : rootType === "array"
+    ? []
+    : null;
+  const placeholder: Json = options?.placeholder ?? defaultPlaceholder;
+
+  return {
+    mode: "sync",
+    metavar,
+    placeholder,
+    parse(input: string): ValueParserResult<Json> {
+      let value: Json;
+      try {
+        value = JSON.parse(input) as Json;
+      } catch (e) {
+        const err = e instanceof Error ? e : new Error(String(e));
+        const error: Message = invalidJsonError instanceof Function
+          ? invalidJsonError(input)
+          : invalidJsonError ?? [text(`Not a valid JSON: ${err.message}`)];
+        return { success: false, error };
+      }
+      if (rootType != null) {
+        const actual = jsonTypeOf(value);
+        if (actual !== rootType) {
+          const error: Message = invalidRootTypeError instanceof Function
+            ? invalidRootTypeError(value, rootType)
+            : invalidRootTypeError ??
+              [text(`Expected JSON ${rootType}, but got ${actual}.`)];
+          return { success: false, error };
+        }
+      }
+      return { success: true, value };
+    },
+    format(value: Json): string {
+      return JSON.stringify(value);
+    },
+  };
+}
+
+function jsonTypeOf(value: Json): string {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "array";
+  return typeof value;
+}

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -8322,8 +8322,10 @@ export function semVer(
 /**
  * Any JSON-serializable value.
  *
- * This type covers all values that can be round-tripped through
- * `JSON.stringify` and `JSON.parse` without loss.
+ * This type covers all values that `JSON.stringify` can serialize without
+ * error.  Note that certain JavaScript distinctions are not preserved
+ * through serialization: for example, `-0` serializes as `"0"`, so a
+ * round-trip through `format()` and `parse()` may return `0` instead.
  *
  * @since 1.1.0
  */
@@ -8525,8 +8527,8 @@ export function json(options?: JsonOptions): ValueParser<"sync", Json>;
  * @throws {TypeError} If `options.metavar` is provided but is an empty string.
  * @throws {TypeError} If `options.rootType` is provided but is not one of the
  *   six allowed values.
- * @throws {TypeError} If `options.placeholder` is a non-finite number
- *   (`Infinity`, `-Infinity`, or `NaN`).
+ * @throws {TypeError} If `options.placeholder` or any value nested within
+ *   it is a non-finite number (`Infinity`, `-Infinity`, or `NaN`).
  * @throws {TypeError} If `options.placeholder` is provided with a `rootType`
  *   but its JSON type does not match the `rootType`.
  * @throws {TypeError} If the returned parser's `format()` method is called

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -8640,22 +8640,28 @@ function jsonTypeOf(value: Json): string {
  * anywhere in a JSON structure.
  *
  * Uses an explicit stack rather than recursion to avoid call-stack overflows
- * on deeply nested inputs.
+ * on deeply nested inputs.  Tracks visited objects to handle circular
+ * references without looping forever.
  *
  * @returns The first non-finite number found, or `undefined` if all numbers
  *   in the structure are finite.
  */
 function findNonFiniteNumber(root: Json): number | undefined {
   const stack: Json[] = [root];
+  const seen = new Set<object>();
   while (stack.length > 0) {
     const value = stack.pop()!;
     if (typeof value === "number") {
       if (!Number.isFinite(value)) return value;
     } else if (Array.isArray(value)) {
+      if (seen.has(value)) continue;
+      seen.add(value);
       for (const item of value) {
         stack.push(item);
       }
     } else if (value !== null && typeof value === "object") {
+      if (seen.has(value)) continue;
+      seen.add(value);
       for (const item of Object.values(value)) {
         stack.push(item);
       }

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -8523,6 +8523,8 @@ export function json(options?: JsonOptions): ValueParser<"sync", Json>;
  * @returns A {@link ValueParser} that converts JSON-encoded strings to the
  *   appropriate JavaScript type.
  * @throws {TypeError} If `options.metavar` is provided but is an empty string.
+ * @throws {TypeError} If `options.rootType` is provided but is not one of the
+ *   six allowed values.
  * @throws {TypeError} If `options.placeholder` is provided with a `rootType`
  *   but its JSON type does not match the `rootType`.
  * @since 1.1.0
@@ -8530,6 +8532,14 @@ export function json(options?: JsonOptions): ValueParser<"sync", Json>;
 export function json(options?: JsonOptions): ValueParser<"sync", Json> {
   const metavar = options?.metavar ?? "JSON";
   ensureNonEmptyString(metavar);
+  checkEnumOption(options, "rootType", [
+    "string",
+    "number",
+    "boolean",
+    "null",
+    "object",
+    "array",
+  ]);
   const rootType = options?.rootType;
   const invalidJsonError = options?.errors?.invalidJson;
   const invalidRootTypeError = options?.errors?.invalidRootType;

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -8635,30 +8635,29 @@ function jsonTypeOf(value: Json): string {
 
 /**
  * Finds the first non-finite number (`NaN`, `Infinity`, or `-Infinity`)
- * anywhere in a JSON structure, recursively.
+ * anywhere in a JSON structure.
+ *
+ * Uses an explicit stack rather than recursion to avoid call-stack overflows
+ * on deeply nested inputs.
  *
  * @returns The first non-finite number found, or `undefined` if all numbers
  *   in the structure are finite.
  */
-function findNonFiniteNumber(value: Json): number | undefined {
-  if (typeof value === "number") {
-    return Number.isFinite(value) ? undefined : value;
-  }
-  if (
-    value === null || typeof value === "string" || typeof value === "boolean"
-  ) {
-    return undefined;
-  }
-  if (Array.isArray(value)) {
-    for (const item of value) {
-      const found = findNonFiniteNumber(item);
-      if (found !== undefined) return found;
+function findNonFiniteNumber(root: Json): number | undefined {
+  const stack: Json[] = [root];
+  while (stack.length > 0) {
+    const value = stack.pop()!;
+    if (typeof value === "number") {
+      if (!Number.isFinite(value)) return value;
+    } else if (Array.isArray(value)) {
+      for (const item of value) {
+        stack.push(item);
+      }
+    } else if (value !== null && typeof value === "object") {
+      for (const item of Object.values(value)) {
+        stack.push(item);
+      }
     }
-    return undefined;
-  }
-  for (const item of Object.values(value)) {
-    const found = findNonFiniteNumber(item);
-    if (found !== undefined) return found;
   }
   return undefined;
 }

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -8550,10 +8550,11 @@ export function json(options?: JsonOptions): ValueParser<"sync", Json> {
 
   if (options?.placeholder !== undefined) {
     const p = options.placeholder;
-    if (typeof p === "number" && !Number.isFinite(p)) {
+    const nonFinitePlaceholder = findNonFiniteNumber(p);
+    if (nonFinitePlaceholder !== undefined) {
       throw new TypeError(
-        `Expected placeholder to be a finite JSON number, but got ${
-          String(p)
+        `Expected placeholder to contain only finite numbers, but found ${
+          String(nonFinitePlaceholder)
         }.`,
       );
     }
@@ -8632,6 +8633,13 @@ function jsonTypeOf(value: Json): string {
   return typeof value;
 }
 
+/**
+ * Finds the first non-finite number (`NaN`, `Infinity`, or `-Infinity`)
+ * anywhere in a JSON structure, recursively.
+ *
+ * @returns The first non-finite number found, or `undefined` if all numbers
+ *   in the structure are finite.
+ */
 function findNonFiniteNumber(value: Json): number | undefined {
   if (typeof value === "number") {
     return Number.isFinite(value) ? undefined : value;


### PR DESCRIPTION
Closes https://github.com/dahlia/optique/issues/811.

Adds a `json()` value parser to *@optique/core* and exports the `Json` type it produces. The parser calls `JSON.parse()` and surfaces the native `SyntaxError` message on failure, so users see something like "Unexpected token 'n'" rather than a generic error.

The `rootType` option restricts which root type is accepted and, when set, narrows the TypeScript return type. Each of the six values (`"string"`, `"number"`, `"boolean"`, `"null"`, `"object"`, `"array"`) maps to a specific overload: `json({ rootType: "object" })` resolves to `ValueParser<"sync", { readonly [property: string]: Json }>` rather than the widened `ValueParser<"sync", Json>`. The `placeholder` field follows the same pattern, narrowed to the declared `rootType`'s corresponding TypeScript type; a mismatched placeholder throws `TypeError` at construction.

Callers who hold a pre-typed `const opts: JsonOptions` variable can pass it directly; a broad fallback overload accepts `JsonOptions` and returns the widened type.

Files changed: *packages/core/src/valueparser.ts* (implementation), *packages/core/src/valueparser.test.ts* (tests), *docs/concepts/valueparsers.md* (documentation), *CHANGES.md* (changelog).