### PR TITLE
Add runtime-aware command discovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,9 @@ Architecture
  -  *@optique/run* (*packages/run/*): CLI integration wrapper.  Provides
     process-integrated `run()` function, argument reading from `process.argv`
     or `Deno.args`, and `process.exit()` handling.
+ -  *@optique/discover* (*packages/discover/*): Runtime-aware command
+    discovery.  Provides `defineCommand()` and `runProgram()` for file-based
+    command modules with handler dispatch.
  -  *@optique/config* (*packages/config/*): Configuration file integration.
     Provides `createConfigContext()` and `bindConfig()` for config fallbacks.
  -  *@optique/env* (*packages/env/*): Environment variable integration.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -110,6 +110,16 @@ To be released.
 [#816]: https://github.com/dahlia/optique/pull/816
 [#817]: https://github.com/dahlia/optique/pull/817
 
+### @optique/discover
+
+ -  Added the new *@optique/discover* package for runtime-aware command module
+    discovery.  Command modules export `defineCommand()` definitions containing
+    parser, metadata, and handler logic; `runProgram()` scans a command
+    directory, builds a nested parser tree, enables help/version/completion via
+    *@optique/run*, and dispatches to the selected command handler.  [[#812]]
+
+[#812]: https://github.com/dahlia/optique/issues/812
+
 ### @optique/env
 
  -  `bindEnv()` now emits a distinct error message when other source contexts
@@ -121,6 +131,13 @@ To be released.
  -  `bindConfig()` now emits a distinct error message when other source
     contexts are registered via `run()`'s `contexts` option but the config
     context is not included.  [[#803], [#805]]
+
+### @optique/temporal
+
+ -  Fixed single-segment time zone parsing on runtimes whose Temporal
+    implementation rejects curated IANA links such as `CET`.  The curated
+    cross-runtime allowlist is now applied before runtime Temporal validation
+    for single-segment identifiers.
 
 
 Version 1.0.2

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Why Optique
     (with *@optique/man*) man pages from the same parser definition.
  -  *Practical integrations*: Extend parsers with config files, environment
     variables, schema validators, interactive prompts, and git-aware parsing.
+ -  *Command discovery*: Split larger command trees into files with
+    *@optique/discover* while keeping parser-driven help and completion.
  -  *Cross-runtime consistency*: Use the same parser model in Deno, Node.js,
     and Bun.
 
@@ -75,6 +77,8 @@ Features
     that validate against external sources like git refs or remote APIs
  -  *Man page generation*: Generate Unix man pages directly from parser
     definitions (via *@optique/man*), keeping documentation always in sync
+ -  *Command discovery*: Discover command modules from a directory and dispatch
+    to type-checked handlers (via *@optique/discover*)
  -  *Shell completion*: Automatic completion script generation for Bash, zsh,
     fish, PowerShell, and Nushell
  -  *Smart error messages*: “Did you mean?” suggestions for typos with
@@ -182,6 +186,7 @@ The following is a list of the available packages:
 | ---------------------------------------- | ---------------------------- | ---------------------------- | -------------------------------------------- |
 | [@optique/core](/packages/core/)         | [JSR][jsr:@optique/core]     | [npm][npm:@optique/core]     | Shared types and parser combinators          |
 | [@optique/run](/packages/run/)           | [JSR][jsr:@optique/run]      | [npm][npm:@optique/run]      | Runner for Node.js/Deno/Bun                  |
+| [@optique/discover](/packages/discover/) | [JSR][jsr:@optique/discover] | [npm][npm:@optique/discover] | Runtime-aware command discovery              |
 | [@optique/config](/packages/config/)     | [JSR][jsr:@optique/config]   | [npm][npm:@optique/config]   | Config file support with [Standard Schema]   |
 | [@optique/env](/packages/env/)           | [JSR][jsr:@optique/env]      | [npm][npm:@optique/env]      | Environment variable integration             |
 | [@optique/git](/packages/git/)           | [JSR][jsr:@optique/git]      | [npm][npm:@optique/git]      | Git reference parsers (branches, tags, etc)  |
@@ -196,6 +201,8 @@ The following is a list of the available packages:
 [npm:@optique/core]: https://www.npmjs.com/package/@optique/core
 [jsr:@optique/run]: https://jsr.io/@optique/run
 [npm:@optique/run]: https://www.npmjs.com/package/@optique/run
+[jsr:@optique/discover]: https://jsr.io/@optique/discover
+[npm:@optique/discover]: https://www.npmjs.com/package/@optique/discover
 [jsr:@optique/config]: https://jsr.io/@optique/config
 [npm:@optique/config]: https://www.npmjs.com/package/@optique/config
 [Standard Schema]: https://standardschema.dev/

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -59,6 +59,7 @@ const CONCEPTS = {
     { text: "Inter-option dependencies", link: "/concepts/dependencies" },
     { text: "Shell completion", link: "/concepts/completion" },
     { text: "Man pages", link: "/concepts/man" },
+    { text: "Command discovery", link: "/concepts/discover" },
     { text: "Messages", link: "/concepts/messages" },
     { text: "Runners and execution", link: "/concepts/runners" },
     { text: "Runtime context extension", link: "/concepts/extend" },
@@ -84,6 +85,10 @@ const REFERENCES = {
   items: [
     { text: "@optique/core", link: "https://jsr.io/@optique/core/doc" },
     { text: "@optique/run", link: "https://jsr.io/@optique/run/doc" },
+    {
+      text: "@optique/discover",
+      link: "https://jsr.io/@optique/discover/doc",
+    },
     { text: "@optique/man", link: "https://jsr.io/@optique/man/doc" },
     { text: "@optique/env", link: "https://jsr.io/@optique/env/doc" },
     { text: "@optique/config", link: "https://jsr.io/@optique/config/doc" },

--- a/docs/concepts/discover.md
+++ b/docs/concepts/discover.md
@@ -129,15 +129,15 @@ suffix.  Compound suffixes are supported, so `user/add.cmd.ts` can become
 
 By default, *@optique/discover* chooses extensions for the current runtime:
 
-| Runtime | Default extensions           |
-| ------- | ---------------------------- |
-| Deno    | `.ts`, `.mts`, `.js`, `.mjs` |
-| Bun     | `.ts`, `.mts`, `.js`, `.mjs` |
-| Node.js | `.js`, `.mjs`, `.cjs`        |
+| Runtime | Default extensions                                  |
+| ------- | --------------------------------------------------- |
+| Deno    | `.ts`, `.mts`, `.js`, `.mjs`                        |
+| Bun     | `.ts`, `.mts`, `.js`, `.mjs`                        |
+| Node.js | `.js`, `.mjs`, `.cjs`, and sometimes TypeScript too |
 
 Node.js also includes `.ts`, `.mts`, and `.cts` when it appears to be running
-with a TypeScript loader such as `tsx`, `ts-node`, `tsimp`, or `jiti`, or with
-Node's built-in type-stripping flags.
+with native TypeScript support, a TypeScript loader such as `tsx`, `ts-node`,
+`tsimp`, or `jiti`, or Node's built-in type-stripping flags.
 
 TypeScript declaration files (`.d.ts`, `.d.mts`, and `.d.cts`) are ignored even
 when their suffix matches the configured extension list.

--- a/docs/concepts/discover.md
+++ b/docs/concepts/discover.md
@@ -19,6 +19,13 @@ discovery.  The alternative name *@optique/program* would overlap with
 `@optique/core/program`, which already provides parser-and-metadata objects for
 man pages and runner integration.
 
+> [!WARNING]
+> Command discovery is a runtime feature, not a static registry.  It reads the
+> command directory and imports matching modules dynamically, so bundlers cannot
+> reliably see which command files are used.  If your CLI depends on tree
+> shaking, static bundling, or single-file executable packaging, import command
+> modules manually and pass them to `runProgram()` with `commands`.
+
 
 Command modules
 ---------------
@@ -49,6 +56,9 @@ export default defineCommand({
 
 `defineCommand()` preserves the parser's inferred value type for `handler`.
 If you change the parser, TypeScript checks the handler against the new shape.
+When commands are passed manually to `runProgram()`, add a `path` field to the
+command definition.  File-based discovery can omit `path`; if it is present,
+it must match the path derived from the file name.
 
 
 Running a discovered program
@@ -120,6 +130,48 @@ await runProgram({
 ~~~~
 
 
+Running statically imported commands
+------------------------------------
+
+When command modules need to be visible to a bundler or single-file packager,
+import them manually and pass them as `commands`.  Each command declares its
+own path:
+
+~~~~ typescript twoslash
+import { object } from "@optique/core/constructs";
+import { message } from "@optique/core/message";
+import { withDefault } from "@optique/core/modifiers";
+import { option } from "@optique/core/primitives";
+import { string } from "@optique/core/valueparser";
+import { defineCommand, runProgram } from "@optique/discover";
+
+const build = defineCommand({
+  path: ["build"],
+  parser: object({
+    target: withDefault(option("--target", string()), "app"),
+  }),
+  metadata: {
+    brief: message`Build the project.`,
+  },
+  handler(value) {
+    console.log(`Building ${value.target}.`);
+  },
+});
+
+await runProgram({
+  commands: [build],
+  metadata: {
+    name: "admin",
+    version: "1.0.0",
+    brief: message`Administrative command-line tools.`,
+  },
+});
+~~~~
+
+`commands` and `dir` are mutually exclusive.  Use `commands` when static
+imports matter; use `dir` when the runtime file layout is the command registry.
+
+
 File names and extensions
 -------------------------
 
@@ -188,6 +240,12 @@ Use *@optique/discover* when:
  -  Each command should keep its parser, help metadata, and handler together
  -  You want *@optique/run* help, version, and completion behavior without
     manually composing the whole command tree
+
+Use static `commands` with manually imported command modules when:
+
+ -  You need tree shaking, static bundling, or single-file executable
+    packaging
+ -  You want command modules to be visible through ordinary static imports
 
 Use plain *@optique/core* and *@optique/run* when:
 

--- a/docs/concepts/discover.md
+++ b/docs/concepts/discover.md
@@ -1,0 +1,194 @@
+---
+description: >-
+  Build command-oriented CLI applications by discovering Optique command
+  modules from the file system and dispatching to command handlers.
+---
+
+Command discovery
+=================
+
+Optique's core command combinators work well when the whole command tree fits
+comfortably in one module.  Larger applications often want a file layout where
+each command owns its parser, metadata, and handler.  The *@optique/discover*
+package provides that layer: it scans a command directory, imports command
+modules, builds a nested parser tree, and dispatches to the matched command
+handler.
+
+The package is named *@optique/discover* because its main job is command module
+discovery.  The alternative name *@optique/program* would overlap with
+`@optique/core/program`, which already provides parser-and-metadata objects for
+man pages and runner integration.
+
+
+Command modules
+---------------
+
+A command module default-exports a value created with `defineCommand()`.
+The parser describes the command-specific arguments and options, `metadata`
+feeds help and completion output, and `handler` receives the parsed value.
+
+~~~~ typescript twoslash
+import { defineCommand } from "@optique/discover/command";
+import { object } from "@optique/core/constructs";
+import { message } from "@optique/core/message";
+import { option } from "@optique/core/primitives";
+import { string } from "@optique/core/valueparser";
+
+export default defineCommand({
+  parser: object({
+    name: option("--name", string()),
+  }),
+  metadata: {
+    brief: message`Add a user.`,
+  },
+  handler(value) {
+    console.log(`Adding ${value.name}.`);
+  },
+});
+~~~~
+
+`defineCommand()` preserves the parser's inferred value type for `handler`.
+If you change the parser, TypeScript checks the handler against the new shape.
+
+
+Running a discovered program
+----------------------------
+
+Point `runProgram()` at a command directory and provide root program metadata:
+
+~~~~ typescript twoslash
+import { runProgram } from "@optique/discover";
+import { message } from "@optique/core/message";
+
+await runProgram({
+  dir: new URL("./commands/", import.meta.url),
+  metadata: {
+    name: "admin",
+    version: "1.0.0",
+    brief: message`Administrative command-line tools.`,
+  },
+});
+~~~~
+
+With this file layout:
+
+~~~~ text
+commands/
+  build.ts
+  user/
+    add.ts
+    remove.ts
+~~~~
+
+the discovered command paths are:
+
+~~~~ bash
+admin build
+admin user add
+admin user remove
+~~~~
+
+`runProgram()` uses *@optique/run* internally.  Help and shell completion are
+enabled in both command and option forms by default, and version output is
+enabled when `metadata.version` is present:
+
+~~~~ bash
+admin --help
+admin help
+admin --version
+admin completion bash
+admin --completion bash
+~~~~
+
+You can disable or customize these runner features with the same option shapes
+accepted by `run()`:
+
+~~~~ typescript twoslash
+import { runProgram } from "@optique/discover";
+import { message } from "@optique/core/message";
+
+await runProgram({
+  dir: new URL("./commands/", import.meta.url),
+  metadata: {
+    name: "admin",
+    brief: message`Administrative command-line tools.`,
+  },
+  help: { option: true },
+  version: false,
+  completion: false,
+});
+~~~~
+
+
+File names and extensions
+-------------------------
+
+The relative file path becomes the command path after removing the configured
+suffix.  Compound suffixes are supported, so `user/add.cmd.ts` can become
+`user add` when `.cmd.ts` is listed before `.ts`.
+
+By default, *@optique/discover* chooses extensions for the current runtime:
+
+| Runtime | Default extensions           |
+| ------- | ---------------------------- |
+| Deno    | `.ts`, `.mts`, `.js`, `.mjs` |
+| Bun     | `.ts`, `.mts`, `.js`, `.mjs` |
+| Node.js | `.js`, `.mjs`, `.cjs`        |
+
+Node.js also includes `.ts`, `.mts`, and `.cts` when it appears to be running
+with a TypeScript loader such as `tsx`, `ts-node`, `tsimp`, or `jiti`, or with
+Node's built-in type-stripping flags.
+
+Pass `extensions` when you want an explicit policy:
+
+~~~~ typescript twoslash
+import { runProgram } from "@optique/discover";
+
+await runProgram({
+  dir: new URL("./commands/", import.meta.url),
+  metadata: { name: "admin" },
+  extensions: [".cmd.ts"],
+});
+~~~~
+
+> [!NOTE]
+> Command modules are imported eagerly during startup.  This keeps discovery
+> simple and makes help, errors, and completion aware of the full command tree.
+> Avoid side effects at module top level other than defining the command.
+
+
+Path conflicts
+--------------
+
+Each discovered file must map to exactly one command path.  Discovery rejects
+duplicate paths, such as `build.ts` and `build.cmd.ts` both becoming `build`.
+It also rejects file-vs-namespace conflicts such as:
+
+~~~~ text
+commands/
+  user.ts
+  user/
+    add.ts
+~~~~
+
+In that layout, `user` would need to be both a leaf command and a namespace for
+`user add`.  Move the shared behavior into a helper module or choose a deeper
+leaf command path instead.
+
+
+When to use command discovery
+-----------------------------
+
+Use *@optique/discover* when:
+
+ -  Your CLI has enough commands that a file-per-command layout is clearer
+ -  Each command should keep its parser, help metadata, and handler together
+ -  You want *@optique/run* help, version, and completion behavior without
+    manually composing the whole command tree
+
+Use plain *@optique/core* and *@optique/run* when:
+
+ -  The command tree is small enough to define directly with `command()` and
+    `or()`
+ -  You need lazy command loading or a custom plugin registry
+ -  You want to parse commands without coupling them to handlers

--- a/docs/concepts/discover.md
+++ b/docs/concepts/discover.md
@@ -139,6 +139,9 @@ Node.js also includes `.ts`, `.mts`, and `.cts` when it appears to be running
 with a TypeScript loader such as `tsx`, `ts-node`, `tsimp`, or `jiti`, or with
 Node's built-in type-stripping flags.
 
+TypeScript declaration files (`.d.ts`, `.d.mts`, and `.d.cts`) are ignored even
+when their suffix matches the configured extension list.
+
 Pass `extensions` when you want an explicit policy:
 
 ~~~~ typescript twoslash

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -1691,6 +1691,88 @@ sensible fallbacks and [`optional()`](./concepts/modifiers.md#optional-parser)
 when absence is meaningful.
 
 
+Application structure patterns
+------------------------------
+
+These recipes use packages that sit above individual parsers and help shape a
+larger CLI application.
+
+### File-based command discovery
+
+When a command tree grows beyond a handful of branches, keeping every command
+inside one `or(command(...))` expression can make the entry point do too much.
+The *@optique/discover* package lets each command live in its own module with
+its parser, help metadata, and handler.
+
+Put command modules under a directory:
+
+~~~~ typescript twoslash
+// commands/build.ts
+import { object } from "@optique/core/constructs";
+import { message } from "@optique/core/message";
+import { withDefault } from "@optique/core/modifiers";
+import { option } from "@optique/core/primitives";
+import { string } from "@optique/core/valueparser";
+import { defineCommand } from "@optique/discover/command";
+
+export default defineCommand({
+  parser: object({
+    target: withDefault(option("--target", string()), "app"),
+  }),
+  metadata: {
+    brief: message`Build the project.`,
+  },
+  handler(value) {
+    console.log(`Building ${value.target}.`);
+  },
+});
+~~~~
+
+Then point `runProgram()` at the command directory:
+
+~~~~ typescript twoslash
+import { message } from "@optique/core/message";
+import { runProgram } from "@optique/discover";
+
+await runProgram({
+  dir: new URL("./commands/", import.meta.url),
+  metadata: {
+    name: "tasks",
+    version: "1.0.0",
+    brief: message`Project task runner.`,
+  },
+});
+~~~~
+
+With this layout:
+
+~~~~ text
+commands/
+  build.ts
+  deploy.ts
+  release/
+    notes.ts
+~~~~
+
+the file paths become command paths:
+
+~~~~ bash
+tasks build
+tasks deploy
+tasks release notes
+~~~~
+
+Use this pattern when the command module is the natural unit of ownership.
+It keeps the root file focused on program metadata and runner configuration,
+while each command file owns the parser and the code that acts on its parsed
+value.  The discovered program still gets the usual *@optique/run* help,
+version, and shell completion behavior.
+
+The repository also includes a runnable version of this pattern in
+`examples/patterns/command-discovery.ts`.  For the full API details, see
+[command discovery](./concepts/discover.md).
+
+
 Integration patterns
 --------------------
 

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -1704,6 +1704,13 @@ inside one `or(command(...))` expression can make the entry point do too much.
 The *@optique/discover* package lets each command live in its own module with
 its parser, help metadata, and handler.
 
+> [!WARNING]
+> This pattern discovers and imports command modules at runtime.  It works best
+> when those command files are present beside the running CLI.  For CLIs that
+> rely on tree shaking, static bundling, or single-file executable packaging,
+> import command modules manually and pass them to `runProgram()` with
+> `commands`.
+
 Put command modules under a directory:
 
 ~~~~ typescript twoslash
@@ -1736,6 +1743,40 @@ import { runProgram } from "@optique/discover";
 
 await runProgram({
   dir: new URL("./commands/", import.meta.url),
+  metadata: {
+    name: "tasks",
+    version: "1.0.0",
+    brief: message`Project task runner.`,
+  },
+});
+~~~~
+
+For a bundled CLI, add a path to each command definition and import the command
+modules manually:
+
+~~~~ typescript twoslash
+import { object } from "@optique/core/constructs";
+import { message } from "@optique/core/message";
+import { withDefault } from "@optique/core/modifiers";
+import { option } from "@optique/core/primitives";
+import { string } from "@optique/core/valueparser";
+import { defineCommand, runProgram } from "@optique/discover";
+
+const build = defineCommand({
+  path: ["build"],
+  parser: object({
+    target: withDefault(option("--target", string()), "app"),
+  }),
+  metadata: {
+    brief: message`Build the project.`,
+  },
+  handler(value) {
+    console.log(`Building ${value.target}.`);
+  },
+});
+
+await runProgram({
+  commands: [build],
   metadata: {
     name: "tasks",
     version: "1.0.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -3,6 +3,7 @@
     "@logtape/logtape": "catalog:",
     "@optique/config": "workspace:",
     "@optique/core": "workspace:",
+    "@optique/discover": "workspace:",
     "@optique/env": "workspace:",
     "@optique/git": "workspace:",
     "@optique/logtape": "workspace:",

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -592,6 +592,92 @@ subcommands, each with their own options and behaviors. The type system
 tracks the structure automatically, so you never have to worry about
 accessing the wrong properties or forgetting to handle a case.
 
+### When commands outgrow one file
+
+The examples above define the command tree directly with `command()` and
+`or()`.  That is the clearest way to learn the model, and it works well for
+small and medium CLIs.  When each command starts to feel like its own module,
+*@optique/discover* can build the same command tree from files instead.
+
+> [!WARNING]
+> `runProgram()` discovers command modules from the runtime file system and
+> imports them dynamically.  This is useful for source-layout CLIs, but it is
+> not a good default when the CLI must be aggressively tree-shaken, statically
+> bundled, or packaged as a single executable.  In those cases, import command
+> modules manually and pass them as `commands`.
+
+Each command module default-exports a command created with `defineCommand()`.
+The entry point then points `runProgram()` at the command directory:
+
+~~~~ typescript twoslash
+import { message } from "@optique/core/message";
+import { runProgram } from "@optique/discover";
+
+await runProgram({
+  dir: new URL("./commands/", import.meta.url),
+  metadata: {
+    name: "app",
+    brief: message`Project tools.`,
+  },
+});
+~~~~
+
+For a bundled CLI, declare each command's path and pass the imported commands
+directly:
+
+~~~~ typescript twoslash
+import { object } from "@optique/core/constructs";
+import { message } from "@optique/core/message";
+import { option } from "@optique/core/primitives";
+import { string } from "@optique/core/valueparser";
+import { defineCommand, runProgram } from "@optique/discover";
+
+const build = defineCommand({
+  path: ["build"],
+  parser: object({
+    target: option("--target", string()),
+  }),
+  metadata: {
+    brief: message`Build the project.`,
+  },
+  handler(value) {
+    console.log(`Building ${value.target}.`);
+  },
+});
+
+await runProgram({
+  commands: [build],
+  metadata: {
+    name: "app",
+    brief: message`Project tools.`,
+  },
+});
+~~~~
+
+With this layout:
+
+~~~~ text
+commands/
+  build.ts
+  deploy.ts
+  config/
+    set.ts
+~~~~
+
+the file paths become command paths:
+
+~~~~ bash
+app build
+app deploy
+app config set
+~~~~
+
+Use this pattern when the command file is the natural place to keep the
+parser, help metadata, and handler together.  See the
+[command discovery guide](./concepts/discover.md) for the full API and the
+[cookbook recipe](./cookbook.md#file-based-command-discovery) for a complete
+example.
+
 
 Modularization and reusability
 ------------------------------
@@ -1344,6 +1430,9 @@ Here are some directions to explore next:
 
  -  [Cookbook](./cookbook.md): Practical recipes for common patterns like
     mutually exclusive options, dependent flags, and integration examples
+ -  [Command discovery](./concepts/discover.md): File-based command modules
+    and static `runProgram({ commands })` registration for CLIs that have
+    outgrown a single parser file
  -  [Concept guides](./concepts/primitives.md): Deep dives into primitives,
     value parsers, combinators, shell completion, and man page generation
  -  Integration packages:

--- a/examples/patterns/command-discovery.ts
+++ b/examples/patterns/command-discovery.ts
@@ -1,0 +1,26 @@
+import { message } from "@optique/core/message";
+import { runProgram } from "@optique/discover";
+import process from "node:process";
+
+// This example shows how @optique/discover can turn a directory of command
+// modules into a runnable CLI.  Each file under command-discovery/ exports a
+// defineCommand() result with its parser, metadata, and handler.
+//
+// Usage:
+//   deno run -A examples/patterns/command-discovery.ts build --target web
+//   deno run -A examples/patterns/command-discovery.ts deploy --env staging
+//   deno run -A examples/patterns/command-discovery.ts --help
+
+await runProgram({
+  dir: new URL("./command-discovery/", import.meta.url),
+  metadata: {
+    name: "tasks",
+    version: "1.0.0",
+    brief: message`Project task runner.`,
+    description:
+      message`A small task runner whose commands are discovered from files.`,
+  },
+  args: process.argv.slice(2),
+  showDefault: true,
+  showChoices: true,
+});

--- a/examples/patterns/command-discovery/build.ts
+++ b/examples/patterns/command-discovery/build.ts
@@ -1,0 +1,24 @@
+import { object } from "@optique/core/constructs";
+import { message, text } from "@optique/core/message";
+import { withDefault } from "@optique/core/modifiers";
+import { option } from "@optique/core/primitives";
+import { string } from "@optique/core/valueparser";
+import { defineCommand } from "@optique/discover/command";
+import { print } from "@optique/run";
+
+export default defineCommand({
+  parser: object({
+    target: withDefault(
+      option("--target", string({ metavar: "TARGET" }), {
+        description: message`Build target`,
+      }),
+      "app",
+    ),
+  }),
+  metadata: {
+    brief: message`Build the project.`,
+  },
+  handler(value) {
+    print(message`Building ${text(value.target)}.`);
+  },
+});

--- a/examples/patterns/command-discovery/deploy.ts
+++ b/examples/patterns/command-discovery/deploy.ts
@@ -1,0 +1,28 @@
+import { object } from "@optique/core/constructs";
+import { message, text } from "@optique/core/message";
+import { flag, option } from "@optique/core/primitives";
+import { choice } from "@optique/core/valueparser";
+import { defineCommand } from "@optique/discover/command";
+import { print } from "@optique/run";
+
+export default defineCommand({
+  parser: object({
+    environment: option(
+      "--env",
+      choice(["staging", "production"] as const),
+      {
+        description: message`Deployment environment`,
+      },
+    ),
+    dryRun: flag("--dry-run", {
+      description: message`Show the deployment plan without applying it`,
+    }),
+  }),
+  metadata: {
+    brief: message`Deploy the project.`,
+  },
+  handler(value) {
+    const mode = value.dryRun ? "Planning" : "Deploying";
+    print(message`${text(mode)} ${text(value.environment)}.`);
+  },
+});

--- a/packages/discover/README.md
+++ b/packages/discover/README.md
@@ -74,9 +74,9 @@ admin completion bash
 ~~~~
 
 By default, Deno and Bun discover `.ts`, `.mts`, `.js`, and `.mjs` files.
-Node.js discovers `.js`, `.mjs`, and `.cjs` files unless it is running with a
-recognized TypeScript loader.  TypeScript declaration files such as `.d.ts`
-are ignored.
+Node.js discovers `.js`, `.mjs`, and `.cjs` files, plus `.ts`, `.mts`, and
+`.cts` when it reports native TypeScript support or runs with a recognized
+TypeScript loader.  TypeScript declaration files such as `.d.ts` are ignored.
 
 For more resources, see the [docs] and the [*examples/*](/examples/)
 directory.

--- a/packages/discover/README.md
+++ b/packages/discover/README.md
@@ -75,7 +75,8 @@ admin completion bash
 
 By default, Deno and Bun discover `.ts`, `.mts`, `.js`, and `.mjs` files.
 Node.js discovers `.js`, `.mjs`, and `.cjs` files unless it is running with a
-recognized TypeScript loader.
+recognized TypeScript loader.  TypeScript declaration files such as `.d.ts`
+are ignored.
 
 For more resources, see the [docs] and the [*examples/*](/examples/)
 directory.

--- a/packages/discover/README.md
+++ b/packages/discover/README.md
@@ -1,0 +1,83 @@
+@optique/discover
+=================
+
+Runtime-aware command discovery for Optique CLI programs.
+
+Use *@optique/discover* when your CLI has many commands and you want the
+command tree to come from files instead of one large `or(command(...))`
+definition.  Each command module exports a `defineCommand()` result, and
+`runProgram()` discovers those modules, builds a parser tree, enables help,
+version, and shell completion, then dispatches to the selected command's
+handler.
+
+
+Installation
+------------
+
+~~~~ bash
+deno add jsr:@optique/discover jsr:@optique/core jsr:@optique/run
+npm  add     @optique/discover     @optique/core     @optique/run
+pnpm add     @optique/discover     @optique/core     @optique/run
+yarn add     @optique/discover     @optique/core     @optique/run
+~~~~
+
+
+Quick example
+-------------
+
+Create command modules under a directory:
+
+~~~~ typescript
+// commands/user/add.ts
+import { defineCommand } from "@optique/discover/command";
+import { object } from "@optique/core/constructs";
+import { message } from "@optique/core/message";
+import { option } from "@optique/core/primitives";
+import { string } from "@optique/core/valueparser";
+
+export default defineCommand({
+  parser: object({
+    name: option("--name", string()),
+  }),
+  metadata: {
+    brief: message`Add a user.`,
+  },
+  handler(value) {
+    console.log(`Adding ${value.name}.`);
+  },
+});
+~~~~
+
+Then run the discovered program from your entry point:
+
+~~~~ typescript
+// cli.ts
+import { runProgram } from "@optique/discover";
+import { message } from "@optique/core/message";
+
+await runProgram({
+  dir: new URL("./commands/", import.meta.url),
+  metadata: {
+    name: "admin",
+    version: "1.0.0",
+    brief: message`Administrative command-line tools.`,
+  },
+});
+~~~~
+
+The file path becomes the command path, so the example above is available as:
+
+~~~~ bash
+admin user add --name Ada
+admin --help
+admin completion bash
+~~~~
+
+By default, Deno and Bun discover `.ts`, `.mts`, `.js`, and `.mjs` files.
+Node.js discovers `.js`, `.mjs`, and `.cjs` files unless it is running with a
+recognized TypeScript loader.
+
+For more resources, see the [docs] and the [*examples/*](/examples/)
+directory.
+
+[docs]: https://optique.dev/concepts/discover

--- a/packages/discover/README.md
+++ b/packages/discover/README.md
@@ -10,6 +10,12 @@ definition.  Each command module exports a `defineCommand()` result, and
 version, and shell completion, then dispatches to the selected command's
 handler.
 
+> [!WARNING]
+> *@optique/discover* reads command files and imports them dynamically at
+> runtime.  It is a poor fit for CLIs that rely on aggressive tree shaking,
+> static bundling, or single-file executable packaging.  In those cases, use
+> manually imported commands with `runProgram({ commands })`.
+
 
 Installation
 ------------
@@ -71,6 +77,40 @@ The file path becomes the command path, so the example above is available as:
 admin user add --name Ada
 admin --help
 admin completion bash
+~~~~
+
+For bundlers and single-file packagers, import commands manually and declare
+their paths in the command definitions:
+
+~~~~ typescript
+// cli.ts
+import { defineCommand, runProgram } from "@optique/discover";
+import { object } from "@optique/core/constructs";
+import { message } from "@optique/core/message";
+import { option } from "@optique/core/primitives";
+import { string } from "@optique/core/valueparser";
+
+const addUser = defineCommand({
+  path: ["user", "add"],
+  parser: object({
+    name: option("--name", string()),
+  }),
+  metadata: {
+    brief: message`Add a user.`,
+  },
+  handler(value) {
+    console.log(`Adding ${value.name}.`);
+  },
+});
+
+await runProgram({
+  commands: [addUser],
+  metadata: {
+    name: "admin",
+    version: "1.0.0",
+    brief: message`Administrative command-line tools.`,
+  },
+});
 ~~~~
 
 By default, Deno and Bun discover `.ts`, `.mts`, `.js`, and `.mjs` files.

--- a/packages/discover/deno.json
+++ b/packages/discover/deno.json
@@ -1,0 +1,37 @@
+{
+  "name": "@optique/discover",
+  "version": "1.1.0",
+  "license": "MIT",
+  "exports": {
+    ".": "./src/index.ts",
+    "./command": "./src/command.ts"
+  },
+  "exclude": [
+    "dist/",
+    "node_modules",
+    "tsdown.config.ts"
+  ],
+  "tasks": {
+    "build": "pnpm build",
+    "test": "deno test --allow-read --allow-write --allow-env",
+    "test:node": {
+      "dependencies": [
+        "build"
+      ],
+      "command": "node --experimental-transform-types --test"
+    },
+    "test:bun": {
+      "dependencies": [
+        "build"
+      ],
+      "command": "bun test"
+    },
+    "test-all": {
+      "dependencies": [
+        "test",
+        "test:node",
+        "test:bun"
+      ]
+    }
+  }
+}

--- a/packages/discover/package.json
+++ b/packages/discover/package.json
@@ -76,7 +76,7 @@
     "prepublish": "tsdown",
     "test": "node --experimental-transform-types --test",
     "test:bun": "bun test",
-    "test:deno": "deno test",
-    "test-all": "tsdown && node --experimental-transform-types --test && bun test && deno test"
+    "test:deno": "deno test --allow-read --allow-write --allow-env",
+    "test-all": "tsdown && node --experimental-transform-types --test && bun test && deno test --allow-read --allow-write --allow-env"
   }
 }

--- a/packages/discover/package.json
+++ b/packages/discover/package.json
@@ -1,0 +1,82 @@
+{
+  "name": "@optique/discover",
+  "version": "1.1.0",
+  "description": "Runtime-aware command discovery for Optique CLI programs",
+  "keywords": [
+    "CLI",
+    "command-line",
+    "commandline",
+    "parser",
+    "commands",
+    "discovery"
+  ],
+  "license": "MIT",
+  "author": {
+    "name": "Hong Minhee",
+    "email": "hong@minhee.org",
+    "url": "https://hongminhee.org/"
+  },
+  "homepage": "https://optique.dev/",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dahlia/optique.git",
+    "directory": "packages/discover/"
+  },
+  "bugs": {
+    "url": "https://github.com/dahlia/optique/issues"
+  },
+  "funding": [
+    "https://github.com/sponsors/dahlia"
+  ],
+  "engines": {
+    "node": ">=20.0.0",
+    "bun": ">=1.2.0",
+    "deno": ">=2.3.0"
+  },
+  "files": [
+    "dist/",
+    "package.json",
+    "README.md"
+  ],
+  "type": "module",
+  "module": "./dist/index.js",
+  "main": "./dist/index.cjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": {
+        "import": "./dist/index.d.ts",
+        "require": "./dist/index.d.cts"
+      },
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./command": {
+      "types": {
+        "import": "./dist/command.d.ts",
+        "require": "./dist/command.d.cts"
+      },
+      "import": "./dist/command.js",
+      "require": "./dist/command.cjs"
+    }
+  },
+  "sideEffects": false,
+  "dependencies": {
+    "@optique/core": "workspace:*",
+    "@optique/run": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "tsdown": "catalog:",
+    "typescript": "catalog:"
+  },
+  "scripts": {
+    "build": "tsdown",
+    "prepack": "tsdown",
+    "prepublish": "tsdown",
+    "test": "node --experimental-transform-types --test",
+    "test:bun": "bun test",
+    "test:deno": "deno test",
+    "test-all": "tsdown && node --experimental-transform-types --test && bun test && deno test"
+  }
+}

--- a/packages/discover/src/command.ts
+++ b/packages/discover/src/command.ts
@@ -1,0 +1,119 @@
+import type { CommandOptions } from "@optique/core/primitives";
+import type { Mode, Parser } from "@optique/core/parser";
+
+const commandBrand = Symbol.for("@optique/discover/command");
+
+/**
+ * Metadata shown for a discovered command.
+ *
+ * This uses the same shape as Optique's `command()` options so discovered
+ * commands can provide descriptions, usage overrides, visibility, and custom
+ * command-level errors.
+ *
+ * @since 1.1.0
+ */
+export type CommandMetadata = CommandOptions;
+
+/**
+ * Input accepted by {@link defineCommand}.
+ *
+ * @template M The mode of the command parser.
+ * @template T The parsed value passed to the command handler.
+ * @since 1.1.0
+ */
+export interface CommandDefinition<M extends Mode, T> {
+  /**
+   * Parser for this command's command-specific arguments and options.
+   */
+  readonly parser: Parser<M, T, unknown>;
+
+  /**
+   * Metadata used in help output and shell completion.
+   */
+  readonly metadata?: CommandMetadata;
+
+  /**
+   * Handles the parsed command value.
+   *
+   * @param value Parsed command value.
+   * @returns Nothing, or a promise that resolves when command handling
+   *          completes.
+   */
+  handler(value: T): void | Promise<void>;
+}
+
+/**
+ * A discovered command module definition.
+ *
+ * @template M The mode of the command parser.
+ * @template T The parsed value passed to the command handler.
+ * @since 1.1.0
+ */
+export interface Command<M extends Mode, T> extends CommandDefinition<M, T> {
+  /**
+   * Internal marker used to validate discovered modules.
+   *
+   * @internal
+   */
+  readonly [commandBrand]: true;
+}
+
+/**
+ * Defines a command module for `@optique/discover`.
+ *
+ * This helper returns its argument unchanged while preserving parser value
+ * inference for the handler callback.
+ *
+ * @template M The mode of the command parser.
+ * @template T The parsed value passed to the command handler.
+ * @param command The command definition.
+ * @returns The same command definition with inferred types.
+ * @throws {TypeError} If the parser or handler is missing or malformed.
+ * @since 1.1.0
+ */
+export function defineCommand<M extends Mode, T>(
+  command: CommandDefinition<M, T>,
+): Command<M, T> {
+  if (!isParser(command.parser)) {
+    throw new TypeError("Command parser must be an Optique parser.");
+  }
+  if (typeof command.handler !== "function") {
+    throw new TypeError("Command handler must be a function.");
+  }
+  return {
+    ...command,
+    [commandBrand]: true,
+  };
+}
+
+/**
+ * Returns whether a value is a command created by {@link defineCommand}.
+ *
+ * @param value The value to inspect.
+ * @returns `true` when the value is a discovered command definition.
+ * @since 1.1.0
+ */
+export function isCommand(value: unknown): value is Command<Mode, unknown> {
+  return (
+    value != null &&
+    typeof value === "object" &&
+    (value as { readonly [commandBrand]?: unknown })[commandBrand] === true &&
+    isParser((value as { readonly parser?: unknown }).parser) &&
+    typeof (value as { readonly handler?: unknown }).handler === "function"
+  );
+}
+
+function isParser(value: unknown): value is Parser<Mode, unknown, unknown> {
+  return (
+    value != null &&
+    typeof value === "object" &&
+    typeof (value as { readonly parse?: unknown }).parse === "function" &&
+    typeof (value as { readonly complete?: unknown }).complete ===
+      "function" &&
+    typeof (value as { readonly suggest?: unknown }).suggest === "function" &&
+    typeof (value as { readonly getDocFragments?: unknown })
+        .getDocFragments === "function" &&
+    ((value as { readonly mode?: unknown }).mode === "sync" ||
+      (value as { readonly mode?: unknown }).mode === "async")
+  );
+}

--- a/packages/discover/src/command.ts
+++ b/packages/discover/src/command.ts
@@ -15,6 +15,13 @@ const commandBrand = Symbol.for("@optique/discover/command");
 export type CommandMetadata = CommandOptions;
 
 /**
+ * Non-empty command path used by static command registration.
+ *
+ * @since 1.1.0
+ */
+export type CommandPath = readonly [string, ...string[]];
+
+/**
  * Input accepted by {@link defineCommand}.
  *
  * @template M The mode of the command parser.
@@ -22,6 +29,14 @@ export type CommandMetadata = CommandOptions;
  * @since 1.1.0
  */
 export interface CommandDefinition<M extends Mode, T> {
+  /**
+   * Command path used when commands are passed directly to `runProgram()`.
+   *
+   * File-based discovery derives the command path from the file name and uses
+   * this field only to validate that the declared path matches.
+   */
+  readonly path?: CommandPath;
+
   /**
    * Parser for this command's command-specific arguments and options.
    */
@@ -59,6 +74,22 @@ export interface Command<M extends Mode, T> extends CommandDefinition<M, T> {
 }
 
 /**
+ * A command that declares its own command path.
+ *
+ * Static `runProgram({ commands })` registration accepts this shape.
+ *
+ * @template M The mode of the command parser.
+ * @template T The parsed value passed to the command handler.
+ * @since 1.1.0
+ */
+export interface StaticCommand<M extends Mode, T> extends Command<M, T> {
+  /**
+   * Command path used by static command registration.
+   */
+  readonly path: CommandPath;
+}
+
+/**
  * Defines a command module for `@optique/discover`.
  *
  * This helper returns its argument unchanged while preserving parser value
@@ -68,15 +99,22 @@ export interface Command<M extends Mode, T> extends CommandDefinition<M, T> {
  * @template T The parsed value passed to the command handler.
  * @param command The command definition.
  * @returns The same command definition with inferred types.
- * @throws {TypeError} If the parser or handler is missing or malformed.
+ * @throws {TypeError} If the parser, path, or handler is missing or malformed.
  * @since 1.1.0
  */
+export function defineCommand<M extends Mode, T>(
+  command: CommandDefinition<M, T> & { readonly path: CommandPath },
+): StaticCommand<M, T>;
+export function defineCommand<M extends Mode, T>(
+  command: CommandDefinition<M, T>,
+): Command<M, T>;
 export function defineCommand<M extends Mode, T>(
   command: CommandDefinition<M, T>,
 ): Command<M, T> {
   if (!isParser(command.parser)) {
     throw new TypeError("Command parser must be an Optique parser.");
   }
+  if (command.path != null) validateCommandPath(command.path);
   if (typeof command.handler !== "function") {
     throw new TypeError("Command handler must be a function.");
   }
@@ -98,9 +136,27 @@ export function isCommand(value: unknown): value is Command<Mode, unknown> {
     value != null &&
     typeof value === "object" &&
     (value as { readonly [commandBrand]?: unknown })[commandBrand] === true &&
+    (
+      (value as { readonly path?: unknown }).path == null ||
+      isCommandPath((value as { readonly path?: unknown }).path)
+    ) &&
     isParser((value as { readonly parser?: unknown }).parser) &&
     typeof (value as { readonly handler?: unknown }).handler === "function"
   );
+}
+
+function validateCommandPath(path: unknown): asserts path is CommandPath {
+  if (!isCommandPath(path)) {
+    throw new TypeError(
+      "Command path must be a non-empty array of non-empty strings.",
+    );
+  }
+}
+
+function isCommandPath(path: unknown): path is CommandPath {
+  return Array.isArray(path) &&
+    path.length > 0 &&
+    path.every((segment) => typeof segment === "string" && segment.length > 0);
 }
 
 function isParser(value: unknown): value is Parser<Mode, unknown, unknown> {

--- a/packages/discover/src/command.ts
+++ b/packages/discover/src/command.ts
@@ -54,7 +54,7 @@ export interface CommandDefinition<M extends Mode, T> {
    * @returns Nothing, or a promise that resolves when command handling
    *          completes.
    */
-  handler(value: T): void | Promise<void>;
+  readonly handler: (value: T) => void | Promise<void>;
 }
 
 /**
@@ -88,6 +88,34 @@ export interface StaticCommand<M extends Mode, T> extends Command<M, T> {
    */
   readonly path: CommandPath;
 }
+
+/**
+ * A command with its handler value type erased.
+ *
+ * This type is used by discovery APIs that collect commands with different
+ * parsed value types.  The handler cannot be called directly without first
+ * recovering the parser's value type.
+ *
+ * @since 1.1.0
+ */
+export type AnyCommand = Omit<Command<Mode, unknown>, "handler"> & {
+  /**
+   * Erased command handler.
+   */
+  readonly handler: (value: never) => void | Promise<void>;
+};
+
+/**
+ * A statically registered command with its handler value type erased.
+ *
+ * @since 1.1.0
+ */
+export type AnyStaticCommand = Omit<StaticCommand<Mode, unknown>, "handler"> & {
+  /**
+   * Erased command handler.
+   */
+  readonly handler: (value: never) => void | Promise<void>;
+};
 
 /**
  * Defines a command module for `@optique/discover`.
@@ -131,7 +159,7 @@ export function defineCommand<M extends Mode, T>(
  * @returns `true` when the value is a discovered command definition.
  * @since 1.1.0
  */
-export function isCommand(value: unknown): value is Command<Mode, unknown> {
+export function isCommand(value: unknown): value is AnyCommand {
   return (
     value != null &&
     typeof value === "object" &&

--- a/packages/discover/src/index.test.ts
+++ b/packages/discover/src/index.test.ts
@@ -625,6 +625,31 @@ describe("runProgram()", () => {
     );
   });
 
+  it("rejects static commands without declared paths", async () => {
+    const command = defineCommand({
+      parser: object({}),
+      handler() {},
+    });
+
+    await assert.rejects(
+      () =>
+        runProgram({
+          commands: [command] as never,
+          metadata: { name: "tool" },
+          args: ["build"],
+          stdout() {},
+          stderr() {},
+          onExit(exitCode): never {
+            throw new Error(`Unexpected exit ${exitCode}.`);
+          },
+        }),
+      {
+        name: "TypeError",
+        message: "Static command entries must declare a non-empty path.",
+      },
+    );
+  });
+
   it("runs the discovered command and waits for async handlers", async () => {
     const dir = await makeTempDir();
     const output = join(dir, "out.txt");

--- a/packages/discover/src/index.test.ts
+++ b/packages/discover/src/index.test.ts
@@ -7,7 +7,7 @@ import { option } from "@optique/core/primitives";
 import type { SourceContext } from "@optique/core/context";
 import { integer, string } from "@optique/core/valueparser";
 import assert from "node:assert/strict";
-import { mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdir, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { describe, it } from "node:test";
@@ -59,7 +59,10 @@ describe("defineCommand()", () => {
           parser: {} as never,
           handler() {},
         }),
-      /Command parser must be an Optique parser\./,
+      {
+        name: "TypeError",
+        message: "Command parser must be an Optique parser.",
+      },
     );
     assert.throws(
       () =>
@@ -67,7 +70,7 @@ describe("defineCommand()", () => {
           parser: object({}),
           handler: undefined as never,
         }),
-      /Command handler must be a function\./,
+      { name: "TypeError", message: "Command handler must be a function." },
     );
     assert.throws(
       () =>
@@ -76,7 +79,10 @@ describe("defineCommand()", () => {
           parser: object({}),
           handler() {},
         }),
-      /Command path must be a non-empty array of non-empty strings\./,
+      {
+        name: "TypeError",
+        message: "Command path must be a non-empty array of non-empty strings.",
+      },
     );
     assert.throws(
       () =>
@@ -85,7 +91,10 @@ describe("defineCommand()", () => {
           parser: object({}),
           handler() {},
         }),
-      /Command path must be a non-empty array of non-empty strings\./,
+      {
+        name: "TypeError",
+        message: "Command path must be a non-empty array of non-empty strings.",
+      },
     );
   });
 });
@@ -189,6 +198,64 @@ describe("discoverCommands()", () => {
         () => discoverCommands({ dir, extensions: [".ts"] }),
         /default export must be created with defineCommand\(\)\./,
       );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("unwraps CommonJS default-wrapped command exports", async () => {
+    const dir = await makeTempDir();
+    const globalCommand = defineCommand({
+      parser: object({}),
+      metadata: { brief: message`Build the project.` },
+      handler() {},
+    });
+    const testGlobal = globalThis as {
+      __optiqueDiscoverDefaultWrappedCommand?: unknown;
+    };
+    testGlobal.__optiqueDiscoverDefaultWrappedCommand = globalCommand;
+    try {
+      await writeFile(
+        join(dir, "build.cjs"),
+        `
+          module.exports = {
+            default: globalThis.__optiqueDiscoverDefaultWrappedCommand,
+          };
+        `,
+      );
+
+      const commands = await discoverCommands({ dir, extensions: [".cjs"] });
+
+      assert.deepEqual(commands.map((command) => command.path), [["build"]]);
+      assert.equal(commands[0]?.command, globalCommand);
+    } finally {
+      delete testGlobal.__optiqueDiscoverDefaultWrappedCommand;
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("follows symlinked command files and directories", async () => {
+    const dir = await makeTempDir();
+    try {
+      const targetDir = join(dir, "targets");
+      await writeCommand(targetDir, ["build.ts"], "build");
+      await writeCommand(targetDir, ["deploy.ts"], "deploy");
+      await symlink(
+        join(targetDir, "build.ts"),
+        join(dir, "linked-build.ts"),
+      );
+      await symlink(targetDir, join(dir, "linked"));
+      await symlink(dir, join(targetDir, "loop"));
+
+      const commands = await discoverCommands({ dir, extensions: [".ts"] });
+
+      assert.deepEqual(commands.map((command) => command.path), [
+        ["linked-build"],
+        ["linked", "build"],
+        ["linked", "deploy"],
+        ["targets", "build"],
+        ["targets", "deploy"],
+      ]);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
@@ -531,6 +598,30 @@ describe("runProgram()", () => {
           metadata: { name: "tool" },
         } as never),
       /runProgram\(\) requires exactly one of dir or commands\./,
+    );
+  });
+
+  it("rejects static command values not created by defineCommand()", async () => {
+    await assert.rejects(
+      () =>
+        runProgram({
+          commands: [{
+            path: ["build"],
+            parser: object({}),
+            handler() {},
+          }] as never,
+          metadata: { name: "tool" },
+          args: ["build"],
+          stdout() {},
+          stderr() {},
+          onExit(exitCode): never {
+            throw new Error(`Unexpected exit ${exitCode}.`);
+          },
+        }),
+      {
+        name: "TypeError",
+        message: "Static command entries must be created with defineCommand().",
+      },
     );
   });
 

--- a/packages/discover/src/index.test.ts
+++ b/packages/discover/src/index.test.ts
@@ -13,6 +13,7 @@ import { dirname, join } from "node:path";
 import { describe, it } from "node:test";
 import { defineCommand } from "./command.ts";
 import {
+  type CommandPath,
   createProgramParser,
   discoverCommands,
   getDefaultExtensions,
@@ -35,6 +36,22 @@ describe("defineCommand()", () => {
     });
   });
 
+  it("preserves static command paths", () => {
+    const staticCommand = defineCommand({
+      path: ["user", "add"],
+      parser: object({
+        name: option("--name", string()),
+      }),
+      handler(value) {
+        const name: string = value.name;
+        assert.equal(typeof name, "string");
+      },
+    });
+
+    const path: CommandPath = staticCommand.path;
+    assert.deepEqual(path, ["user", "add"]);
+  });
+
   it("rejects malformed command definitions", () => {
     assert.throws(
       () =>
@@ -51,6 +68,24 @@ describe("defineCommand()", () => {
           handler: undefined as never,
         }),
       /Command handler must be a function\./,
+    );
+    assert.throws(
+      () =>
+        defineCommand({
+          path: [] as never,
+          parser: object({}),
+          handler() {},
+        }),
+      /Command path must be a non-empty array of non-empty strings\./,
+    );
+    assert.throws(
+      () =>
+        defineCommand({
+          path: ["build", ""] as never,
+          parser: object({}),
+          handler() {},
+        }),
+      /Command path must be a non-empty array of non-empty strings\./,
     );
   });
 });
@@ -137,6 +172,63 @@ describe("discoverCommands()", () => {
         () => discoverCommands({ dir, extensions: [".ts"] }),
         /default export must be created with defineCommand\(\)\./,
       );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects declared paths that do not match file-derived paths", async () => {
+    const dir = await makeTempDir();
+    try {
+      await writeCommand(
+        dir,
+        ["build.ts"],
+        "build",
+        `
+          import { defineCommand } from "${moduleUrl("command.ts")}";
+          import { object } from "${moduleUrl("../../core/src/constructs.ts")}";
+
+          export default defineCommand({
+            path: ["deploy"],
+            parser: object({}),
+            handler() {},
+          });
+        `,
+      );
+
+      await assert.rejects(
+        () => discoverCommands({ dir, extensions: [".ts"] }),
+        /declares command path "deploy" but file path defines "build"\./,
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts declared paths that match file-derived paths", async () => {
+    const dir = await makeTempDir();
+    try {
+      await writeCommand(
+        dir,
+        ["user", "add.ts"],
+        "add",
+        `
+          import { defineCommand } from "${moduleUrl("command.ts")}";
+          import { object } from "${moduleUrl("../../core/src/constructs.ts")}";
+
+          export default defineCommand({
+            path: ["user", "add"],
+            parser: object({}),
+            handler() {},
+          });
+        `,
+      );
+
+      const commands = await discoverCommands({ dir, extensions: [".ts"] });
+
+      assert.deepEqual(commands.map((command) => command.path), [
+        ["user", "add"],
+      ]);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
@@ -289,6 +381,125 @@ describe("createProgramParser()", () => {
 });
 
 describe("runProgram()", () => {
+  it("runs statically registered commands and waits for async handlers", async () => {
+    const calls: unknown[] = [];
+    const writeCommand = defineCommand({
+      path: ["write"],
+      parser: object({
+        value: option("--value", string()),
+      }),
+      async handler(value) {
+        await Promise.resolve();
+        calls.push(value);
+      },
+    });
+
+    await runProgram({
+      commands: [writeCommand],
+      metadata: { name: "tool", version: "1.0.0" },
+      args: ["write", "--value", "done"],
+      stdout() {},
+      stderr() {},
+      onExit(exitCode): never {
+        throw new Error(`Unexpected exit ${exitCode}.`);
+      },
+    });
+
+    assert.deepEqual(calls, [{ value: "done" }]);
+  });
+
+  it("shows statically registered nested commands in root help", async () => {
+    const addCommand = defineCommand({
+      path: ["user", "add"],
+      parser: object({}),
+      metadata: { brief: message`Add a user.` },
+      handler() {},
+    });
+    const removeCommand = defineCommand({
+      path: ["user", "remove"],
+      parser: object({}),
+      metadata: { brief: message`Remove a user.` },
+      handler() {},
+    });
+    let stdout = "";
+
+    await assert.rejects(
+      () =>
+        runProgram({
+          commands: [addCommand, removeCommand],
+          metadata: { name: "tool", version: "1.0.0" },
+          args: ["--help"],
+          stdout(text) {
+            stdout += `${text}\n`;
+          },
+          stderr() {},
+          onExit(exitCode): never {
+            throw new ExitSignal(exitCode);
+          },
+        }),
+      ExitSignal,
+    );
+
+    assert.match(stdout, /Usage: tool user add/);
+    assert.match(stdout, /user add\s+Add a user\./);
+    assert.match(stdout, /user remove\s+Remove a user\./);
+  });
+
+  it("passes static command values to phase-two source contexts", async () => {
+    const phase2Values: unknown[] = [];
+    const context: SourceContext = {
+      id: Symbol("test-context"),
+      phase: "two-pass",
+      getAnnotations(request) {
+        if (request?.phase === "phase2") {
+          phase2Values.push(request.parsed);
+        }
+        return {};
+      },
+    };
+    const showCommand = defineCommand({
+      path: ["show"],
+      parser: object({
+        config: withDefault(option("--config", string()), "app.json"),
+      }),
+      handler() {},
+    });
+
+    await runProgram({
+      commands: [showCommand],
+      metadata: { name: "tool", version: "1.0.0" },
+      args: ["show"],
+      contexts: [context],
+      stdout() {},
+      stderr() {},
+      onExit(exitCode): never {
+        throw new Error(`Unexpected exit ${exitCode}.`);
+      },
+    });
+
+    assert.deepEqual(phase2Values, [{ config: "app.json" }]);
+  });
+
+  it("rejects ambiguous command sources", async () => {
+    await assert.rejects(
+      () =>
+        runProgram({
+          dir: ".",
+          commands: [],
+          metadata: { name: "tool" },
+        } as never),
+      /runProgram\(\) requires exactly one of dir or commands\./,
+    );
+
+    await assert.rejects(
+      () =>
+        runProgram({
+          metadata: { name: "tool" },
+        } as never),
+      /runProgram\(\) requires exactly one of dir or commands\./,
+    );
+  });
+
   it("runs the discovered command and waits for async handlers", async () => {
     const dir = await makeTempDir();
     const output = join(dir, "out.txt");

--- a/packages/discover/src/index.test.ts
+++ b/packages/discover/src/index.test.ts
@@ -121,6 +121,20 @@ describe("discoverCommands()", () => {
     }
   });
 
+  it("ignores TypeScript declaration files", async () => {
+    const dir = await makeTempDir();
+    try {
+      await writeCommand(dir, ["build.ts"], "build");
+      await writeFile(join(dir, "build.d.ts"), "export default {};\n");
+
+      const commands = await discoverCommands({ dir, extensions: [".ts"] });
+
+      assert.deepEqual(commands.map((command) => command.path), [["build"]]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it("returns runtime-aware extension defaults", () => {
     const nodeDefaults = getDefaultExtensions({
       runtime: "node",

--- a/packages/discover/src/index.test.ts
+++ b/packages/discover/src/index.test.ts
@@ -163,6 +163,23 @@ describe("discoverCommands()", () => {
     }
   });
 
+  it("keeps command path segments distinct when they contain spaces", async () => {
+    const dir = await makeTempDir();
+    try {
+      await writeCommand(dir, ["foo bar", "c.ts"], "foo-bar-c");
+      await writeCommand(dir, ["foo", "bar c.ts"], "foo-bar-c");
+
+      const commands = await discoverCommands({ dir, extensions: [".ts"] });
+
+      assert.deepEqual(commands.map((command) => command.path), [
+        ["foo bar", "c"],
+        ["foo", "bar c"],
+      ]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it("rejects modules whose default export is not a command", async () => {
     const dir = await makeTempDir();
     try {
@@ -325,7 +342,7 @@ describe("createProgramParser()", () => {
     const state = await parseAll(parser, ["user", "add", "--name", "Ada"]);
     const result = await parser.complete(state);
 
-    assert.equal(result.success, true);
+    assert.ok(result.success);
     if (result.success) {
       await result.value.handler(result.value.value);
     }
@@ -376,6 +393,23 @@ describe("createProgramParser()", () => {
           { path: ["build"], command: makeCommand() },
         ]),
       /Duplicate command path "build"/,
+    );
+  });
+
+  it("does not collapse distinct static paths before validation", () => {
+    const makeCommand = () =>
+      defineCommand({
+        parser: object({}),
+        handler() {},
+      });
+
+    assert.throws(
+      () =>
+        createProgramParser([
+          { path: ["foo bar", "c"], command: makeCommand() },
+          { path: ["foo", "bar c"], command: makeCommand() },
+        ]),
+      /Command name must not contain whitespace: "foo bar"\./,
     );
   });
 });
@@ -716,7 +750,7 @@ async function parseAll(
   };
   while (context.buffer.length > 0) {
     const result = await parser.parse(context);
-    assert.equal(result.success, true);
+    assert.ok(result.success);
     if (!result.success) break;
     context = result.next;
   }

--- a/packages/discover/src/index.test.ts
+++ b/packages/discover/src/index.test.ts
@@ -161,13 +161,30 @@ describe("discoverCommands()", () => {
       runtime: "node",
       execArgv: [],
       nodeOptions: "",
+      nodeTypeScriptSupport: false,
     });
     assert.deepEqual(nodeDefaults, [".js", ".mjs", ".cjs"]);
+
+    const nodeNativeTsDefaults = getDefaultExtensions({
+      runtime: "node",
+      execArgv: [],
+      nodeOptions: "",
+      nodeTypeScriptSupport: true,
+    });
+    assert.deepEqual(nodeNativeTsDefaults, [
+      ".js",
+      ".mjs",
+      ".cjs",
+      ".ts",
+      ".mts",
+      ".cts",
+    ]);
 
     const nodeTsDefaults = getDefaultExtensions({
       runtime: "node",
       execArgv: ["--import", "tsx"],
       nodeOptions: "",
+      nodeTypeScriptSupport: false,
     });
     assert.deepEqual(nodeTsDefaults, [
       ".js",

--- a/packages/discover/src/index.test.ts
+++ b/packages/discover/src/index.test.ts
@@ -345,6 +345,39 @@ describe("runProgram()", () => {
       await rm(dir, { recursive: true, force: true });
     }
   });
+
+  it("shows nested leaf commands in root help output", async () => {
+    const dir = await makeTempDir();
+    let stdout = "";
+    try {
+      await writeCommand(dir, ["user", "add.ts"], "Add a user");
+      await writeCommand(dir, ["user", "remove.ts"], "Remove a user");
+
+      await assert.rejects(
+        () =>
+          runProgram({
+            dir,
+            extensions: [".ts"],
+            metadata: { name: "tool", version: "1.0.0" },
+            args: ["--help"],
+            stdout(text) {
+              stdout += `${text}\n`;
+            },
+            stderr() {},
+            onExit(exitCode): never {
+              throw new ExitSignal(exitCode);
+            },
+          }),
+        ExitSignal,
+      );
+
+      assert.match(stdout, /Usage: tool user add/);
+      assert.match(stdout, /user add\s+Add a user command\./);
+      assert.match(stdout, /user remove\s+Remove a user command\./);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
 });
 
 class ExitSignal extends Error {

--- a/packages/discover/src/index.test.ts
+++ b/packages/discover/src/index.test.ts
@@ -75,6 +75,26 @@ describe("discoverCommands()", () => {
     }
   });
 
+  it("returns commands sorted by command path after extension stripping", async () => {
+    const dir = await makeTempDir();
+    try {
+      await writeCommand(dir, ["a-zzz.ts"], "a-zzz");
+      await writeCommand(dir, ["a.cmd.ts"], "a");
+
+      const commands = await discoverCommands({
+        dir,
+        extensions: [".cmd.ts", ".ts"],
+      });
+
+      assert.deepEqual(commands.map((command) => command.path), [
+        ["a"],
+        ["a-zzz"],
+      ]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it("rejects duplicate command paths and file namespace conflicts", async () => {
     const duplicateDir = await makeTempDir();
     try {

--- a/packages/discover/src/index.test.ts
+++ b/packages/discover/src/index.test.ts
@@ -1,0 +1,371 @@
+import { object } from "@optique/core/constructs";
+import { formatDocPage } from "@optique/core/doc";
+import { message } from "@optique/core/message";
+import { withDefault } from "@optique/core/modifiers";
+import { getDocPageAsync } from "@optique/core/parser";
+import { option } from "@optique/core/primitives";
+import { integer, string } from "@optique/core/valueparser";
+import assert from "node:assert/strict";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { describe, it } from "node:test";
+import { defineCommand } from "./command.ts";
+import {
+  createProgramParser,
+  discoverCommands,
+  getDefaultExtensions,
+  runProgram,
+} from "./index.ts";
+
+describe("defineCommand()", () => {
+  it("preserves handler value inference", () => {
+    defineCommand({
+      parser: object({
+        count: withDefault(option("--count", integer()), 1),
+        name: option("--name", string()),
+      }),
+      handler(value) {
+        const count: number = value.count;
+        const name: string = value.name;
+        assert.equal(count, 1);
+        assert.equal(typeof name, "string");
+      },
+    });
+  });
+
+  it("rejects malformed command definitions", () => {
+    assert.throws(
+      () =>
+        defineCommand({
+          parser: {} as never,
+          handler() {},
+        }),
+      /Command parser must be an Optique parser\./,
+    );
+    assert.throws(
+      () =>
+        defineCommand({
+          parser: object({}),
+          handler: undefined as never,
+        }),
+      /Command handler must be a function\./,
+    );
+  });
+});
+
+describe("discoverCommands()", () => {
+  it("discovers nested command modules in deterministic order", async () => {
+    const dir = await makeTempDir();
+    try {
+      await writeCommand(dir, ["user", "add.cmd.ts"], "add");
+      await writeCommand(dir, ["build.cmd.ts"], "build");
+
+      const commands = await discoverCommands({
+        dir,
+        extensions: [".cmd.ts"],
+      });
+
+      assert.deepEqual(commands.map((command) => command.path), [
+        ["build"],
+        ["user", "add"],
+      ]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects duplicate command paths and file namespace conflicts", async () => {
+    const duplicateDir = await makeTempDir();
+    try {
+      await writeCommand(duplicateDir, ["build.ts"], "build");
+      await writeCommand(duplicateDir, ["build.cmd.ts"], "build");
+
+      await assert.rejects(
+        () =>
+          discoverCommands({
+            dir: duplicateDir,
+            extensions: [".cmd.ts", ".ts"],
+          }),
+        /Duplicate command path "build"/,
+      );
+    } finally {
+      await rm(duplicateDir, { recursive: true, force: true });
+    }
+
+    const conflictDir = await makeTempDir();
+    try {
+      await writeCommand(conflictDir, ["user.ts"], "user");
+      await writeCommand(conflictDir, ["user", "add.ts"], "add");
+
+      await assert.rejects(
+        () => discoverCommands({ dir: conflictDir, extensions: [".ts"] }),
+        /Command path "user" conflicts with nested command "user add"\./,
+      );
+    } finally {
+      await rm(conflictDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects modules whose default export is not a command", async () => {
+    const dir = await makeTempDir();
+    try {
+      await writeFile(join(dir, "bad.ts"), "export default {};\n");
+
+      await assert.rejects(
+        () => discoverCommands({ dir, extensions: [".ts"] }),
+        /default export must be created with defineCommand\(\)\./,
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns runtime-aware extension defaults", () => {
+    const nodeDefaults = getDefaultExtensions({
+      runtime: "node",
+      execArgv: [],
+      nodeOptions: "",
+    });
+    assert.deepEqual(nodeDefaults, [".js", ".mjs", ".cjs"]);
+
+    const nodeTsDefaults = getDefaultExtensions({
+      runtime: "node",
+      execArgv: ["--import", "tsx"],
+      nodeOptions: "",
+    });
+    assert.deepEqual(nodeTsDefaults, [
+      ".js",
+      ".mjs",
+      ".cjs",
+      ".ts",
+      ".mts",
+      ".cts",
+    ]);
+
+    const denoDefaults = getDefaultExtensions({ runtime: "deno" });
+    assert.deepEqual(denoDefaults, [".ts", ".mts", ".js", ".mjs"]);
+  });
+});
+
+describe("createProgramParser()", () => {
+  it("dispatches to the matched command handler with parsed values", async () => {
+    const calls: unknown[] = [];
+    const parser = createProgramParser([
+      {
+        path: ["build"],
+        command: defineCommand({
+          parser: object({
+            target: option("--target", string()),
+          }),
+          metadata: { brief: message`Build the project.` },
+          handler(value) {
+            calls.push(value);
+          },
+        }),
+      },
+      {
+        path: ["user", "add"],
+        command: defineCommand({
+          parser: object({
+            name: option("--name", string()),
+          }),
+          metadata: { brief: message`Add a user.` },
+          handler(value) {
+            calls.push(value);
+          },
+        }),
+      },
+    ]);
+
+    const state = await parseAll(parser, ["user", "add", "--name", "Ada"]);
+    const result = await parser.complete(state);
+
+    assert.equal(result.success, true);
+    if (result.success) {
+      await result.value.handler(result.value.value);
+    }
+    assert.deepEqual(calls, [{ name: "Ada" }]);
+  });
+
+  it("shows leaf command paths in root help", async () => {
+    const parser = createProgramParser([
+      {
+        path: ["build"],
+        command: defineCommand({
+          parser: object({}),
+          metadata: { brief: message`Build the project.` },
+          handler() {},
+        }),
+      },
+      {
+        path: ["user", "add"],
+        command: defineCommand({
+          parser: object({}),
+          metadata: { brief: message`Add a user.` },
+          handler() {},
+        }),
+      },
+    ], { brief: message`Project tool.` });
+
+    const page = await getDocPageAsync(parser);
+    assert.ok(page != null);
+    const text = formatDocPage("tool", page);
+
+    assert.match(text, /Usage: tool build/);
+    assert.match(text, /tool user add/);
+    assert.match(text, /build\s+Build the project\./);
+    assert.match(text, /user add\s+Add a user\./);
+  });
+
+  it("rejects duplicate command paths", () => {
+    const makeCommand = () =>
+      defineCommand({
+        parser: object({}),
+        handler() {},
+      });
+
+    assert.throws(
+      () =>
+        createProgramParser([
+          { path: ["build"], command: makeCommand() },
+          { path: ["build"], command: makeCommand() },
+        ]),
+      /Duplicate command path "build"/,
+    );
+  });
+});
+
+describe("runProgram()", () => {
+  it("runs the discovered command and waits for async handlers", async () => {
+    const dir = await makeTempDir();
+    const output = join(dir, "out.txt");
+    try {
+      await writeCommand(
+        dir,
+        ["write.ts"],
+        "write",
+        `
+          import { writeFile } from "node:fs/promises";
+          import { defineCommand } from "${moduleUrl("command.ts")}";
+          import { object } from "${moduleUrl("../../core/src/constructs.ts")}";
+          import { option } from "${moduleUrl("../../core/src/primitives.ts")}";
+          import { string } from "${
+          moduleUrl("../../core/src/valueparser.ts")
+        }";
+
+          export default defineCommand({
+            parser: object({ value: option("--value", string()) }),
+            async handler(value) {
+              await writeFile(${JSON.stringify(output)}, value.value, "utf-8");
+            },
+          });
+        `,
+      );
+
+      await runProgram({
+        dir,
+        extensions: [".ts"],
+        metadata: { name: "tool", version: "1.0.0" },
+        args: ["write", "--value", "done"],
+        stdout() {},
+        stderr() {},
+        onExit(exitCode): never {
+          throw new Error(`Unexpected exit ${exitCode}.`);
+        },
+      });
+
+      const { readFile } = await import("node:fs/promises");
+      assert.equal(await readFile(output, "utf-8"), "done");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not run handlers for help output", async () => {
+    const dir = await makeTempDir();
+    let stdout = "";
+    try {
+      await writeCommand(dir, ["build.ts"], "build");
+
+      await assert.rejects(
+        () =>
+          runProgram({
+            dir,
+            extensions: [".ts"],
+            metadata: { name: "tool", version: "1.0.0" },
+            args: ["--help"],
+            stdout(text) {
+              stdout += `${text}\n`;
+            },
+            stderr() {},
+            onExit(exitCode): never {
+              throw new ExitSignal(exitCode);
+            },
+          }),
+        ExitSignal,
+      );
+
+      assert.match(stdout, /Usage: tool build/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+class ExitSignal extends Error {
+  constructor(readonly exitCode: number) {
+    super(`Exited with ${exitCode}.`);
+  }
+}
+
+async function makeTempDir(): Promise<string> {
+  const { mkdtemp } = await import("node:fs/promises");
+  return await mkdtemp(join(tmpdir(), "optique-discover-"));
+}
+
+async function writeCommand(
+  baseDir: string,
+  path: readonly string[],
+  label: string,
+  body = `
+    import { defineCommand } from "${moduleUrl("command.ts")}";
+    import { object } from "${moduleUrl("../../core/src/constructs.ts")}";
+    import { message } from "${moduleUrl("../../core/src/message.ts")}";
+
+    export default defineCommand({
+      parser: object({}),
+      metadata: { brief: message\`${label} command.\` },
+      handler() {
+        throw new Error("Handler should not run.");
+      },
+    });
+  `,
+): Promise<void> {
+  const filePath = join(baseDir, ...path);
+  await mkdir(dirname(filePath), { recursive: true });
+  await writeFile(filePath, body, "utf-8");
+}
+
+function moduleUrl(relative: string): string {
+  return new URL(relative, import.meta.url).href;
+}
+
+async function parseAll(
+  parser: ReturnType<typeof createProgramParser>,
+  args: readonly string[],
+): Promise<unknown> {
+  let context = {
+    buffer: args,
+    state: parser.initialState,
+    optionsTerminated: false,
+    usage: parser.usage,
+  };
+  while (context.buffer.length > 0) {
+    const result = await parser.parse(context);
+    assert.equal(result.success, true);
+    if (!result.success) break;
+    context = result.next;
+  }
+  return context.state;
+}

--- a/packages/discover/src/index.test.ts
+++ b/packages/discover/src/index.test.ts
@@ -4,6 +4,7 @@ import { message } from "@optique/core/message";
 import { withDefault } from "@optique/core/modifiers";
 import { getDocPageAsync } from "@optique/core/parser";
 import { option } from "@optique/core/primitives";
+import type { SourceContext } from "@optique/core/context";
 import { integer, string } from "@optique/core/valueparser";
 import assert from "node:assert/strict";
 import { mkdir, rm, writeFile } from "node:fs/promises";
@@ -374,6 +375,63 @@ describe("runProgram()", () => {
       assert.match(stdout, /Usage: tool user add/);
       assert.match(stdout, /user add\s+Add a user command\./);
       assert.match(stdout, /user remove\s+Remove a user command\./);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("passes command values to phase-two source contexts", async () => {
+    const dir = await makeTempDir();
+    const phase2Values: unknown[] = [];
+    const context: SourceContext = {
+      id: Symbol("test-context"),
+      phase: "two-pass",
+      getAnnotations(request) {
+        if (request?.phase === "phase2") {
+          phase2Values.push(request.parsed);
+        }
+        return {};
+      },
+    };
+    try {
+      await writeCommand(
+        dir,
+        ["show.ts"],
+        "show",
+        `
+          import { defineCommand } from "${moduleUrl("command.ts")}";
+          import { object } from "${moduleUrl("../../core/src/constructs.ts")}";
+          import { withDefault } from "${
+          moduleUrl("../../core/src/modifiers.ts")
+        }";
+          import { option } from "${moduleUrl("../../core/src/primitives.ts")}";
+          import { string } from "${
+          moduleUrl("../../core/src/valueparser.ts")
+        }";
+
+          export default defineCommand({
+            parser: object({
+              config: withDefault(option("--config", string()), "app.json"),
+            }),
+            handler() {},
+          });
+        `,
+      );
+
+      await runProgram({
+        dir,
+        extensions: [".ts"],
+        metadata: { name: "tool", version: "1.0.0" },
+        args: ["show"],
+        contexts: [context],
+        stdout() {},
+        stderr() {},
+        onExit(exitCode): never {
+          throw new Error(`Unexpected exit ${exitCode}.`);
+        },
+      });
+
+      assert.deepEqual(phase2Values, [{ config: "app.json" }]);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/packages/discover/src/index.ts
+++ b/packages/discover/src/index.ts
@@ -1,4 +1,8 @@
 import { or } from "@optique/core/constructs";
+import type {
+  SourceContext,
+  SourceContextRequest,
+} from "@optique/core/context";
 import type { DocState } from "@optique/core/parser";
 import type { DocFragments } from "@optique/core/doc";
 import { map } from "@optique/core/modifiers";
@@ -542,8 +546,9 @@ function buildRunOptions(options: RunProgramOptions): RunOptions {
     completion,
     ...rest
   } = options;
-  return {
+  const runOptions: RunOptions = {
     ...rest,
+    contexts: unwrapProgramContexts(rest.contexts),
     programName: options.programName ?? metadata.name,
     brief: options.brief ?? metadata.brief,
     description: options.description ?? metadata.description,
@@ -557,4 +562,80 @@ function buildRunOptions(options: RunProgramOptions): RunOptions {
       : version ?? (metadata.version == null ? undefined : metadata.version),
     completion: completion === false ? undefined : completion ?? "both",
   };
+  return runOptions;
+}
+
+function unwrapProgramContexts(
+  contexts: readonly SourceContext<unknown>[] | undefined,
+): readonly SourceContext<unknown>[] | undefined {
+  if (contexts == null) return undefined;
+  return contexts.map(wrapProgramContext);
+}
+
+function wrapProgramContext(
+  context: SourceContext<unknown>,
+): SourceContext<unknown> {
+  const wrapped: SourceContext<unknown> = {
+    id: context.id,
+    phase: context.phase,
+    getAnnotations(request, options) {
+      return context.getAnnotations(
+        unwrapProgramContextRequest(request),
+        options,
+      );
+    },
+  };
+  if (context.getInternalAnnotations != null) {
+    Object.defineProperty(wrapped, "getInternalAnnotations", {
+      value(
+        request: SourceContextRequest,
+        annotations: Parameters<
+          NonNullable<SourceContext<unknown>["getInternalAnnotations"]>
+        >[1],
+      ) {
+        return context.getInternalAnnotations!(
+          unwrapProgramContextRequest(request) ?? request,
+          annotations,
+        );
+      },
+    });
+  }
+  if (context[Symbol.dispose] != null) {
+    Object.defineProperty(wrapped, Symbol.dispose, {
+      value() {
+        return context[Symbol.dispose]!();
+      },
+    });
+  }
+  if (context[Symbol.asyncDispose] != null) {
+    Object.defineProperty(wrapped, Symbol.asyncDispose, {
+      value() {
+        return context[Symbol.asyncDispose]!();
+      },
+    });
+  }
+  return wrapped;
+}
+
+function unwrapProgramContextRequest(
+  request: SourceContextRequest | undefined,
+): SourceContextRequest | undefined {
+  if (
+    request?.phase === "phase2" &&
+    isProgramInvocation(request.parsed)
+  ) {
+    return { phase: "phase2", parsed: request.parsed.value };
+  }
+  return request;
+}
+
+function isProgramInvocation(value: unknown): value is ProgramInvocation {
+  if (value == null || typeof value !== "object") return false;
+  const candidate = value as {
+    readonly command?: unknown;
+    readonly handler?: unknown;
+  };
+  return "value" in value &&
+    isCommand(candidate.command) &&
+    typeof candidate.handler === "function";
 }

--- a/packages/discover/src/index.ts
+++ b/packages/discover/src/index.ts
@@ -108,6 +108,12 @@ export interface RuntimeExtensionOptions {
    * The `NODE_OPTIONS` value used for TypeScript loader detection.
    */
   readonly nodeOptions?: string;
+
+  /**
+   * Whether the Node.js runtime supports TypeScript files without a custom
+   * loader or flag.
+   */
+  readonly nodeTypeScriptSupport?: boolean;
 }
 
 /**
@@ -184,6 +190,7 @@ export function getDefaultExtensions(
     hasNodeTypeScriptLoader(
       options.execArgv ?? process.execArgv,
       options.nodeOptions ?? process.env.NODE_OPTIONS ?? "",
+      options.nodeTypeScriptSupport ?? hasNativeNodeTypeScriptSupport(),
     )
   ) {
     extensions.push(".ts", ".mts", ".cts");
@@ -330,11 +337,21 @@ function getRuntime(): "node" | "deno" | "bun" {
 function hasNodeTypeScriptLoader(
   execArgv: readonly string[],
   nodeOptions: string,
+  nativeSupport: boolean,
 ): boolean {
   const haystack = [...execArgv, nodeOptions].join(" ");
-  return /\b(?:tsx|ts-node|tsimp|jiti)\b/.test(haystack) ||
+  return nativeSupport ||
+    /\b(?:tsx|ts-node|tsimp|jiti)\b/.test(haystack) ||
     /--(?:experimental-)?transform-types\b/.test(haystack) ||
     /--experimental-strip-types\b/.test(haystack);
+}
+
+function hasNativeNodeTypeScriptSupport(): boolean {
+  const features: typeof process.features & {
+    readonly typescript?: unknown;
+  } = process.features;
+  return features.typescript === "strip" ||
+    features.typescript === "transform";
 }
 
 function pathFromDir(dir: string | URL): string {

--- a/packages/discover/src/index.ts
+++ b/packages/discover/src/index.ts
@@ -497,6 +497,23 @@ function withRootDocs(
   metadata: ProgramHelpMetadata,
 ): Parser<Mode, ProgramInvocation, unknown> {
   const rootState = parser.initialState;
+  const rootDocs = (): DocFragments => ({
+    brief: metadata.brief,
+    description: metadata.description,
+    footer: metadata.footer,
+    fragments: [{
+      type: "section",
+      entries: commands.map((entry) => ({
+        term: {
+          type: "command",
+          name: entry.path.join(" "),
+          hidden: entry.command.metadata?.hidden,
+        },
+        description: entry.command.metadata?.brief ??
+          entry.command.metadata?.description,
+      })),
+    }],
+  });
   return {
     ...parser,
     getDocFragments(
@@ -504,26 +521,10 @@ function withRootDocs(
       defaultValue?: ProgramInvocation,
     ): DocFragments {
       if (
-        state.kind === "available" &&
-        Object.is(state.state, rootState)
+        state.kind === "unavailable" ||
+        (state.kind === "available" && Object.is(state.state, rootState))
       ) {
-        return {
-          brief: metadata.brief,
-          description: metadata.description,
-          footer: metadata.footer,
-          fragments: [{
-            type: "section",
-            entries: commands.map((entry) => ({
-              term: {
-                type: "command",
-                name: entry.path.join(" "),
-                hidden: entry.command.metadata?.hidden,
-              },
-              description: entry.command.metadata?.brief ??
-                entry.command.metadata?.description,
-            })),
-          }],
-        };
+        return rootDocs();
       }
       return parser.getDocFragments(state, defaultValue);
     },

--- a/packages/discover/src/index.ts
+++ b/packages/discover/src/index.ts
@@ -17,14 +17,16 @@ import { relative, resolve, sep } from "node:path";
 import process from "node:process";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import {
-  type Command,
+  type AnyCommand,
+  type AnyStaticCommand,
   type CommandPath,
   isCommand,
-  type StaticCommand,
 } from "./command.ts";
 
 export { defineCommand, isCommand } from "./command.ts";
 export type {
+  AnyCommand,
+  AnyStaticCommand,
   Command,
   CommandDefinition,
   CommandMetadata,
@@ -44,7 +46,7 @@ export interface ProgramInvocation {
   /**
    * The command definition that matched the input.
    */
-  readonly command: Command<Mode, unknown>;
+  readonly command: AnyCommand;
 
   /**
    * Parsed value produced by the command parser.
@@ -76,7 +78,7 @@ export interface DiscoveredCommand {
   /**
    * The command exported by the module.
    */
-  readonly command: Command<Mode, unknown>;
+  readonly command: AnyCommand;
 }
 
 /**
@@ -198,7 +200,7 @@ export interface RunProgramStaticOptions extends RunProgramBaseOptions {
   /**
    * Commands to compose without file-system discovery.
    */
-  readonly commands: readonly StaticCommand<Mode, unknown>[];
+  readonly commands: readonly AnyStaticCommand[];
 
   /**
    * File-system discovery cannot be used together with `commands`.
@@ -273,11 +275,12 @@ export async function discoverCommands(
   const discovered: DiscoveredCommand[] = [];
   for (const filePath of files) {
     const path = commandPathFromFile(dir, filePath, extensions);
-    const key = path.join(" ");
+    const key = commandPathKey(path);
     const previous = seen.get(key);
     if (previous != null) {
+      const displayPath = path.join(" ");
       throw new TypeError(
-        `Duplicate command path "${key}" from ${previous} and ${filePath}.`,
+        `Duplicate command path "${displayPath}" from ${previous} and ${filePath}.`,
       );
     }
     seen.set(key, filePath);
@@ -389,7 +392,7 @@ export interface ProgramHelpMetadata {
 
 interface CommandTreeNode {
   readonly children: Map<string, CommandTreeNode>;
-  command?: Command<Mode, unknown>;
+  command?: AnyCommand;
 }
 
 function getRuntime(): "node" | "deno" | "bun" {
@@ -494,12 +497,12 @@ function rejectPathConflicts(
   commands: readonly Pick<DiscoveredCommand, "path" | "filePath">[],
 ): void {
   const paths = new Map(
-    commands.map((entry) => [entry.path.join("\0"), entry]),
+    commands.map((entry) => [commandPathKey(entry.path), entry]),
   );
   for (const entry of commands) {
     for (let i = 1; i < entry.path.length; i++) {
       const parent = entry.path.slice(0, i);
-      const parentEntry = paths.get(parent.join("\0"));
+      const parentEntry = paths.get(commandPathKey(parent));
       if (parentEntry != null) {
         throw new TypeError(
           `Command path "${parent.join(" ")}" conflicts with nested command "${
@@ -516,11 +519,12 @@ function rejectDuplicatePaths(
 ): void {
   const seen = new Map<string, string>();
   for (const entry of commands) {
-    const key = entry.path.join(" ");
+    const key = commandPathKey(entry.path);
     const previous = seen.get(key);
     if (previous != null) {
+      const displayPath = entry.path.join(" ");
       throw new TypeError(
-        `Duplicate command path "${key}" from ${previous} and ${entry.filePath}.`,
+        `Duplicate command path "${displayPath}" from ${previous} and ${entry.filePath}.`,
       );
     }
     seen.set(key, entry.filePath);
@@ -549,7 +553,7 @@ function isStaticRunProgramOptions(
 }
 
 function staticCommandsToEntries(
-  commands: readonly StaticCommand<Mode, unknown>[],
+  commands: readonly AnyStaticCommand[],
 ): readonly Pick<DiscoveredCommand, "path" | "command">[] {
   return commands.map((command) => ({
     path: command.path,
@@ -592,7 +596,7 @@ function buildNodeParser(
 }
 
 function createLeafParser(
-  commandDefinition: Command<Mode, unknown>,
+  commandDefinition: AnyCommand,
 ): Parser<Mode, ProgramInvocation, unknown> {
   return map(commandDefinition.parser, (value): ProgramInvocation => ({
     command: commandDefinition,

--- a/packages/discover/src/index.ts
+++ b/packages/discover/src/index.ts
@@ -234,7 +234,7 @@ export async function discoverCommands(
   }
 
   rejectPathConflicts(discovered);
-  return discovered;
+  return sortCommands(discovered);
 }
 
 /**

--- a/packages/discover/src/index.ts
+++ b/packages/discover/src/index.ts
@@ -419,11 +419,13 @@ function hasNodeTypeScriptLoader(
 }
 
 function hasNativeNodeTypeScriptSupport(): boolean {
-  const features: typeof process.features & {
-    readonly typescript?: unknown;
-  } = process.features;
-  return features.typescript === "strip" ||
-    features.typescript === "transform";
+  const features = process.features as
+    | (typeof process.features & {
+      readonly typescript?: unknown;
+    })
+    | undefined;
+  return features?.typescript === "strip" ||
+    features?.typescript === "transform";
 }
 
 function pathFromDir(dir: string | URL): string {

--- a/packages/discover/src/index.ts
+++ b/packages/discover/src/index.ts
@@ -307,21 +307,6 @@ export interface ProgramHelpMetadata {
   readonly description?: Message;
 
   /**
-   * Usage examples shown in help output.
-   */
-  readonly examples?: Message;
-
-  /**
-   * Author text shown in help output.
-   */
-  readonly author?: Message;
-
-  /**
-   * Bug-reporting text shown in help output.
-   */
-  readonly bugs?: Message;
-
-  /**
    * Footer text shown after the command list.
    */
   readonly footer?: Message;
@@ -383,12 +368,18 @@ async function collectCommandFiles(
     if (entry.isDirectory()) {
       files.push(...await collectCommandFiles(path, extensions));
     } else if (
-      entry.isFile() && extensions.some((ext) => entry.name.endsWith(ext))
+      entry.isFile() &&
+      !isDeclarationFile(entry.name) &&
+      extensions.some((ext) => entry.name.endsWith(ext))
     ) {
       files.push(path);
     }
   }
   return files;
+}
+
+function isDeclarationFile(fileName: string): boolean {
+  return /\.d\.[cm]?ts$/.test(fileName);
 }
 
 function commandPathFromFile(

--- a/packages/discover/src/index.ts
+++ b/packages/discover/src/index.ts
@@ -12,7 +12,7 @@ import type { ProgramMetadata } from "@optique/core/program";
 import { command } from "@optique/core/primitives";
 import { runAsync } from "@optique/run";
 import type { RunOptions } from "@optique/run";
-import { readdir } from "node:fs/promises";
+import { readdir, realpath, stat } from "node:fs/promises";
 import { relative, resolve, sep } from "node:path";
 import process from "node:process";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -288,22 +288,23 @@ export async function discoverCommands(
     const mod = await import(pathToFileURL(filePath).href) as {
       readonly default?: unknown;
     };
-    if (!isCommand(mod.default)) {
+    const commandDefinition = unwrapCommandExport(mod.default);
+    if (commandDefinition == null) {
       throw new TypeError(
         `Module ${filePath} default export must be created with defineCommand().`,
       );
     }
     if (
-      mod.default.path != null &&
-      commandPathKey(mod.default.path) !== commandPathKey(path)
+      commandDefinition.path != null &&
+      commandPathKey(commandDefinition.path) !== commandPathKey(path)
     ) {
       throw new TypeError(
         `Module ${filePath} declares command path "${
-          mod.default.path.join(" ")
+          commandDefinition.path.join(" ")
         }" but file path defines "${path.join(" ")}".`,
       );
     }
-    discovered.push({ path, filePath, command: mod.default });
+    discovered.push({ path, filePath, command: commandDefinition });
   }
 
   rejectPathConflicts(discovered);
@@ -446,17 +447,26 @@ function normalizeExtensions(extensions: readonly string[]): readonly string[] {
 async function collectCommandFiles(
   dir: string,
   extensions: readonly string[],
+  activeDirs = new Set<string>(),
 ): Promise<readonly string[]> {
+  const canonicalDir = await realpath(dir);
+  if (activeDirs.has(canonicalDir)) return [];
+  const nextActiveDirs = new Set(activeDirs);
+  nextActiveDirs.add(canonicalDir);
+
   const entries = await readdir(dir, { withFileTypes: true });
   const files: string[] = [];
   for (
     const entry of entries.toSorted((a, b) => a.name.localeCompare(b.name))
   ) {
     const path = resolve(dir, entry.name);
-    if (entry.isDirectory()) {
-      files.push(...await collectCommandFiles(path, extensions));
+    const entryType = await getCommandFileEntryType(path, entry);
+    if (entryType === "directory") {
+      files.push(
+        ...await collectCommandFiles(path, extensions, nextActiveDirs),
+      );
     } else if (
-      entry.isFile() &&
+      entryType === "file" &&
       !isDeclarationFile(entry.name) &&
       extensions.some((ext) => entry.name.endsWith(ext))
     ) {
@@ -464,6 +474,27 @@ async function collectCommandFiles(
     }
   }
   return files;
+}
+
+async function getCommandFileEntryType(
+  path: string,
+  entry: {
+    isDirectory(): boolean;
+    isFile(): boolean;
+    isSymbolicLink(): boolean;
+  },
+): Promise<"directory" | "file" | undefined> {
+  if (entry.isDirectory()) return "directory";
+  if (entry.isFile()) return "file";
+  if (!entry.isSymbolicLink()) return undefined;
+  try {
+    const target = await stat(path);
+    if (target.isDirectory()) return "directory";
+    if (target.isFile()) return "file";
+    return undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 function isDeclarationFile(fileName: string): boolean {
@@ -555,10 +586,26 @@ function isStaticRunProgramOptions(
 function staticCommandsToEntries(
   commands: readonly AnyStaticCommand[],
 ): readonly Pick<DiscoveredCommand, "path" | "command">[] {
-  return commands.map((command) => ({
-    path: command.path,
-    command,
-  }));
+  return commands.map((command) => {
+    if (!isCommand(command)) {
+      throw new TypeError(
+        "Static command entries must be created with defineCommand().",
+      );
+    }
+    return {
+      path: command.path,
+      command,
+    };
+  });
+}
+
+function unwrapCommandExport(value: unknown): AnyCommand | undefined {
+  if (isCommand(value)) return value;
+  if (value != null && typeof value === "object") {
+    const nestedDefault = (value as { readonly default?: unknown }).default;
+    if (isCommand(nestedDefault)) return nestedDefault;
+  }
+  return undefined;
 }
 
 function buildCommandTree(

--- a/packages/discover/src/index.ts
+++ b/packages/discover/src/index.ts
@@ -1,0 +1,568 @@
+import { or } from "@optique/core/constructs";
+import type { DocState } from "@optique/core/parser";
+import type { DocFragments } from "@optique/core/doc";
+import { map } from "@optique/core/modifiers";
+import type { Message } from "@optique/core/message";
+import type { Mode, Parser } from "@optique/core/parser";
+import type { ProgramMetadata } from "@optique/core/program";
+import { command } from "@optique/core/primitives";
+import { runAsync } from "@optique/run";
+import type { RunOptions } from "@optique/run";
+import { readdir } from "node:fs/promises";
+import { relative, resolve, sep } from "node:path";
+import process from "node:process";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { type Command, isCommand } from "./command.ts";
+
+export { defineCommand, isCommand } from "./command.ts";
+export type { Command, CommandDefinition, CommandMetadata } from "./command.ts";
+
+/**
+ * The parsed command selected by a discovered command parser.
+ *
+ * Most applications receive this only indirectly through {@link runProgram},
+ * which calls the handler automatically.
+ *
+ * @since 1.1.0
+ */
+export interface ProgramInvocation {
+  /**
+   * The command definition that matched the input.
+   */
+  readonly command: Command<Mode, unknown>;
+
+  /**
+   * Parsed value produced by the command parser.
+   */
+  readonly value: unknown;
+
+  /**
+   * Handler to call with {@link ProgramInvocation.value}.
+   */
+  readonly handler: (value: unknown) => void | Promise<void>;
+}
+
+/**
+ * A command found on disk.
+ *
+ * @since 1.1.0
+ */
+export interface DiscoveredCommand {
+  /**
+   * Command path derived from the module's relative path.
+   */
+  readonly path: readonly string[];
+
+  /**
+   * Absolute path to the command module.
+   */
+  readonly filePath: string;
+
+  /**
+   * The command exported by the module.
+   */
+  readonly command: Command<Mode, unknown>;
+}
+
+/**
+ * Options for {@link discoverCommands}.
+ *
+ * @since 1.1.0
+ */
+export interface DiscoverCommandsOptions {
+  /**
+   * Directory to scan recursively.
+   */
+  readonly dir: string | URL;
+
+  /**
+   * File suffixes to include.  Compound suffixes such as `.cmd.ts` are
+   * supported.
+   *
+   * @default Runtime-aware extension defaults from {@link getDefaultExtensions}
+   */
+  readonly extensions?: readonly string[];
+}
+
+/**
+ * Runtime hint for {@link getDefaultExtensions}.
+ *
+ * @since 1.1.0
+ */
+export interface RuntimeExtensionOptions {
+  /**
+   * Runtime to model.
+   */
+  readonly runtime?: "node" | "deno" | "bun";
+
+  /**
+   * Node.js execution arguments used for TypeScript loader detection.
+   */
+  readonly execArgv?: readonly string[];
+
+  /**
+   * The `NODE_OPTIONS` value used for TypeScript loader detection.
+   */
+  readonly nodeOptions?: string;
+}
+
+/**
+ * Options for {@link runProgram}.
+ *
+ * @since 1.1.0
+ */
+export interface RunProgramOptions extends
+  Omit<
+    RunOptions,
+    "help" | "version" | "completion" | "programName"
+  > {
+  /**
+   * Directory containing command modules.
+   */
+  readonly dir: string | URL;
+
+  /**
+   * Root program metadata.
+   */
+  readonly metadata: ProgramMetadata;
+
+  /**
+   * File suffixes to include during discovery.
+   */
+  readonly extensions?: readonly string[];
+
+  /**
+   * Program name override for help, errors, and completion scripts.
+   *
+   * @default `metadata.name`
+   */
+  readonly programName?: string;
+
+  /**
+   * Help configuration.  Pass `false` to disable built-in help.
+   *
+   * @default `"both"`
+   */
+  readonly help?: RunOptions["help"] | false;
+
+  /**
+   * Version configuration.  Pass `false` to disable built-in version output.
+   *
+   * @default `metadata.version` as `--version`, when present
+   */
+  readonly version?: RunOptions["version"] | false;
+
+  /**
+   * Shell completion configuration.  Pass `false` to disable built-in
+   * completion.
+   *
+   * @default `"both"`
+   */
+  readonly completion?: RunOptions["completion"] | false;
+}
+
+/**
+ * Returns runtime-aware command module suffixes.
+ *
+ * @param options Runtime detection overrides for testing or custom launchers.
+ * @returns File suffixes to scan.
+ * @since 1.1.0
+ */
+export function getDefaultExtensions(
+  options: RuntimeExtensionOptions = {},
+): readonly string[] {
+  const runtime = options.runtime ?? getRuntime();
+  if (runtime === "deno" || runtime === "bun") {
+    return [".ts", ".mts", ".js", ".mjs"];
+  }
+  const extensions = [".js", ".mjs", ".cjs"];
+  if (
+    hasNodeTypeScriptLoader(
+      options.execArgv ?? process.execArgv,
+      options.nodeOptions ?? process.env.NODE_OPTIONS ?? "",
+    )
+  ) {
+    extensions.push(".ts", ".mts", ".cts");
+  }
+  return extensions;
+}
+
+/**
+ * Discovers command modules under a directory.
+ *
+ * @param options Discovery options.
+ * @returns Discovered commands sorted by command path.
+ * @throws {TypeError} If options are invalid, discovery finds no commands,
+ *         command paths conflict, or a module does not default-export a
+ *         command created with `defineCommand()`.
+ * @since 1.1.0
+ */
+export async function discoverCommands(
+  options: DiscoverCommandsOptions,
+): Promise<readonly DiscoveredCommand[]> {
+  const dir = pathFromDir(options.dir);
+  const extensions = normalizeExtensions(
+    options.extensions ?? getDefaultExtensions(),
+  );
+  const files = await collectCommandFiles(dir, extensions);
+  if (files.length < 1) {
+    throw new TypeError(`No command modules found in ${dir}.`);
+  }
+
+  const seen = new Map<string, string>();
+  const discovered: DiscoveredCommand[] = [];
+  for (const filePath of files) {
+    const path = commandPathFromFile(dir, filePath, extensions);
+    const key = path.join(" ");
+    const previous = seen.get(key);
+    if (previous != null) {
+      throw new TypeError(
+        `Duplicate command path "${key}" from ${previous} and ${filePath}.`,
+      );
+    }
+    seen.set(key, filePath);
+
+    const mod = await import(pathToFileURL(filePath).href) as {
+      readonly default?: unknown;
+    };
+    if (!isCommand(mod.default)) {
+      throw new TypeError(
+        `Module ${filePath} default export must be created with defineCommand().`,
+      );
+    }
+    discovered.push({ path, filePath, command: mod.default });
+  }
+
+  rejectPathConflicts(discovered);
+  return discovered;
+}
+
+/**
+ * Builds a parser that dispatches to discovered command handlers.
+ *
+ * @param commands Commands to compose.
+ * @param metadata Optional root documentation metadata.
+ * @returns A parser that resolves to an internal command invocation.
+ * @throws {TypeError} If no commands are provided or command paths conflict.
+ * @since 1.1.0
+ */
+export function createProgramParser(
+  commands: readonly Pick<DiscoveredCommand, "path" | "command">[],
+  metadata: ProgramHelpMetadata = {},
+): Parser<Mode, ProgramInvocation, unknown> {
+  if (commands.length < 1) {
+    throw new TypeError("createProgramParser() requires at least one command.");
+  }
+  const sortedCommands = sortCommands(commands);
+  rejectDuplicatePaths(
+    sortedCommands.map((entry) => ({
+      path: entry.path,
+      filePath: entry.path.join("/"),
+    })),
+  );
+  rejectPathConflicts(
+    sortedCommands.map((entry) => ({
+      path: entry.path,
+      filePath: entry.path.join("/"),
+    })),
+  );
+  const rootNode = buildCommandTree(sortedCommands);
+  const parser = buildNodeParser(rootNode);
+  return withRootDocs(parser, sortedCommands, metadata);
+}
+
+/**
+ * Discovers and runs a command program.
+ *
+ * @param options Program options.
+ * @returns A promise that resolves after the selected command handler
+ *          completes.
+ * @throws {TypeError} If discovery or command loading fails.
+ * @since 1.1.0
+ */
+export async function runProgram(options: RunProgramOptions): Promise<void> {
+  const commands = await discoverCommands({
+    dir: options.dir,
+    extensions: options.extensions,
+  });
+  const parser = createProgramParser(commands, options.metadata);
+  const invocation = await runAsync(parser, buildRunOptions(options));
+  await invocation.handler(invocation.value);
+}
+
+/**
+ * Root help metadata for {@link createProgramParser}.
+ *
+ * @since 1.1.0
+ */
+export interface ProgramHelpMetadata {
+  /**
+   * Brief text shown before the command list.
+   */
+  readonly brief?: Message;
+
+  /**
+   * Detailed text shown before the command list.
+   */
+  readonly description?: Message;
+
+  /**
+   * Usage examples shown in help output.
+   */
+  readonly examples?: Message;
+
+  /**
+   * Author text shown in help output.
+   */
+  readonly author?: Message;
+
+  /**
+   * Bug-reporting text shown in help output.
+   */
+  readonly bugs?: Message;
+
+  /**
+   * Footer text shown after the command list.
+   */
+  readonly footer?: Message;
+}
+
+interface CommandTreeNode {
+  readonly children: Map<string, CommandTreeNode>;
+  command?: Command<Mode, unknown>;
+}
+
+function getRuntime(): "node" | "deno" | "bun" {
+  if ("Deno" in globalThis) return "deno";
+  if ("Bun" in globalThis) return "bun";
+  return "node";
+}
+
+function hasNodeTypeScriptLoader(
+  execArgv: readonly string[],
+  nodeOptions: string,
+): boolean {
+  const haystack = [...execArgv, nodeOptions].join(" ");
+  return /\b(?:tsx|ts-node|tsimp|jiti)\b/.test(haystack) ||
+    /--(?:experimental-)?transform-types\b/.test(haystack) ||
+    /--experimental-strip-types\b/.test(haystack);
+}
+
+function pathFromDir(dir: string | URL): string {
+  return typeof dir === "string" ? resolve(dir) : fileURLToPath(dir);
+}
+
+function normalizeExtensions(extensions: readonly string[]): readonly string[] {
+  if (extensions.length < 1) {
+    throw new TypeError("At least one command file extension is required.");
+  }
+  const normalized: string[] = [];
+  for (const extension of extensions) {
+    if (!extension.startsWith(".") || extension.length < 2) {
+      throw new TypeError(
+        `Command file extension must start with a dot: ${extension}`,
+      );
+    }
+    if (!normalized.includes(extension)) normalized.push(extension);
+  }
+  return normalized.toSorted((a, b) =>
+    b.length - a.length || a.localeCompare(b)
+  );
+}
+
+async function collectCommandFiles(
+  dir: string,
+  extensions: readonly string[],
+): Promise<readonly string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files: string[] = [];
+  for (
+    const entry of entries.toSorted((a, b) => a.name.localeCompare(b.name))
+  ) {
+    const path = resolve(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...await collectCommandFiles(path, extensions));
+    } else if (
+      entry.isFile() && extensions.some((ext) => entry.name.endsWith(ext))
+    ) {
+      files.push(path);
+    }
+  }
+  return files;
+}
+
+function commandPathFromFile(
+  rootDir: string,
+  filePath: string,
+  extensions: readonly string[],
+): readonly string[] {
+  const matchedExtension = extensions.find((ext) => filePath.endsWith(ext));
+  if (matchedExtension == null) {
+    throw new TypeError(`No configured extension matches ${filePath}.`);
+  }
+  const withoutExtension = filePath.slice(0, -matchedExtension.length);
+  const relativePath = relative(rootDir, withoutExtension);
+  const path = relativePath.split(sep).filter((segment) => segment.length > 0);
+  if (path.length < 1) {
+    throw new TypeError(`Command file ${filePath} does not define a path.`);
+  }
+  return path;
+}
+
+function rejectPathConflicts(
+  commands: readonly Pick<DiscoveredCommand, "path" | "filePath">[],
+): void {
+  const paths = new Map(
+    commands.map((entry) => [entry.path.join("\0"), entry]),
+  );
+  for (const entry of commands) {
+    for (let i = 1; i < entry.path.length; i++) {
+      const parent = entry.path.slice(0, i);
+      const parentEntry = paths.get(parent.join("\0"));
+      if (parentEntry != null) {
+        throw new TypeError(
+          `Command path "${parent.join(" ")}" conflicts with nested command "${
+            entry.path.join(" ")
+          }".`,
+        );
+      }
+    }
+  }
+}
+
+function rejectDuplicatePaths(
+  commands: readonly Pick<DiscoveredCommand, "path" | "filePath">[],
+): void {
+  const seen = new Map<string, string>();
+  for (const entry of commands) {
+    const key = entry.path.join(" ");
+    const previous = seen.get(key);
+    if (previous != null) {
+      throw new TypeError(
+        `Duplicate command path "${key}" from ${previous} and ${entry.filePath}.`,
+      );
+    }
+    seen.set(key, entry.filePath);
+  }
+}
+
+function sortCommands<T extends Pick<DiscoveredCommand, "path">>(
+  commands: readonly T[],
+): readonly T[] {
+  return commands.toSorted((a, b) =>
+    a.path.join("\0").localeCompare(b.path.join("\0"))
+  );
+}
+
+function buildCommandTree(
+  commands: readonly Pick<DiscoveredCommand, "path" | "command">[],
+): CommandTreeNode {
+  const root: CommandTreeNode = { children: new Map() };
+  for (const entry of commands) {
+    let current = root;
+    for (const segment of entry.path) {
+      let child = current.children.get(segment);
+      if (child == null) {
+        child = { children: new Map() };
+        current.children.set(segment, child);
+      }
+      current = child;
+    }
+    current.command = entry.command;
+  }
+  return root;
+}
+
+function buildNodeParser(
+  node: CommandTreeNode,
+): Parser<Mode, ProgramInvocation, unknown> {
+  const parsers: Parser<Mode, ProgramInvocation, unknown>[] = [];
+  for (const [name, child] of node.children) {
+    const childParser = child.command != null
+      ? createLeafParser(child.command)
+      : buildNodeParser(child);
+    const metadata = child.command?.metadata;
+    parsers.push(command(name, childParser, metadata));
+  }
+  if (parsers.length === 1) return parsers[0];
+  return or(...parsers) as Parser<Mode, ProgramInvocation, unknown>;
+}
+
+function createLeafParser(
+  commandDefinition: Command<Mode, unknown>,
+): Parser<Mode, ProgramInvocation, unknown> {
+  return map(commandDefinition.parser, (value): ProgramInvocation => ({
+    command: commandDefinition,
+    value,
+    handler: commandDefinition.handler as (
+      value: unknown,
+    ) => void | Promise<void>,
+  })) as Parser<Mode, ProgramInvocation, unknown>;
+}
+
+function withRootDocs(
+  parser: Parser<Mode, ProgramInvocation, unknown>,
+  commands: readonly Pick<DiscoveredCommand, "path" | "command">[],
+  metadata: ProgramHelpMetadata,
+): Parser<Mode, ProgramInvocation, unknown> {
+  const rootState = parser.initialState;
+  return {
+    ...parser,
+    getDocFragments(
+      state: DocState<unknown>,
+      defaultValue?: ProgramInvocation,
+    ): DocFragments {
+      if (
+        state.kind === "available" &&
+        Object.is(state.state, rootState)
+      ) {
+        return {
+          brief: metadata.brief,
+          description: metadata.description,
+          footer: metadata.footer,
+          fragments: [{
+            type: "section",
+            entries: commands.map((entry) => ({
+              term: {
+                type: "command",
+                name: entry.path.join(" "),
+                hidden: entry.command.metadata?.hidden,
+              },
+              description: entry.command.metadata?.brief ??
+                entry.command.metadata?.description,
+            })),
+          }],
+        };
+      }
+      return parser.getDocFragments(state, defaultValue);
+    },
+  };
+}
+
+function buildRunOptions(options: RunProgramOptions): RunOptions {
+  const metadata = options.metadata;
+  const {
+    dir: _dir,
+    extensions: _extensions,
+    metadata: _metadata,
+    help,
+    version,
+    completion,
+    ...rest
+  } = options;
+  return {
+    ...rest,
+    programName: options.programName ?? metadata.name,
+    brief: options.brief ?? metadata.brief,
+    description: options.description ?? metadata.description,
+    examples: options.examples ?? metadata.examples,
+    author: options.author ?? metadata.author,
+    bugs: options.bugs ?? metadata.bugs,
+    footer: options.footer ?? metadata.footer,
+    help: help === false ? undefined : help ?? "both",
+    version: version === false
+      ? undefined
+      : version ?? (metadata.version == null ? undefined : metadata.version),
+    completion: completion === false ? undefined : completion ?? "both",
+  };
+}

--- a/packages/discover/src/index.ts
+++ b/packages/discover/src/index.ts
@@ -396,6 +396,10 @@ interface CommandTreeNode {
   command?: AnyCommand;
 }
 
+type MutableSourceContext = {
+  -readonly [K in keyof SourceContext<unknown>]: SourceContext<unknown>[K];
+};
+
 function getRuntime(): "node" | "deno" | "bun" {
   if ("Deno" in globalThis) return "deno";
   if ("Bun" in globalThis) return "bun";
@@ -524,6 +528,12 @@ function commandPathKey(path: readonly string[]): string {
   return path.join("\0");
 }
 
+function isCommandPath(path: unknown): path is CommandPath {
+  return Array.isArray(path) &&
+    path.length > 0 &&
+    path.every((segment) => typeof segment === "string" && segment.length > 0);
+}
+
 function rejectPathConflicts(
   commands: readonly Pick<DiscoveredCommand, "path" | "filePath">[],
 ): void {
@@ -590,6 +600,11 @@ function staticCommandsToEntries(
     if (!isCommand(command)) {
       throw new TypeError(
         "Static command entries must be created with defineCommand().",
+      );
+    }
+    if (!isCommandPath(command.path)) {
+      throw new TypeError(
+        "Static command entries must declare a non-empty path.",
       );
     }
     return {
@@ -735,7 +750,7 @@ function unwrapProgramContexts(
 function wrapProgramContext(
   context: SourceContext<unknown>,
 ): SourceContext<unknown> {
-  const wrapped: SourceContext<unknown> = {
+  const wrapped: MutableSourceContext = {
     id: context.id,
     phase: context.phase,
     getAnnotations(request, options) {
@@ -746,33 +761,18 @@ function wrapProgramContext(
     },
   };
   if (context.getInternalAnnotations != null) {
-    Object.defineProperty(wrapped, "getInternalAnnotations", {
-      value(
-        request: SourceContextRequest,
-        annotations: Parameters<
-          NonNullable<SourceContext<unknown>["getInternalAnnotations"]>
-        >[1],
-      ) {
-        return context.getInternalAnnotations!(
-          unwrapProgramContextRequest(request) ?? request,
-          annotations,
-        );
-      },
-    });
+    wrapped.getInternalAnnotations = (request, annotations) => {
+      return context.getInternalAnnotations!(
+        unwrapProgramContextRequest(request) ?? request,
+        annotations,
+      );
+    };
   }
   if (context[Symbol.dispose] != null) {
-    Object.defineProperty(wrapped, Symbol.dispose, {
-      value() {
-        return context[Symbol.dispose]!();
-      },
-    });
+    wrapped[Symbol.dispose] = () => context[Symbol.dispose]!();
   }
   if (context[Symbol.asyncDispose] != null) {
-    Object.defineProperty(wrapped, Symbol.asyncDispose, {
-      value() {
-        return context[Symbol.asyncDispose]!();
-      },
-    });
+    wrapped[Symbol.asyncDispose] = () => context[Symbol.asyncDispose]!();
   }
   return wrapped;
 }

--- a/packages/discover/src/index.ts
+++ b/packages/discover/src/index.ts
@@ -16,10 +16,21 @@ import { readdir } from "node:fs/promises";
 import { relative, resolve, sep } from "node:path";
 import process from "node:process";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { type Command, isCommand } from "./command.ts";
+import {
+  type Command,
+  type CommandPath,
+  isCommand,
+  type StaticCommand,
+} from "./command.ts";
 
 export { defineCommand, isCommand } from "./command.ts";
-export type { Command, CommandDefinition, CommandMetadata } from "./command.ts";
+export type {
+  Command,
+  CommandDefinition,
+  CommandMetadata,
+  CommandPath,
+  StaticCommand,
+} from "./command.ts";
 
 /**
  * The parsed command selected by a discovered command parser.
@@ -55,7 +66,7 @@ export interface DiscoveredCommand {
   /**
    * Command path derived from the module's relative path.
    */
-  readonly path: readonly string[];
+  readonly path: CommandPath;
 
   /**
    * Absolute path to the command module.
@@ -116,30 +127,15 @@ export interface RuntimeExtensionOptions {
   readonly nodeTypeScriptSupport?: boolean;
 }
 
-/**
- * Options for {@link runProgram}.
- *
- * @since 1.1.0
- */
-export interface RunProgramOptions extends
+interface RunProgramBaseOptions extends
   Omit<
     RunOptions,
     "help" | "version" | "completion" | "programName"
   > {
   /**
-   * Directory containing command modules.
-   */
-  readonly dir: string | URL;
-
-  /**
    * Root program metadata.
    */
   readonly metadata: ProgramMetadata;
-
-  /**
-   * File suffixes to include during discovery.
-   */
-  readonly extensions?: readonly string[];
 
   /**
    * Program name override for help, errors, and completion scripts.
@@ -170,6 +166,59 @@ export interface RunProgramOptions extends
    */
   readonly completion?: RunOptions["completion"] | false;
 }
+
+/**
+ * Options for {@link runProgram} when discovering commands from files.
+ *
+ * @since 1.1.0
+ */
+export interface RunProgramDiscoveryOptions extends RunProgramBaseOptions {
+  /**
+   * Directory containing command modules.
+   */
+  readonly dir: string | URL;
+
+  /**
+   * File suffixes to include during discovery.
+   */
+  readonly extensions?: readonly string[];
+
+  /**
+   * Static commands cannot be used together with `dir`.
+   */
+  readonly commands?: never;
+}
+
+/**
+ * Options for {@link runProgram} when commands are imported manually.
+ *
+ * @since 1.1.0
+ */
+export interface RunProgramStaticOptions extends RunProgramBaseOptions {
+  /**
+   * Commands to compose without file-system discovery.
+   */
+  readonly commands: readonly StaticCommand<Mode, unknown>[];
+
+  /**
+   * File-system discovery cannot be used together with `commands`.
+   */
+  readonly dir?: never;
+
+  /**
+   * File suffixes are only used with file-system discovery.
+   */
+  readonly extensions?: never;
+}
+
+/**
+ * Options for {@link runProgram}.
+ *
+ * @since 1.1.0
+ */
+export type RunProgramOptions =
+  | RunProgramDiscoveryOptions
+  | RunProgramStaticOptions;
 
 /**
  * Returns runtime-aware command module suffixes.
@@ -241,6 +290,16 @@ export async function discoverCommands(
         `Module ${filePath} default export must be created with defineCommand().`,
       );
     }
+    if (
+      mod.default.path != null &&
+      commandPathKey(mod.default.path) !== commandPathKey(path)
+    ) {
+      throw new TypeError(
+        `Module ${filePath} declares command path "${
+          mod.default.path.join(" ")
+        }" but file path defines "${path.join(" ")}".`,
+      );
+    }
     discovered.push({ path, filePath, command: mod.default });
   }
 
@@ -292,10 +351,15 @@ export function createProgramParser(
  * @since 1.1.0
  */
 export async function runProgram(options: RunProgramOptions): Promise<void> {
-  const commands = await discoverCommands({
-    dir: options.dir,
-    extensions: options.extensions,
-  });
+  let commands: readonly Pick<DiscoveredCommand, "path" | "command">[];
+  if (isStaticRunProgramOptions(options)) {
+    commands = staticCommandsToEntries(options.commands);
+  } else {
+    commands = await discoverCommands({
+      dir: options.dir,
+      extensions: options.extensions,
+    });
+  }
   const parser = createProgramParser(commands, options.metadata);
   const invocation = await runAsync(parser, buildRunOptions(options));
   await invocation.handler(invocation.value);
@@ -407,7 +471,7 @@ function commandPathFromFile(
   rootDir: string,
   filePath: string,
   extensions: readonly string[],
-): readonly string[] {
+): CommandPath {
   const matchedExtension = extensions.find((ext) => filePath.endsWith(ext));
   if (matchedExtension == null) {
     throw new TypeError(`No configured extension matches ${filePath}.`);
@@ -415,10 +479,15 @@ function commandPathFromFile(
   const withoutExtension = filePath.slice(0, -matchedExtension.length);
   const relativePath = relative(rootDir, withoutExtension);
   const path = relativePath.split(sep).filter((segment) => segment.length > 0);
-  if (path.length < 1) {
+  const [first, ...rest] = path;
+  if (first == null) {
     throw new TypeError(`Command file ${filePath} does not define a path.`);
   }
-  return path;
+  return [first, ...rest];
+}
+
+function commandPathKey(path: readonly string[]): string {
+  return path.join("\0");
 }
 
 function rejectPathConflicts(
@@ -462,8 +531,30 @@ function sortCommands<T extends Pick<DiscoveredCommand, "path">>(
   commands: readonly T[],
 ): readonly T[] {
   return commands.toSorted((a, b) =>
-    a.path.join("\0").localeCompare(b.path.join("\0"))
+    commandPathKey(a.path).localeCompare(commandPathKey(b.path))
   );
+}
+
+function isStaticRunProgramOptions(
+  options: RunProgramOptions,
+): options is RunProgramStaticOptions {
+  const hasCommands = "commands" in options && options.commands != null;
+  const hasDir = "dir" in options && options.dir != null;
+  if (hasCommands === hasDir) {
+    throw new TypeError(
+      "runProgram() requires exactly one of dir or commands.",
+    );
+  }
+  return hasCommands;
+}
+
+function staticCommandsToEntries(
+  commands: readonly StaticCommand<Mode, unknown>[],
+): readonly Pick<DiscoveredCommand, "path" | "command">[] {
+  return commands.map((command) => ({
+    path: command.path,
+    command,
+  }));
 }
 
 function buildCommandTree(
@@ -556,6 +647,7 @@ function buildRunOptions(options: RunProgramOptions): RunOptions {
   const metadata = options.metadata;
   const {
     dir: _dir,
+    commands: _commands,
     extensions: _extensions,
     metadata: _metadata,
     help,

--- a/packages/discover/tsdown.config.ts
+++ b/packages/discover/tsdown.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+  entry: [
+    "src/index.ts",
+    "src/command.ts",
+  ],
+  dts: true,
+  format: ["esm", "cjs"],
+  platform: "node",
+});

--- a/packages/temporal/src/index.ts
+++ b/packages/temporal/src/index.ts
@@ -857,20 +857,11 @@ export function timeZone(
     parse(input: string): ValueParserResult<TimeZone> {
       ensureTemporal();
       try {
-        // Validate by creating a ZonedDateTime with this timezone
-        // This will throw if the timezone is invalid
-        Temporal.ZonedDateTime.from({
-          year: 2020,
-          month: 1,
-          day: 1,
-          timeZone: input,
-        });
         // For single-segment identifiers (no "/"), only accept those
         // in the curated allowlist to ensure cross-runtime consistency.
-        // Some Temporal implementations accept identifiers (e.g.,
-        // "Factory") that others reject.  The lookup is
-        // case-insensitive and normalizes to canonical casing so the
-        // returned value is always a valid SingleSegmentTimeZone member.
+        // Some Temporal implementations reject allowlisted links such as
+        // "CET", while others accept additional identifiers like "Factory".
+        // The lookup is case-insensitive and normalizes to canonical casing.
         if (!input.includes("/")) {
           const canonical = singleSegmentTimeZoneLookup.get(
             input.toLowerCase(),
@@ -880,6 +871,15 @@ export function timeZone(
           }
           return { success: true, value: canonical };
         }
+
+        // Validate by creating a ZonedDateTime with this timezone
+        // This will throw if the timezone is invalid
+        Temporal.ZonedDateTime.from({
+          year: 2020,
+          month: 1,
+          day: 1,
+          timeZone: input,
+        });
         return { success: true, value: input as TimeZone };
       } catch {
         return {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       '@optique/core':
         specifier: 'workspace:'
         version: link:../packages/core
+      '@optique/discover':
+        specifier: 'workspace:'
+        version: link:../packages/discover
       '@optique/env':
         specifier: 'workspace:'
         version: link:../packages/env

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,6 +186,25 @@ importers:
         specifier: 'catalog:'
         version: 5.8.3
 
+  packages/discover:
+    dependencies:
+      '@optique/core':
+        specifier: workspace:*
+        version: link:../core
+      '@optique/run':
+        specifier: workspace:*
+        version: link:../run
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 20.19.9
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.13.0(typescript@5.8.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.8.3
+
   packages/env:
     dependencies:
       '@optique/core':


### PR DESCRIPTION
## Summary

Add *@optique/discover*, a new package for CLIs that keep large command trees in separate command modules. Command modules use `defineCommand()` to pair parser metadata with handlers, and `runProgram()` builds the nested parser tree, wires help/version/completion through *@optique/run*, and dispatches to the selected handler.

This supports both runtime file discovery and explicitly imported static commands. The static `commands` path is meant for bundlers, tree shaking, and single-file executable builds where dynamic command discovery is not a good fit.

The PR also documents the package in *README.md*, *CHANGES.md*, *docs/concepts/discover.md*, *docs/cookbook.md*, *docs/tutorial.md*, and *packages/discover/README.md*, adds a command discovery example under *examples/patterns/command-discovery/*, and registers *@optique/discover* in the docs config and package metadata.

## Notes

`timeZone()` in *packages/temporal/src/index.ts* now applies the curated single-segment time zone allowlist before runtime Temporal validation, so links such as `CET` stay accepted on runtimes whose Temporal implementation rejects them directly.

Fixes #812.

## Testing

 -  `deno test --allow-read --allow-write --allow-env packages/discover/src/index.test.ts`
 -  `mise check`
 -  `cd docs && pnpm build`
 -  `mise run --jobs=1 test`
