### PR TITLE
Ordered `seq` parser

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -96,6 +96,15 @@ To be released.
     the TypeScript return type accordingly.  Also exports the `Json` type
     representing any JSON-serializable value.  [[#811], [#817]]
 
+ -  Added `seq()` as an ordered construct combinator for CLI grammars where
+    child parsers must run in declaration order instead of shared-buffer
+    priority order.  It returns a tuple of child values, preserves declaration
+    order in usage output and suggestions, skips optional boundaries before
+    later command names, and supports position-aware duplicate option checking.
+    The parser protocol now exposes `canSkip()` for combinators that need to
+    determine whether a child can finish without more CLI input.
+    [[#819], [#820]]
+
 [Semantic Versioning 2.0.0]: https://semver.org/
 [#801]: https://github.com/dahlia/optique/issues/801
 [#802]: https://github.com/dahlia/optique/pull/802
@@ -109,6 +118,8 @@ To be released.
 [#815]: https://github.com/dahlia/optique/pull/815
 [#816]: https://github.com/dahlia/optique/pull/816
 [#817]: https://github.com/dahlia/optique/pull/817
+[#819]: https://github.com/dahlia/optique/issues/819
+[#820]: https://github.com/dahlia/optique/pull/820
 
 ### @optique/discover
 

--- a/docs/concepts/constructs.md
+++ b/docs/concepts/constructs.md
@@ -1,7 +1,7 @@
 ---
 description: >-
   Construct combinators compose multiple parsers into complex structures
-  using object(), tuple(), or(), and merge() to build sophisticated CLI
+  using object(), tuple(), seq(), or(), and merge() to build sophisticated CLI
   interfaces with full type inference.
 ---
 
@@ -190,6 +190,110 @@ if (config.success) {
   console.log(`Processing range ${start} to ${end}.`);
 }
 ~~~~
+
+
+`seq()` parser
+--------------
+
+The `seq()` parser combines multiple parsers into an ordered parser that
+produces a tuple of results. Unlike [`tuple()`](#tuple-parser), which lets
+child parsers compete by priority, `seq()` keeps a cursor and applies child
+parsers in declaration order.
+
+This is useful when the grammar itself is ordered, especially when an
+optional positional value appears before a later command:
+
+~~~~ typescript twoslash
+import { object, or, seq } from "@optique/core/constructs";
+import { optional } from "@optique/core/modifiers";
+import type { InferValue } from "@optique/core/parser";
+import { argument, command, constant, option } from "@optique/core/primitives";
+import { string } from "@optique/core/valueparser";
+
+const parser = seq(
+  optional(argument(string({ metavar: "PROFILE" }))),
+  or(
+    command(
+      "build",
+      object({
+        action: constant("build"),
+        target: argument(string({ metavar: "TARGET" })),
+      }),
+    ),
+    command(
+      "deploy",
+      object({
+        action: constant("deploy"),
+        environment: argument(string({ metavar: "ENV" })),
+        force: option("--force"),
+      }),
+    ),
+  ),
+);
+
+type Parsed = InferValue<typeof parser>;
+//   ^?
+
+
+
+
+
+
+
+
+
+
+// Type automatically inferred as above.
+~~~~
+
+With this parser, both of these forms are valid:
+
+~~~~ bash
+tool build app
+tool staging deploy production --force
+~~~~
+
+The first command leaves the optional profile as `undefined`; the second
+command sets it to `"staging"`. When the current child parser can finish
+without consuming more input, `seq()` can advance to a later command name.
+
+### Ordered usage output
+
+Because `seq()` preserves declaration order, generated usage follows the
+grammar you wrote instead of priority order:
+
+~~~~ typescript twoslash
+import { object, or, seq } from "@optique/core/constructs";
+import { formatUsage } from "@optique/core/usage";
+import { argument, command, option } from "@optique/core/primitives";
+import { string } from "@optique/core/valueparser";
+// ---cut-before---
+const copyParser = seq(
+  argument(string({ metavar: "SOURCE" })),
+  or(command("local", object({})), command("remote", object({}))),
+  option("--force"),
+);
+
+const usage = formatUsage("copy", copyParser.usage);
+//    ^?
+
+
+// "copy SOURCE (local | remote) [--force]"
+~~~~
+
+### Duplicate options
+
+`seq()` rejects duplicate option names only when the same option can be active
+at the same cursor position. Duplicate options separated by a required
+sequential boundary are allowed, but ambiguous duplicates can be enabled
+explicitly with `{ allowDuplicates: true }`.
+
+### No backtracking
+
+`seq()` does not backtrack after a later parser succeeds. It can skip fixed
+optional parsers before a later command name, but ambiguous variadic
+positionals still need an explicit grammar boundary such as a command name,
+an option, or `--`.
 
 
 `or()` parser

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -37,7 +37,6 @@ import { object, or } from "@optique/core/constructs";
 import { optional } from "@optique/core/modifiers";
 import { argument, command, constant, option } from "@optique/core/primitives";
 import { string } from "@optique/core/valueparser";
-import { message } from "@optique/core/message";
 import { run } from "@optique/run";
 // ---cut-before---
 const addCommand = command(
@@ -144,6 +143,81 @@ if (result.action === "add") {
 
 This pattern scales well because adding new subcommands only requires extending
 the `or()` combinator with new command parsers.
+
+### Positional prefixes before subcommands
+
+Some tools accept a small positional prefix before the subcommand itself. For
+example, a deployment tool might accept an optional profile before commands
+such as `build` or `deploy`:
+
+~~~~ bash
+tool build app
+tool staging deploy production --force
+~~~~
+
+Use [`seq()`](./concepts/constructs.md#seq-parser) when the order of parsers is
+part of the grammar. The optional profile is considered first, then the command
+parser is considered after it:
+
+~~~~ typescript twoslash
+import { object, or, seq } from "@optique/core/constructs";
+import { optional } from "@optique/core/modifiers";
+import { argument, command, constant, option } from "@optique/core/primitives";
+import { string } from "@optique/core/valueparser";
+import { run } from "@optique/run";
+// ---cut-before---
+const parser = seq(
+  optional(argument(string({ metavar: "PROFILE" }))),
+  or(
+    command(
+      "build",
+      object({
+        action: constant("build"),
+        target: argument(string({ metavar: "TARGET" })),
+      }),
+    ),
+    command(
+      "deploy",
+      object({
+        action: constant("deploy"),
+        environment: argument(string({ metavar: "ENV" })),
+        force: option("--force"),
+      }),
+    ),
+  ),
+);
+
+const [profile, commandResult] = run(parser);
+//     ^?
+
+
+
+
+
+
+
+
+
+
+const profileName = profile ?? "default";
+
+if (commandResult.action === "build") {
+  console.log(`Building ${commandResult.target} with ${profileName}.`);
+} else {
+  console.log(`Deploying ${commandResult.environment} with ${profileName}.`);
+}
+~~~~
+
+The important distinction from
+[`tuple()`](./concepts/constructs.md#tuple-parser) is that `seq()` advances
+through child parsers in declaration order. A fixed optional positional parser
+can be skipped when the next token is a later command name, so `tool build app`
+is parsed as “no profile, then the `build` command.”
+
+`seq()` deliberately avoids backtracking. If you put a variadic positional
+parser before a command, it may consume too much input before the command has a
+chance to match. Keep the prefix fixed, or add a clear boundary such as an
+option, command name, or `--`.
 
 ### Mutually exclusive options
 

--- a/examples/patterns/ordered-sequence.ts
+++ b/examples/patterns/ordered-sequence.ts
@@ -43,9 +43,12 @@ const profileName = profile ?? "default";
 
 if (commandResult.action === "build") {
   print(message`Building ${commandResult.target} with ${profileName}.`);
-} else {
-  const suffix = commandResult.force ? " with force" : "";
+} else if (commandResult.force) {
   print(
-    message`Deploying ${commandResult.environment} with ${profileName}${suffix}.`,
+    message`Deploying ${commandResult.environment} with ${profileName} with force.`,
+  );
+} else {
+  print(
+    message`Deploying ${commandResult.environment} with ${profileName}.`,
   );
 }

--- a/examples/patterns/ordered-sequence.ts
+++ b/examples/patterns/ordered-sequence.ts
@@ -1,0 +1,51 @@
+import { object, or, seq } from "@optique/core/constructs";
+import { optional } from "@optique/core/modifiers";
+import { argument, command, constant, option } from "@optique/core/primitives";
+import { string } from "@optique/core/valueparser";
+import { message } from "@optique/core/message";
+import { print, run } from "@optique/run";
+
+const parser = seq(
+  optional(argument(string({ metavar: "PROFILE" }))),
+  or(
+    command(
+      "build",
+      object({
+        action: constant("build"),
+        target: argument(string({ metavar: "TARGET" })),
+      }),
+      {
+        description: message`Build an artifact for the selected profile.`,
+      },
+    ),
+    command(
+      "deploy",
+      object({
+        action: constant("deploy"),
+        environment: argument(string({ metavar: "ENV" })),
+        force: option("--force", {
+          description: message`Deploy even when safety checks fail.`,
+        }),
+      }),
+      {
+        description: message`Deploy an environment for the selected profile.`,
+      },
+    ),
+  ),
+);
+
+const [profile, commandResult] = run(parser, {
+  help: "both",
+  version: { command: true, option: true, value: "1.0.0" },
+});
+
+const profileName = profile ?? "default";
+
+if (commandResult.action === "build") {
+  print(message`Building ${commandResult.target} with ${profileName}.`);
+} else {
+  const suffix = commandResult.force ? " with force" : "";
+  print(
+    message`Deploying ${commandResult.environment} with ${profileName}${suffix}.`,
+  );
+}

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -451,6 +451,29 @@ describe("bindConfig", () => {
     });
   });
 
+  test("lets seq skip config-bound accessor values before commands", () => {
+    const schema = z.object({
+      profile: z.string().optional(),
+    });
+    const context = createConfigContext({ schema });
+    const parser = seq(
+      bindConfig(argument(string()), {
+        context,
+        key: (config) => config.profile,
+      }),
+      command("run", object({})),
+    );
+
+    const result = parse(parser, ["run"], {
+      annotations: { [context.id]: { data: { profile: "config-profile" } } },
+    });
+
+    assert.deepEqual(result, {
+      success: true,
+      value: ["config-profile", {}],
+    });
+  });
+
   test("should always prefer CLI over config and default values", () => {
     fc.assert(
       fc.property(

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -3007,6 +3007,65 @@ describe("createConfigContext error paths", () => {
     },
   );
 
+  test("bindConfig canSkip preserves annotations on no-cli fallback", () => {
+    const context = createConfigContext({
+      schema: z.object({
+        host: z.string().optional(),
+      }),
+    });
+    const annotationKey = Symbol("@optique/test/canSkip");
+    class InnerState {
+      #marker = "inner";
+
+      get marker(): string {
+        return this.#marker;
+      }
+    }
+    const initialState = new InnerState();
+    const inner: Parser<"sync", string, InnerState | undefined> = {
+      mode: "sync" as const,
+      $valueType: [] as readonly string[],
+      $stateType: [] as readonly (InnerState | undefined)[],
+      priority: 0,
+      usage: [],
+      leadingNames: new Set<string>(),
+      acceptingAnyToken: true,
+      initialState,
+      parse(_parseContext) {
+        return {
+          success: false as const,
+          consumed: 0,
+          error: message`No CLI value.`,
+        };
+      },
+      complete: () => ({ success: true as const, value: "ok" }),
+      suggest: () => [],
+      canSkip(state) {
+        return state instanceof InnerState &&
+          state.marker === "inner" &&
+          getAnnotations(state)?.[annotationKey] === true;
+      },
+      getDocFragments: () => ({ fragments: [] }),
+    };
+    const parser = bindConfig(inner, {
+      context,
+      key: "host",
+    });
+
+    const parsed = parser.parse({
+      buffer: [],
+      state: injectAnnotations(undefined, {
+        [annotationKey]: true,
+      }),
+      optionsTerminated: false,
+      usage: parser.usage,
+    });
+    assert.ok(parsed.success);
+    if (!parsed.success) return;
+
+    assert.ok(parser.canSkip?.(parsed.next.state));
+  });
+
   test("bindConfig getSuggestRuntimeNodes preserves inner nodes for source parsers", () => {
     const context = createConfigContext({
       schema: z.object({

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -10,6 +10,7 @@ import {
   merge,
   object,
   or,
+  seq,
   tuple,
 } from "@optique/core/constructs";
 import { type Annotations, getAnnotations } from "@optique/core/annotations";
@@ -17,7 +18,14 @@ import type { SourceContextRequest } from "@optique/core/context";
 import { dependency } from "@optique/core/dependency";
 import { injectAnnotations } from "@optique/core/extension";
 import { map, multiple, optional, withDefault } from "@optique/core/modifiers";
-import { constant, fail, flag, option } from "@optique/core/primitives";
+import {
+  argument,
+  command,
+  constant,
+  fail,
+  flag,
+  option,
+} from "@optique/core/primitives";
 import type { ValueParser, ValueParserResult } from "@optique/core/valueparser";
 import { choice, integer, string } from "@optique/core/valueparser";
 import { formatMessage, message } from "@optique/core/message";
@@ -394,6 +402,53 @@ describe("bindConfig", () => {
     const result = parse(parser, []);
     assert.ok(result.success);
     assert.equal(result.value, "localhost");
+  });
+
+  test("lets seq skip config-bound positional defaults before commands", () => {
+    const schema = z.object({
+      profile: z.string().optional(),
+    });
+    const context = createConfigContext({ schema });
+    const parser = seq(
+      bindConfig(argument(string()), {
+        context,
+        key: "profile",
+        default: "default",
+      }),
+      command("run", object({})),
+    );
+
+    const result = parse(parser, ["run"], {
+      annotations: { [context.id]: { data: {} } },
+    });
+
+    assert.deepEqual(result, {
+      success: true,
+      value: ["default", {}],
+    });
+  });
+
+  test("lets seq skip config-bound positional values before commands", () => {
+    const schema = z.object({
+      profile: z.string().optional(),
+    });
+    const context = createConfigContext({ schema });
+    const parser = seq(
+      bindConfig(argument(string()), {
+        context,
+        key: "profile",
+      }),
+      command("run", object({})),
+    );
+
+    const result = parse(parser, ["run"], {
+      annotations: { [context.id]: { data: { profile: "config-profile" } } },
+    });
+
+    assert.deepEqual(result, {
+      success: true,
+      value: ["config-profile", {}],
+    });
   });
 
   test("should always prefer CLI over config and default values", () => {

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -33,6 +33,7 @@ import {
   mapModeValue,
   mapSourceMetadata,
   type ParserSourceMetadata,
+  withAnnotationView,
   wrapForMode,
 } from "@optique/core/extension";
 import { message } from "@optique/core/message";
@@ -709,12 +710,26 @@ export function bindConfig<
   // parser isolated from those legacy markers prevents optional()/withDefault()
   // wrappers from invoking it without the annotation context it requires.
 
-  const getSuggestInnerState = (state: TState): TState =>
-    isConfigBindState(state)
-      ? (state.cliState === undefined
-        ? inheritAnnotations(state, parser.initialState)
-        : state.cliState as TState)
-      : state;
+  function getInnerState(state: TState): TState {
+    if (!isConfigBindState(state)) return state;
+    if (state.cliState !== undefined) return state.cliState as TState;
+    const initialState = parser.initialState;
+    if (initialState != null && typeof initialState !== "object") {
+      return initialState;
+    }
+    const annotated = inheritAnnotations(state, initialState);
+    if (
+      annotated === initialState &&
+      initialState != null &&
+      typeof initialState === "object"
+    ) {
+      const annotations = getAnnotations(state);
+      return annotations == null
+        ? initialState
+        : withAnnotationView(initialState, annotations);
+    }
+    return annotated;
+  }
 
   function hasConfigFallback(state: TState): boolean {
     if (options.default !== undefined) return true;
@@ -761,13 +776,13 @@ export function bindConfig<
           return parser.canSkip?.(state.cliState!, exec) === true;
         }
         if (hasConfigFallback(state)) return true;
-        return parser.canSkip?.(getSuggestInnerState(state), exec) === true;
+        return parser.canSkip?.(getInnerState(state), exec) === true;
       }
       if (hasConfigFallback(state)) return true;
       return parser.canSkip?.(state, exec) === true;
     },
     getSuggestRuntimeNodes(state: TState, path: readonly PropertyKey[]) {
-      const innerState = getSuggestInnerState(state);
+      const innerState = getInnerState(state);
       return delegateSuggestNodes(
         parser,
         boundParser,
@@ -858,7 +873,7 @@ export function bindConfig<
     },
 
     suggest: (context, prefix) => {
-      const innerState = getSuggestInnerState(context.state);
+      const innerState = getInnerState(context.state);
       const innerContext = innerState !== context.state
         ? { ...context, state: innerState }
         : context;

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -718,13 +718,30 @@ export function bindConfig<
 
   function hasConfigFallback(state: TState): boolean {
     if (options.default !== undefined) return true;
-    if (typeof options.key === "function") return false;
     const annotations = getAnnotations(state);
     const annotationValue = annotations?.[options.context.id] as
       | { readonly data: T; readonly meta?: TConfigMeta | undefined }
       | undefined;
     const configData = annotationValue?.data;
-    return configData != null && configData[options.key] !== undefined;
+    const configMeta = annotationValue?.meta;
+    if (configData == null) return false;
+    if (typeof options.key !== "function") {
+      return configData[options.key] !== undefined;
+    }
+    const configValue = options.key(configData, configMeta);
+    if (
+      configValue != null &&
+      (typeof configValue === "object" ||
+        typeof configValue === "function") &&
+      "then" in configValue &&
+      typeof (configValue as Record<string, unknown>).then === "function"
+    ) {
+      throw new TypeError(
+        "The key callback must return a synchronous value, " +
+          "but got a thenable.",
+      );
+    }
+    return configValue !== undefined;
   }
 
   const boundParser: Parser<M, TValue, TState> = {
@@ -739,10 +756,14 @@ export function bindConfig<
     acceptingAnyToken: parser.acceptingAnyToken,
     initialState: parser.initialState,
     canSkip(state: TState, exec?: ExecutionContext) {
-      if (hasConfigFallback(state)) return true;
       if (isConfigBindState(state)) {
+        if (state.hasCliValue) {
+          return parser.canSkip?.(state.cliState!, exec) === true;
+        }
+        if (hasConfigFallback(state)) return true;
         return parser.canSkip?.(getSuggestInnerState(state), exec) === true;
       }
+      if (hasConfigFallback(state)) return true;
       return parser.canSkip?.(state, exec) === true;
     },
     getSuggestRuntimeNodes(state: TState, path: readonly PropertyKey[]) {

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -716,6 +716,17 @@ export function bindConfig<
         : state.cliState as TState)
       : state;
 
+  function hasConfigFallback(state: TState): boolean {
+    if (options.default !== undefined) return true;
+    if (typeof options.key === "function") return false;
+    const annotations = getAnnotations(state);
+    const annotationValue = annotations?.[options.context.id] as
+      | { readonly data: T; readonly meta?: TConfigMeta | undefined }
+      | undefined;
+    const configData = annotationValue?.data;
+    return configData != null && configData[options.key] !== undefined;
+  }
+
   const boundParser: Parser<M, TValue, TState> = {
     mode: parser.mode,
     $valueType: parser.$valueType,
@@ -727,6 +738,13 @@ export function bindConfig<
     leadingNames: parser.leadingNames,
     acceptingAnyToken: parser.acceptingAnyToken,
     initialState: parser.initialState,
+    canSkip(state: TState, exec?: ExecutionContext) {
+      if (hasConfigFallback(state)) return true;
+      if (isConfigBindState(state)) {
+        return parser.canSkip?.(getSuggestInnerState(state), exec) === true;
+      }
+      return parser.canSkip?.(state, exec) === true;
+    },
     getSuggestRuntimeNodes(state: TState, path: readonly PropertyKey[]) {
       const innerState = getSuggestInnerState(state);
       return delegateSuggestNodes(

--- a/packages/config/src/run.test.ts
+++ b/packages/config/src/run.test.ts
@@ -19,7 +19,10 @@ import type { OptionName } from "@optique/core/usage";
 import { bindConfig, createConfigContext } from "./index.ts";
 import type { ConfigMeta } from "./index.ts";
 
-const TEST_DIR = join(import.meta.dirname ?? ".", "test-configs");
+const TEST_DIR = join(
+  import.meta.dirname ?? ".",
+  `test-configs-${process.pid}`,
+);
 
 function requireValue<T>(value: T | undefined, message: string): T {
   if (value === undefined) {

--- a/packages/core/src/constructs.test.ts
+++ b/packages/core/src/constructs.test.ts
@@ -22217,6 +22217,17 @@ describe("seq", () => {
     assertErrorIncludes(result.error, "consume at least one token");
   });
 
+  it("should not skip nonEmpty() with fresh composite initial state", () => {
+    const parser = seq(
+      nonEmpty(object({ x: optional(option("--x")) })),
+      command("run", object({})),
+    );
+
+    const result = parseSync(parser, ["run"]);
+
+    assert.equal(result.success, false);
+  });
+
   it("should advance after nonEmpty() consumes input", () => {
     const parser = seq(
       nonEmpty(option("--active")),

--- a/packages/core/src/constructs.test.ts
+++ b/packages/core/src/constructs.test.ts
@@ -22132,6 +22132,44 @@ describe("seq", () => {
     });
   });
 
+  it("should preserve consumed depth on child failures", () => {
+    const parser = seq(
+      argument(string({ metavar: "PROFILE" })),
+      option("--x", string()),
+    );
+
+    const result = parser.parse({
+      buffer: ["a", "--x", "1", "--x", "2"],
+      state: parser.initialState,
+      optionsTerminated: false,
+      usage: parser.usage,
+    });
+
+    assert.equal(result.success, false);
+    if (!result.success) {
+      assert.equal(result.consumed, 4);
+    }
+  });
+
+  it("should preserve async consumed depth on child failures", async () => {
+    const parser = seq(
+      toAsyncParser(argument(string({ metavar: "PROFILE" }))),
+      option("--x", string()),
+    );
+
+    const result = await parser.parse({
+      buffer: ["a", "--x", "1", "--x", "2"],
+      state: parser.initialState,
+      optionsTerminated: false,
+      usage: parser.usage,
+    });
+
+    assert.equal(result.success, false);
+    if (!result.success) {
+      assert.equal(result.consumed, 4);
+    }
+  });
+
   it("should not skip initial optional duplicates when duplicates are allowed", () => {
     const parser = seq(
       optional(option("--x", string())),

--- a/packages/core/src/constructs.test.ts
+++ b/packages/core/src/constructs.test.ts
@@ -22120,6 +22120,60 @@ describe("seq", () => {
     });
   });
 
+  it("should skip skippable merged children before commands", () => {
+    const parser = seq(
+      merge(object({ profile: optional(argument(string())) })),
+      command("run", object({})),
+    );
+
+    assert.deepEqual(parseSync(parser, ["run"]), {
+      success: true,
+      value: [{ profile: undefined }, {}],
+    });
+  });
+
+  it("should skip skippable concatenated children before commands", () => {
+    const parser = seq(
+      concat(tuple([optional(argument(string()))])),
+      command("run", object({})),
+    );
+
+    assert.deepEqual(parseSync(parser, ["run"]), {
+      success: true,
+      value: [[undefined], {}],
+    });
+  });
+
+  it("should skip async skippable merged children before commands", async () => {
+    const parser = seq(
+      merge(object({ profile: optional(argument(string())) })),
+      command(
+        "run",
+        object({ token: optional(option("--token", asyncStringValue())) }),
+      ),
+    );
+
+    assert.deepEqual(await parseAsync(parser, ["run"]), {
+      success: true,
+      value: [{ profile: undefined }, { token: undefined }],
+    });
+  });
+
+  it("should skip async skippable concatenated children before commands", async () => {
+    const parser = seq(
+      concat(tuple([optional(argument(string()))])),
+      command(
+        "run",
+        object({ token: optional(option("--token", asyncStringValue())) }),
+      ),
+    );
+
+    assert.deepEqual(await parseAsync(parser, ["run"]), {
+      success: true,
+      value: [[undefined], { token: undefined }],
+    });
+  });
+
   it("should advance through grouped children", () => {
     const parser = seq(
       group("First", option("--a", string())),

--- a/packages/core/src/constructs.test.ts
+++ b/packages/core/src/constructs.test.ts
@@ -21977,6 +21977,30 @@ describe("seq", () => {
     });
   });
 
+  it("should not treat command=value as a later command name", () => {
+    const parser = seq(
+      optional(argument(string({ metavar: "PROFILE" }))),
+      command("build", object({})),
+    );
+
+    assert.deepEqual(parseSync(parser, ["build=prod", "build"]), {
+      success: true,
+      value: ["build=prod", {}],
+    });
+  });
+
+  it("should treat option=value as a later value option", () => {
+    const parser = seq(
+      optional(argument(string({ metavar: "PROFILE" }))),
+      option("--name", string()),
+    );
+
+    assert.deepEqual(parseSync(parser, ["--name=alice"]), {
+      success: true,
+      value: [undefined, "alice"],
+    });
+  });
+
   it("should consume -- when advancing to a later positional parser", () => {
     const parser = seq(
       option("--name", string()),
@@ -22038,6 +22062,30 @@ describe("seq", () => {
     assert.deepEqual(suggestSync(parser, ["--name", "alice", ""]), [{
       kind: "literal",
       text: "run",
+    }]);
+  });
+
+  it("should preserve skippable child suggestions at the cursor", () => {
+    const parser = seq(
+      optional(option("--name", string())),
+      command("run", object({})),
+    );
+
+    assert.deepEqual(suggestSync(parser, ["--"]), [{
+      kind: "literal",
+      text: "--name",
+    }]);
+  });
+
+  it("should preserve async skippable child suggestions at the cursor", async () => {
+    const parser = seq(
+      optional(option("--name", string())),
+      command("run", object({})),
+    );
+
+    assert.deepEqual(await suggestAsync(parser, ["--"]), [{
+      kind: "literal",
+      text: "--name",
     }]);
   });
 });

--- a/packages/core/src/constructs.test.ts
+++ b/packages/core/src/constructs.test.ts
@@ -22441,6 +22441,34 @@ describe("seq", () => {
     });
   });
 
+  it("should not skip fresh composite state with matching commands", () => {
+    const parser = seq(
+      object({
+        sub: optional(command("run", object({ x: option("--x", string()) }))),
+      }),
+      command("run", object({})),
+    );
+
+    assert.deepEqual(parseSync(parser, ["run", "--x", "one", "run"]), {
+      success: true,
+      value: [{ sub: { x: "one" } }, {}],
+    });
+  });
+
+  it("should not skip async fresh composite state with matching commands", async () => {
+    const parser = seq(
+      toAsyncParser(object({
+        sub: optional(command("run", object({ x: option("--x", string()) }))),
+      })),
+      command("run", object({})),
+    );
+
+    assert.deepEqual(await parseAsync(parser, ["run", "--x", "one", "run"]), {
+      success: true,
+      value: [{ sub: { x: "one" } }, {}],
+    });
+  });
+
   it("should keep parsing a matched withDefault command child", () => {
     const parser = seq(
       withDefault(command("add", argument(string())), "default"),

--- a/packages/core/src/constructs.test.ts
+++ b/packages/core/src/constructs.test.ts
@@ -22065,6 +22065,30 @@ describe("seq", () => {
     }]);
   });
 
+  it("should preserve suggestions after a consumed command", () => {
+    const parser = seq(
+      optional(argument(string({ metavar: "PROFILE" }))),
+      command("deploy", object({ force: option("--force") })),
+    );
+
+    assert.deepEqual(suggestSync(parser, ["deploy", "--"]), [{
+      kind: "literal",
+      text: "--force",
+    }]);
+  });
+
+  it("should preserve async suggestions after a consumed command", async () => {
+    const parser = seq(
+      optional(argument(string({ metavar: "PROFILE" }))),
+      command("deploy", object({ force: option("--force") })),
+    );
+
+    assert.deepEqual(await suggestAsync(parser, ["deploy", "--"]), [{
+      kind: "literal",
+      text: "--force",
+    }]);
+  });
+
   it("should preserve skippable child suggestions at the cursor", () => {
     const parser = seq(
       optional(option("--name", string())),
@@ -22087,5 +22111,20 @@ describe("seq", () => {
       kind: "literal",
       text: "--name",
     }]);
+  });
+
+  it("should preserve invalid value errors during completion", () => {
+    const parser = seq(option("--num", integer()));
+
+    const result = parseSync(parser, ["--num", "bad"]);
+
+    assert.equal(result.success, false);
+    assertErrorIncludes(result.error, "integer");
+  });
+
+  it("should propagate hidden usage through sequence terms", () => {
+    const parser = group("hidden", seq(option("--secret")), { hidden: true });
+
+    assert.equal(formatUsage("tool", parser.usage), "tool");
   });
 });

--- a/packages/core/src/constructs.test.ts
+++ b/packages/core/src/constructs.test.ts
@@ -72,6 +72,7 @@ import {
   type ValueParser,
   type ValueParserResult,
 } from "@optique/core/valueparser";
+import type { NonEmptyString } from "@optique/core/nonempty";
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
@@ -22101,6 +22102,33 @@ describe("seq", () => {
     }]);
   });
 
+  it("should use dependency source values in suggestions", () => {
+    const mode = dependency(choice(["dev", "prod"] as const));
+    const level = mode.derive({
+      metavar: "LEVEL",
+      mode: "sync",
+      factory: (value) =>
+        choice(
+          value === "dev"
+            ? (["debug", "verbose"] as const)
+            : (["silent", "strict"] as const),
+        ),
+      defaultValue: () => "dev" as const,
+    });
+    const parser = seq(
+      option("--mode", mode),
+      option("--level", level),
+    );
+
+    assert.deepEqual(
+      suggestSync(parser, ["--mode", "prod", "--level", "s"]),
+      [
+        { kind: "literal", text: "silent" },
+        { kind: "literal", text: "strict" },
+      ],
+    );
+  });
+
   it("should preserve async skippable child suggestions at the cursor", async () => {
     const parser = seq(
       optional(option("--name", string())),
@@ -22111,6 +22139,63 @@ describe("seq", () => {
       kind: "literal",
       text: "--name",
     }]);
+  });
+
+  it("should use async dependency source values in suggestions", async () => {
+    function asyncChoice<T extends string>(
+      choices: readonly T[],
+    ): ValueParser<"async", T> {
+      return {
+        mode: "async",
+        metavar: "ASYNC_CHOICE" as NonEmptyString,
+        placeholder: choices[0],
+        parse(input: string): Promise<ValueParserResult<T>> {
+          return Promise.resolve(
+            choices.includes(input as T)
+              ? { success: true, value: input as T }
+              : {
+                success: false,
+                error: message`Must be one of: ${choices.join(", ")}`,
+              },
+          );
+        },
+        format(value: T): string {
+          return value;
+        },
+        async *suggest(prefix: string): AsyncIterable<Suggestion> {
+          for (const choice of choices) {
+            if (choice.startsWith(prefix)) {
+              yield { kind: "literal", text: choice };
+            }
+          }
+        },
+      };
+    }
+
+    const mode = dependency(asyncChoice(["dev", "prod"] as const));
+    const level = mode.derive({
+      metavar: "LEVEL",
+      mode: "async",
+      factory: (value) =>
+        asyncChoice(
+          value === "dev"
+            ? (["debug", "verbose"] as const)
+            : (["silent", "strict"] as const),
+        ),
+      defaultValue: () => "dev" as const,
+    });
+    const parser = seq(
+      option("--mode", mode),
+      option("--level", level),
+    );
+
+    assert.deepEqual(
+      await suggestAsync(parser, ["--mode", "prod", "--level", "s"]),
+      [
+        { kind: "literal", text: "silent" },
+        { kind: "literal", text: "strict" },
+      ],
+    );
   });
 
   it("should preserve invalid value errors during completion", () => {

--- a/packages/core/src/constructs.test.ts
+++ b/packages/core/src/constructs.test.ts
@@ -22078,6 +22078,56 @@ describe("seq", () => {
     });
   });
 
+  it("should advance past completed repeated composite items", () => {
+    const parser = seq(
+      multiple(object({ x: option("--x") })),
+      command("run", object({})),
+    );
+
+    assert.deepEqual(parseSync(parser, ["--x", "run"]), {
+      success: true,
+      value: [[{ x: true }], {}],
+    });
+  });
+
+  it("should advance async past completed repeated composite items", async () => {
+    const parser = seq(
+      multiple(toAsyncParser(object({ x: option("--x") }))),
+      command("run", object({})),
+    );
+
+    assert.deepEqual(await parseAsync(parser, ["--x", "run"]), {
+      success: true,
+      value: [[{ x: true }], {}],
+    });
+  });
+
+  it("should not skip initial optional duplicates when duplicates are allowed", () => {
+    const parser = seq(
+      optional(option("--x", string())),
+      option("--x", string()),
+      { allowDuplicates: true },
+    );
+
+    assert.deepEqual(parseSync(parser, ["--x", "a", "--x", "b"]), {
+      success: true,
+      value: ["a", "b"],
+    });
+  });
+
+  it("should not skip initial async optional duplicates when duplicates are allowed", async () => {
+    const parser = seq(
+      optional(toAsyncParser(option("--x", string()))),
+      option("--x", string()),
+      { allowDuplicates: true },
+    );
+
+    assert.deepEqual(await parseAsync(parser, ["--x", "a", "--x", "b"]), {
+      success: true,
+      value: ["a", "b"],
+    });
+  });
+
   it("should consume -- when advancing to a later positional parser", () => {
     const parser = seq(
       option("--name", string()),

--- a/packages/core/src/constructs.test.ts
+++ b/packages/core/src/constructs.test.ts
@@ -22054,6 +22054,20 @@ describe("seq", () => {
     );
   });
 
+  it("should reject duplicate options active after required input", () => {
+    assert.throws(
+      () =>
+        seq(
+          object({
+            input: argument(string()),
+            x: option("--x"),
+          }),
+          option("--x"),
+        ),
+      DuplicateOptionError,
+    );
+  });
+
   it("should allow duplicate options across sequential command boundaries", () => {
     const parser = seq(
       object({ path: option("--path") }),
@@ -22174,6 +22188,7 @@ describe("seq", () => {
     const parser = seq(
       command("deploy", object({ inner: option("--force") })),
       option("--force"),
+      { allowDuplicates: true },
     );
 
     assert.deepEqual(parseSync(parser, ["deploy", "--force"]), {
@@ -22188,6 +22203,7 @@ describe("seq", () => {
         command("deploy", object({ inner: option("--force") })),
       ),
       option("--force"),
+      { allowDuplicates: true },
     );
 
     assert.deepEqual(await parseAsync(parser, ["deploy", "--force"]), {

--- a/packages/core/src/constructs.test.ts
+++ b/packages/core/src/constructs.test.ts
@@ -3680,6 +3680,40 @@ describe("object", () => {
     assert.ok(!texts.includes("dist"));
   });
 
+  it("should suggest only nested seq option values after option token", () => {
+    const parser = object({
+      sequence: seq(
+        option("--mode", choice(["dev", "prod"])),
+        argument(choice(["target"])),
+      ),
+      other: argument(choice(["zzz"])),
+    });
+
+    const suggestions = suggestSync(parser, ["--mode", ""]);
+    const texts = suggestions
+      .filter((s) => s.kind === "literal")
+      .map((s) => s.text);
+
+    assert.deepEqual(texts, ["dev", "prod"]);
+  });
+
+  it("should suggest only nested async seq option values after option token", async () => {
+    const parser = toAsyncParser(object({
+      sequence: seq(
+        option("--mode", choice(["dev", "prod"])),
+        argument(choice(["target"])),
+      ),
+      other: argument(choice(["zzz"])),
+    }));
+
+    const suggestions = await suggestAsync(parser, ["--mode", ""]);
+    const texts = suggestions
+      .filter((s) => s.kind === "literal")
+      .map((s) => s.text);
+
+    assert.deepEqual(texts, ["dev", "prod"]);
+  });
+
   it("should fall back to initial state in suggest when field state is missing", () => {
     const parser = object({
       mode: option("--mode", choice(["dev", "prod"])),
@@ -22017,6 +22051,30 @@ describe("seq", () => {
     assert.deepEqual(parseSync(parser, ["--secret=abc"]), {
       success: true,
       value: [undefined, "abc"],
+    });
+  });
+
+  it("should advance past a completed required option before parsing duplicates", () => {
+    const parser = seq(
+      option("--x", string()),
+      option("--x", string()),
+    );
+
+    assert.deepEqual(parseSync(parser, ["--x", "a", "--x", "b"]), {
+      success: true,
+      value: ["a", "b"],
+    });
+  });
+
+  it("should advance async past a completed required option before parsing duplicates", async () => {
+    const parser = seq(
+      toAsyncParser(option("--x", string())),
+      option("--x", string()),
+    );
+
+    assert.deepEqual(await parseAsync(parser, ["--x", "a", "--x", "b"]), {
+      success: true,
+      value: ["a", "b"],
     });
   });
 

--- a/packages/core/src/constructs.test.ts
+++ b/packages/core/src/constructs.test.ts
@@ -21939,9 +21939,9 @@ describe("canSkip", () => {
   });
 
   it("should be false for required primitive parsers", () => {
-    assert.equal(option("--name", string()).canSkip?.(undefined), false);
-    assert.equal(argument(string()).canSkip?.(undefined), false);
-    assert.equal(command("run", object({})).canSkip?.(undefined), false);
+    assert.ok(!option("--name", string()).canSkip?.(undefined));
+    assert.ok(!argument(string()).canSkip?.(undefined));
+    assert.ok(!command("run", object({})).canSkip?.(undefined));
   });
 
   it("should be true for required parsers after successful consumption", () => {
@@ -21965,15 +21965,16 @@ describe("canSkip", () => {
         name: undefined,
       }),
     );
-    assert.equal(
-      object({
-        input: argument(string()),
-        verbose: optional(flag("--verbose")),
-      }).canSkip?.({
-        input: undefined,
-        verbose: undefined,
-      }),
-      false,
+    assert.ok(
+      !(
+        object({
+          input: argument(string()),
+          verbose: optional(flag("--verbose")),
+        }).canSkip?.({
+          input: undefined,
+          verbose: undefined,
+        })
+      ),
     );
     assert.ok(
       tuple([
@@ -22001,10 +22002,7 @@ describe("seq", () => {
       parseSync(parser, ["--first", "a", "--second", "b"]),
       { success: true, value: ["a", "b"] },
     );
-    assert.equal(
-      parseSync(parser, ["--second", "b", "--first", "a"]).success,
-      false,
-    );
+    assert.ok(!parseSync(parser, ["--second", "b", "--first", "a"]).success);
   });
 
   it("should preserve declaration order in usage output", () => {
@@ -22199,7 +22197,7 @@ describe("seq", () => {
       usage: parser.usage,
     });
 
-    assert.equal(result.success, false);
+    assert.ok(!result.success);
     if (!result.success) {
       assert.equal(result.consumed, 4);
     }
@@ -22218,7 +22216,7 @@ describe("seq", () => {
       usage: parser.usage,
     });
 
-    assert.equal(result.success, false);
+    assert.ok(!result.success);
     if (!result.success) {
       assert.equal(result.consumed, 4);
     }
@@ -22335,7 +22333,7 @@ describe("seq", () => {
 
     const result = parseSync(parser, ["run"]);
 
-    assert.equal(result.success, false);
+    assert.ok(!result.success);
     assertErrorIncludes(result.error, "consume at least one token");
   });
 
@@ -22347,7 +22345,7 @@ describe("seq", () => {
 
     const result = parseSync(parser, ["run"]);
 
-    assert.equal(result.success, false);
+    assert.ok(!result.success);
   });
 
   it("should advance after nonEmpty() consumes input", () => {
@@ -22370,7 +22368,7 @@ describe("seq", () => {
 
     const result = await parseAsync(parser, ["run"]);
 
-    assert.equal(result.success, false);
+    assert.ok(!result.success);
     assertErrorIncludes(result.error, "consume at least one token");
   });
 
@@ -22401,7 +22399,7 @@ describe("seq", () => {
 
     const result = parseSync(parser, ["run"]);
 
-    assert.equal(result.success, false);
+    assert.ok(!result.success);
     assertErrorIncludes(result.error, "required input");
   });
 
@@ -22421,7 +22419,7 @@ describe("seq", () => {
 
     const result = await parseAsync(parser, ["run"]);
 
-    assert.equal(result.success, false);
+    assert.ok(!result.success);
     assertErrorIncludes(result.error, "required input");
   });
 
@@ -22602,7 +22600,7 @@ describe("seq", () => {
 
     const result = parseSync(parser, ["--num", "bad"]);
 
-    assert.equal(result.success, false);
+    assert.ok(!result.success);
     assertErrorIncludes(result.error, "integer");
   });
 
@@ -22614,7 +22612,7 @@ describe("seq", () => {
 
     const result = parseSync(parser, ["--num", "bad", "--name", "x"]);
 
-    assert.equal(result.success, false);
+    assert.ok(!result.success);
     assertErrorIncludes(result.error, "integer");
   });
 
@@ -22626,7 +22624,7 @@ describe("seq", () => {
 
     const result = parseSync(parser, ["bad", "run"]);
 
-    assert.equal(result.success, false);
+    assert.ok(!result.success);
     assertErrorIncludes(result.error, "integer");
   });
 
@@ -22638,7 +22636,7 @@ describe("seq", () => {
 
     const result = await parseAsync(parser, ["--num", "bad", "--name", "x"]);
 
-    assert.equal(result.success, false);
+    assert.ok(!result.success);
     assertErrorIncludes(result.error, "integer");
   });
 

--- a/packages/core/src/constructs.test.ts
+++ b/packages/core/src/constructs.test.ts
@@ -21830,3 +21830,67 @@ describe("acceptingAnyToken", () => {
     assert.ok(!withCatchAllDiscriminator.acceptingAnyToken);
   });
 });
+
+describe("canSkip", () => {
+  it("should be true for parsers that can complete without CLI input", () => {
+    assert.ok(constant("value").canSkip?.("value"));
+    assert.ok(optional(option("--name", string())).canSkip?.(undefined));
+    assert.ok(
+      withDefault(option("--name", string()), "default").canSkip?.(
+        undefined,
+      ),
+    );
+    assert.ok(multiple(option("--tag", string())).canSkip?.([]));
+  });
+
+  it("should be false for required primitive parsers", () => {
+    assert.equal(option("--name", string()).canSkip?.(undefined), false);
+    assert.equal(argument(string()).canSkip?.(undefined), false);
+    assert.equal(command("run", object({})).canSkip?.(undefined), false);
+  });
+
+  it("should be true for required parsers after successful consumption", () => {
+    assert.ok(
+      option("--name", string()).canSkip?.({ success: true, value: "alice" }),
+    );
+    assert.ok(flag("--force").canSkip?.({ success: true, value: true }));
+    assert.ok(
+      argument(string()).canSkip?.({ success: true, value: "input.txt" }),
+    );
+    assert.ok(command("run", object({})).canSkip?.(["matched", "run"]));
+  });
+
+  it("should compose through parser combinators", () => {
+    assert.ok(
+      object({
+        verbose: optional(flag("--verbose")),
+        name: withDefault(option("--name", string()), "default"),
+      }).canSkip?.({
+        verbose: undefined,
+        name: undefined,
+      }),
+    );
+    assert.equal(
+      object({
+        input: argument(string()),
+        verbose: optional(flag("--verbose")),
+      }).canSkip?.({
+        input: undefined,
+        verbose: undefined,
+      }),
+      false,
+    );
+    assert.ok(
+      tuple([
+        optional(flag("--verbose")),
+        constant("ok"),
+      ]).canSkip?.([undefined, "ok"]),
+    );
+    assert.ok(
+      or(
+        argument(string()),
+        constant("fallback"),
+      ).canSkip?.(undefined),
+    );
+  });
+});

--- a/packages/core/src/constructs.test.ts
+++ b/packages/core/src/constructs.test.ts
@@ -22552,6 +22552,42 @@ describe("seq", () => {
     assertErrorIncludes(result.error, "integer");
   });
 
+  it("should preserve invalid option values before later children", () => {
+    const parser = seq(
+      option("--num", integer()),
+      option("--name", string()),
+    );
+
+    const result = parseSync(parser, ["--num", "bad", "--name", "x"]);
+
+    assert.equal(result.success, false);
+    assertErrorIncludes(result.error, "integer");
+  });
+
+  it("should preserve invalid argument values before later children", () => {
+    const parser = seq(
+      argument(integer()),
+      command("run", object({})),
+    );
+
+    const result = parseSync(parser, ["bad", "run"]);
+
+    assert.equal(result.success, false);
+    assertErrorIncludes(result.error, "integer");
+  });
+
+  it("should preserve async invalid values before later children", async () => {
+    const parser = seq(
+      toAsyncParser(option("--num", integer())),
+      option("--name", string()),
+    );
+
+    const result = await parseAsync(parser, ["--num", "bad", "--name", "x"]);
+
+    assert.equal(result.success, false);
+    assertErrorIncludes(result.error, "integer");
+  });
+
   it("should propagate hidden usage through sequence terms", () => {
     const parser = group("hidden", seq(option("--secret")), { hidden: true });
 

--- a/packages/core/src/constructs.test.ts
+++ b/packages/core/src/constructs.test.ts
@@ -22102,6 +22102,18 @@ describe("seq", () => {
     });
   });
 
+  it("should advance through grouped children", () => {
+    const parser = seq(
+      group("First", option("--a", string())),
+      option("--b", string()),
+    );
+
+    assert.deepEqual(parseSync(parser, ["--a", "x", "--b", "y"]), {
+      success: true,
+      value: ["x", "y"],
+    });
+  });
+
   it("should not skip initial optional duplicates when duplicates are allowed", () => {
     const parser = seq(
       optional(option("--x", string())),

--- a/packages/core/src/constructs.test.ts
+++ b/packages/core/src/constructs.test.ts
@@ -22297,6 +22297,17 @@ describe("seq", () => {
     );
   });
 
+  it("should reject duplicate required repeated options after minimum", () => {
+    assert.throws(
+      () =>
+        seq(
+          multiple(option("--x", string()), { min: 1 }),
+          option("--x", string()),
+        ),
+      DuplicateOptionError,
+    );
+  });
+
   it("should allow duplicate options across sequential command boundaries", () => {
     const parser = seq(
       object({ path: option("--path") }),

--- a/packages/core/src/constructs.test.ts
+++ b/packages/core/src/constructs.test.ts
@@ -22008,6 +22008,18 @@ describe("seq", () => {
     });
   });
 
+  it("should treat hidden option=value as a later value option", () => {
+    const parser = seq(
+      optional(argument(string({ metavar: "PROFILE" }))),
+      option("--secret", string(), { hidden: true }),
+    );
+
+    assert.deepEqual(parseSync(parser, ["--secret=abc"]), {
+      success: true,
+      value: [undefined, "abc"],
+    });
+  });
+
   it("should consume -- when advancing to a later positional parser", () => {
     const parser = seq(
       option("--name", string()),

--- a/packages/core/src/constructs.test.ts
+++ b/packages/core/src/constructs.test.ts
@@ -21866,6 +21866,28 @@ describe("leadingNames", () => {
     );
     assert.deepEqual(parser.leadingNames, new Set(["tool"]));
   });
+
+  it("seq() should hide positional names after a reachable catch-all", () => {
+    const parser = tuple([
+      seq(
+        or(argument(string()), command("foo", object({}))),
+        constant("tail"),
+      ),
+      command("help", object({})),
+    ]);
+
+    assert.ok(parser.leadingNames.has("foo"));
+    assert.ok(!parser.leadingNames.has("help"));
+  });
+
+  it("seq() should expose the highest reachable leading priority", () => {
+    const parser = seq(
+      optional(argument(string())),
+      command("run", object({})),
+    );
+
+    assert.equal(parser.priority, command("run", object({})).priority);
+  });
 });
 
 describe("acceptingAnyToken", () => {
@@ -21924,6 +21946,15 @@ describe("acceptingAnyToken", () => {
       { server: object({}) },
     );
     assert.ok(!withCatchAllDiscriminator.acceptingAnyToken);
+  });
+
+  it("should be true for seq() with a named reachable catch-all child", () => {
+    const parser = seq(
+      or(argument(string()), command("foo", object({}))),
+      constant("tail"),
+    );
+
+    assert.ok(parser.acceptingAnyToken);
   });
 });
 

--- a/packages/core/src/constructs.test.ts
+++ b/packages/core/src/constructs.test.ts
@@ -61,6 +61,7 @@ import {
   constant,
   fail,
   flag,
+  negatableFlag,
   option,
   passThrough,
 } from "@optique/core/primitives";
@@ -22373,15 +22374,55 @@ describe("seq", () => {
   });
 
   it("should accept a callable parser object", () => {
-    const fnParser = Object.assign(
+    const baseParser = option("--active");
+    const fnParser: typeof baseParser = Object.assign(
       () => {},
-      option("--active"),
+      baseParser,
     );
-    const parser = seq(fnParser as never);
+    const parser = seq(fnParser);
 
     assert.deepEqual(parseSync(parser, ["--active"]), {
       success: true,
       value: [true],
+    });
+  });
+
+  it("should keep parsing a matched optional command child", () => {
+    const parser = seq(
+      optional(command("add", argument(string()))),
+      argument(string()),
+    );
+
+    assert.deepEqual(parseSync(parser, ["add", "item", "tail"]), {
+      success: true,
+      value: ["item", "tail"],
+    });
+  });
+
+  it("should keep parsing a matched withDefault command child", () => {
+    const parser = seq(
+      withDefault(command("add", argument(string())), "default"),
+      argument(string()),
+    );
+
+    assert.deepEqual(parseSync(parser, ["add", "item", "tail"]), {
+      success: true,
+      value: ["item", "tail"],
+    });
+  });
+
+  it("should advance after negatableFlag() consumes input", () => {
+    const parser = seq(
+      negatableFlag({
+        positive: "--color",
+        negative: "--no-color",
+      }),
+      argument(string()),
+    );
+
+    assert.deepEqual(parseSync(parser, ["--no-color", "file.txt"]), {
+      success: true,
+      value: [false, "file.txt"],
     });
   });
 

--- a/packages/core/src/constructs.test.ts
+++ b/packages/core/src/constructs.test.ts
@@ -7,6 +7,7 @@ import {
   merge,
   object,
   or,
+  seq,
   tuple,
 } from "@optique/core/constructs";
 import type { DocEntry, DocFragment, DocSection } from "@optique/core/doc";
@@ -80,6 +81,7 @@ import {
   merge as mergeLocal,
   object as objectLocal,
   or as orLocal,
+  seq as seqLocal,
   tuple as tupleLocal,
 } from "./constructs.ts";
 import { dependency as dependencyLocal } from "./internal/dependency.ts";
@@ -16068,6 +16070,40 @@ describe("branch coverage: constructs.ts edge cases", () => {
         assert.equal(getCallCount(), 1);
       });
 
+      it("seq() reuses sync pre-completed defaults", () => {
+        const { parser: modeParser, getCallCount } =
+          createCountingSourceParser();
+        const parser = seqLocal(
+          modeParser,
+          optionLocal("--required", string()),
+        );
+
+        const seed = getLocalPhase2SeedExtractor(parser)(parser.initialState);
+
+        assert.deepEqual(seed, {
+          value: ["alpha"],
+        });
+        assert.equal(getCallCount(), 1);
+      });
+
+      it("seq() reuses async pre-completed defaults", async () => {
+        const { parser: modeParser, getCallCount } =
+          createCountingSourceParser();
+        const parser = seqLocal(
+          modeParser,
+          toAsyncParser(optionLocal("--required", string())),
+        );
+
+        const seed = await getLocalPhase2SeedExtractor(parser)(
+          parser.initialState,
+        );
+
+        assert.deepEqual(seed, {
+          value: ["alpha"],
+        });
+        assert.equal(getCallCount(), 1);
+      });
+
       it("concat() extracts sync seeds across child boundaries", () => {
         const { parser: modeParser, getCallCount } =
           createCountingSourceParser();
@@ -21892,5 +21928,116 @@ describe("canSkip", () => {
         constant("fallback"),
       ).canSkip?.(undefined),
     );
+  });
+});
+
+describe("seq", () => {
+  it("should parse child parsers in declaration order", () => {
+    const parser = seq(
+      option("--first", string()),
+      option("--second", string()),
+    );
+
+    assert.deepEqual(
+      parseSync(parser, ["--first", "a", "--second", "b"]),
+      { success: true, value: ["a", "b"] },
+    );
+    assert.equal(
+      parseSync(parser, ["--second", "b", "--first", "a"]).success,
+      false,
+    );
+  });
+
+  it("should preserve declaration order in usage output", () => {
+    const parser = seq(
+      argument(string({ metavar: "SOURCE" })),
+      or(command("local", object({})), command("remote", object({}))),
+      option("--force"),
+    );
+
+    assert.equal(
+      formatUsage("copy", parser.usage),
+      "copy SOURCE (local | remote) [--force]",
+    );
+  });
+
+  it("should skip fixed optional positionals before later commands", () => {
+    const parser = seq(
+      optional(argument(string({ metavar: "ALIAS" }))),
+      command("run", object({})),
+    );
+
+    assert.deepEqual(parseSync(parser, ["run"]), {
+      success: true,
+      value: [undefined, {}],
+    });
+    assert.deepEqual(parseSync(parser, ["main", "run"]), {
+      success: true,
+      value: ["main", {}],
+    });
+  });
+
+  it("should consume -- when advancing to a later positional parser", () => {
+    const parser = seq(
+      option("--name", string()),
+      argument(string({ metavar: "VALUE" })),
+    );
+
+    assert.deepEqual(parseSync(parser, ["--name", "alice", "--", "--raw"]), {
+      success: true,
+      value: ["alice", "--raw"],
+    });
+  });
+
+  it("should reject duplicate options active at the same position", () => {
+    assert.throws(
+      () =>
+        seq(
+          optional(option("--path", string())),
+          option("--path", string()),
+        ),
+      DuplicateOptionError,
+    );
+  });
+
+  it("should allow duplicate options across sequential command boundaries", () => {
+    const parser = seq(
+      object({ path: option("--path") }),
+      command("local", object({ path: option("--path") })),
+    );
+
+    assert.deepEqual(parseSync(parser, ["local", "--path"]), {
+      success: true,
+      value: [{ path: false }, { path: true }],
+    });
+  });
+
+  it("should evaluate lazy defaults once during completion", () => {
+    let calls = 0;
+    const parser = seq(
+      withDefault(option("--name", string()), () => {
+        calls++;
+        return "default";
+      }),
+      command("run", object({})),
+    );
+
+    assert.deepEqual(parseSync(parser, ["run"]), {
+      success: true,
+      value: ["default", {}],
+    });
+    assert.equal(calls, 1);
+  });
+
+  it("should suggest from the active sequential position", () => {
+    const parser = seq(
+      option("--name", string()),
+      command("run", object({})),
+    );
+
+    assert.deepEqual(suggestSync(parser, ["--name", "alice", ""]), [{
+      kind: "literal",
+      text: "run",
+    }]);
   });
 });

--- a/packages/core/src/constructs.test.ts
+++ b/packages/core/src/constructs.test.ts
@@ -22054,6 +22054,70 @@ describe("seq", () => {
     assert.equal(calls, 1);
   });
 
+  it("should not skip a non-skippable parser on no-match", () => {
+    const required = createSyncBranchParser(
+      undefined,
+      () => ({
+        success: false,
+        consumed: 0,
+        error: message`Expected required input.`,
+      }),
+      "default",
+    );
+    const parser = seq(required, command("run", object({})));
+
+    const result = parseSync(parser, ["run"]);
+
+    assert.equal(result.success, false);
+    assertErrorIncludes(result.error, "required input");
+  });
+
+  it("should not skip an async non-skippable parser on no-match", async () => {
+    const required = toAsyncParser(
+      createSyncBranchParser(
+        undefined,
+        () => ({
+          success: false,
+          consumed: 0,
+          error: message`Expected required input.`,
+        }),
+        "default",
+      ),
+    );
+    const parser = seq(required, command("run", object({})));
+
+    const result = await parseAsync(parser, ["run"]);
+
+    assert.equal(result.success, false);
+    assertErrorIncludes(result.error, "required input");
+  });
+
+  it("should keep active child precedence over later options", () => {
+    const parser = seq(
+      command("deploy", object({ inner: option("--force") })),
+      option("--force"),
+    );
+
+    assert.deepEqual(parseSync(parser, ["deploy", "--force"]), {
+      success: true,
+      value: [{ inner: true }, false],
+    });
+  });
+
+  it("should keep async active child precedence over later options", async () => {
+    const parser = seq(
+      toAsyncParser(
+        command("deploy", object({ inner: option("--force") })),
+      ),
+      option("--force"),
+    );
+
+    assert.deepEqual(await parseAsync(parser, ["deploy", "--force"]), {
+      success: true,
+      value: [{ inner: true }, false],
+    });
+  });
+
   it("should suggest from the active sequential position", () => {
     const parser = seq(
       option("--name", string()),

--- a/packages/core/src/constructs.test.ts
+++ b/packages/core/src/constructs.test.ts
@@ -14981,6 +14981,24 @@ describe("branch coverage: constructs.ts edge cases", () => {
     assert.ok(result.success);
   });
 
+  it("conditional() rewrites discriminator literals inside seq usage", () => {
+    const parser = conditional(
+      map(
+        seq(option("--kind", choice(["a", "b"] as const))),
+        ([kind]) => kind,
+      ),
+      {
+        a: object({ aa: option("--aa") }),
+        b: object({ bb: option("--bb") }),
+      },
+    );
+
+    assert.equal(
+      formatUsage("tool", parser.usage),
+      "tool (--kind a [--aa] | --kind b [--bb])",
+    );
+  });
+
   // ----- conditional() async complete: discriminatorCompleteResult failure (line 7085) -----
   it("conditional() async complete falls back to selectedBranch.key on discriminator failure", async () => {
     // Build an async conditional where discriminator complete is normal

--- a/packages/core/src/constructs.test.ts
+++ b/packages/core/src/constructs.test.ts
@@ -33,7 +33,13 @@ import {
   text,
   valueSet,
 } from "@optique/core/message";
-import { map, multiple, optional, withDefault } from "@optique/core/modifiers";
+import {
+  map,
+  multiple,
+  nonEmpty,
+  optional,
+  withDefault,
+} from "@optique/core/modifiers";
 import { defineInheritedAnnotationParser } from "./internal/parser.ts";
 import {
   type ExecutionContext,
@@ -22025,6 +22031,17 @@ describe("seq", () => {
     );
   });
 
+  it("should reject hidden duplicate options active at the same position", () => {
+    assert.throws(
+      () =>
+        seq(
+          optional(option("--path", string(), { hidden: true })),
+          option("--path", string()),
+        ),
+      DuplicateOptionError,
+    );
+  });
+
   it("should allow duplicate options across sequential command boundaries", () => {
     const parser = seq(
       object({ path: option("--path") }),
@@ -22052,6 +22069,55 @@ describe("seq", () => {
       value: ["default", {}],
     });
     assert.equal(calls, 1);
+  });
+
+  it("should not skip nonEmpty() before it parses input", () => {
+    const parser = seq(
+      nonEmpty(optional(option("--alias", string()))),
+      command("run", object({})),
+    );
+
+    const result = parseSync(parser, ["run"]);
+
+    assert.equal(result.success, false);
+    assertErrorIncludes(result.error, "consume at least one token");
+  });
+
+  it("should advance after nonEmpty() consumes input", () => {
+    const parser = seq(
+      nonEmpty(option("--active")),
+      command("run", object({})),
+    );
+
+    assert.deepEqual(parseSync(parser, ["--active", "run"]), {
+      success: true,
+      value: [true, {}],
+    });
+  });
+
+  it("should not skip async nonEmpty() before it parses input", async () => {
+    const parser = seq(
+      nonEmpty(toAsyncParser(optional(option("--alias", string())))),
+      command("run", object({})),
+    );
+
+    const result = await parseAsync(parser, ["run"]);
+
+    assert.equal(result.success, false);
+    assertErrorIncludes(result.error, "consume at least one token");
+  });
+
+  it("should accept a callable parser object", () => {
+    const fnParser = Object.assign(
+      () => {},
+      option("--active"),
+    );
+    const parser = seq(fnParser as never);
+
+    assert.deepEqual(parseSync(parser, ["--active"]), {
+      success: true,
+      value: [true],
+    });
   });
 
   it("should not skip a non-skippable parser on no-match", () => {

--- a/packages/core/src/constructs.ts
+++ b/packages/core/src/constructs.ts
@@ -6984,6 +6984,7 @@ function checkSequentialDuplicateOptionNames(
     const parser = parsers[i];
     const optionNames = new Set<string>();
     collectLeadingCandidates(parser.usage, optionNames, new Set(), true);
+    const retainedOptionNames = collectRetainedOptionNames(parser.usage);
     for (const name of optionNames) {
       const sources = active.get(name);
       if (sources != null) {
@@ -6996,6 +6997,64 @@ function checkSequentialDuplicateOptionNames(
     }
     if (!parserCanSkipAt(parser, parser.initialState, undefined, i)) {
       active.clear();
+    }
+    for (const name of retainedOptionNames) {
+      const sources = active.get(name);
+      active.set(name, sources == null ? [String(i)] : [...sources, String(i)]);
+    }
+  }
+}
+
+function collectRetainedOptionNames(terms: Usage): Set<string> {
+  const optionNames = new Set<string>();
+  collectRetainedOptionNamesInto(terms, optionNames);
+  return optionNames;
+}
+
+function collectRetainedOptionNamesInto(
+  terms: Usage,
+  optionNames: Set<string>,
+): void {
+  for (const term of terms) {
+    if (term.type === "optional") {
+      collectLeadingCandidates(term.terms, optionNames, new Set(), true);
+      collectRetainedOptionNamesInto(term.terms, optionNames);
+      continue;
+    }
+
+    if (term.type === "multiple") {
+      if (term.min === 0) {
+        collectLeadingCandidates(term.terms, optionNames, new Set(), true);
+      }
+      collectRetainedOptionNamesInto(term.terms, optionNames);
+      continue;
+    }
+
+    if (term.type === "sequence") {
+      collectRetainedOptionNamesInto(term.terms, optionNames);
+      continue;
+    }
+
+    if (term.type === "exclusive") {
+      let canSkipBranch = false;
+      const branchOptionNames: Set<string>[] = [];
+      for (const branch of term.terms) {
+        const branchOptions = new Set<string>();
+        const branchCanSkip = collectLeadingCandidates(
+          branch,
+          branchOptions,
+          new Set(),
+          true,
+        );
+        canSkipBranch = canSkipBranch || branchCanSkip;
+        branchOptionNames.push(branchOptions);
+        collectRetainedOptionNamesInto(branch, optionNames);
+      }
+      if (canSkipBranch) {
+        for (const branchOptions of branchOptionNames) {
+          for (const name of branchOptions) optionNames.add(name);
+        }
+      }
     }
   }
 }

--- a/packages/core/src/constructs.ts
+++ b/packages/core/src/constructs.ts
@@ -6972,6 +6972,33 @@ function sequenceLeadingNames(
   return names.size === 0 ? EMPTY_LEADING_NAMES : names;
 }
 
+function sequenceAcceptingAnyToken(
+  parsers: readonly Parser<Mode, unknown, unknown>[],
+): boolean {
+  for (let i = 0; i < parsers.length; i++) {
+    const parser = parsers[i];
+    if (parser.acceptingAnyToken) return true;
+    if (!parserCanSkipAt(parser, parser.initialState, undefined, i)) {
+      break;
+    }
+  }
+  return false;
+}
+
+function sequencePriority(
+  parsers: readonly Parser<Mode, unknown, unknown>[],
+): number {
+  let priority = 0;
+  for (let i = 0; i < parsers.length; i++) {
+    const parser = parsers[i];
+    priority = Math.max(priority, parser.priority);
+    if (!parserCanSkipAt(parser, parser.initialState, undefined, i)) {
+      break;
+    }
+  }
+  return priority;
+}
+
 function leadingCandidatesAfter(
   parsers: readonly Parser<Mode, unknown, unknown>[],
   startIndex: number,
@@ -9170,6 +9197,7 @@ export function seq<
     };
   };
 
+  const leadingNames = sequenceLeadingNames(parsers);
   const seqParser = {
     mode: combinedMode,
     $valueType: [],
@@ -9185,21 +9213,9 @@ export function seq<
       type: "sequence" as const,
       terms: parsers.flatMap((parser) => parser.usage),
     }],
-    leadingNames: sequenceLeadingNames(parsers),
-    acceptingAnyToken: parsers.length > 0 &&
-      sequenceLeadingNames(parsers).size < 1 &&
-      parsers.some((parser, index) => {
-        if (!parser.acceptingAnyToken) return false;
-        return parsers.slice(0, index).every((previous, previousIndex) =>
-          parserCanSkipAt(
-            previous,
-            previous.initialState,
-            undefined,
-            previousIndex,
-          )
-        );
-      }),
-    priority: parsers[0]?.priority ?? 0,
+    leadingNames,
+    acceptingAnyToken: sequenceAcceptingAnyToken(parsers),
+    priority: sequencePriority(parsers),
     initialState,
     canSkip(state: SeqState, exec?: ExecutionContext) {
       for (let i = state.index; i < parsers.length; i++) {

--- a/packages/core/src/constructs.ts
+++ b/packages/core/src/constructs.ts
@@ -8993,6 +8993,15 @@ export function seq<
     parsers.map((parser) => parser.initialState),
   );
   type ParseResult = ParserResult<SeqState>;
+  type ParseFailure = Extract<ParseResult, { readonly success: false }>;
+
+  const withSeqConsumedDepth = (
+    result: ParseFailure,
+    consumed: readonly string[],
+  ): ParseFailure => ({
+    ...result,
+    consumed: consumed.length + result.consumed,
+  });
 
   const parseSync = (context: ParserContext<SeqState>): ParseResult => {
     let currentContext = context;
@@ -9029,9 +9038,11 @@ export function seq<
       );
 
       if (!result.success) {
-        if (result.consumed > 0) return result;
+        if (result.consumed > 0) {
+          return withSeqConsumedDepth(result, allConsumed);
+        }
         if (!parserCanSkipAt(parser, parserState, currentContext.exec, index)) {
-          return result;
+          return withSeqConsumedDepth(result, allConsumed);
         }
         currentContext = advanceSeqContext(currentContext, index + 1, false);
         continue;
@@ -9104,9 +9115,11 @@ export function seq<
       );
 
       if (!result.success) {
-        if (result.consumed > 0) return result;
+        if (result.consumed > 0) {
+          return withSeqConsumedDepth(result, allConsumed);
+        }
         if (!parserCanSkipAt(parser, parserState, currentContext.exec, index)) {
-          return result;
+          return withSeqConsumedDepth(result, allConsumed);
         }
         currentContext = advanceSeqContext(currentContext, index + 1, false);
         continue;

--- a/packages/core/src/constructs.ts
+++ b/packages/core/src/constructs.ts
@@ -644,6 +644,7 @@ import {
   extractOptionNames,
   type HiddenVisibility,
   isDocHidden,
+  isSuggestionHidden,
   mergeHidden,
   type Usage,
   type UsageTerm,
@@ -6813,6 +6814,12 @@ interface SeqState {
   readonly states: readonly unknown[];
 }
 
+interface SeqLeadingCandidates {
+  readonly optionNames: ReadonlySet<string>;
+  readonly joinedOptionNames: ReadonlySet<string>;
+  readonly commandNames: ReadonlySet<string>;
+}
+
 function isParserLike(value: unknown): value is Parser<Mode, unknown, unknown> {
   return value != null &&
     typeof value === "object" &&
@@ -6823,11 +6830,23 @@ function isParserLike(value: unknown): value is Parser<Mode, unknown, unknown> {
 
 function tokenMatchesLeadingName(
   token: string | undefined,
-  names: ReadonlySet<string>,
+  candidates: SeqLeadingCandidates,
 ): boolean {
   if (token == null) return false;
-  for (const name of names) {
-    if (token === name || token.startsWith(`${name}=`)) return true;
+  for (const name of candidates.optionNames) {
+    if (token === name) return true;
+  }
+  for (const name of candidates.joinedOptionNames) {
+    if (
+      name.startsWith("/") && token.startsWith(`${name}:`) ||
+      (name.startsWith("--") || name.startsWith("-") && name.length > 2) &&
+        token.startsWith(`${name}=`)
+    ) {
+      return true;
+    }
+  }
+  for (const name of candidates.commandNames) {
+    if (token === name) return true;
   }
   return false;
 }
@@ -6844,28 +6863,112 @@ function parserCanSkipAt(
   ) === true;
 }
 
-function sequenceLeadingNames(
+function collectLeadingJoinedOptionNames(
+  terms: Usage,
+  optionNames: Set<string>,
+): boolean {
+  for (const term of terms) {
+    if (term.type === "option") {
+      if (!isSuggestionHidden(term.hidden) && term.metavar != null) {
+        for (const name of term.names) optionNames.add(name);
+      }
+      return false;
+    }
+
+    if (term.type === "command" || term.type === "argument") return false;
+
+    if (term.type === "optional") {
+      collectLeadingJoinedOptionNames(term.terms, optionNames);
+      continue;
+    }
+
+    if (term.type === "multiple") {
+      collectLeadingJoinedOptionNames(term.terms, optionNames);
+      if (term.min === 0) continue;
+      return false;
+    }
+
+    if (term.type === "sequence") {
+      if (collectLeadingJoinedOptionNames(term.terms, optionNames)) {
+        continue;
+      }
+      return false;
+    }
+
+    if (term.type === "exclusive") {
+      let allSkippable = true;
+      for (const branch of term.terms) {
+        const branchSkippable = collectLeadingJoinedOptionNames(
+          branch,
+          optionNames,
+        );
+        allSkippable = allSkippable && branchSkippable;
+      }
+      if (allSkippable) continue;
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function sequenceLeadingCandidates(
   parsers: readonly Parser<Mode, unknown, unknown>[],
-): ReadonlySet<string> {
-  const names = new Set<string>();
+): SeqLeadingCandidates {
+  const optionNames = new Set<string>();
+  const joinedOptionNames = new Set<string>();
+  const commandNames = new Set<string>();
   let positionalBlocked = false;
   for (let i = 0; i < parsers.length; i++) {
     const parser = parsers[i];
-    for (const name of parser.leadingNames) {
-      if (positionalBlocked && !name.startsWith("-")) continue;
-      names.add(name);
+    const parserOptions = new Set<string>();
+    const parserJoinedOptions = new Set<string>();
+    const parserCommands = new Set<string>();
+    collectLeadingCandidates(parser.usage, parserOptions, parserCommands);
+    collectLeadingJoinedOptionNames(parser.usage, parserJoinedOptions);
+    for (const name of parserOptions) optionNames.add(name);
+    for (const name of parserJoinedOptions) joinedOptionNames.add(name);
+    if (!positionalBlocked) {
+      for (const name of parserCommands) commandNames.add(name);
+      for (const name of parser.leadingNames) {
+        if (!parserOptions.has(name)) commandNames.add(name);
+      }
+    } else {
+      for (const name of parser.leadingNames) {
+        if (!parserOptions.has(name) && name.startsWith("-")) {
+          commandNames.add(name);
+        }
+      }
     }
     if (parser.acceptingAnyToken) positionalBlocked = true;
     if (!parserCanSkipAt(parser, parser.initialState, undefined, i)) break;
   }
+  return {
+    optionNames: optionNames.size === 0 ? EMPTY_LEADING_NAMES : optionNames,
+    joinedOptionNames: joinedOptionNames.size === 0
+      ? EMPTY_LEADING_NAMES
+      : joinedOptionNames,
+    commandNames: commandNames.size === 0 ? EMPTY_LEADING_NAMES : commandNames,
+  };
+}
+
+function sequenceLeadingNames(
+  parsers: readonly Parser<Mode, unknown, unknown>[],
+): ReadonlySet<string> {
+  const candidates = sequenceLeadingCandidates(parsers);
+  const names = new Set<string>([
+    ...candidates.optionNames,
+    ...candidates.joinedOptionNames,
+    ...candidates.commandNames,
+  ]);
   return names.size === 0 ? EMPTY_LEADING_NAMES : names;
 }
 
-function leadingNamesAfter(
+function leadingCandidatesAfter(
   parsers: readonly Parser<Mode, unknown, unknown>[],
   startIndex: number,
-): ReadonlySet<string> {
-  return sequenceLeadingNames(parsers.slice(startIndex));
+): SeqLeadingCandidates {
+  return sequenceLeadingCandidates(parsers.slice(startIndex));
 }
 
 function checkSequentialDuplicateOptionNames(
@@ -6943,8 +7046,8 @@ function shouldAdvanceSeqBeforeParse(
   }
   const token = currentContext.buffer[0];
   if (token === "--") return true;
-  const laterLeadingNames = leadingNamesAfter(parsers, index + 1);
-  return tokenMatchesLeadingName(token, laterLeadingNames);
+  const laterLeadingCandidates = leadingCandidatesAfter(parsers, index + 1);
+  return tokenMatchesLeadingName(token, laterLeadingCandidates);
 }
 
 function advanceSeqContext(
@@ -7006,13 +7109,7 @@ function advanceSeqSuggestContextSync(
     const parser = parsers[index];
     const parserState = getSeqChildState(currentContext.state, index, parser);
 
-    if (currentContext.buffer.length < 1) {
-      if (parserCanSkipAt(parser, parserState, currentContext.exec, index)) {
-        currentContext = advanceSeqContext(currentContext, index + 1, false);
-        continue;
-      }
-      break;
-    }
+    if (currentContext.buffer.length < 1) break;
 
     if (
       shouldAdvanceSeqBeforeParse(
@@ -7065,13 +7162,7 @@ async function advanceSeqSuggestContextAsync(
     const parser = parsers[index];
     const parserState = getSeqChildState(currentContext.state, index, parser);
 
-    if (currentContext.buffer.length < 1) {
-      if (parserCanSkipAt(parser, parserState, currentContext.exec, index)) {
-        currentContext = advanceSeqContext(currentContext, index + 1, false);
-        continue;
-      }
-      break;
-    }
+    if (currentContext.buffer.length < 1) break;
 
     if (
       shouldAdvanceSeqBeforeParse(

--- a/packages/core/src/constructs.ts
+++ b/packages/core/src/constructs.ts
@@ -12988,6 +12988,11 @@ export function conditional(
           ...term,
           terms: appendLiteralToUsage(term.terms, literalValue),
         });
+      } else if (term.type === "sequence") {
+        result.push({
+          ...term,
+          terms: appendLiteralToUsage(term.terms, literalValue),
+        });
       } else if (term.type === "exclusive") {
         result.push({
           ...term,

--- a/packages/core/src/constructs.ts
+++ b/packages/core/src/constructs.ts
@@ -7110,6 +7110,19 @@ function collectLeadingOptionCandidates(
   collectLeadingJoinedOptionNames(terms, joinedOptionNames);
 }
 
+function collectRetainedLeadingCandidatesAtState(
+  terms: Usage,
+  state: unknown,
+): SeqLeadingCandidates {
+  if (
+    terms.length === 1 && terms[0].type === "optional" &&
+    Array.isArray(state)
+  ) {
+    return collectRetainedLeadingCandidates(terms[0].terms);
+  }
+  return collectRetainedLeadingCandidates(terms);
+}
+
 function createSeqState(
   sourceState: unknown,
   index: number,
@@ -7163,10 +7176,16 @@ function shouldAdvanceSeqBeforeParse(
   if (token === "--") return true;
   const laterLeadingCandidates = leadingCandidatesAfter(parsers, index + 1);
   if (!tokenMatchesLeadingName(token, laterLeadingCandidates)) return false;
-  if (currentContext.state.states[index] === parser.initialState) return true;
+  if (currentContext.state.states[index] === parser.initialState) {
+    const currentLeadingCandidates = sequenceLeadingCandidates([parser]);
+    return !tokenMatchesLeadingName(token, currentLeadingCandidates);
+  }
   return !tokenMatchesLeadingName(
     token,
-    collectRetainedLeadingCandidates(parser.usage),
+    collectRetainedLeadingCandidatesAtState(
+      parser.usage,
+      currentContext.state.states[index],
+    ),
   );
 }
 

--- a/packages/core/src/constructs.ts
+++ b/packages/core/src/constructs.ts
@@ -785,7 +785,10 @@ function isOptionRequiringValue(usage: Usage, token: string): boolean {
         if (term.metavar && term.names.includes(token)) {
           return true;
         }
-      } else if (term.type === "optional" || term.type === "multiple") {
+      } else if (
+        term.type === "optional" || term.type === "multiple" ||
+        term.type === "sequence"
+      ) {
         if (traverse(term.terms)) return true;
       } else if (term.type === "exclusive") {
         for (const exclusiveUsage of term.terms) {
@@ -6984,7 +6987,9 @@ function checkSequentialDuplicateOptionNames(
     const parser = parsers[i];
     const optionNames = new Set<string>();
     collectLeadingCandidates(parser.usage, optionNames, new Set(), true);
-    const retainedOptionNames = collectRetainedOptionNames(parser.usage);
+    const retainedOptionNames = collectRetainedLeadingCandidates(
+      parser.usage,
+    ).optionNames;
     for (const name of optionNames) {
       const sources = active.get(name);
       if (sources != null) {
@@ -7005,58 +7010,104 @@ function checkSequentialDuplicateOptionNames(
   }
 }
 
-function collectRetainedOptionNames(terms: Usage): Set<string> {
+function collectRetainedLeadingCandidates(terms: Usage): SeqLeadingCandidates {
   const optionNames = new Set<string>();
-  collectRetainedOptionNamesInto(terms, optionNames);
-  return optionNames;
+  const joinedOptionNames = new Set<string>();
+  collectRetainedLeadingCandidatesInto(terms, optionNames, joinedOptionNames);
+  return {
+    optionNames,
+    joinedOptionNames,
+    commandNames: EMPTY_LEADING_NAMES,
+  };
 }
 
-function collectRetainedOptionNamesInto(
+function collectRetainedLeadingCandidatesInto(
   terms: Usage,
   optionNames: Set<string>,
+  joinedOptionNames: Set<string>,
 ): void {
   for (const term of terms) {
     if (term.type === "optional") {
-      collectLeadingCandidates(term.terms, optionNames, new Set(), true);
-      collectRetainedOptionNamesInto(term.terms, optionNames);
+      collectLeadingOptionCandidates(
+        term.terms,
+        optionNames,
+        joinedOptionNames,
+      );
+      collectRetainedLeadingCandidatesInto(
+        term.terms,
+        optionNames,
+        joinedOptionNames,
+      );
       continue;
     }
 
     if (term.type === "multiple") {
       if (term.min === 0) {
-        collectLeadingCandidates(term.terms, optionNames, new Set(), true);
+        collectLeadingOptionCandidates(
+          term.terms,
+          optionNames,
+          joinedOptionNames,
+        );
       }
-      collectRetainedOptionNamesInto(term.terms, optionNames);
+      collectRetainedLeadingCandidatesInto(
+        term.terms,
+        optionNames,
+        joinedOptionNames,
+      );
       continue;
     }
 
     if (term.type === "sequence") {
-      collectRetainedOptionNamesInto(term.terms, optionNames);
+      collectRetainedLeadingCandidatesInto(
+        term.terms,
+        optionNames,
+        joinedOptionNames,
+      );
       continue;
     }
 
     if (term.type === "exclusive") {
       let canSkipBranch = false;
       const branchOptionNames: Set<string>[] = [];
+      const branchJoinedOptionNames: Set<string>[] = [];
       for (const branch of term.terms) {
         const branchOptions = new Set<string>();
+        const branchJoinedOptions = new Set<string>();
         const branchCanSkip = collectLeadingCandidates(
           branch,
           branchOptions,
           new Set(),
           true,
         );
+        collectLeadingJoinedOptionNames(branch, branchJoinedOptions);
         canSkipBranch = canSkipBranch || branchCanSkip;
         branchOptionNames.push(branchOptions);
-        collectRetainedOptionNamesInto(branch, optionNames);
+        branchJoinedOptionNames.push(branchJoinedOptions);
+        collectRetainedLeadingCandidatesInto(
+          branch,
+          optionNames,
+          joinedOptionNames,
+        );
       }
       if (canSkipBranch) {
         for (const branchOptions of branchOptionNames) {
           for (const name of branchOptions) optionNames.add(name);
         }
+        for (const branchJoinedOptions of branchJoinedOptionNames) {
+          for (const name of branchJoinedOptions) joinedOptionNames.add(name);
+        }
       }
     }
   }
+}
+
+function collectLeadingOptionCandidates(
+  terms: Usage,
+  optionNames: Set<string>,
+  joinedOptionNames: Set<string>,
+): void {
+  collectLeadingCandidates(terms, optionNames, new Set(), true);
+  collectLeadingJoinedOptionNames(terms, joinedOptionNames);
 }
 
 function createSeqState(
@@ -7110,9 +7161,13 @@ function shouldAdvanceSeqBeforeParse(
   }
   const token = currentContext.buffer[0];
   if (token === "--") return true;
-  if (currentContext.state.states[index] !== parser.initialState) return false;
   const laterLeadingCandidates = leadingCandidatesAfter(parsers, index + 1);
-  return tokenMatchesLeadingName(token, laterLeadingCandidates);
+  if (!tokenMatchesLeadingName(token, laterLeadingCandidates)) return false;
+  if (currentContext.state.states[index] === parser.initialState) return true;
+  return !tokenMatchesLeadingName(
+    token,
+    collectRetainedLeadingCandidates(parser.usage),
+  );
 }
 
 function advanceSeqContext(

--- a/packages/core/src/constructs.ts
+++ b/packages/core/src/constructs.ts
@@ -7170,13 +7170,15 @@ function shouldAdvanceSeqBeforeParse(
   index: number,
   parsers: readonly Parser<Mode, unknown, unknown>[],
 ): boolean {
+  const token = currentContext.buffer[0];
+  if (token !== "--") {
+    const laterLeadingCandidates = leadingCandidatesAfter(parsers, index + 1);
+    if (!tokenMatchesLeadingName(token, laterLeadingCandidates)) return false;
+  }
   if (!parserCanSkipAt(parser, parserState, currentContext.exec, index)) {
     return false;
   }
-  const token = currentContext.buffer[0];
   if (token === "--") return true;
-  const laterLeadingCandidates = leadingCandidatesAfter(parsers, index + 1);
-  if (!tokenMatchesLeadingName(token, laterLeadingCandidates)) return false;
   if (currentContext.state.states[index] === parser.initialState) {
     const currentLeadingCandidates = sequenceLeadingCandidates([parser]);
     return !tokenMatchesLeadingName(token, currentLeadingCandidates);

--- a/packages/core/src/constructs.ts
+++ b/packages/core/src/constructs.ts
@@ -6790,6 +6790,491 @@ export interface TupleOptions {
   readonly allowDuplicates?: boolean;
 }
 
+/**
+ * Options for the {@link seq} parser.
+ * @since 1.1.0
+ */
+export interface SeqOptions {
+  /**
+   * When `true`, allows duplicate option names even when they can be active
+   * at the same sequential position. By default (`false`), duplicate option
+   * names at the same position cause a construction-time error.
+   *
+   * @default `false`
+   * @since 1.1.0
+   */
+  readonly allowDuplicates?: boolean;
+}
+
+type SeqTailOptions = SeqOptions & { readonly $valueType?: never };
+
+interface SeqState {
+  readonly index: number;
+  readonly states: readonly unknown[];
+}
+
+function isParserLike(value: unknown): value is Parser<Mode, unknown, unknown> {
+  return value != null &&
+    typeof value === "object" &&
+    "parse" in value &&
+    "$valueType" in value &&
+    "$stateType" in value;
+}
+
+function tokenMatchesLeadingName(
+  token: string | undefined,
+  names: ReadonlySet<string>,
+): boolean {
+  if (token == null) return false;
+  for (const name of names) {
+    if (token === name || token.startsWith(`${name}=`)) return true;
+  }
+  return false;
+}
+
+function parserCanSkipAt(
+  parser: Parser<Mode, unknown, unknown>,
+  state: unknown,
+  exec: ExecutionContext | undefined,
+  index: number,
+): boolean {
+  return parser.canSkip?.(
+    getAnnotatedChildState(undefined, state, parser),
+    withChildExecPath(exec, index),
+  ) === true;
+}
+
+function sequenceLeadingNames(
+  parsers: readonly Parser<Mode, unknown, unknown>[],
+): ReadonlySet<string> {
+  const names = new Set<string>();
+  let positionalBlocked = false;
+  for (let i = 0; i < parsers.length; i++) {
+    const parser = parsers[i];
+    for (const name of parser.leadingNames) {
+      if (positionalBlocked && !name.startsWith("-")) continue;
+      names.add(name);
+    }
+    if (parser.acceptingAnyToken) positionalBlocked = true;
+    if (!parserCanSkipAt(parser, parser.initialState, undefined, i)) break;
+  }
+  return names.size === 0 ? EMPTY_LEADING_NAMES : names;
+}
+
+function leadingNamesAfter(
+  parsers: readonly Parser<Mode, unknown, unknown>[],
+  startIndex: number,
+): ReadonlySet<string> {
+  return sequenceLeadingNames(parsers.slice(startIndex));
+}
+
+function checkSequentialDuplicateOptionNames(
+  parsers: readonly Parser<Mode, unknown, unknown>[],
+): void {
+  const active = new Map<string, (string | symbol)[]>();
+  for (let i = 0; i < parsers.length; i++) {
+    const parser = parsers[i];
+    const optionNames = new Set<string>();
+    collectLeadingCandidates(parser.usage, optionNames, new Set());
+    for (const name of optionNames) {
+      const sources = active.get(name);
+      if (sources != null) {
+        throw new DuplicateOptionError(name, [...sources, String(i)]);
+      }
+    }
+    for (const name of optionNames) {
+      const sources = active.get(name);
+      active.set(name, sources == null ? [String(i)] : [...sources, String(i)]);
+    }
+    if (!parserCanSkipAt(parser, parser.initialState, undefined, i)) {
+      active.clear();
+    }
+  }
+}
+
+function createSeqState(
+  sourceState: unknown,
+  index: number,
+  states: readonly unknown[],
+): SeqState {
+  return {
+    index,
+    states: annotateFreshArray(sourceState, states),
+  };
+}
+
+function getSeqChildState(
+  seqState: SeqState,
+  index: number,
+  parser: Parser<Mode, unknown, unknown>,
+): unknown {
+  return getAnnotatedChildState(
+    seqState.states,
+    seqState.states[index],
+    parser,
+  );
+}
+
+function updateSeqChildState(
+  sourceState: SeqState,
+  index: number,
+  childState: unknown,
+  parser: Parser<Mode, unknown, unknown>,
+): readonly unknown[] {
+  return annotateFreshArray(
+    sourceState.states,
+    sourceState.states.map((state, stateIndex) =>
+      stateIndex === index
+        ? getAnnotatedChildState(sourceState.states, childState, parser)
+        : state
+    ),
+  );
+}
+
+function shouldAdvanceSeqBeforeParse(
+  parser: Parser<Mode, unknown, unknown>,
+  parserState: unknown,
+  currentContext: ParserContext<SeqState>,
+  index: number,
+  parsers: readonly Parser<Mode, unknown, unknown>[],
+): boolean {
+  if (!parserCanSkipAt(parser, parserState, currentContext.exec, index)) {
+    return false;
+  }
+  const token = currentContext.buffer[0];
+  if (token === "--") return true;
+  const laterLeadingNames = leadingNamesAfter(parsers, index + 1);
+  return tokenMatchesLeadingName(token, laterLeadingNames);
+}
+
+function advanceSeqContext(
+  currentContext: ParserContext<SeqState>,
+  nextIndex: number,
+  consumedTerminator: boolean,
+): ParserContext<SeqState> {
+  return {
+    ...currentContext,
+    buffer: consumedTerminator
+      ? currentContext.buffer.slice(1)
+      : currentContext.buffer,
+    optionsTerminated: consumedTerminator
+      ? true
+      : currentContext.optionsTerminated,
+    state: createSeqState(
+      currentContext.state,
+      nextIndex,
+      currentContext.state.states,
+    ),
+  };
+}
+
+function updateSeqContextFromChildResult(
+  currentContext: ParserContext<SeqState>,
+  index: number,
+  parser: Parser<Mode, unknown, unknown>,
+  result: Extract<ParserResult<unknown>, { readonly success: true }>,
+  nextIndex: number,
+): ParserContext<SeqState> {
+  const states = updateSeqChildState(
+    currentContext.state,
+    index,
+    result.next.state,
+    parser,
+  );
+  const mergedExec = mergeChildExec(currentContext.exec, result.next.exec);
+  return {
+    ...currentContext,
+    buffer: result.next.buffer,
+    optionsTerminated: result.next.optionsTerminated,
+    state: createSeqState(currentContext.state, nextIndex, states),
+    ...(mergedExec != null
+      ? {
+        exec: mergedExec,
+        dependencyRegistry: mergedExec.dependencyRegistry,
+      }
+      : {}),
+  };
+}
+
+function advanceSeqSuggestContextSync(
+  context: ParserContext<SeqState>,
+  parsers: readonly Parser<"sync", unknown, unknown>[],
+): ParserContext<SeqState> {
+  let currentContext = context;
+  while (currentContext.state.index < parsers.length) {
+    const index = currentContext.state.index;
+    const parser = parsers[index];
+    const parserState = getSeqChildState(currentContext.state, index, parser);
+
+    if (currentContext.buffer.length < 1) {
+      if (parserCanSkipAt(parser, parserState, currentContext.exec, index)) {
+        currentContext = advanceSeqContext(currentContext, index + 1, false);
+        continue;
+      }
+      break;
+    }
+
+    if (
+      shouldAdvanceSeqBeforeParse(
+        parser,
+        parserState,
+        currentContext,
+        index,
+        parsers,
+      )
+    ) {
+      const consumedTerminator = currentContext.buffer[0] === "--";
+      currentContext = advanceSeqContext(
+        currentContext,
+        index + 1,
+        consumedTerminator,
+      );
+      continue;
+    }
+
+    const result = parser.parse(
+      withChildContext(currentContext, index, parserState, parser),
+    );
+    if (!result.success) {
+      if (result.consumed > 0) break;
+      if (parserCanSkipAt(parser, parserState, currentContext.exec, index)) {
+        currentContext = advanceSeqContext(currentContext, index + 1, false);
+        continue;
+      }
+      break;
+    }
+    const nextIndex = result.consumed.length > 0 ? index : index + 1;
+    currentContext = updateSeqContextFromChildResult(
+      currentContext,
+      index,
+      parser,
+      result,
+      nextIndex,
+    );
+  }
+  return currentContext;
+}
+
+async function advanceSeqSuggestContextAsync(
+  context: ParserContext<SeqState>,
+  parsers: readonly Parser<Mode, unknown, unknown>[],
+): Promise<ParserContext<SeqState>> {
+  let currentContext = context;
+  while (currentContext.state.index < parsers.length) {
+    const index = currentContext.state.index;
+    const parser = parsers[index];
+    const parserState = getSeqChildState(currentContext.state, index, parser);
+
+    if (currentContext.buffer.length < 1) {
+      if (parserCanSkipAt(parser, parserState, currentContext.exec, index)) {
+        currentContext = advanceSeqContext(currentContext, index + 1, false);
+        continue;
+      }
+      break;
+    }
+
+    if (
+      shouldAdvanceSeqBeforeParse(
+        parser,
+        parserState,
+        currentContext,
+        index,
+        parsers,
+      )
+    ) {
+      const consumedTerminator = currentContext.buffer[0] === "--";
+      currentContext = advanceSeqContext(
+        currentContext,
+        index + 1,
+        consumedTerminator,
+      );
+      continue;
+    }
+
+    const result = await parser.parse(
+      withChildContext(currentContext, index, parserState, parser),
+    );
+    if (!result.success) {
+      if (result.consumed > 0) break;
+      if (parserCanSkipAt(parser, parserState, currentContext.exec, index)) {
+        currentContext = advanceSeqContext(currentContext, index + 1, false);
+        continue;
+      }
+      break;
+    }
+    const nextIndex = result.consumed.length > 0 ? index : index + 1;
+    currentContext = updateSeqContextFromChildResult(
+      currentContext,
+      index,
+      parser,
+      result,
+      nextIndex,
+    );
+  }
+  return currentContext;
+}
+
+function createSeqComplete(
+  parsers: readonly Parser<Mode, unknown, unknown>[],
+  combinedMode: Mode,
+) {
+  const syncParsers = parsers as readonly Parser<"sync", unknown, unknown>[];
+  return (state: SeqState, exec?: ExecutionContext) =>
+    dispatchByMode(
+      combinedMode,
+      () => {
+        const stateArray = state.states as unknown[];
+        const runtime = exec?.dependencyRuntime ??
+          createDependencyRuntimeContext(exec?.dependencyRegistry);
+        const childExec: ExecutionContext = {
+          ...exec,
+          dependencyRuntime: runtime,
+        } as ExecutionContext;
+        const pairs = buildIndexedParserPairs(syncParsers);
+        const stateRecord = createAnnotatedArrayStateRecord(stateArray);
+        const preCompleted = preCompleteAndRegisterDependencies(
+          stateRecord,
+          pairs,
+          runtime.registry,
+          childExec,
+        );
+        collectExplicitSourceValues(
+          filterPreCompletedRuntimeNodes(
+            buildRuntimeNodesFromArray(syncParsers, stateArray, exec?.path),
+            new Set(preCompleted.keys()),
+          ),
+          runtime,
+        );
+        const phase3Exec: ExecutionContext = {
+          ...childExec,
+          preCompletedByParser: undefined,
+        } as ExecutionContext;
+        const resolvedArray = resolveStateWithRuntime(
+          stateArray,
+          runtime,
+        ) as unknown[];
+        const result: unknown[] = [];
+        const deferredKeys = new Map<PropertyKey, DeferredMap | null>();
+        let hasDeferred = false;
+        for (let i = 0; i < syncParsers.length; i++) {
+          const elementParser = syncParsers[i];
+          const preCompletedResult = preCompleted.get(String(i));
+          const valueResult = preCompletedResult !== undefined
+            ? unwrapCompleteResult(preCompletedResult)
+            : unwrapCompleteResult(
+              elementParser.complete(
+                prepareStateForCompletion(resolvedArray[i], elementParser),
+                withChildExecPath(phase3Exec, i),
+              ),
+            );
+          if (!valueResult.success) {
+            return { success: false as const, error: valueResult.error };
+          }
+          result[i] = valueResult.value;
+          if (valueResult.deferred) {
+            if (valueResult.deferredKeys) {
+              deferredKeys.set(i, valueResult.deferredKeys);
+            } else if (
+              valueResult.value == null ||
+              typeof valueResult.value !== "object"
+            ) {
+              deferredKeys.set(i, null);
+            } else {
+              hasDeferred = true;
+            }
+          }
+        }
+        return {
+          success: true as const,
+          value: result,
+          ...(deferredKeys.size > 0 || hasDeferred
+            ? {
+              deferred: true as const,
+              ...(deferredKeys.size > 0
+                ? { deferredKeys: deferredKeys as DeferredMap }
+                : {}),
+            }
+            : {}),
+        };
+      },
+      async () => {
+        const stateArray = state.states as unknown[];
+        const runtime = exec?.dependencyRuntime ??
+          createDependencyRuntimeContext(exec?.dependencyRegistry);
+        const childExec: ExecutionContext = {
+          ...exec,
+          dependencyRuntime: runtime,
+        } as ExecutionContext;
+        const pairs = buildIndexedParserPairs(parsers);
+        const stateRecord = createAnnotatedArrayStateRecord(stateArray);
+        const preCompleted = await preCompleteAndRegisterDependenciesAsync(
+          stateRecord,
+          pairs,
+          runtime.registry,
+          childExec,
+        );
+        await collectExplicitSourceValuesAsync(
+          filterPreCompletedRuntimeNodes(
+            buildRuntimeNodesFromArray(parsers, stateArray, exec?.path),
+            new Set(preCompleted.keys()),
+          ),
+          runtime,
+        );
+        const phase3Exec: ExecutionContext = {
+          ...childExec,
+          preCompletedByParser: undefined,
+        } as ExecutionContext;
+        const resolvedArray = await resolveStateWithRuntimeAsync(
+          stateArray,
+          runtime,
+        ) as unknown[];
+        const result: unknown[] = [];
+        const deferredKeys = new Map<PropertyKey, DeferredMap | null>();
+        let hasDeferred = false;
+        for (let i = 0; i < parsers.length; i++) {
+          const elementParser = parsers[i];
+          const preCompletedResult = preCompleted.get(String(i));
+          const valueResult = preCompletedResult !== undefined
+            ? unwrapCompleteResult(preCompletedResult)
+            : unwrapCompleteResult(
+              await elementParser.complete(
+                prepareStateForCompletion(resolvedArray[i], elementParser),
+                withChildExecPath(phase3Exec, i),
+              ),
+            );
+          if (!valueResult.success) {
+            return { success: false as const, error: valueResult.error };
+          }
+          result[i] = valueResult.value;
+          if (valueResult.deferred) {
+            if (valueResult.deferredKeys) {
+              deferredKeys.set(i, valueResult.deferredKeys);
+            } else if (
+              valueResult.value == null ||
+              typeof valueResult.value !== "object"
+            ) {
+              deferredKeys.set(i, null);
+            } else {
+              hasDeferred = true;
+            }
+          }
+        }
+        return {
+          success: true as const,
+          value: result,
+          ...(deferredKeys.size > 0 || hasDeferred
+            ? {
+              deferred: true as const,
+              ...(deferredKeys.size > 0
+                ? { deferredKeys: deferredKeys as DeferredMap }
+                : {}),
+            }
+            : {}),
+        };
+      },
+    );
+}
+
 function suggestTupleSync(
   context: ParserContext<readonly unknown[]>,
   prefix: string,
@@ -8144,6 +8629,667 @@ export function tuple<
 
   defineInheritedAnnotationParser(tupleParser);
   return tupleParser;
+}
+
+/**
+ * Creates an ordered parser that applies child parsers in declaration order.
+ *
+ * Unlike {@link tuple}, which lets child parsers compete for a shared input
+ * buffer by priority, `seq()` keeps a cursor and only parses the current child.
+ * A child may be skipped when its {@link Parser.canSkip} predicate reports
+ * that it can complete without consuming more CLI input.
+ *
+ * @template T A readonly array type where each element is a {@link Parser}.
+ * @param parsers Parsers to apply in the order they are provided.
+ * @returns A parser that produces a readonly tuple of child values.
+ * @since 1.1.0
+ */
+export function seq<
+  const T extends readonly Parser<Mode, unknown, unknown>[],
+>(
+  ...parsers: T
+): Parser<
+  CombineTupleModes<T>,
+  {
+    readonly [K in keyof T]: T[K]["$valueType"][number] extends (infer U) ? U
+      : never;
+  },
+  SeqState
+>;
+
+/**
+ * Creates an ordered parser with a label for generated documentation.
+ *
+ * @template T A readonly array type where each element is a {@link Parser}.
+ * @param label A descriptive label for this parser group.
+ * @param parsers Parsers to apply in the order they are provided.
+ * @returns A parser that produces a readonly tuple of child values.
+ * @throws {TypeError} If the label is empty, whitespace-only, or contains
+ *         control characters.
+ * @since 1.1.0
+ */
+export function seq<
+  const T extends readonly Parser<Mode, unknown, unknown>[],
+>(
+  label: string,
+  ...parsers: T
+): Parser<
+  CombineTupleModes<T>,
+  {
+    readonly [K in keyof T]: T[K]["$valueType"][number] extends (infer U) ? U
+      : never;
+  },
+  SeqState
+>;
+
+/**
+ * Creates an ordered parser with options.
+ *
+ * @template T A readonly array type where each element is a {@link Parser}.
+ * @param parsers Parsers to apply in the order they are provided, followed by
+ *                {@link SeqOptions}.
+ * @returns A parser that produces a readonly tuple of child values.
+ * @since 1.1.0
+ */
+export function seq<
+  const T extends readonly Parser<Mode, unknown, unknown>[],
+>(
+  ...args: readonly [...T, SeqTailOptions]
+): Parser<
+  CombineTupleModes<T>,
+  {
+    readonly [K in keyof T]: T[K]["$valueType"][number] extends (infer U) ? U
+      : never;
+  },
+  SeqState
+>;
+
+/**
+ * Creates a labeled ordered parser with options.
+ *
+ * @template T A readonly array type where each element is a {@link Parser}.
+ * @param label A descriptive label for this parser group.
+ * @param args Parsers to apply in the order they are provided, followed by
+ *             {@link SeqOptions}.
+ * @returns A parser that produces a readonly tuple of child values.
+ * @throws {TypeError} If the label is empty, whitespace-only, or contains
+ *         control characters.
+ * @since 1.1.0
+ */
+export function seq<
+  const T extends readonly Parser<Mode, unknown, unknown>[],
+>(
+  label: string,
+  ...args: readonly [...T, SeqTailOptions]
+): Parser<
+  CombineTupleModes<T>,
+  {
+    readonly [K in keyof T]: T[K]["$valueType"][number] extends (infer U) ? U
+      : never;
+  },
+  SeqState
+>;
+
+export function seq<
+  const T extends readonly Parser<Mode, unknown, unknown>[],
+>(
+  ...rawArgs: readonly unknown[]
+): Parser<Mode, { readonly [K in keyof T]: unknown }, SeqState> {
+  const label = typeof rawArgs[0] === "string" ? rawArgs[0] : undefined;
+  if (label != null) validateLabel(label);
+
+  const args = label == null ? rawArgs : rawArgs.slice(1);
+  const lastArg = args.at(-1);
+  const hasOptions = lastArg != null && !isParserLike(lastArg);
+  const options: SeqOptions = hasOptions ? lastArg as SeqOptions : {};
+  const parsers = (hasOptions ? args.slice(0, -1) : args) as readonly Parser<
+    Mode,
+    unknown,
+    unknown
+  >[];
+
+  const combinedMode: Mode = parsers.some((p) => p.mode === "async")
+    ? "async"
+    : "sync";
+  const syncParsers = parsers as readonly Parser<"sync", unknown, unknown>[];
+
+  if (!options.allowDuplicates) {
+    checkSequentialDuplicateOptionNames(parsers);
+  }
+
+  const initialState = createSeqState(
+    undefined,
+    0,
+    parsers.map((parser) => parser.initialState),
+  );
+  type ParseResult = ParserResult<SeqState>;
+
+  const parseSync = (context: ParserContext<SeqState>): ParseResult => {
+    let currentContext = context;
+    const allConsumed: string[] = [];
+
+    while (currentContext.state.index < syncParsers.length) {
+      const index = currentContext.state.index;
+      const parser = syncParsers[index];
+      const parserState = getSeqChildState(currentContext.state, index, parser);
+
+      if (
+        shouldAdvanceSeqBeforeParse(
+          parser,
+          parserState,
+          currentContext,
+          index,
+          syncParsers,
+        )
+      ) {
+        const consumedTerminator = currentContext.buffer[0] === "--";
+        if (consumedTerminator) allConsumed.push("--");
+        currentContext = advanceSeqContext(
+          currentContext,
+          index + 1,
+          consumedTerminator,
+        );
+        continue;
+      }
+
+      const result = parser.parse(
+        withChildContext(currentContext, index, parserState, parser),
+      );
+
+      if (!result.success) {
+        if (result.consumed > 0) return result;
+        if (
+          currentContext.buffer.length < 1 &&
+          !parserCanSkipAt(parser, parserState, currentContext.exec, index)
+        ) {
+          return result;
+        }
+        currentContext = advanceSeqContext(currentContext, index + 1, false);
+        continue;
+      }
+
+      const states = updateSeqChildState(
+        currentContext.state,
+        index,
+        result.next.state,
+        parser,
+      );
+      const nextIndex = result.consumed.length > 0 ? index : index + 1;
+      const mergedExec = mergeChildExec(currentContext.exec, result.next.exec);
+      currentContext = {
+        ...currentContext,
+        buffer: result.next.buffer,
+        optionsTerminated: result.next.optionsTerminated,
+        state: createSeqState(currentContext.state, nextIndex, states),
+        ...(mergedExec != null
+          ? {
+            exec: mergedExec,
+            dependencyRegistry: mergedExec.dependencyRegistry,
+          }
+          : {}),
+      };
+      allConsumed.push(...result.consumed);
+    }
+
+    return {
+      success: true,
+      next: currentContext,
+      consumed: allConsumed,
+    };
+  };
+
+  const parseAsync = async (
+    context: ParserContext<SeqState>,
+  ): Promise<ParseResult> => {
+    let currentContext = context;
+    const allConsumed: string[] = [];
+
+    while (currentContext.state.index < parsers.length) {
+      const index = currentContext.state.index;
+      const parser = parsers[index];
+      const parserState = getSeqChildState(currentContext.state, index, parser);
+
+      if (
+        shouldAdvanceSeqBeforeParse(
+          parser,
+          parserState,
+          currentContext,
+          index,
+          parsers,
+        )
+      ) {
+        const consumedTerminator = currentContext.buffer[0] === "--";
+        if (consumedTerminator) allConsumed.push("--");
+        currentContext = advanceSeqContext(
+          currentContext,
+          index + 1,
+          consumedTerminator,
+        );
+        continue;
+      }
+
+      const result = await parser.parse(
+        withChildContext(currentContext, index, parserState, parser),
+      );
+
+      if (!result.success) {
+        if (result.consumed > 0) return result;
+        if (
+          currentContext.buffer.length < 1 &&
+          !parserCanSkipAt(parser, parserState, currentContext.exec, index)
+        ) {
+          return result;
+        }
+        currentContext = advanceSeqContext(currentContext, index + 1, false);
+        continue;
+      }
+
+      const states = updateSeqChildState(
+        currentContext.state,
+        index,
+        result.next.state,
+        parser,
+      );
+      const nextIndex = result.consumed.length > 0 ? index : index + 1;
+      const mergedExec = mergeChildExec(currentContext.exec, result.next.exec);
+      currentContext = {
+        ...currentContext,
+        buffer: result.next.buffer,
+        optionsTerminated: result.next.optionsTerminated,
+        state: createSeqState(currentContext.state, nextIndex, states),
+        ...(mergedExec != null
+          ? {
+            exec: mergedExec,
+            dependencyRegistry: mergedExec.dependencyRegistry,
+          }
+          : {}),
+      };
+      allConsumed.push(...result.consumed);
+    }
+
+    return {
+      success: true,
+      next: currentContext,
+      consumed: allConsumed,
+    };
+  };
+
+  const seqParser = {
+    mode: combinedMode,
+    $valueType: [],
+    $stateType: [],
+    [fieldParsersKey]: parsers.map(
+      (parser, index) =>
+        [String(index), parser] as [
+          string,
+          Parser<Mode, unknown, unknown>,
+        ],
+    ),
+    usage: [{
+      type: "sequence" as const,
+      terms: parsers.flatMap((parser) => parser.usage),
+    }],
+    leadingNames: sequenceLeadingNames(parsers),
+    acceptingAnyToken: parsers.length > 0 &&
+      sequenceLeadingNames(parsers).size < 1 &&
+      parsers.some((parser, index) => {
+        if (!parser.acceptingAnyToken) return false;
+        return parsers.slice(0, index).every((previous, previousIndex) =>
+          parserCanSkipAt(
+            previous,
+            previous.initialState,
+            undefined,
+            previousIndex,
+          )
+        );
+      }),
+    priority: parsers[0]?.priority ?? 0,
+    initialState,
+    canSkip(state: SeqState, exec?: ExecutionContext) {
+      for (let i = state.index; i < parsers.length; i++) {
+        const parser = parsers[i];
+        if (
+          parser.canSkip?.(
+            getSeqChildState(state, i, parser),
+            withChildExecPath(exec, i),
+          ) !== true
+        ) {
+          return false;
+        }
+      }
+      return true;
+    },
+    parse(context: ParserContext<SeqState>) {
+      return dispatchByMode(
+        combinedMode,
+        () => parseSync(context),
+        () => parseAsync(context),
+      );
+    },
+    complete: undefined as unknown as Parser<
+      Mode,
+      { readonly [K in keyof T]: unknown },
+      SeqState
+    >["complete"],
+    [extractPhase2SeedKey](state: SeqState, exec?: ExecutionContext) {
+      return dispatchByMode(
+        combinedMode,
+        () => {
+          const stateArray = state.states as unknown[];
+          const runtime = exec?.dependencyRuntime ??
+            createDependencyRuntimeContext(exec?.dependencyRegistry);
+          const childExec = withDependencyRuntimeExec(
+            seqParser.usage,
+            exec,
+            runtime,
+          );
+          const pairs = buildIndexedParserPairs(syncParsers);
+          const stateRecord = createAnnotatedArrayStateRecord(stateArray);
+          const preCompleted = preCompleteAndRegisterDependencies(
+            stateRecord,
+            pairs,
+            runtime.registry,
+            childExec,
+          );
+          collectExplicitSourceValues(
+            filterPreCompletedRuntimeNodes(
+              buildRuntimeNodesFromArray(syncParsers, stateArray, exec?.path),
+              new Set(preCompleted.keys()),
+            ),
+            runtime,
+          );
+          const phase3Exec: ExecutionContext = {
+            ...childExec,
+            preCompletedByParser: undefined,
+          } as ExecutionContext;
+          const resolvedArray = resolveStateWithRuntime(
+            stateArray,
+            runtime,
+          ) as unknown[];
+
+          const result: unknown[] = [];
+          const deferredKeys = new Map<PropertyKey, DeferredMap | null>();
+          let hasDeferred = false;
+          let hasAnySeed = false;
+          for (let i = 0; i < syncParsers.length; i++) {
+            const elementParser = syncParsers[i];
+            const childExec = withChildExecPath(phase3Exec, i);
+            const preCompletedResult = preCompleted.get(String(i));
+            const seed = preCompletedResult !== undefined
+              ? reusePreCompletedPhase2Seed(
+                elementParser,
+                prepareStateForCompletion(resolvedArray[i], elementParser),
+                preCompletedResult,
+                childExec,
+              )
+              : completeOrExtractPhase2Seed(
+                elementParser,
+                prepareStateForCompletion(resolvedArray[i], elementParser),
+                childExec,
+              );
+            if (seed == null) continue;
+            hasAnySeed = true;
+            result[i] = seed.value;
+            if (seed.deferred) {
+              if (seed.deferredKeys) {
+                deferredKeys.set(i, seed.deferredKeys);
+              } else if (
+                seed.value == null ||
+                typeof seed.value !== "object"
+              ) {
+                deferredKeys.set(i, null);
+              } else {
+                hasDeferred = true;
+              }
+            }
+          }
+
+          if (!hasAnySeed) return null;
+          return {
+            value: result as { [K in keyof T]: T[K]["$valueType"][number] },
+            ...(deferredKeys.size > 0 || hasDeferred
+              ? {
+                deferred: true as const,
+                ...(deferredKeys.size > 0
+                  ? { deferredKeys: deferredKeys as DeferredMap }
+                  : {}),
+              }
+              : {}),
+          };
+        },
+        async () => {
+          const stateArray = state.states as unknown[];
+          const runtime = exec?.dependencyRuntime ??
+            createDependencyRuntimeContext(exec?.dependencyRegistry);
+          const childExec = withDependencyRuntimeExec(
+            seqParser.usage,
+            exec,
+            runtime,
+          );
+          const pairs = buildIndexedParserPairs(parsers);
+          const stateRecord = createAnnotatedArrayStateRecord(stateArray);
+          const preCompleted = await preCompleteAndRegisterDependenciesAsync(
+            stateRecord,
+            pairs,
+            runtime.registry,
+            childExec,
+          );
+          await collectExplicitSourceValuesAsync(
+            filterPreCompletedRuntimeNodes(
+              buildRuntimeNodesFromArray(parsers, stateArray, exec?.path),
+              new Set(preCompleted.keys()),
+            ),
+            runtime,
+          );
+          const phase3Exec: ExecutionContext = {
+            ...childExec,
+            preCompletedByParser: undefined,
+          } as ExecutionContext;
+          const resolvedArray = await resolveStateWithRuntimeAsync(
+            stateArray,
+            runtime,
+          ) as unknown[];
+
+          const result: unknown[] = [];
+          const deferredKeys = new Map<PropertyKey, DeferredMap | null>();
+          let hasDeferred = false;
+          let hasAnySeed = false;
+          for (let i = 0; i < parsers.length; i++) {
+            const elementParser = parsers[i];
+            const childExec = withChildExecPath(phase3Exec, i);
+            const preCompletedResult = preCompleted.get(String(i));
+            const seed = preCompletedResult !== undefined
+              ? await reusePreCompletedPhase2SeedAsync(
+                elementParser,
+                prepareStateForCompletion(resolvedArray[i], elementParser),
+                preCompletedResult,
+                childExec,
+              )
+              : await completeOrExtractPhase2Seed(
+                elementParser,
+                prepareStateForCompletion(resolvedArray[i], elementParser),
+                childExec,
+              );
+            if (seed == null) continue;
+            hasAnySeed = true;
+            result[i] = seed.value;
+            if (seed.deferred) {
+              if (seed.deferredKeys) {
+                deferredKeys.set(i, seed.deferredKeys);
+              } else if (
+                seed.value == null ||
+                typeof seed.value !== "object"
+              ) {
+                deferredKeys.set(i, null);
+              } else {
+                hasDeferred = true;
+              }
+            }
+          }
+
+          if (!hasAnySeed) return null;
+          return {
+            value: result as { [K in keyof T]: T[K]["$valueType"][number] },
+            ...(deferredKeys.size > 0 || hasDeferred
+              ? {
+                deferred: true as const,
+                ...(deferredKeys.size > 0
+                  ? { deferredKeys: deferredKeys as DeferredMap }
+                  : {}),
+              }
+              : {}),
+          };
+        },
+      );
+    },
+    suggest(context: ParserContext<SeqState>, prefix: string) {
+      return dispatchIterableByMode(
+        combinedMode,
+        () => {
+          const suggestions: Suggestion[] = [];
+          const advancedContext = advanceSeqSuggestContextSync(
+            context,
+            syncParsers,
+          );
+          const state = advancedContext.state;
+          for (let i = state.index; i < syncParsers.length; i++) {
+            const parser = syncParsers[i];
+            const parserState = getSeqChildState(state, i, parser);
+            suggestions.push(
+              ...parser.suggest(
+                withChildContext(advancedContext, i, parserState, parser),
+                prefix,
+              ),
+            );
+            if (
+              parser.canSkip?.(
+                parserState,
+                withChildExecPath(advancedContext.exec, i),
+              ) !== true
+            ) {
+              break;
+            }
+          }
+          return deduplicateSuggestions(suggestions);
+        },
+        async function* () {
+          const suggestions: Suggestion[] = [];
+          const advancedContext = await advanceSeqSuggestContextAsync(
+            context,
+            parsers,
+          );
+          const state = advancedContext.state;
+          for (let i = state.index; i < parsers.length; i++) {
+            const parser = parsers[i];
+            const parserState = getSeqChildState(state, i, parser);
+            const parserSuggestions = parser.suggest(
+              withChildContext(advancedContext, i, parserState, parser),
+              prefix,
+            );
+            if (parser.mode === "async") {
+              for await (
+                const suggestion of parserSuggestions as AsyncIterable<
+                  Suggestion
+                >
+              ) {
+                suggestions.push(suggestion);
+              }
+            } else {
+              suggestions.push(...parserSuggestions as Iterable<Suggestion>);
+            }
+            if (
+              parser.canSkip?.(
+                parserState,
+                withChildExecPath(advancedContext.exec, i),
+              ) !== true
+            ) {
+              break;
+            }
+          }
+          yield* deduplicateSuggestions(suggestions);
+        },
+      );
+    },
+    getDocFragments(
+      state: DocState<SeqState>,
+      defaultValue?: readonly unknown[],
+    ) {
+      const fragments = syncParsers.flatMap((parser, index) => {
+        const indexState: DocState<unknown> = state.kind === "unavailable"
+          ? { kind: "unavailable" }
+          : {
+            kind: "available",
+            state: state.state.states[index],
+          };
+        return parser.getDocFragments(indexState, defaultValue?.[index])
+          .fragments;
+      });
+      const entries: DocEntry[] = fragments.filter((d) => d.type === "entry");
+      const sections: DocSection[] = [];
+      for (const fragment of fragments) {
+        if (fragment.type !== "section") continue;
+        if (fragment.title == null) {
+          entries.push(...fragment.entries);
+        } else {
+          sections.push(fragment);
+        }
+      }
+      sections.push({ title: label, entries });
+      return { fragments: sections.map((s) => ({ ...s, type: "section" })) };
+    },
+    [Symbol.for("Deno.customInspect")]() {
+      const parsersStr = parsers.length === 1
+        ? "1 parser"
+        : `${parsers.length} parsers`;
+      return label == null
+        ? `seq(${parsersStr})`
+        : `seq(${JSON.stringify(label)}, ${parsersStr})`;
+    },
+  } as Parser<Mode, { readonly [K in keyof T]: unknown }, SeqState>;
+
+  Object.defineProperty(seqParser, "complete", {
+    value: createSeqComplete(parsers, combinedMode),
+    configurable: true,
+    enumerable: true,
+  });
+
+  const normalizers: [number, (v: unknown) => unknown][] = [];
+  for (let i = 0; i < parsers.length; i++) {
+    const parser = parsers[i];
+    if (typeof parser.normalizeValue === "function") {
+      normalizers.push([i, parser.normalizeValue.bind(parser)]);
+    }
+  }
+  if (normalizers.length > 0) {
+    Object.defineProperty(seqParser, "normalizeValue", {
+      value(arr: readonly unknown[]): readonly unknown[] {
+        if (!Array.isArray(arr)) return arr;
+        let changed = false;
+        let result: unknown[] | undefined;
+        for (const [index, normalize] of normalizers) {
+          if (index < arr.length && Object.hasOwn(arr, index)) {
+            try {
+              const original = arr[index];
+              const normalized = normalize(original);
+              if (normalized !== original) {
+                result ??= [...arr];
+                result[index] = normalized;
+                changed = true;
+              }
+            } catch {
+              // best-effort
+            }
+          }
+        }
+        return changed ? result! : arr;
+      },
+      configurable: true,
+      enumerable: false,
+    });
+  }
+
+  defineInheritedAnnotationParser(seqParser);
+  return seqParser;
 }
 
 /**

--- a/packages/core/src/constructs.ts
+++ b/packages/core/src/constructs.ts
@@ -12565,6 +12565,11 @@ export function group<M extends Mode, TValue, TState>(
         shouldDeferCompletion: parser.shouldDeferCompletion.bind(parser),
       }
       : {}),
+    ...(typeof parser.canSkip === "function"
+      ? {
+        canSkip: parser.canSkip.bind(parser),
+      }
+      : {}),
     getSuggestRuntimeNodes(state: TState, path: readonly PropertyKey[]) {
       return parser.getSuggestRuntimeNodes?.(state, path) ??
         (parser.dependencyMetadata?.source != null

--- a/packages/core/src/constructs.ts
+++ b/packages/core/src/constructs.ts
@@ -3868,6 +3868,18 @@ export function or(
     leadingNames: unionLeadingNames(parsers),
     acceptingAnyToken: parsers.some((p) => p.acceptingAnyToken),
     initialState: undefined,
+    canSkip(state: OrState, exec?: ExecutionContext) {
+      const activeState = normalizeExclusiveState(state);
+      if (activeState != null) {
+        const [index, result] = activeState;
+        const parser = parsers[index];
+        return result.success && parser?.canSkip?.(result.next.state, exec) ===
+            true;
+      }
+      return parsers.some((parser) =>
+        parser.canSkip?.(parser.initialState, exec) === true
+      );
+    },
     complete: createExclusiveComplete(
       parsers,
       options,
@@ -6091,6 +6103,19 @@ export function object<
     ),
     leadingNames: sharedBufferLeadingNames(parserPairs.map(([_, p]) => p)),
     acceptingAnyToken: parserPairs.some(([_, p]) => p.acceptingAnyToken),
+    canSkip(
+      state: { readonly [K in keyof T]: unknown },
+      exec?: ExecutionContext,
+    ) {
+      const getFieldState = createFieldStateGetter(state);
+      return parserKeys.every((field) => {
+        const parser = parsers[field];
+        return parser.canSkip?.(
+          getFieldState(field, parser),
+          withChildExecPath(exec, field as string | symbol),
+        ) === true;
+      });
+    },
     get initialState(): {
       readonly [K in keyof T]: T[K]["$stateType"][number] extends (infer U3)
         ? U3
@@ -7641,6 +7666,15 @@ export function tuple<
       readonly [K in keyof T]: T[K]["$stateType"][number] extends (infer U3)
         ? U3
         : never;
+    },
+    canSkip(state: TupleState, exec?: ExecutionContext) {
+      const stateArray = state as readonly unknown[];
+      return parsers.every((parser, index) =>
+        parser.canSkip?.(
+          getAnnotatedChildState(stateArray, stateArray[index], parser),
+          withChildExecPath(exec, index),
+        ) === true
+      );
     },
     parse(context: ParserContext<TupleState>) {
       return dispatchByMode(

--- a/packages/core/src/constructs.ts
+++ b/packages/core/src/constructs.ts
@@ -7128,10 +7128,11 @@ function createSeqState(
   index: number,
   states: readonly unknown[],
 ): SeqState {
-  return {
+  const seqState: SeqState = {
     index,
     states: annotateFreshArray(sourceState, states),
   };
+  return inheritAnnotations(sourceState, seqState) as SeqState;
 }
 
 function getSeqChildState(
@@ -7140,7 +7141,7 @@ function getSeqChildState(
   parser: Parser<Mode, unknown, unknown>,
 ): unknown {
   return getAnnotatedChildState(
-    seqState.states,
+    seqState,
     seqState.states[index],
     parser,
   );
@@ -7353,7 +7354,7 @@ function createSeqComplete(
     dispatchByMode(
       combinedMode,
       () => {
-        const stateArray = state.states as unknown[];
+        const stateArray = annotateFreshArray(state, state.states) as unknown[];
         const runtime = exec?.dependencyRuntime ??
           createDependencyRuntimeContext(exec?.dependencyRegistry);
         const childExec: ExecutionContext = {
@@ -7393,7 +7394,14 @@ function createSeqComplete(
             ? unwrapCompleteResult(preCompletedResult)
             : unwrapCompleteResult(
               elementParser.complete(
-                prepareStateForCompletion(resolvedArray[i], elementParser),
+                prepareStateForCompletion(
+                  getAnnotatedChildState(
+                    stateArray,
+                    resolvedArray[i],
+                    elementParser,
+                  ),
+                  elementParser,
+                ),
                 withChildExecPath(phase3Exec, i),
               ),
             );
@@ -7428,7 +7436,7 @@ function createSeqComplete(
         };
       },
       async () => {
-        const stateArray = state.states as unknown[];
+        const stateArray = annotateFreshArray(state, state.states) as unknown[];
         const runtime = exec?.dependencyRuntime ??
           createDependencyRuntimeContext(exec?.dependencyRegistry);
         const childExec: ExecutionContext = {
@@ -7468,7 +7476,14 @@ function createSeqComplete(
             ? unwrapCompleteResult(preCompletedResult)
             : unwrapCompleteResult(
               await elementParser.complete(
-                prepareStateForCompletion(resolvedArray[i], elementParser),
+                prepareStateForCompletion(
+                  getAnnotatedChildState(
+                    stateArray,
+                    resolvedArray[i],
+                    elementParser,
+                  ),
+                  elementParser,
+                ),
                 withChildExecPath(phase3Exec, i),
               ),
             );

--- a/packages/core/src/constructs.ts
+++ b/packages/core/src/constructs.ts
@@ -7052,6 +7052,7 @@ function shouldAdvanceSeqBeforeParse(
   }
   const token = currentContext.buffer[0];
   if (token === "--") return true;
+  if (currentContext.state.states[index] !== parser.initialState) return false;
   const laterLeadingCandidates = leadingCandidatesAfter(parsers, index + 1);
   return tokenMatchesLeadingName(token, laterLeadingCandidates);
 }
@@ -8897,10 +8898,7 @@ export function seq<
 
       if (!result.success) {
         if (result.consumed > 0) return result;
-        if (
-          currentContext.buffer.length < 1 &&
-          !parserCanSkipAt(parser, parserState, currentContext.exec, index)
-        ) {
+        if (!parserCanSkipAt(parser, parserState, currentContext.exec, index)) {
           return result;
         }
         currentContext = advanceSeqContext(currentContext, index + 1, false);
@@ -8975,10 +8973,7 @@ export function seq<
 
       if (!result.success) {
         if (result.consumed > 0) return result;
-        if (
-          currentContext.buffer.length < 1 &&
-          !parserCanSkipAt(parser, parserState, currentContext.exec, index)
-        ) {
+        if (!parserCanSkipAt(parser, parserState, currentContext.exec, index)) {
           return result;
         }
         currentContext = advanceSeqContext(currentContext, index + 1, false);

--- a/packages/core/src/constructs.ts
+++ b/packages/core/src/constructs.ts
@@ -9252,20 +9252,54 @@ export function seq<
             context,
             syncParsers,
           );
+          const runtime = createDependencyRuntimeContext(
+            advancedContext.dependencyRegistry?.clone(),
+          );
           const state = advancedContext.state;
+          const stateArray = state.states as unknown[];
+          const nodes = buildSuggestRuntimeNodesFromArray(
+            syncParsers,
+            stateArray,
+            advancedContext.exec?.path,
+          );
+          collectExplicitSourceValues(nodes, runtime);
+          fillMissingSourceDefaults(nodes, runtime);
+          collectSourcesFromState(stateArray, runtime);
+          completeDependencySourceDefaults(
+            {
+              ...advancedContext,
+              state: createAnnotatedArrayStateRecord(stateArray),
+            },
+            buildIndexedParserPairs(syncParsers),
+            runtime.registry,
+            advancedContext.exec,
+          );
+          const contextWithRegistry = {
+            ...advancedContext,
+            dependencyRegistry: runtime.registry,
+            ...(advancedContext.exec != null
+              ? {
+                exec: {
+                  ...advancedContext.exec,
+                  dependencyRuntime: runtime,
+                  dependencyRegistry: runtime.registry,
+                },
+              }
+              : {}),
+          };
           for (let i = state.index; i < syncParsers.length; i++) {
             const parser = syncParsers[i];
             const parserState = getSeqChildState(state, i, parser);
             suggestions.push(
               ...parser.suggest(
-                withChildContext(advancedContext, i, parserState, parser),
+                withChildContext(contextWithRegistry, i, parserState, parser),
                 prefix,
               ),
             );
             if (
               parser.canSkip?.(
                 parserState,
-                withChildExecPath(advancedContext.exec, i),
+                withChildExecPath(contextWithRegistry.exec, i),
               ) !== true
             ) {
               break;
@@ -9279,12 +9313,46 @@ export function seq<
             context,
             parsers,
           );
+          const runtime = createDependencyRuntimeContext(
+            advancedContext.dependencyRegistry?.clone(),
+          );
           const state = advancedContext.state;
+          const stateArray = state.states as unknown[];
+          const nodes = buildSuggestRuntimeNodesFromArray(
+            parsers,
+            stateArray,
+            advancedContext.exec?.path,
+          );
+          await collectExplicitSourceValuesAsync(nodes, runtime);
+          await fillMissingSourceDefaultsAsync(nodes, runtime);
+          collectSourcesFromState(stateArray, runtime);
+          await completeDependencySourceDefaultsAsync(
+            {
+              ...advancedContext,
+              state: createAnnotatedArrayStateRecord(stateArray),
+            },
+            buildIndexedParserPairs(parsers),
+            runtime.registry,
+            advancedContext.exec,
+          );
+          const contextWithRegistry = {
+            ...advancedContext,
+            dependencyRegistry: runtime.registry,
+            ...(advancedContext.exec != null
+              ? {
+                exec: {
+                  ...advancedContext.exec,
+                  dependencyRuntime: runtime,
+                  dependencyRegistry: runtime.registry,
+                },
+              }
+              : {}),
+          };
           for (let i = state.index; i < parsers.length; i++) {
             const parser = parsers[i];
             const parserState = getSeqChildState(state, i, parser);
             const parserSuggestions = parser.suggest(
-              withChildContext(advancedContext, i, parserState, parser),
+              withChildContext(contextWithRegistry, i, parserState, parser),
               prefix,
             );
             if (parser.mode === "async") {
@@ -9301,7 +9369,7 @@ export function seq<
             if (
               parser.canSkip?.(
                 parserState,
-                withChildExecPath(advancedContext.exec, i),
+                withChildExecPath(contextWithRegistry.exec, i),
               ) !== true
             ) {
               break;

--- a/packages/core/src/constructs.ts
+++ b/packages/core/src/constructs.ts
@@ -7191,6 +7191,7 @@ function updateSeqChildState(
 function shouldAdvanceSeqBeforeParse(
   parser: Parser<Mode, unknown, unknown>,
   parserState: unknown,
+  initialParserState: unknown,
   currentContext: ParserContext<SeqState>,
   index: number,
   parsers: readonly Parser<Mode, unknown, unknown>[],
@@ -7204,7 +7205,7 @@ function shouldAdvanceSeqBeforeParse(
     return false;
   }
   if (token === "--") return true;
-  if (currentContext.state.states[index] === parser.initialState) {
+  if (currentContext.state.states[index] === initialParserState) {
     const currentLeadingCandidates = sequenceLeadingCandidates([parser]);
     return !tokenMatchesLeadingName(token, currentLeadingCandidates);
   }
@@ -7269,6 +7270,7 @@ function updateSeqContextFromChildResult(
 function advanceSeqSuggestContextSync(
   context: ParserContext<SeqState>,
   parsers: readonly Parser<"sync", unknown, unknown>[],
+  initialStates: readonly unknown[],
 ): ParserContext<SeqState> {
   let currentContext = context;
   while (currentContext.state.index < parsers.length) {
@@ -7282,6 +7284,7 @@ function advanceSeqSuggestContextSync(
       shouldAdvanceSeqBeforeParse(
         parser,
         parserState,
+        initialStates[index],
         currentContext,
         index,
         parsers,
@@ -7322,6 +7325,7 @@ function advanceSeqSuggestContextSync(
 async function advanceSeqSuggestContextAsync(
   context: ParserContext<SeqState>,
   parsers: readonly Parser<Mode, unknown, unknown>[],
+  initialStates: readonly unknown[],
 ): Promise<ParserContext<SeqState>> {
   let currentContext = context;
   while (currentContext.state.index < parsers.length) {
@@ -7335,6 +7339,7 @@ async function advanceSeqSuggestContextAsync(
       shouldAdvanceSeqBeforeParse(
         parser,
         parserState,
+        initialStates[index],
         currentContext,
         index,
         parsers,
@@ -9060,6 +9065,7 @@ export function seq<
         shouldAdvanceSeqBeforeParse(
           parser,
           parserState,
+          initialState.states[index],
           currentContext,
           index,
           syncParsers,
@@ -9137,6 +9143,7 @@ export function seq<
         shouldAdvanceSeqBeforeParse(
           parser,
           parserState,
+          initialState.states[index],
           currentContext,
           index,
           parsers,
@@ -9422,6 +9429,7 @@ export function seq<
           const advancedContext = advanceSeqSuggestContextSync(
             context,
             syncParsers,
+            initialState.states,
           );
           const runtime = createDependencyRuntimeContext(
             advancedContext.dependencyRegistry?.clone(),
@@ -9483,6 +9491,7 @@ export function seq<
           const advancedContext = await advanceSeqSuggestContextAsync(
             context,
             parsers,
+            initialState.states,
           );
           const runtime = createDependencyRuntimeContext(
             advancedContext.dependencyRegistry?.clone(),

--- a/packages/core/src/constructs.ts
+++ b/packages/core/src/constructs.ts
@@ -698,6 +698,12 @@ function applyHiddenToUsageTerm(
       min: term.min,
     };
   }
+  if (term.type === "sequence") {
+    return {
+      type: "sequence",
+      terms: applyHiddenToUsage(term.terms, hidden),
+    };
+  }
   if (term.type === "exclusive") {
     return {
       type: "exclusive",
@@ -8864,6 +8870,8 @@ export function seq<
       const parser = syncParsers[index];
       const parserState = getSeqChildState(currentContext.state, index, parser);
 
+      if (currentContext.buffer.length < 1) break;
+
       if (
         shouldAdvanceSeqBeforeParse(
           parser,
@@ -8939,6 +8947,8 @@ export function seq<
       const index = currentContext.state.index;
       const parser = parsers[index];
       const parserState = getSeqChildState(currentContext.state, index, parser);
+
+      if (currentContext.buffer.length < 1) break;
 
       if (
         shouldAdvanceSeqBeforeParse(

--- a/packages/core/src/constructs.ts
+++ b/packages/core/src/constructs.ts
@@ -644,7 +644,6 @@ import {
   extractOptionNames,
   type HiddenVisibility,
   isDocHidden,
-  isSuggestionHidden,
   mergeHidden,
   type Usage,
   type UsageTerm,
@@ -6875,7 +6874,7 @@ function collectLeadingJoinedOptionNames(
 ): boolean {
   for (const term of terms) {
     if (term.type === "option") {
-      if (!isSuggestionHidden(term.hidden) && term.metavar != null) {
+      if (term.metavar != null) {
         for (const name of term.names) optionNames.add(name);
       }
       return false;

--- a/packages/core/src/constructs.ts
+++ b/packages/core/src/constructs.ts
@@ -9886,9 +9886,9 @@ export function merge(
   type MergeParseResult = ParserResult<MergeState>;
 
   // Helper function to extract the appropriate state for a parser
-  const extractParserState = (
+  const extractParserStateFromState = (
     parser: Parser<Mode, MergeState, MergeState>,
-    context: ParserContext<MergeState>,
+    state: MergeState,
     index: number,
   ): unknown => {
     if (parser.initialState === undefined) {
@@ -9896,10 +9896,10 @@ export function merge(
       // check if they have accumulated state during parsing
       const key = parserStateKey(index);
       if (
-        context.state && typeof context.state === "object" &&
-        key in context.state
+        state && typeof state === "object" &&
+        key in state
       ) {
-        return context.state[key];
+        return state[key];
       }
       return undefined;
     } else if (
@@ -9908,17 +9908,17 @@ export function merge(
       const localStateKey = localObjectStateKey(index);
       if (
         shouldPreserveLocalChildState(parser) &&
-        context.state && typeof context.state === "object" &&
-        localStateKey in context.state
+        state && typeof state === "object" &&
+        localStateKey in state
       ) {
-        return context.state[localStateKey];
+        return state[localStateKey];
       }
       // For object parsers, extract matching fields from context state
-      if (context.state && typeof context.state === "object") {
+      if (state && typeof state === "object") {
         const extractedState: MergeState = {};
         for (const field in parser.initialState) {
-          extractedState[field] = field in context.state
-            ? context.state[field]
+          extractedState[field] = field in state
+            ? state[field]
             : parser.initialState[field];
         }
         return extractedState;
@@ -9927,6 +9927,11 @@ export function merge(
     }
     return parser.initialState;
   };
+  const extractParserState = (
+    parser: Parser<Mode, MergeState, MergeState>,
+    context: ParserContext<MergeState>,
+    index: number,
+  ): unknown => extractParserStateFromState(parser, context.state, index);
 
   // Helper function to merge result state into context state
   const mergeResultState = (
@@ -10156,6 +10161,15 @@ export function merge(
     leadingNames: sharedBufferLeadingNames(parsers),
     acceptingAnyToken: parsers.some((p) => p.acceptingAnyToken),
     initialState,
+    canSkip(state: MergeState, exec?: ExecutionContext) {
+      return parsers.every((parser, index) => {
+        const parserState = extractParserStateFromState(parser, state, index);
+        return parser.canSkip?.(
+          getAnnotatedChildState(state, parserState as MergeState, parser),
+          withChildExecPath(exec, index),
+        ) === true;
+      });
+    },
     parse(context: ParserContext<MergeState>) {
       if (isAsync) {
         return parseAsync(context);
@@ -12246,6 +12260,15 @@ export function concat(
     leadingNames: sharedBufferLeadingNames(parsers),
     acceptingAnyToken: parsers.some((p) => p.acceptingAnyToken),
     initialState,
+    canSkip(state, exec?: ExecutionContext) {
+      const stateArray = state as readonly unknown[];
+      return parsers.every((parser, index) =>
+        parser.canSkip?.(
+          getAnnotatedChildState(stateArray, stateArray[index], parser),
+          withChildExecPath(exec, index),
+        ) === true
+      );
+    },
     parse(context) {
       if (isAsync) {
         return parseAsync(context);

--- a/packages/core/src/constructs.ts
+++ b/packages/core/src/constructs.ts
@@ -6828,7 +6828,7 @@ interface SeqLeadingCandidates {
 
 function isParserLike(value: unknown): value is Parser<Mode, unknown, unknown> {
   return value != null &&
-    typeof value === "object" &&
+    (typeof value === "object" || typeof value === "function") &&
     "parse" in value &&
     "$valueType" in value &&
     "$stateType" in value;
@@ -6984,7 +6984,7 @@ function checkSequentialDuplicateOptionNames(
   for (let i = 0; i < parsers.length; i++) {
     const parser = parsers[i];
     const optionNames = new Set<string>();
-    collectLeadingCandidates(parser.usage, optionNames, new Set());
+    collectLeadingCandidates(parser.usage, optionNames, new Set(), true);
     for (const name of optionNames) {
       const sources = active.get(name);
       if (sources != null) {

--- a/packages/core/src/constructs.ts
+++ b/packages/core/src/constructs.ts
@@ -7042,13 +7042,11 @@ function collectRetainedLeadingCandidatesInto(
     }
 
     if (term.type === "multiple") {
-      if (term.min === 0) {
-        collectLeadingOptionCandidates(
-          term.terms,
-          optionNames,
-          joinedOptionNames,
-        );
-      }
+      collectLeadingOptionCandidates(
+        term.terms,
+        optionNames,
+        joinedOptionNames,
+      );
       collectRetainedLeadingCandidatesInto(
         term.terms,
         optionNames,

--- a/packages/core/src/doc.ts
+++ b/packages/core/src/doc.ts
@@ -1106,6 +1106,9 @@ function maxVisibleAtomicWidth(usage: Usage): number {
           max = Math.max(max, maxVisibleAtomicWidth(branch));
         }
         break;
+      case "sequence":
+        max = Math.max(max, maxVisibleAtomicWidth(term.terms));
+        break;
       case "literal":
         if (term.value !== "") {
           max = Math.max(max, getDisplayWidth(term.value));

--- a/packages/core/src/facade.ts
+++ b/packages/core/src/facade.ts
@@ -2006,6 +2006,7 @@ function collectRootOptionNamesFromTerm(
       return;
     case "optional":
     case "multiple":
+    case "sequence":
       collectRootOptionNames(term.terms, names, rootLeadingNames);
       return;
     case "exclusive":
@@ -2064,7 +2065,10 @@ function collectActiveOptionNames(
           includeDirectAfterCommandOptions,
         );
       }
-    } else if (term.type === "optional" || term.type === "multiple") {
+    } else if (
+      term.type === "optional" || term.type === "multiple" ||
+      term.type === "sequence"
+    ) {
       collectActiveOptionNames(
         term.terms,
         commandPath,
@@ -2121,6 +2125,7 @@ function collectOptionNamesAtCurrentCommandDepthFromTerm(
       return false;
     case "optional":
     case "multiple":
+    case "sequence":
       collectOptionNamesAtCurrentCommandDepth(
         term.terms,
         names,

--- a/packages/core/src/internal/parser.ts
+++ b/packages/core/src/internal/parser.ts
@@ -1875,13 +1875,17 @@ function buildDocPage(
     let term = usage[i];
     const canSearchCommand = commandArgIndices == null ||
       commandArgIndices.has(argIndex);
-    const found = canSearchCommand
-      ? findCommandInCurrentUsageTerm(
-        term,
-        arg,
-        usage.slice(i + 1),
-      )
-      : null;
+    let found: Usage | null = null;
+    if (canSearchCommand) {
+      for (let searchIndex = i; searchIndex < usage.length; searchIndex++) {
+        found = findCommandInCurrentUsageTerm(
+          usage[searchIndex],
+          arg,
+          usage.slice(searchIndex + 1),
+        );
+        if (found != null) break;
+      }
+    }
     if (found) {
       usage.splice(i, usage.length - i, ...found);
       term = usage[i];

--- a/packages/core/src/internal/parser.ts
+++ b/packages/core/src/internal/parser.ts
@@ -1819,6 +1819,10 @@ function buildDocPage(
     );
   };
   let i = 0;
+  const consumedArgsCount = Math.max(
+    0,
+    effectiveArgs.length - context.buffer.length,
+  );
   for (let argIndex = 0; argIndex < effectiveArgs.length; argIndex++) {
     const arg = effectiveArgs[argIndex];
     if (i >= usage.length) break;
@@ -1838,7 +1842,13 @@ function buildDocPage(
       argIndex === effectiveArgs.length - 1,
       i,
     );
-    i++;
+    if (
+      found != null ||
+      term.type !== "sequence" ||
+      argIndex >= consumedArgsCount
+    ) {
+      i++;
+    }
   }
   // When no args navigate into a command, apply usageLine for the first
   // bare command term (not inside an exclusive) so the page's own usage

--- a/packages/core/src/internal/parser.ts
+++ b/packages/core/src/internal/parser.ts
@@ -1429,21 +1429,68 @@ function findCommandInExclusive(
 
   for (const termGroup of term.terms) {
     const firstTerm = termGroup[0];
+    if (firstTerm == null) continue;
+    const found = findCommandInCurrentUsageTerm(
+      firstTerm,
+      commandName,
+      termGroup.slice(1),
+    );
+    if (found) return found;
+  }
 
-    // Direct match: first term is the command we're looking for
-    if (firstTerm?.type === "command" && firstTerm.name === commandName) {
-      return termGroup;
-    }
+  return null;
+}
 
-    // Recursive case: first term is another exclusive (nested structure)
-    if (firstTerm?.type === "exclusive") {
-      const found = findCommandInExclusive(firstTerm, commandName);
-      if (found) {
-        // Replace the nested exclusive with the found terms,
-        // then append the rest of termGroup (e.g., global options)
-        return [...found, ...termGroup.slice(1)];
-      }
-    }
+/**
+ * Searches for a command inside an ordered usage sequence and returns the
+ * usage from the matched command onward.  This lets contextual command
+ * documentation enter sequence terms while dropping sequence prefixes that
+ * were skipped by parsing, such as optional positionals before a subcommand.
+ *
+ * @param usage The usage terms to search.
+ * @param commandName The command name to find.
+ * @returns The contextual usage terms if found, null otherwise.
+ */
+function findCommandInUsageSequence(
+  usage: Usage,
+  commandName: string,
+): Usage | null {
+  for (let index = 0; index < usage.length; index++) {
+    const found = findCommandInCurrentUsageTerm(
+      usage[index],
+      commandName,
+      usage.slice(index + 1),
+    );
+    if (found) return found;
+  }
+
+  return null;
+}
+
+/**
+ * Searches the current usage term for a command and appends the trailing
+ * usage terms that remain valid after that current term.
+ *
+ * @param term The current usage term to search.
+ * @param commandName The command name to find.
+ * @param trailingUsage Usage terms that follow the current term.
+ * @returns The contextual usage terms if found, null otherwise.
+ */
+function findCommandInCurrentUsageTerm(
+  term: UsageTerm,
+  commandName: string,
+  trailingUsage: Usage,
+): Usage | null {
+  if (term.type === "command" && term.name === commandName) {
+    return [term, ...trailingUsage];
+  }
+
+  if (term.type === "exclusive") {
+    const found = findCommandInExclusive(term, commandName);
+    if (found) return [...found, ...trailingUsage];
+  } else if (term.type === "sequence") {
+    const found = findCommandInUsageSequence(term.terms, commandName);
+    if (found) return [...found, ...trailingUsage];
   }
 
   return null;
@@ -1776,12 +1823,14 @@ function buildDocPage(
     const arg = effectiveArgs[argIndex];
     if (i >= usage.length) break;
     let term = usage[i];
-    if (term.type === "exclusive") {
-      const found = findCommandInExclusive(term, arg);
-      if (found) {
-        usage.splice(i, 1, ...found);
-        term = usage[i];
-      }
+    const found = findCommandInCurrentUsageTerm(
+      term,
+      arg,
+      usage.slice(i + 1),
+    );
+    if (found) {
+      usage.splice(i, usage.length - i, ...found);
+      term = usage[i];
     }
     maybeApplyCommandUsageLine(
       term,

--- a/packages/core/src/internal/parser.ts
+++ b/packages/core/src/internal/parser.ts
@@ -1509,6 +1509,7 @@ function recordMatchedCommandArgIndices(
 
   let searchEnd = consumed.length;
   for (let index = next.length - 1; index >= previousLength; index--) {
+    if (searchEnd <= 0) break;
     const commandName = next[index];
     const localIndex = consumed.lastIndexOf(commandName, searchEnd - 1);
     if (localIndex < 0) continue;

--- a/packages/core/src/internal/parser.ts
+++ b/packages/core/src/internal/parser.ts
@@ -187,6 +187,21 @@ export interface Parser<
   readonly acceptingAnyToken: boolean;
 
   /**
+   * Returns whether this parser can be skipped at the current state without
+   * consuming more CLI input or evaluating completion-time defaults.
+   *
+   * Sequential combinators use this as a lightweight boundary predicate.  It
+   * must be synchronous and side-effect free.  Custom parsers that omit this
+   * method are treated as not skippable.
+   *
+   * @param state The current parser state.
+   * @param exec Optional shared execution context.
+   * @returns `true` when parsing may advance past this parser.
+   * @since 1.1.0
+   */
+  canSkip?(state: TState, exec?: ExecutionContext): boolean;
+
+  /**
    * The initial state for this parser.  This is used to initialize the
    * state when parsing starts.
    */

--- a/packages/core/src/internal/parser.ts
+++ b/packages/core/src/internal/parser.ts
@@ -1496,6 +1496,27 @@ function findCommandInCurrentUsageTerm(
   return null;
 }
 
+function recordMatchedCommandArgIndices(
+  consumed: readonly string[],
+  previousCommandPath: readonly string[] | undefined,
+  nextCommandPath: readonly string[] | undefined,
+  consumedOffset: number,
+  indices: Set<number>,
+): void {
+  const previousLength = previousCommandPath?.length ?? 0;
+  const next = nextCommandPath ?? [];
+  if (next.length <= previousLength || consumed.length < 1) return;
+
+  let searchEnd = consumed.length;
+  for (let index = next.length - 1; index >= previousLength; index--) {
+    const commandName = next[index];
+    const localIndex = consumed.lastIndexOf(commandName, searchEnd - 1);
+    if (localIndex < 0) continue;
+    indices.add(consumedOffset + localIndex);
+    searchEnd = localIndex;
+  }
+}
+
 /**
  * Generates a documentation page for a synchronous parser.
  *
@@ -1670,14 +1691,25 @@ function getDocPageSyncImpl(
     { buffer: args, state: initialState, optionsTerminated: false },
     exec,
   );
+  const matchedCommandArgIndices = new Set<number>();
+  let consumedArgCount = 0;
   while (context.buffer.length > 0) {
     const result = parser.parse(context);
     if (!result.success) break;
+    const previousCommandPath = context.exec?.commandPath;
     const previousBuffer = context.buffer;
     context = result.next;
+    recordMatchedCommandArgIndices(
+      result.consumed,
+      previousCommandPath,
+      context.exec?.commandPath,
+      consumedArgCount,
+      matchedCommandArgIndices,
+    );
+    consumedArgCount += result.consumed.length;
     if (isBufferUnchanged(previousBuffer, context.buffer)) break;
   }
-  return buildDocPage(parser, context, args);
+  return buildDocPage(parser, context, args, matchedCommandArgIndices);
 }
 
 /**
@@ -1699,14 +1731,25 @@ async function getDocPageAsyncImpl(
     { buffer: args, state: initialState, optionsTerminated: false },
     exec,
   );
+  const matchedCommandArgIndices = new Set<number>();
+  let consumedArgCount = 0;
   while (context.buffer.length > 0) {
     const result = await parser.parse(context);
     if (!result.success) break;
+    const previousCommandPath = context.exec?.commandPath;
     const previousBuffer = context.buffer;
     context = result.next;
+    recordMatchedCommandArgIndices(
+      result.consumed,
+      previousCommandPath,
+      context.exec?.commandPath,
+      consumedArgCount,
+      matchedCommandArgIndices,
+    );
+    consumedArgCount += result.consumed.length;
     if (isBufferUnchanged(previousBuffer, context.buffer)) break;
   }
-  return buildDocPage(parser, context, args);
+  return buildDocPage(parser, context, args, matchedCommandArgIndices);
 }
 
 /**
@@ -1717,6 +1760,7 @@ function buildDocPage(
   parser: Parser<Mode, unknown, unknown>,
   context: ParserContext<unknown>,
   args: readonly string[],
+  matchedCommandArgIndices?: ReadonlySet<number>,
 ): DocPage | undefined {
   let effectiveArgs: readonly string[] = args;
   let { brief, description, fragments, footer } = parser.getDocFragments(
@@ -1823,15 +1867,20 @@ function buildDocPage(
     0,
     effectiveArgs.length - context.buffer.length,
   );
+  const commandArgIndices = args.length > 0 ? matchedCommandArgIndices : null;
   for (let argIndex = 0; argIndex < effectiveArgs.length; argIndex++) {
     const arg = effectiveArgs[argIndex];
     if (i >= usage.length) break;
     let term = usage[i];
-    const found = findCommandInCurrentUsageTerm(
-      term,
-      arg,
-      usage.slice(i + 1),
-    );
+    const canSearchCommand = commandArgIndices == null ||
+      commandArgIndices.has(argIndex);
+    const found = canSearchCommand
+      ? findCommandInCurrentUsageTerm(
+        term,
+        arg,
+        usage.slice(i + 1),
+      )
+      : null;
     if (found) {
       usage.splice(i, usage.length - i, ...found);
       term = usage[i];

--- a/packages/core/src/internal/parser.ts
+++ b/packages/core/src/internal/parser.ts
@@ -1693,21 +1693,20 @@ function getDocPageSyncImpl(
     exec,
   );
   const matchedCommandArgIndices = new Set<number>();
-  let consumedArgCount = 0;
   while (context.buffer.length > 0) {
     const result = parser.parse(context);
     if (!result.success) break;
     const previousCommandPath = context.exec?.commandPath;
     const previousBuffer = context.buffer;
     context = result.next;
+    const consumedCount = previousBuffer.length - context.buffer.length;
     recordMatchedCommandArgIndices(
-      result.consumed,
+      previousBuffer.slice(0, consumedCount),
       previousCommandPath,
       context.exec?.commandPath,
-      consumedArgCount,
+      args.length - previousBuffer.length,
       matchedCommandArgIndices,
     );
-    consumedArgCount += result.consumed.length;
     if (isBufferUnchanged(previousBuffer, context.buffer)) break;
   }
   return buildDocPage(parser, context, args, matchedCommandArgIndices);
@@ -1733,21 +1732,20 @@ async function getDocPageAsyncImpl(
     exec,
   );
   const matchedCommandArgIndices = new Set<number>();
-  let consumedArgCount = 0;
   while (context.buffer.length > 0) {
     const result = await parser.parse(context);
     if (!result.success) break;
     const previousCommandPath = context.exec?.commandPath;
     const previousBuffer = context.buffer;
     context = result.next;
+    const consumedCount = previousBuffer.length - context.buffer.length;
     recordMatchedCommandArgIndices(
-      result.consumed,
+      previousBuffer.slice(0, consumedCount),
       previousCommandPath,
       context.exec?.commandPath,
-      consumedArgCount,
+      args.length - previousBuffer.length,
       matchedCommandArgIndices,
     );
-    consumedArgCount += result.consumed.length;
     if (isBufferUnchanged(previousBuffer, context.buffer)) break;
   }
   return buildDocPage(parser, context, args, matchedCommandArgIndices);
@@ -1875,16 +1873,15 @@ function buildDocPage(
     let term = usage[i];
     const canSearchCommand = commandArgIndices == null ||
       commandArgIndices.has(argIndex);
+    if (!canSearchCommand) continue;
     let found: Usage | null = null;
-    if (canSearchCommand) {
-      for (let searchIndex = i; searchIndex < usage.length; searchIndex++) {
-        found = findCommandInCurrentUsageTerm(
-          usage[searchIndex],
-          arg,
-          usage.slice(searchIndex + 1),
-        );
-        if (found != null) break;
-      }
+    for (let searchIndex = i; searchIndex < usage.length; searchIndex++) {
+      found = findCommandInCurrentUsageTerm(
+        usage[searchIndex],
+        arg,
+        usage.slice(searchIndex + 1),
+      );
+      if (found != null) break;
     }
     if (found) {
       usage.splice(i, usage.length - i, ...found);

--- a/packages/core/src/modifiers.test.ts
+++ b/packages/core/src/modifiers.test.ts
@@ -2619,6 +2619,38 @@ describe("multiple", () => {
     }
   });
 
+  it("should extend matched command items with optional arguments", () => {
+    const parser = multiple(command(
+      "add",
+      object({
+        x: optional(option("--x")),
+      }),
+    ));
+
+    const result = parse(parser, ["add", "--x"]);
+
+    assert.ok(result.success);
+    if (result.success) {
+      assert.deepEqual(result.value, [{ x: true }]);
+    }
+  });
+
+  it("should extend async matched command items with optional arguments", async () => {
+    const parser = multiple(command(
+      "add",
+      object({
+        x: optional(option("--x", asyncChoice(["yes"] as const))),
+      }),
+    ));
+
+    const result = await parseAsync(parser, ["add", "--x", "yes"]);
+
+    assert.ok(result.success);
+    if (result.success) {
+      assert.deepEqual(result.value, [{ x: "yes" }]);
+    }
+  });
+
   it("should preserve annotations on each item state in complete()", () => {
     const annotation = Symbol.for("@test/multiple-item-annotations");
     const baseParser: Parser<"sync", string, { value: string }> = {

--- a/packages/core/src/modifiers.ts
+++ b/packages/core/src/modifiers.ts
@@ -714,6 +714,9 @@ export function optional<M extends Mode, TValue, TState>(
     // parser's catch-all status does not apply to the wrapper.
     acceptingAnyToken: false,
     initialState: undefined,
+    canSkip() {
+      return true;
+    },
     // Forward completion deferral hook from inner parser, adapting the
     // outer state shape ([TState] | undefined) to the inner TState.
     ...(typeof parser.shouldDeferCompletion === "function"
@@ -1132,6 +1135,9 @@ export function withDefault<
     // parser's catch-all status does not apply to the wrapper.
     acceptingAnyToken: false,
     initialState: undefined,
+    canSkip() {
+      return true;
+    },
     // Forward completion deferral hook from inner parser, adapting the
     // outer state shape ([TState] | undefined) to the inner TState.
     ...(typeof parser.shouldDeferCompletion === "function"
@@ -2275,6 +2281,12 @@ export function multiple<M extends Mode, TValue, TState>(
     // catch-all status when at least one match is required.
     acceptingAnyToken: min > 0 && (parser.acceptingAnyToken ?? false),
     initialState: [] as readonly TState[],
+    canSkip(state: MultipleState) {
+      if (state.length < min) return false;
+      const currentItemState = state.at(-1);
+      return currentItemState == null ||
+        isTerminalMultipleItemState(currentItemState);
+    },
     getSuggestRuntimeNodes(state: MultipleState, path: readonly PropertyKey[]) {
       const innerNodes = state.flatMap((item, i) => [
         ...getInnerSuggestRuntimeNodes(item as TState, [...path, i]),
@@ -2996,6 +3008,9 @@ export function nonEmpty<M extends Mode, T, TState>(
     leadingNames: parser.leadingNames,
     acceptingAnyToken: parser.acceptingAnyToken,
     initialState: parser.initialState,
+    ...(typeof parser.canSkip === "function"
+      ? { canSkip: parser.canSkip.bind(parser) }
+      : {}),
     // Forward shouldDeferCompletion from inner parser so that prompt()
     // can defer through nonEmpty() wrappers.
     ...(typeof parser.shouldDeferCompletion === "function"

--- a/packages/core/src/modifiers.ts
+++ b/packages/core/src/modifiers.ts
@@ -2987,6 +2987,7 @@ export function nonEmpty<M extends Mode, T, TState>(
   parser: Parser<M, T, TState>,
 ): Parser<M, T, TState> {
   const syncParser = parser as Parser<"sync", T, TState>;
+  const initialState = parser.initialState;
 
   // Helper to process the result of the inner parser
   const processNonEmptyResult = (
@@ -3030,12 +3031,12 @@ export function nonEmpty<M extends Mode, T, TState>(
     usage: parser.usage,
     leadingNames: parser.leadingNames,
     acceptingAnyToken: parser.acceptingAnyToken,
-    initialState: parser.initialState,
+    initialState,
     ...(typeof parser.canSkip === "function"
       ? {
         canSkip(state: TState, exec?: ExecutionContext) {
           const unwrappedState = unwrapInjectedAnnotationWrapper(state);
-          if (unwrappedState === parser.initialState) return false;
+          if (unwrappedState === initialState) return false;
           return parser.canSkip?.(state, exec) === true;
         },
       }

--- a/packages/core/src/modifiers.ts
+++ b/packages/core/src/modifiers.ts
@@ -57,6 +57,20 @@ function isTerminalMultipleItemState(state: unknown): boolean {
     typeof (unwrapped as { success?: unknown }).success === "boolean";
 }
 
+function isMatchedCommandParserState(
+  parser: Parser<Mode, unknown, unknown>,
+  state: unknown,
+): boolean {
+  if (Reflect.get(parser, Symbol.for("@optique/core/commandParser")) !== true) {
+    return false;
+  }
+  const unwrapped = unwrapMultipleItemState(state).value;
+  return Array.isArray(unwrapped) &&
+    unwrapped.length === 2 &&
+    unwrapped[0] === "matched" &&
+    typeof unwrapped[1] === "string";
+}
+
 function isUnstartedMultipleItemState(
   state: unknown,
   originalState?: unknown,
@@ -1950,7 +1964,10 @@ export function multiple<M extends Mode, TValue, TState>(
   ): state is TState =>
     state != null &&
     !isTerminalMultipleItemState(state) &&
-    parser.canSkip?.(state, withChildExecPath(exec, itemIndex)) !== true;
+    (
+      isMatchedCommandParserState(parser, state) ||
+      parser.canSkip?.(state, withChildExecPath(exec, itemIndex)) !== true
+    );
 
   // Sync parse implementation
   const parseSync = (

--- a/packages/core/src/modifiers.ts
+++ b/packages/core/src/modifiers.ts
@@ -1943,14 +1943,26 @@ export function multiple<M extends Mode, TValue, TState>(
       (parser.dependencyMetadata?.source != null
         ? [{ path, parser, state }]
         : []);
+  const canExtendMultipleItem = (
+    state: TState | undefined,
+    itemIndex: number,
+    exec: ExecutionContext | undefined,
+  ): state is TState =>
+    state != null &&
+    !isTerminalMultipleItemState(state) &&
+    parser.canSkip?.(state, withChildExecPath(exec, itemIndex)) !== true;
 
   // Sync parse implementation
   const parseSync = (
     context: ParserContext<MultipleState>,
   ): ParseResult => {
     const currentItemState = context.state.at(-1);
-    const canExtendCurrent = currentItemState != null &&
-      !isTerminalMultipleItemState(currentItemState);
+    const currentItemIndex = context.state.length - 1;
+    const canExtendCurrent = canExtendMultipleItem(
+      currentItemState as TState | undefined,
+      currentItemIndex,
+      context.exec,
+    );
     const canOpenFreshItem = context.state.length < max;
     if (!canExtendCurrent && !canOpenFreshItem) {
       return {
@@ -2112,8 +2124,12 @@ export function multiple<M extends Mode, TValue, TState>(
     context: ParserContext<MultipleState>,
   ): Promise<ParseResult> => {
     const currentItemState = context.state.at(-1);
-    const canExtendCurrent = currentItemState != null &&
-      !isTerminalMultipleItemState(currentItemState);
+    const currentItemIndex = context.state.length - 1;
+    const canExtendCurrent = canExtendMultipleItem(
+      currentItemState as TState | undefined,
+      currentItemIndex,
+      context.exec,
+    );
     const canOpenFreshItem = context.state.length < max;
     if (!canExtendCurrent && !canOpenFreshItem) {
       return {
@@ -2281,11 +2297,14 @@ export function multiple<M extends Mode, TValue, TState>(
     // catch-all status when at least one match is required.
     acceptingAnyToken: min > 0 && (parser.acceptingAnyToken ?? false),
     initialState: [] as readonly TState[],
-    canSkip(state: MultipleState) {
+    canSkip(state: MultipleState, exec?: ExecutionContext) {
       if (state.length < min) return false;
       const currentItemState = state.at(-1);
-      return currentItemState == null ||
-        isTerminalMultipleItemState(currentItemState);
+      return !canExtendMultipleItem(
+        currentItemState as TState | undefined,
+        state.length - 1,
+        exec,
+      );
     },
     getSuggestRuntimeNodes(state: MultipleState, path: readonly PropertyKey[]) {
       const innerNodes = state.flatMap((item, i) => [
@@ -2457,8 +2476,12 @@ export function multiple<M extends Mode, TValue, TState>(
       // Extract already-selected values from completed states to exclude them
       // from suggestions (fixes https://github.com/dahlia/optique/issues/73)
       const currentItemState = context.state.at(-1);
-      const canExtendCurrent = currentItemState != null &&
-        !isTerminalMultipleItemState(currentItemState);
+      const currentItemIndex = context.state.length - 1;
+      const canExtendCurrent = canExtendMultipleItem(
+        currentItemState as TState | undefined,
+        currentItemIndex,
+        context.exec,
+      );
       const canOpenNew = context.state.length < max;
       if (!canExtendCurrent && !canOpenNew) {
         return dispatchIterableByMode(
@@ -2611,7 +2634,7 @@ export function multiple<M extends Mode, TValue, TState>(
                 withChildContext(
                   context,
                   itemIndex,
-                  suggestInitialState,
+                  suggestInitialState as TState,
                 ),
                 prefix,
               ) as AsyncIterable<Suggestion>,

--- a/packages/core/src/modifiers.ts
+++ b/packages/core/src/modifiers.ts
@@ -728,8 +728,14 @@ export function optional<M extends Mode, TValue, TState>(
     // parser's catch-all status does not apply to the wrapper.
     acceptingAnyToken: false,
     initialState: undefined,
-    canSkip() {
-      return true;
+    canSkip(state: [TState] | undefined, exec?: ExecutionContext) {
+      if (!Array.isArray(state)) return true;
+      const innerState = normalizeOptionalLikeInnerState(
+        state,
+        parser.initialState,
+        parser,
+      );
+      return parser.canSkip?.(innerState, exec) === true;
     },
     // Forward completion deferral hook from inner parser, adapting the
     // outer state shape ([TState] | undefined) to the inner TState.
@@ -1149,8 +1155,14 @@ export function withDefault<
     // parser's catch-all status does not apply to the wrapper.
     acceptingAnyToken: false,
     initialState: undefined,
-    canSkip() {
-      return true;
+    canSkip(state: [TState] | undefined, exec?: ExecutionContext) {
+      if (!Array.isArray(state)) return true;
+      const innerState = normalizeOptionalLikeInnerState(
+        state,
+        parser.initialState,
+        parser,
+      );
+      return parser.canSkip?.(innerState, exec) === true;
     },
     // Forward completion deferral hook from inner parser, adapting the
     // outer state shape ([TState] | undefined) to the inner TState.

--- a/packages/core/src/modifiers.ts
+++ b/packages/core/src/modifiers.ts
@@ -3009,7 +3009,13 @@ export function nonEmpty<M extends Mode, T, TState>(
     acceptingAnyToken: parser.acceptingAnyToken,
     initialState: parser.initialState,
     ...(typeof parser.canSkip === "function"
-      ? { canSkip: parser.canSkip.bind(parser) }
+      ? {
+        canSkip(state: TState, exec?: ExecutionContext) {
+          const unwrappedState = unwrapInjectedAnnotationWrapper(state);
+          if (unwrappedState === parser.initialState) return false;
+          return parser.canSkip?.(state, exec) === true;
+        },
+      }
       : {}),
     // Forward shouldDeferCompletion from inner parser so that prompt()
     // can defer through nonEmpty() wrappers.

--- a/packages/core/src/modifiers.ts
+++ b/packages/core/src/modifiers.ts
@@ -3054,7 +3054,7 @@ export function nonEmpty<M extends Mode, T, TState>(
         canSkip(state: TState, exec?: ExecutionContext) {
           const unwrappedState = unwrapInjectedAnnotationWrapper(state);
           if (unwrappedState === initialState) return false;
-          return parser.canSkip?.(state, exec) === true;
+          return parser.canSkip?.(unwrappedState, exec) === true;
         },
       }
       : {}),

--- a/packages/core/src/parser.test.ts
+++ b/packages/core/src/parser.test.ts
@@ -2111,6 +2111,72 @@ describe("getDocPage", () => {
     );
   });
 
+  it("should not enter seq command docs for positional command names", () => {
+    const parser = seq(
+      argument(string({ metavar: "PROFILE" })),
+      command("deploy", object({ force: option("--force") }), {
+        usageLine: [{ type: "literal", value: "deployment-usage" }],
+      }),
+    );
+
+    const docPage = getDocPage(parser, ["deploy"]);
+
+    assert.ok(docPage);
+    assert.ok(docPage.usage);
+    assert.equal(
+      formatUsage("tool", docPage.usage),
+      "tool PROFILE deploy [--force]",
+    );
+    const allEntries = docPage.sections.flatMap((s) => s.entries);
+    assert.ok(
+      !allEntries.some((e) =>
+        e.term.type === "option" && e.term.names.includes("--force")
+      ),
+    );
+  });
+
+  it("should not enter async seq command docs for positional command names", async () => {
+    const parser = seq(
+      argument(string({ metavar: "PROFILE" })),
+      command("deploy", object({ force: option("--force") }), {
+        usageLine: [{ type: "literal", value: "deployment-usage" }],
+      }),
+    );
+
+    const docPage = await getDocPageAsync(parser, ["deploy"]);
+
+    assert.ok(docPage);
+    assert.ok(docPage.usage);
+    assert.equal(
+      formatUsage("tool", docPage.usage),
+      "tool PROFILE deploy [--force]",
+    );
+    const allEntries = docPage.sections.flatMap((s) => s.entries);
+    assert.ok(
+      !allEntries.some((e) =>
+        e.term.type === "option" && e.term.names.includes("--force")
+      ),
+    );
+  });
+
+  it("should enter seq command docs after repeated positional names", () => {
+    const parser = seq(
+      argument(string({ metavar: "PROFILE" })),
+      command("deploy", object({ force: option("--force") }), {
+        usageLine: [{ type: "literal", value: "deployment-usage" }],
+      }),
+    );
+
+    const docPage = getDocPage(parser, ["deploy", "deploy"]);
+
+    assert.ok(docPage);
+    assert.ok(docPage.usage);
+    assert.equal(
+      formatUsage("tool", docPage.usage),
+      "tool deploy deployment-usage",
+    );
+  });
+
   it("should handle exclusive (or) parsers correctly", () => {
     const parser = or(
       option("-v", "--verbose"),

--- a/packages/core/src/parser.test.ts
+++ b/packages/core/src/parser.test.ts
@@ -2177,6 +2177,62 @@ describe("getDocPage", () => {
     );
   });
 
+  it("should use actual buffer advancement for replayed command docs", () => {
+    const parser = or(
+      object({
+        shared: option("--shared", string()),
+        alpha: command("alpha", object({ a: option("--a") }), {
+          usageLine: [{ type: "literal", value: "alpha-usage" }],
+        }),
+      }),
+      object({
+        shared: option("--shared", string()),
+        deploy: command("deploy", object({ force: option("--force") }), {
+          usageLine: [{ type: "literal", value: "deployment-usage" }],
+        }),
+      }),
+    );
+
+    const docPage = getDocPage(parser, ["--shared", "value", "deploy"]);
+
+    assert.ok(docPage);
+    assert.ok(docPage.usage);
+    assert.equal(
+      formatUsage("tool", docPage.usage),
+      "tool deploy deployment-usage",
+    );
+  });
+
+  it("should use actual buffer advancement for async replayed command docs", async () => {
+    const parser = or(
+      object({
+        shared: option("--shared", string()),
+        alpha: command("alpha", object({ a: option("--a") }), {
+          usageLine: [{ type: "literal", value: "alpha-usage" }],
+        }),
+      }),
+      object({
+        shared: option("--shared", string()),
+        deploy: command("deploy", object({ force: option("--force") }), {
+          usageLine: [{ type: "literal", value: "deployment-usage" }],
+        }),
+      }),
+    );
+
+    const docPage = await getDocPageAsync(parser, [
+      "--shared",
+      "value",
+      "deploy",
+    ]);
+
+    assert.ok(docPage);
+    assert.ok(docPage.usage);
+    assert.equal(
+      formatUsage("tool", docPage.usage),
+      "tool deploy deployment-usage",
+    );
+  });
+
   it("should handle exclusive (or) parsers correctly", () => {
     const parser = or(
       option("-v", "--verbose"),

--- a/packages/core/src/parser.test.ts
+++ b/packages/core/src/parser.test.ts
@@ -4,6 +4,7 @@ import {
   merge,
   object,
   or,
+  seq,
   tuple,
 } from "@optique/core/constructs";
 import {
@@ -38,7 +39,7 @@ import {
   isInjectedAnnotationWrapper,
   type ParseOptions,
 } from "./internal/annotations.ts";
-import type { Usage } from "@optique/core/usage";
+import { formatUsage, type Usage } from "@optique/core/usage";
 import { choice, integer, string } from "@optique/core/valueparser";
 import { type DocEntry, formatDocPage } from "@optique/core/doc";
 import assert from "node:assert/strict";
@@ -2035,6 +2036,38 @@ describe("getDocPage", () => {
     assert.ok(sourceEntry, "Should have --source option entry");
     assert.deepEqual(targetEntry?.description, targetDesc);
     assert.deepEqual(sourceEntry?.description, sourceDesc);
+  });
+
+  it("should preserve command-specific docs inside seq()", () => {
+    const parser = seq(
+      optional(argument(string({ metavar: "PROFILE" }))),
+      or(
+        command("build", object({ clean: option("--clean") })),
+        command("deploy", object({ force: option("--force") }), {
+          usageLine: [{ type: "literal", value: "deployment-usage" }],
+        }),
+      ),
+    );
+
+    const docPage = getDocPage(parser, ["deploy"]);
+
+    assert.ok(docPage);
+    assert.ok(docPage.usage);
+    assert.equal(
+      formatUsage("tool", docPage.usage),
+      "tool deploy deployment-usage",
+    );
+    const allEntries = docPage.sections.flatMap((s) => s.entries);
+    assert.ok(
+      allEntries.some((e) =>
+        e.term.type === "option" && e.term.names.includes("--force")
+      ),
+    );
+    assert.ok(
+      !allEntries.some((e) =>
+        e.term.type === "option" && e.term.names.includes("--clean")
+      ),
+    );
   });
 
   it("should handle exclusive (or) parsers correctly", () => {

--- a/packages/core/src/parser.test.ts
+++ b/packages/core/src/parser.test.ts
@@ -2070,6 +2070,47 @@ describe("getDocPage", () => {
     );
   });
 
+  it("should preserve seq command docs after positional prefixes", () => {
+    const parser = seq(
+      optional(argument(string({ metavar: "PROFILE" }))),
+      or(
+        command("build", object({ clean: option("--clean") })),
+        command("deploy", object({ force: option("--force") }), {
+          usageLine: [{ type: "literal", value: "deployment-usage" }],
+        }),
+      ),
+    );
+
+    const docPage = getDocPage(parser, ["staging", "deploy"]);
+
+    assert.ok(docPage);
+    assert.ok(docPage.usage);
+    assert.equal(
+      formatUsage("tool", docPage.usage),
+      "tool deploy deployment-usage",
+    );
+  });
+
+  it("should not preserve seq command docs after invalid prefixes", () => {
+    const parser = seq(
+      or(
+        command("build", object({ clean: option("--clean") })),
+        command("deploy", object({ force: option("--force") }), {
+          usageLine: [{ type: "literal", value: "deployment-usage" }],
+        }),
+      ),
+    );
+
+    const docPage = getDocPage(parser, ["staging", "deploy"]);
+
+    assert.ok(docPage);
+    assert.ok(docPage.usage);
+    assert.equal(
+      formatUsage("tool", docPage.usage),
+      "tool (build [--clean] | deploy [--force])",
+    );
+  });
+
   it("should handle exclusive (or) parsers correctly", () => {
     const parser = or(
       option("-v", "--verbose"),

--- a/packages/core/src/primitives.ts
+++ b/packages/core/src/primitives.ts
@@ -2144,6 +2144,9 @@ export function negatableFlag(
     leadingNames: new Set<string>(optionNames),
     acceptingAnyToken: false,
     initialState: undefined,
+    canSkip(state) {
+      return state != null;
+    },
     parse(context) {
       if (context.optionsTerminated) {
         return {

--- a/packages/core/src/primitives.ts
+++ b/packages/core/src/primitives.ts
@@ -62,6 +62,15 @@ function hasParsedOptionValue<M extends Mode, T>(
     (state as { value?: boolean }).value === true;
 }
 
+function isSuccessfulValueState<T>(
+  state: ValueParserResult<T> | undefined,
+): boolean {
+  return state != null &&
+    typeof state === "object" &&
+    "success" in state &&
+    state.success === true;
+}
+
 /**
  * Helper function to create the stored state for an option or argument value.
  *
@@ -257,6 +266,9 @@ export function constant<const T>(value: T): Parser<"sync", T, T> {
     leadingNames: EMPTY_LEADING_NAMES,
     acceptingAnyToken: false,
     initialState: value,
+    canSkip() {
+      return true;
+    },
     parse(context) {
       return { success: true, next: context, consumed: [] };
     },
@@ -308,6 +320,9 @@ export function fail<T>(): Parser<"sync", T, undefined> {
     leadingNames: EMPTY_LEADING_NAMES,
     acceptingAnyToken: false,
     initialState: undefined,
+    canSkip() {
+      return false;
+    },
     parse(_context) {
       return {
         success: false,
@@ -956,6 +971,9 @@ export function option<M extends Mode, T>(
     initialState: valueParser == null
       ? { success: true, value: false }
       : undefined,
+    canSkip(state: ValueParserResult<T | boolean> | undefined) {
+      return valueParser == null || isSuccessfulValueState(state);
+    },
     parse(
       context: ParserContext<
         ValueParserResult<T | boolean> | undefined
@@ -1636,6 +1654,9 @@ export function flag(
     leadingNames: new Set<string>(optionNames),
     acceptingAnyToken: false,
     initialState: undefined,
+    canSkip(state) {
+      return isSuccessfulValueState(state);
+    },
     parse(context) {
       if (context.optionsTerminated) {
         return {
@@ -2420,6 +2441,9 @@ export function argument<M extends Mode, T>(
     leadingNames: EMPTY_LEADING_NAMES,
     acceptingAnyToken: true,
     initialState: undefined,
+    canSkip(state: ValueParserResult<T> | undefined) {
+      return isSuccessfulValueState(state);
+    },
     parse(
       context: ParserContext<
         ValueParserResult<T> | undefined
@@ -3015,6 +3039,20 @@ export function command<M extends Mode, T, TState>(
     leadingNames: new Set([name]),
     acceptingAnyToken: false,
     initialState: undefined,
+    canSkip(state: CommandState<TState>, exec?: ExecutionContext) {
+      const normalizedState = normalizeCommandState(state);
+      if (normalizedState === undefined) return false;
+      if (normalizedState[0] === "matched") {
+        return parser.canSkip?.(
+          getCommandChildState(state, parser.initialState, parser),
+          withChildExecPath(exec, name),
+        ) === true;
+      }
+      return parser.canSkip?.(
+        getCommandChildState(state, normalizedState[1], parser),
+        withChildExecPath(exec, name),
+      ) === true;
+    },
     getSuggestRuntimeNodes(
       state: CommandState<TState>,
       path: readonly PropertyKey[],
@@ -3531,6 +3569,9 @@ export function passThrough(
     leadingNames: EMPTY_LEADING_NAMES,
     acceptingAnyToken: false,
     initialState: [],
+    canSkip() {
+      return true;
+    },
 
     parse(context) {
       if (context.buffer.length < 1) {

--- a/packages/core/src/primitives.ts
+++ b/packages/core/src/primitives.ts
@@ -62,13 +62,13 @@ function hasParsedOptionValue<M extends Mode, T>(
     (state as { value?: boolean }).value === true;
 }
 
-function isSuccessfulValueState<T>(
+function isTerminalValueState<T>(
   state: ValueParserResult<T> | undefined,
 ): boolean {
   return state != null &&
     typeof state === "object" &&
     "success" in state &&
-    state.success === true;
+    typeof state.success === "boolean";
 }
 
 /**
@@ -972,7 +972,7 @@ export function option<M extends Mode, T>(
       ? { success: true, value: false }
       : undefined,
     canSkip(state: ValueParserResult<T | boolean> | undefined) {
-      return valueParser == null || isSuccessfulValueState(state);
+      return valueParser == null || isTerminalValueState(state);
     },
     parse(
       context: ParserContext<
@@ -1655,7 +1655,7 @@ export function flag(
     acceptingAnyToken: false,
     initialState: undefined,
     canSkip(state) {
-      return isSuccessfulValueState(state);
+      return isTerminalValueState(state);
     },
     parse(context) {
       if (context.optionsTerminated) {
@@ -2442,7 +2442,7 @@ export function argument<M extends Mode, T>(
     acceptingAnyToken: true,
     initialState: undefined,
     canSkip(state: ValueParserResult<T> | undefined) {
-      return isSuccessfulValueState(state);
+      return isTerminalValueState(state);
     },
     parse(
       context: ParserContext<

--- a/packages/core/src/public-api.test.ts
+++ b/packages/core/src/public-api.test.ts
@@ -127,6 +127,7 @@ test("parser module hides constructs and parser-internal helpers", () => {
 
 test("root module keeps user-facing APIs but not internal machinery", () => {
   assert.equal(typeof root.object, "function");
+  assert.equal(typeof root.seq, "function");
   assert.equal(typeof root.option, "function");
   assert.equal(typeof root.negatableFlag, "function");
   assert.equal(typeof root.parse, "function");

--- a/packages/core/src/usage-internals.ts
+++ b/packages/core/src/usage-internals.ts
@@ -26,12 +26,13 @@ export function collectLeadingCandidates(
   terms: Usage,
   optionNames: Set<string>,
   commandNames: Set<string>,
+  includeHidden = false,
 ): boolean {
   if (!terms || !Array.isArray(terms)) return true;
 
   for (const term of terms) {
     if (term.type === "option") {
-      if (!isSuggestionHidden(term.hidden)) {
+      if (includeHidden || !isSuggestionHidden(term.hidden)) {
         for (const name of term.names) {
           optionNames.add(name);
         }
@@ -40,7 +41,7 @@ export function collectLeadingCandidates(
     }
 
     if (term.type === "command") {
-      if (!isSuggestionHidden(term.hidden)) {
+      if (includeHidden || !isSuggestionHidden(term.hidden)) {
         commandNames.add(term.name);
       }
       return false;
@@ -51,18 +52,35 @@ export function collectLeadingCandidates(
     }
 
     if (term.type === "optional") {
-      collectLeadingCandidates(term.terms, optionNames, commandNames);
+      collectLeadingCandidates(
+        term.terms,
+        optionNames,
+        commandNames,
+        includeHidden,
+      );
       continue;
     }
 
     if (term.type === "multiple") {
-      collectLeadingCandidates(term.terms, optionNames, commandNames);
+      collectLeadingCandidates(
+        term.terms,
+        optionNames,
+        commandNames,
+        includeHidden,
+      );
       if (term.min === 0) continue;
       return false;
     }
 
     if (term.type === "sequence") {
-      if (collectLeadingCandidates(term.terms, optionNames, commandNames)) {
+      if (
+        collectLeadingCandidates(
+          term.terms,
+          optionNames,
+          commandNames,
+          includeHidden,
+        )
+      ) {
         continue;
       }
       return false;
@@ -75,6 +93,7 @@ export function collectLeadingCandidates(
           branch,
           optionNames,
           commandNames,
+          includeHidden,
         );
         allSkippable = allSkippable && branchSkippable;
       }

--- a/packages/core/src/usage-internals.ts
+++ b/packages/core/src/usage-internals.ts
@@ -61,6 +61,13 @@ export function collectLeadingCandidates(
       return false;
     }
 
+    if (term.type === "sequence") {
+      if (collectLeadingCandidates(term.terms, optionNames, commandNames)) {
+        continue;
+      }
+      return false;
+    }
+
     if (term.type === "exclusive") {
       let allSkippable = true;
       for (const branch of term.terms) {

--- a/packages/core/src/usage.test.ts
+++ b/packages/core/src/usage.test.ts
@@ -2834,6 +2834,24 @@ describe("normalizeUsage", () => {
       ];
       assert.deepEqual(result, expected);
     });
+
+    it("should preserve order inside sequence terms", () => {
+      const usage: Usage = [
+        {
+          type: "sequence",
+          terms: [
+            { type: "argument", metavar: "SOURCE" },
+            { type: "command", name: "copy" },
+            { type: "option", names: ["--force"] },
+          ],
+        },
+      ];
+
+      const result = normalizeUsage(usage);
+
+      assert.deepEqual(result, usage);
+      assert.equal(formatUsage("app", usage), "app SOURCE copy --force");
+    });
   });
 });
 
@@ -3691,6 +3709,19 @@ describe("cloneUsageTerm", () => {
       assert.notEqual(cloned.terms, term.terms);
       assert.notEqual(cloned.terms[0], (term as typeof cloned).terms[0]);
       assert.notEqual(cloned.terms[0][0], inner1);
+    }
+  });
+
+  it("should deep-clone a sequence term", () => {
+    const inner: UsageTerm = { type: "argument", metavar: "X" };
+    const term: UsageTerm = { type: "sequence", terms: [inner] };
+    const cloned = cloneUsageTerm(term);
+
+    assert.deepEqual(cloned, term);
+    assert.notEqual(cloned, term);
+    if (cloned.type === "sequence") {
+      assert.notEqual(cloned.terms, term.terms);
+      assert.notEqual(cloned.terms[0], inner);
     }
   });
 

--- a/packages/core/src/usage.ts
+++ b/packages/core/src/usage.ts
@@ -202,6 +202,24 @@ export type UsageTerm =
     readonly terms: readonly Usage[];
   }
   /**
+   * A sequence term, which preserves the declaration order of its child
+   * terms through usage normalization.
+   *
+   * This is used by ordered parser combinators where argument/command/option
+   * order is part of the accepted grammar.
+   * @since 1.1.0
+   */
+  | {
+    /**
+     * The type of the term, which is always `"sequence"` for this term.
+     */
+    readonly type: "sequence";
+    /**
+     * Terms that must be displayed in the given order.
+     */
+    readonly terms: Usage;
+  }
+  /**
    * A literal term, which represents a fixed string value in the command-line
    * usage. Unlike metavars which are placeholders for user-provided values,
    * literals represent exact strings that must be typed as-is.
@@ -302,7 +320,10 @@ export function extractOptionNames(
         for (const name of term.names) {
           names.add(name);
         }
-      } else if (term.type === "optional" || term.type === "multiple") {
+      } else if (
+        term.type === "optional" || term.type === "multiple" ||
+        term.type === "sequence"
+      ) {
         traverseUsage(term.terms);
       } else if (term.type === "exclusive") {
         for (const exclusiveUsage of term.terms) {
@@ -350,7 +371,10 @@ export function extractCommandNames(
       if (term.type === "command") {
         if (!includeHidden && isSuggestionHidden(term.hidden)) continue;
         names.add(term.name);
-      } else if (term.type === "optional" || term.type === "multiple") {
+      } else if (
+        term.type === "optional" || term.type === "multiple" ||
+        term.type === "sequence"
+      ) {
         traverseUsage(term.terms);
       } else if (term.type === "exclusive") {
         for (const exclusiveUsage of term.terms) {
@@ -384,7 +408,10 @@ export function extractLiteralValues(usage: Usage): Set<string> {
     for (const term of terms) {
       if (term.type === "literal") {
         values.add(term.value);
-      } else if (term.type === "optional" || term.type === "multiple") {
+      } else if (
+        term.type === "optional" || term.type === "multiple" ||
+        term.type === "sequence"
+      ) {
         traverseUsage(term.terms);
       } else if (term.type === "exclusive") {
         for (const branch of term.terms) {
@@ -428,7 +455,10 @@ export function extractArgumentMetavars(usage: Usage): Set<string> {
       if (term.type === "argument") {
         if (isSuggestionHidden(term.hidden)) continue;
         metavars.add(term.metavar);
-      } else if (term.type === "optional" || term.type === "multiple") {
+      } else if (
+        term.type === "optional" || term.type === "multiple" ||
+        term.type === "sequence"
+      ) {
         traverseUsage(term.terms);
       } else if (term.type === "exclusive") {
         for (const exclusiveUsage of term.terms) {
@@ -644,6 +674,11 @@ function normalizeUsageTerm(term: UsageTerm): UsageTerm {
       terms: normalizeUsage(term.terms),
       min: term.min,
     };
+  } else if (term.type === "sequence") {
+    return {
+      type: "sequence",
+      terms: term.terms.map(normalizeUsageTerm).filter(isNonDegenerateTerm),
+    };
   } else if (term.type === "exclusive") {
     const terms: Usage[] = [];
     for (const usage of term.terms) {
@@ -685,7 +720,7 @@ function isNonDegenerateTerm(term: UsageTerm): boolean {
   if (term.type === "argument") return term.metavar.length > 0;
   if (
     term.type === "optional" || term.type === "multiple" ||
-    term.type === "exclusive"
+    term.type === "exclusive" || term.type === "sequence"
   ) {
     return term.terms.length > 0;
   }
@@ -697,7 +732,10 @@ function containsMalformedLeaf(usage: Usage): boolean {
     if (term.type === "option" && term.names.length === 0) return true;
     if (term.type === "command" && term.name === "") return true;
     if (term.type === "argument" && term.metavar.length === 0) return true;
-    if (term.type === "optional" || term.type === "multiple") {
+    if (
+      term.type === "optional" || term.type === "multiple" ||
+      term.type === "sequence"
+    ) {
       if (containsMalformedLeaf(term.terms)) return true;
     }
     if (term.type === "exclusive") {
@@ -745,6 +783,8 @@ export function cloneUsageTerm(term: UsageTerm): UsageTerm {
         type: "exclusive",
         terms: term.terms.map((u) => u.map(cloneUsageTerm)),
       };
+    case "sequence":
+      return { type: "sequence", terms: term.terms.map(cloneUsageTerm) };
     case "literal":
     case "passthrough":
     case "ellipsis":
@@ -810,6 +850,13 @@ function filterUsageForDisplay(
         .filter((branch) => branch.length > 0);
       if (filteredBranches.length > 0) {
         terms.push({ type: "exclusive", terms: filteredBranches });
+      }
+      continue;
+    }
+    if (term.type === "sequence") {
+      const filtered = filterUsageForDisplay(term.terms, isHidden);
+      if (filtered.length > 0) {
+        terms.push({ type: "sequence", terms: filtered });
       }
       continue;
     }
@@ -984,6 +1031,8 @@ function* formatUsageTermInternal(
       text: options?.colors ? `\x1b[2m)\x1b[0m` : ")", // Dim
       width: 1,
     };
+  } else if (term.type === "sequence") {
+    yield* formatUsageTerms(term.terms, options);
   } else if (term.type === "multiple") {
     if (term.min < 1) {
       yield {

--- a/packages/env/src/index.test.ts
+++ b/packages/env/src/index.test.ts
@@ -746,6 +746,31 @@ describe("bindEnv()", () => {
     });
   });
 
+  it("does not read env fallbacks after seq consumes CLI values", () => {
+    const context = createEnvContext({
+      source: () => {
+        throw new Error("Environment should not be read.");
+      },
+    });
+    const parser = seq(
+      bindEnv(argument(string()), {
+        context,
+        key: "PROFILE",
+        parser: string(),
+      }),
+      command("run", object({})),
+    );
+
+    const result = parse(parser, ["cli-profile", "run"], {
+      annotations: getSyncAnnotations(context),
+    });
+
+    assert.deepEqual(result, {
+      success: true,
+      value: ["cli-profile", {}],
+    });
+  });
+
   it("should always prefer CLI over env and default values", () => {
     fc.assert(
       fc.property(

--- a/packages/env/src/index.test.ts
+++ b/packages/env/src/index.test.ts
@@ -11,6 +11,7 @@ import {
   merge,
   object,
   or,
+  seq,
   tuple,
 } from "@optique/core/constructs";
 import { dependency } from "@optique/core/dependency";
@@ -25,7 +26,14 @@ import {
   suggestSync,
 } from "@optique/core/parser";
 import { map, multiple, optional, withDefault } from "@optique/core/modifiers";
-import { constant, fail, flag, option } from "@optique/core/primitives";
+import {
+  argument,
+  command,
+  constant,
+  fail,
+  flag,
+  option,
+} from "@optique/core/primitives";
 import { choice, integer, string } from "@optique/core/valueparser";
 import { bindConfig, createConfigContext } from "../../config/src/index.ts";
 import {
@@ -689,6 +697,53 @@ describe("bindEnv()", () => {
     const result = parse(parser, []);
     assert.ok(result.success);
     assert.equal(result.value, 3000);
+  });
+
+  it("lets seq skip env-bound positional defaults before commands", () => {
+    const context = createEnvContext({
+      source: () => undefined,
+    });
+    const parser = seq(
+      bindEnv(argument(string()), {
+        context,
+        key: "PROFILE",
+        parser: string(),
+        default: "default",
+      }),
+      command("run", object({})),
+    );
+
+    const result = parse(parser, ["run"], {
+      annotations: getSyncAnnotations(context),
+    });
+
+    assert.deepEqual(result, {
+      success: true,
+      value: ["default", {}],
+    });
+  });
+
+  it("lets seq skip env-bound positional values before commands", () => {
+    const context = createEnvContext({
+      source: (key) => key === "PROFILE" ? "env-profile" : undefined,
+    });
+    const parser = seq(
+      bindEnv(argument(string()), {
+        context,
+        key: "PROFILE",
+        parser: string(),
+      }),
+      command("run", object({})),
+    );
+
+    const result = parse(parser, ["run"], {
+      annotations: getSyncAnnotations(context),
+    });
+
+    assert.deepEqual(result, {
+      success: true,
+      value: ["env-profile", {}],
+    });
   });
 
   it("should always prefer CLI over env and default values", () => {

--- a/packages/env/src/index.test.ts
+++ b/packages/env/src/index.test.ts
@@ -3,6 +3,7 @@ import * as fc from "fast-check";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, it } from "node:test";
+import { getAnnotations } from "@optique/core/annotations";
 import type { Annotations } from "@optique/core/context";
 import { injectAnnotations } from "@optique/core/extension";
 import {
@@ -744,6 +745,61 @@ describe("bindEnv()", () => {
       success: true,
       value: ["env-profile", {}],
     });
+  });
+
+  it("preserves annotations when checking env-bound skip state", () => {
+    const annotationKey = Symbol("@optique/test/canSkip");
+    const envContext = createEnvContext({
+      source: () => undefined,
+    });
+    const innerParser: Parser<"sync", string, undefined> = {
+      $valueType: [] as readonly string[],
+      $stateType: [] as readonly undefined[],
+      mode: "sync",
+      priority: 0,
+      usage: [{ type: "argument", metavar: "VALUE" }],
+      leadingNames: new Set(),
+      acceptingAnyToken: true,
+      initialState: undefined,
+      parse() {
+        return {
+          success: false,
+          consumed: 0,
+          error: message`No CLI input.`,
+        };
+      },
+      complete() {
+        return { success: true, value: "from-complete" };
+      },
+      canSkip(state) {
+        return getAnnotations(state)?.[annotationKey] === true;
+      },
+      suggest() {
+        return [];
+      },
+      getDocFragments() {
+        return { fragments: [] };
+      },
+    };
+    const parser = bindEnv(innerParser, {
+      context: envContext,
+      key: "PROFILE",
+      parser: string(),
+    });
+    const annotations: Annotations = {
+      ...getSyncAnnotations(envContext),
+      [annotationKey]: true,
+    };
+
+    const result = parser.parse({
+      buffer: [],
+      state: injectAnnotations(parser.initialState, annotations),
+      optionsTerminated: false,
+      usage: parser.usage,
+    });
+
+    assert.ok(result.success);
+    assert.ok(parser.canSkip?.(result.next.state));
   });
 
   it("does not read env fallbacks after seq consumes CLI values", () => {

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -313,8 +313,11 @@ export function bindEnv<
     acceptingAnyToken: parser.acceptingAnyToken,
     initialState: parser.initialState,
     canSkip(state: TState, exec?: ExecutionContext) {
-      if (hasEnvFallback(state)) return true;
       if (isEnvBindState(state)) {
+        if (state.hasCliValue) {
+          return parser.canSkip?.(state.cliState!, exec) === true;
+        }
+        if (hasEnvFallback(state)) return true;
         return parser.canSkip?.(
           state.cliState === undefined
             ? parser.initialState
@@ -322,6 +325,7 @@ export function bindEnv<
           exec,
         ) === true;
       }
+      if (hasEnvFallback(state)) return true;
       return parser.canSkip?.(state, exec) === true;
     },
     getSuggestRuntimeNodes(state: TState, path: readonly PropertyKey[]) {

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -290,6 +290,17 @@ export function bindEnv<
   // parser isolated from those legacy markers prevents optional()/withDefault()
   // wrappers from invoking it without the annotation context it requires.
 
+  function hasEnvFallback(state: TState): boolean {
+    if (options.default !== undefined) return true;
+    const annotations = getAnnotations(state);
+    const sourceData = annotations?.[options.context.id] as
+      | EnvSourceData
+      | undefined;
+    if (sourceData == null) return false;
+    return sourceData.source(`${sourceData.prefix}${options.key}`) !==
+      undefined;
+  }
+
   const boundParser: Parser<M, TValue, TState> = {
     mode: parser.mode,
     $valueType: parser.$valueType,
@@ -301,6 +312,18 @@ export function bindEnv<
     leadingNames: parser.leadingNames,
     acceptingAnyToken: parser.acceptingAnyToken,
     initialState: parser.initialState,
+    canSkip(state: TState, exec?: ExecutionContext) {
+      if (hasEnvFallback(state)) return true;
+      if (isEnvBindState(state)) {
+        return parser.canSkip?.(
+          state.cliState === undefined
+            ? parser.initialState
+            : state.cliState as TState,
+          exec,
+        ) === true;
+      }
+      return parser.canSkip?.(state, exec) === true;
+    },
     getSuggestRuntimeNodes(state: TState, path: readonly PropertyKey[]) {
       const innerState = isEnvBindState(state)
         ? (state.cliState === undefined

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -5,6 +5,7 @@ import {
   delegateSuggestNodes,
   dispatchByMode,
   getTraits,
+  inheritAnnotations,
   injectAnnotations,
   isInjectedAnnotationState,
   mapModeValue,
@@ -301,6 +302,13 @@ export function bindEnv<
       undefined;
   }
 
+  function getInnerState(state: TState): TState {
+    if (!isEnvBindState(state)) return state;
+    return state.cliState === undefined
+      ? inheritAnnotations(state, parser.initialState)
+      : state.cliState as TState;
+  }
+
   const boundParser: Parser<M, TValue, TState> = {
     mode: parser.mode,
     $valueType: parser.$valueType,
@@ -318,22 +326,13 @@ export function bindEnv<
           return parser.canSkip?.(state.cliState!, exec) === true;
         }
         if (hasEnvFallback(state)) return true;
-        return parser.canSkip?.(
-          state.cliState === undefined
-            ? parser.initialState
-            : state.cliState as TState,
-          exec,
-        ) === true;
+        return parser.canSkip?.(getInnerState(state), exec) === true;
       }
       if (hasEnvFallback(state)) return true;
       return parser.canSkip?.(state, exec) === true;
     },
     getSuggestRuntimeNodes(state: TState, path: readonly PropertyKey[]) {
-      const innerState = isEnvBindState(state)
-        ? (state.cliState === undefined
-          ? parser.initialState
-          : state.cliState as TState)
-        : state;
+      const innerState = getInnerState(state);
       return delegateSuggestNodes(
         parser,
         boundParser,

--- a/packages/man/src/man.ts
+++ b/packages/man/src/man.ts
@@ -295,6 +295,9 @@ function formatUsageTermAsRoffInternal(
       return `(${alternatives.join(" | ")})`;
     }
 
+    case "sequence":
+      return formatUsageAsRoffInternal(term.terms, insideBrackets);
+
     case "literal":
       return escapeRoff(term.value);
 
@@ -401,6 +404,9 @@ function formatDocUsageTermAsRoff(term: UsageTerm): string {
       if (alternatives.length === 1) return alternatives[0];
       return `(${alternatives.join(" | ")})`;
     }
+
+    case "sequence":
+      return formatDocUsageAsRoff(term.terms);
 
     case "argument":
       return `\\fI${escapeRoff(term.metavar)}\\fR`;


### PR DESCRIPTION
Fixes #819.

What changed
------------

This PR adds `seq()` to *@optique/core* for CLI grammars that need child parsers to run in declaration order. Unlike `object()`, `tuple()`, `merge()`, and `concat()`, the new parser keeps an ordered cursor and returns a tuple of child values. This makes patterns such as optional positional prefixes before subcommands easier to express without relying on shared-buffer priority rules.

The implementation also adds the lower-level `canSkip()` parser hook used by `seq()` to decide when a child parser can finish without more CLI input. The hook is implemented or forwarded across the built-in combinators and fallback wrappers that can legally complete at a boundary, including optional parsers, groups, repeated parsers, env/config bindings, `merge()`, and `concat()`.

The main implementation lives in *packages/core/src/constructs.ts*, with supporting parser, usage, help, and fallback changes in *packages/core/src/internal/parser.ts*, *packages/core/src/usage.ts*, *packages/core/src/usage-internals.ts*, *packages/core/src/primitives.ts*, *packages/core/src/modifiers.ts*, *packages/config/src/index.ts*, and *packages/env/src/index.ts*.


Behavior covered
----------------

`seq()` preserves declaration order in parsing, completion, and usage output. It can skip optional boundaries before later command names, keeps the current child from being preempted by later overlapping options, carries dependency runtime state into suggestions, preserves invalid value errors, and reports failure depth relative to the full sequence.

Duplicate option checks are position-aware. Options that are active at the same sequence position are rejected unless `allowDuplicates` is set, while the same option name can still appear after a required boundary where it is no longer ambiguous.

Help output also understands sequence usage terms. Hidden usage propagates through `seq()`, command-specific docs still work for ordered subcommand patterns, and conditional discriminator usage can rewrite literals inside a sequence.


Documentation and examples
--------------------------

The new API is documented in *docs/concepts/constructs.md*, with a cookbook pattern in *docs/cookbook.md*. A runnable example was added at *examples/patterns/ordered-sequence.ts*. The release note for PR #820 is in *CHANGES.md*.
