### PR TITLE
Load .env files through env contexts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -135,9 +135,22 @@ To be released.
 
 ### @optique/env
 
+ -  Added `EnvContextOptions.envFile` for loading *.env* files as an
+    internal fallback layer.  `envFile: true` loads *.env* from the current
+    working directory, explicit paths are loaded in order with later files
+    overriding earlier file values, and missing files are skipped.  Loaded
+    values never mutate `process.env` or `Deno.env`, and real environment
+    variables remain higher priority than file values.  The built-in parser
+    supports common dotenv syntax, variable expansion, literal single-quoted
+    values, and opt-in command substitution through `envFile.substitute`.
+    [[#822], [#824]]
+
  -  `bindEnv()` now emits a distinct error message when other source contexts
     are registered via `run()`'s `contexts` option but the env context is not
     included, making this misconfiguration easier to diagnose.  [[#803], [#805]]
+
+[#822]: https://github.com/dahlia/optique/issues/822
+[#824]: https://github.com/dahlia/optique/pull/824
 
 ### @optique/config
 

--- a/docs/integrations/env.md
+++ b/docs/integrations/env.md
@@ -14,10 +14,11 @@ variables while preserving Optique's type safety and parser composition model.
 
 The fallback priority is:
 
-1.  *CLI argument*
-2.  *Environment variable*
-3.  *Default value*
-4.  *Error*
+1.  CLI argument
+2.  Environment variable
+3.  *.env* file value
+4.  Default value
+5.  Error
 
 ::: code-group
 
@@ -71,6 +72,21 @@ const envContext = createEnvContext({
   source: (key) => mockEnv[key],
 });
 ~~~~
+
+To load *.env* files as an internal fallback layer, pass `envFile`:
+
+~~~~ typescript twoslash
+import { createEnvContext } from "@optique/env";
+
+const envContext = createEnvContext({
+  prefix: "MYAPP_",
+  envFile: [".env", ".env.local"],
+});
+~~~~
+
+Values from *.env* files are read by `bindEnv()` but are not written to
+`process.env` or `Deno.env`.  Real environment variables still take
+priority over file values.
 
 ### 2. Bind parsers to environment keys
 
@@ -163,6 +179,58 @@ import { bool } from "@optique/env";
 
 const parser = bool();
 ~~~~
+
+
+*.env* files
+------------
+
+`envFile` accepts `true`, a path string, an array of paths, or an options
+object:
+
+~~~~ typescript twoslash
+import { createEnvContext } from "@optique/env";
+
+const envContext = createEnvContext({
+  prefix: "MYAPP_",
+  envFile: {
+    paths: [".env", ".env.local"],
+    substitute: (command) =>
+      command === "whoami" ? "developer" : undefined,
+  },
+});
+~~~~
+
+Passing `true` loads only *.env* from the current working directory.
+When several paths are provided, files are loaded in order and later
+files override earlier file values.  Missing files are skipped.
+
+The parser supports common dotenv syntax:
+
+ -  blank lines and comments
+ -  optional `export` prefixes
+ -  `KEY=VALUE` assignments
+ -  single-quoted, double-quoted, and unquoted values
+ -  multiline quoted values
+ -  inline comments after unquoted values
+ -  `$VAR` and `${VAR}` expansion
+
+Single-quoted values are literal.  Optique does not expand variables,
+perform command substitution, or interpret escape sequences inside
+single quotes.
+
+Double-quoted and unquoted values expand variables in a single
+left-to-right pass.  Expansion reads from the configured `source` first,
+then from values already loaded from *.env* files.  Missing variables
+expand to the empty string.
+
+Optique recognizes `$(...)` and backtick command-substitution forms, but
+it never executes commands by itself.  If `substitute` is provided, Optique
+passes the command text to that hook and inserts the returned string.  If
+the hook is absent or returns `undefined`, the substitution becomes the
+empty string.
+
+Encrypted dotenvx values are not decrypted; they are treated as ordinary
+string values.
 
 
 Env-only values
@@ -467,6 +535,9 @@ Parameters
      -  `options.source`: Custom function `(key: string) => string | undefined`
         for reading environment values.  Defaults to `Deno.env.get` on Deno
         and `process.env` on Node.js/Bun.
+     -  `options.envFile`: Optional *.env* file fallback layer.  Pass `true`
+        to load *.env*, a path string, an array of paths, or an object with
+        `paths` and `substitute`.
 
 Returns
 :   `EnvContext` implementing `SourceContext` and `Disposable`.
@@ -538,10 +609,17 @@ Limitations
  -  *No schema validation* — Unlike *@optique/config*, there is no schema that
     validates the set of environment variables as a whole.  Each binding is
     validated independently.
+ -  *No automatic dotenv conventions* — `envFile: true` loads only *.env*.
+    Optique does not automatically load *.env.local*, *.env.development*,
+    or framework-specific file sets.
+ -  *No built-in command execution* — Command-substitution syntax is
+    recognized only so applications can opt in with `envFile.substitute`.
+    Without that hook, command substitutions become empty strings.
+ -  *No dotenvx decryption* — Encrypted values remain ordinary strings.
  -  *Synchronous reads*: `createEnvContext()` reads environment variables
-    synchronously via `Deno.env.get` or `process.env`.  The context itself
-    does not add async overhead, but if the `parser` used in `bindEnv()` is
-    async, the overall parsing becomes async.
+    and *.env* files synchronously.  The context itself does not add async
+    overhead, but if the `parser` used in `bindEnv()` is async, the overall
+    parsing becomes async.
 
 > [!TIP]
 > See the [cookbook](../cookbook.md#environment-variable-fallbacks) for

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -6,7 +6,7 @@ Environment variable support for [Optique].
 This package provides a type-safe way to bind CLI parsers to environment
 variables with clear fallback behavior:
 
-CLI arguments > environment variables > defaults.
+CLI arguments > environment variables > *.env* files > defaults.
 
 [Optique]: https://optique.dev/
 
@@ -33,7 +33,10 @@ import { integer, string } from "@optique/core/valueparser";
 import { runAsync } from "@optique/run";
 import { bindEnv, bool, createEnvContext } from "@optique/env";
 
-const envContext = createEnvContext({ prefix: "MYAPP_" });
+const envContext = createEnvContext({
+  prefix: "MYAPP_",
+  envFile: [".env", ".env.local"],
+});
 
 const parser = object({
   host: bindEnv(option("--host", string()), {
@@ -70,6 +73,7 @@ Features
  -  *Type-safe env parsing* with any Optique `ValueParser`
  -  *Common Boolean parser* via `bool()`
  -  *Prefix support* for namespaced environment variables
+ -  *.env file loading* without mutating `process.env` or `Deno.env`
  -  *Custom env source* for Deno, tests, and custom runtimes
  -  *Composable contexts* with `run()`/`runAsync()`/`runWith()`
 

--- a/packages/env/deno.json
+++ b/packages/env/deno.json
@@ -12,7 +12,7 @@
   ],
   "tasks": {
     "build": "pnpm build",
-    "test": "deno test",
+    "test": "deno test --allow-read --allow-write --allow-env",
     "test:node": {
       "dependencies": [
         "build"

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -68,7 +68,7 @@
     "prepublish": "tsdown",
     "test": "node --experimental-transform-types --test",
     "test:bun": "bun test",
-    "test:deno": "deno test",
-    "test-all": "tsdown && node --experimental-transform-types --test && bun test && deno test"
+    "test:deno": "deno test --allow-read --allow-write --allow-env",
+    "test-all": "tsdown && node --experimental-transform-types --test && bun test && deno test --allow-read --allow-write --allow-env"
   }
 }

--- a/packages/env/src/index.test.ts
+++ b/packages/env/src/index.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import * as fc from "fast-check";
-import { readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import process from "node:process";
 import { fileURLToPath } from "node:url";
 import { describe, it } from "node:test";
 import { getAnnotations } from "@optique/core/annotations";
@@ -97,6 +100,15 @@ function getSyncAnnotations(context: {
     throw new TypeError("Expected synchronous annotations.");
   }
   return annotations;
+}
+
+function withTempDir<T>(callback: (dir: string) => T): T {
+  const dir = mkdtempSync(join(tmpdir(), "optique-env-"));
+  try {
+    return callback(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 }
 
 describe("bool()", () => {
@@ -2792,6 +2804,307 @@ describe("createEnvContext defaults", () => {
         Object.defineProperty(globalThis, "process", originalProcess);
       }
     }
+  });
+
+  it("uses envFile values when source is missing", () =>
+    withTempDir((dir) => {
+      const envPath = join(dir, ".env");
+      writeFileSync(envPath, "APP_PORT=8080\n", "utf8");
+      const context = createEnvContext({
+        envFile: envPath,
+        prefix: "APP_",
+        source: () => undefined,
+      });
+      const parser = bindEnv(option("--port", integer()), {
+        context,
+        key: "PORT",
+        parser: integer(),
+        default: 3000,
+      });
+
+      const result = parse(parser, [], {
+        annotations: getSyncAnnotations(context),
+      });
+
+      assert.deepEqual(result, { success: true, value: 8080 });
+    }));
+
+  it("loads .env from the current working directory when envFile is true", () =>
+    withTempDir((dir) => {
+      const originalCwd = process.cwd();
+      writeFileSync(join(dir, ".env"), "APP_HOST=local.example\n", "utf8");
+      try {
+        process.chdir(dir);
+        const context = createEnvContext({
+          envFile: true,
+          prefix: "APP_",
+          source: () => undefined,
+        });
+        assert.equal(context.source("APP_HOST"), "local.example");
+      } finally {
+        process.chdir(originalCwd);
+      }
+    }));
+
+  it("loads envFile paths in order with later files overriding earlier ones", () =>
+    withTempDir((dir) => {
+      const basePath = join(dir, ".env");
+      const localPath = join(dir, ".env.local");
+      writeFileSync(basePath, "APP_HOST=base\nAPP_PORT=3000\n", "utf8");
+      writeFileSync(localPath, "APP_PORT=8080\n", "utf8");
+      const context = createEnvContext({
+        envFile: [basePath, localPath],
+        prefix: "APP_",
+        source: () => undefined,
+      });
+
+      assert.equal(context.source("APP_HOST"), "base");
+      assert.equal(context.source("APP_PORT"), "8080");
+    }));
+
+  it("prefers source values over envFile values", () =>
+    withTempDir((dir) => {
+      const envPath = join(dir, ".env");
+      writeFileSync(envPath, "APP_HOST=file\n", "utf8");
+      const context = createEnvContext({
+        envFile: envPath,
+        prefix: "APP_",
+        source: (key) => key === "APP_HOST" ? "source" : undefined,
+      });
+
+      assert.equal(context.source("APP_HOST"), "source");
+    }));
+
+  it("skips missing envFile paths silently", () =>
+    withTempDir((dir) => {
+      const context = createEnvContext({
+        envFile: join(dir, ".env"),
+        source: () => undefined,
+      });
+
+      assert.equal(context.source("PORT"), undefined);
+    }));
+
+  it("does not mutate process.env when loading envFile values", () =>
+    withTempDir((dir) => {
+      const envPath = join(dir, ".env");
+      const previousValue = process.env.APP_ENV_FILE_ONLY;
+      delete process.env.APP_ENV_FILE_ONLY;
+      writeFileSync(envPath, "APP_ENV_FILE_ONLY=secret\n", "utf8");
+      try {
+        const context = createEnvContext({
+          envFile: envPath,
+          source: () => undefined,
+        });
+
+        assert.equal(context.source("APP_ENV_FILE_ONLY"), "secret");
+        assert.equal(process.env.APP_ENV_FILE_ONLY, undefined);
+      } finally {
+        if (previousValue === undefined) {
+          delete process.env.APP_ENV_FILE_ONLY;
+        } else {
+          process.env.APP_ENV_FILE_ONLY = previousValue;
+        }
+      }
+    }));
+
+  it("parses dotenv comments, export prefixes, quotes, escapes, and multiline values", () =>
+    withTempDir((dir) => {
+      const envPath = join(dir, ".env");
+      writeFileSync(
+        envPath,
+        [
+          "# full-line comment",
+          "export APP_HOST=example.com # inline comment",
+          "APP_SINGLE='literal # value'",
+          'APP_DOUBLE="line\\nwith \\"quotes\\""',
+          'APP_MULTI="first',
+          'second"',
+          "APP_EMPTY=",
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+      const context = createEnvContext({
+        envFile: envPath,
+        source: () => undefined,
+      });
+
+      assert.equal(context.source("APP_HOST"), "example.com");
+      assert.equal(context.source("APP_SINGLE"), "literal # value");
+      assert.equal(context.source("APP_DOUBLE"), 'line\nwith "quotes"');
+      assert.equal(context.source("APP_MULTI"), "first\nsecond");
+      assert.equal(context.source("APP_EMPTY"), "");
+    }));
+
+  it("accepts carriage-return-only envFile line endings", () =>
+    withTempDir((dir) => {
+      const envPath = join(dir, ".env");
+      writeFileSync(envPath, "APP_ONE=1\rAPP_TWO=2\r", "utf8");
+      const context = createEnvContext({
+        envFile: envPath,
+        source: () => undefined,
+      });
+
+      assert.equal(context.source("APP_ONE"), "1");
+      assert.equal(context.source("APP_TWO"), "2");
+    }));
+
+  it("reports line numbers for carriage-return-only envFile syntax errors", () =>
+    withTempDir((dir) => {
+      const envPath = join(dir, ".env");
+      writeFileSync(envPath, "APP_ONE=1\rnot valid\r", "utf8");
+
+      assert.throws(
+        () => createEnvContext({ envFile: envPath }),
+        {
+          name: "SyntaxError",
+          message:
+            `Invalid .env syntax in ${envPath} at line 2: expected KEY=VALUE.`,
+        },
+      );
+    }));
+
+  it("expands variables from source first and envFile values second", () =>
+    withTempDir((dir) => {
+      const envPath = join(dir, ".env");
+      writeFileSync(
+        envPath,
+        [
+          "APP_ROOT=/file",
+          "APP_BIN=$APP_ROOT/bin",
+          "APP_URL=${APP_SCHEME}://example.com",
+          "APP_MISSING=before-${APP_UNKNOWN}-after",
+        ].join("\n"),
+        "utf8",
+      );
+      const context = createEnvContext({
+        envFile: envPath,
+        source: (key) =>
+          key === "APP_ROOT"
+            ? "/source"
+            : key === "APP_SCHEME"
+            ? "https"
+            : undefined,
+      });
+
+      assert.equal(context.source("APP_BIN"), "/source/bin");
+      assert.equal(context.source("APP_URL"), "https://example.com");
+      assert.equal(context.source("APP_MISSING"), "before--after");
+    }));
+
+  it("keeps single-quoted values literal without substitutions", () =>
+    withTempDir((dir) => {
+      const envPath = join(dir, ".env");
+      writeFileSync(
+        envPath,
+        [
+          "APP_NAME=real",
+          "APP_LITERAL='$APP_NAME ${APP_NAME} $(whoami) `date` \\n'",
+        ].join("\n"),
+        "utf8",
+      );
+      const context = createEnvContext({
+        envFile: {
+          paths: envPath,
+          substitute: () => "substituted",
+        },
+        source: (key) => key === "APP_NAME" ? "source" : undefined,
+      });
+
+      assert.equal(
+        context.source("APP_LITERAL"),
+        "$APP_NAME ${APP_NAME} $(whoami) `date` \\n",
+      );
+    }));
+
+  it("substitutes commands in a single left-to-right pass", () =>
+    withTempDir((dir) => {
+      const envPath = join(dir, ".env");
+      writeFileSync(
+        envPath,
+        "APP_VALUE=pre-$(user)-$APP_SUFFIX-`date`-$APP_AFTER\n",
+        "utf8",
+      );
+      const context = createEnvContext({
+        envFile: {
+          paths: envPath,
+          substitute: (command) => command.toUpperCase(),
+        },
+        source: (key) => {
+          const values: Record<string, string> = {
+            APP_SUFFIX: "suffix",
+            APP_AFTER: "$APP_SUFFIX",
+          };
+          return values[key];
+        },
+      });
+
+      assert.equal(
+        context.source("APP_VALUE"),
+        "pre-USER-suffix-DATE-$APP_SUFFIX",
+      );
+    }));
+
+  it("uses an empty string for command substitutions without a hook result", () =>
+    withTempDir((dir) => {
+      const envPath = join(dir, ".env");
+      writeFileSync(envPath, "APP_ONE=$(whoami)\nAPP_TWO=`date`\n", "utf8");
+      const context = createEnvContext({
+        envFile: {
+          paths: envPath,
+          substitute: () => undefined,
+        },
+        source: () => undefined,
+      });
+
+      assert.equal(context.source("APP_ONE"), "");
+      assert.equal(context.source("APP_TWO"), "");
+    }));
+
+  it("throws SyntaxError for invalid envFile lines", () =>
+    withTempDir((dir) => {
+      const envPath = join(dir, ".env");
+      writeFileSync(envPath, "APP_OK=1\nnot valid\n", "utf8");
+
+      assert.throws(
+        () => createEnvContext({ envFile: envPath }),
+        {
+          name: "SyntaxError",
+          message:
+            `Invalid .env syntax in ${envPath} at line 2: expected KEY=VALUE.`,
+        },
+      );
+    }));
+
+  it("throws TypeError for invalid envFile options", () => {
+    assert.throws(
+      () => createEnvContext({ envFile: 123 as never }),
+      {
+        name: "TypeError",
+        message:
+          "Expected envFile to be a boolean, string, array, or object, but got: number.",
+      },
+    );
+    assert.throws(
+      () => createEnvContext({ envFile: { paths: 123 } as never }),
+      {
+        name: "TypeError",
+        message:
+          "Expected envFile.paths to be a boolean, string, array, or undefined, but got: number.",
+      },
+    );
+    assert.throws(
+      () =>
+        createEnvContext({
+          envFile: { paths: ".env", substitute: "nope" } as never,
+        }),
+      {
+        name: "TypeError",
+        message:
+          "Expected envFile.substitute to be a function or undefined, but got: string.",
+      },
+    );
   });
 });
 

--- a/packages/env/src/index.test.ts
+++ b/packages/env/src/index.test.ts
@@ -2950,6 +2950,18 @@ describe("createEnvContext defaults", () => {
       assert.equal(context.source("APP_TWO"), "2");
     }));
 
+  it("accepts trailing whitespace-only envFile lines without a newline", () =>
+    withTempDir((dir) => {
+      const envPath = join(dir, ".env");
+      writeFileSync(envPath, "APP_ONE=1\n\t  ", "utf8");
+      const context = createEnvContext({
+        envFile: envPath,
+        source: () => undefined,
+      });
+
+      assert.equal(context.source("APP_ONE"), "1");
+    }));
+
   it("reports line numbers for carriage-return-only envFile syntax errors", () =>
     withTempDir((dir) => {
       const envPath = join(dir, ".env");

--- a/packages/env/src/index.test.ts
+++ b/packages/env/src/index.test.ts
@@ -2993,6 +2993,62 @@ describe("createEnvContext defaults", () => {
       assert.equal(context.source("APP_MISSING"), "before--after");
     }));
 
+  it("expands current envFile values before previous envFile values", () =>
+    withTempDir((dir) => {
+      const basePath = join(dir, ".env");
+      const localPath = join(dir, ".env.local");
+      writeFileSync(
+        basePath,
+        [
+          "APP_ROOT=/base",
+          "APP_CACHE=$APP_ROOT/cache",
+        ].join("\n"),
+        "utf8",
+      );
+      writeFileSync(
+        localPath,
+        [
+          "APP_ROOT=/local",
+          "APP_BIN=$APP_ROOT/bin",
+          "APP_LOG=$APP_CACHE/log",
+        ].join("\n"),
+        "utf8",
+      );
+      const context = createEnvContext({
+        envFile: [basePath, localPath],
+        source: () => undefined,
+      });
+
+      assert.equal(context.source("APP_ROOT"), "/local");
+      assert.equal(context.source("APP_CACHE"), "/base/cache");
+      assert.equal(context.source("APP_BIN"), "/local/bin");
+      assert.equal(context.source("APP_LOG"), "/base/cache/log");
+    }));
+
+  it("preserves envFile keys that match Object prototype properties", () =>
+    withTempDir((dir) => {
+      const envPath = join(dir, ".env");
+      writeFileSync(
+        envPath,
+        [
+          "__proto__=literal",
+          "APP_PROTO=$__proto__",
+          "constructor=ctor",
+          "APP_CTOR=$constructor",
+        ].join("\n"),
+        "utf8",
+      );
+      const context = createEnvContext({
+        envFile: envPath,
+        source: () => undefined,
+      });
+
+      assert.equal(context.source("__proto__"), "literal");
+      assert.equal(context.source("APP_PROTO"), "literal");
+      assert.equal(context.source("constructor"), "ctor");
+      assert.equal(context.source("APP_CTOR"), "ctor");
+    }));
+
   it("keeps single-quoted values literal without substitutions", () =>
     withTempDir((dir) => {
       const envPath = join(dir, ".env");

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -451,6 +451,7 @@ function parseEnvFile(
   while (index < input.length) {
     const line = getLineNumber(input, index);
     index = skipHorizontalWhitespace(input, index);
+    if (index >= input.length) break;
     if (input[index] === "\r" || input[index] === "\n") {
       index = readNewline(input, index);
       continue;

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { resolve as resolvePath } from "node:path";
 import { getAnnotations } from "@optique/core/annotations";
 import type { Annotations, SourceContext } from "@optique/core/context";
 import {
@@ -36,6 +38,39 @@ import {
  * @since 1.0.0
  */
 export type EnvSource = (key: string) => string | undefined;
+
+/**
+ * Function type for command substitution in `.env` file values.
+ *
+ * @since 1.1.0
+ */
+export type EnvFileSubstitute = (command: string) => string | undefined;
+
+/**
+ * Path option for `.env` files loaded by {@link createEnvContext}.
+ *
+ * @since 1.1.0
+ */
+export type EnvFilePaths = boolean | string | readonly string[];
+
+/**
+ * Options for loading `.env` files.
+ *
+ * @since 1.1.0
+ */
+export interface EnvFileOptions {
+  /**
+   * Path or paths to `.env` files.  When `true` or omitted, loads `.env`
+   * from the current working directory.  Missing files are skipped.
+   */
+  readonly paths?: EnvFilePaths;
+
+  /**
+   * Optional command substitution hook for `$(...)` and backtick forms.
+   * Optique never executes commands by itself.
+   */
+  readonly substitute?: EnvFileSubstitute;
+}
 
 interface EnvSourceData {
   readonly prefix: string;
@@ -78,6 +113,27 @@ export interface EnvContextOptions {
    * @default Runtime-specific source (`Deno.env.get` or `process.env`)
    */
   readonly source?: EnvSource;
+
+  /**
+   * Path(s) to `.env` files to load as an internal fallback layer.
+   *
+   * When `true`, searches for `.env` in the current working directory.
+   * When a string or array of strings, loads those explicit files.
+   * Files are loaded in order; later files override earlier files.
+   *
+   * Values loaded from `.env` files do not mutate `process.env` or
+   * `Deno.env`, and the real environment source remains higher priority.
+   *
+   * @default undefined
+   * @since 1.1.0
+   */
+  readonly envFile?: EnvFilePaths | EnvFileOptions;
+}
+
+function getTypeName(value: unknown): string {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "array";
+  return typeof value;
 }
 
 function defaultEnvSource(key: string): string | undefined {
@@ -91,6 +147,387 @@ function defaultEnvSource(key: string): string | undefined {
     readonly process?: { readonly env?: Record<string, string | undefined> };
   }).process;
   return processGlobal?.env?.[key];
+}
+
+function isErrnoException(error: unknown): error is { readonly code: string } {
+  return error != null &&
+    typeof error === "object" &&
+    "code" in error &&
+    typeof (error as { readonly code?: unknown }).code === "string";
+}
+
+function normalizeEnvFilePaths(paths: EnvFilePaths): readonly string[] {
+  if (paths === false) return [];
+  if (paths === true) return [".env"];
+  if (typeof paths === "string") return [paths];
+  if (Array.isArray(paths)) {
+    for (const path of paths) {
+      if (typeof path !== "string") {
+        throw new TypeError(
+          `Expected envFile paths to be strings, but got: ${
+            getTypeName(path)
+          }.`,
+        );
+      }
+    }
+    return paths;
+  }
+  throw new TypeError(
+    `Expected envFile.paths to be a boolean, string, array, or undefined, but got: ${
+      getTypeName(paths)
+    }.`,
+  );
+}
+
+interface NormalizedEnvFileOptions {
+  readonly paths: readonly string[];
+  readonly substitute?: EnvFileSubstitute;
+}
+
+function normalizeEnvFileOptions(
+  envFile: EnvContextOptions["envFile"],
+): NormalizedEnvFileOptions {
+  if (envFile === undefined || envFile === false) {
+    return { paths: [] };
+  }
+  if (
+    envFile === true ||
+    typeof envFile === "string" ||
+    Array.isArray(envFile)
+  ) {
+    return { paths: normalizeEnvFilePaths(envFile) };
+  }
+  if (envFile == null || typeof envFile !== "object") {
+    throw new TypeError(
+      `Expected envFile to be a boolean, string, array, or object, but got: ${
+        getTypeName(envFile)
+      }.`,
+    );
+  }
+  const options = envFile as EnvFileOptions;
+  const rawSubstitute = options.substitute;
+  if (rawSubstitute !== undefined && typeof rawSubstitute !== "function") {
+    throw new TypeError(
+      `Expected envFile.substitute to be a function or undefined, but got: ${
+        getTypeName(rawSubstitute)
+      }.`,
+    );
+  }
+  return {
+    paths: normalizeEnvFilePaths(options.paths ?? true),
+    ...(rawSubstitute === undefined ? {} : { substitute: rawSubstitute }),
+  };
+}
+
+function isEnvNameStart(character: string): boolean {
+  return /[A-Za-z_]/u.test(character);
+}
+
+function isEnvNamePart(character: string): boolean {
+  return /[A-Za-z0-9_]/u.test(character);
+}
+
+function getLineNumber(input: string, offset: number): number {
+  let line = 1;
+  for (let index = 0; index < offset; index++) {
+    if (input[index] === "\n") {
+      line++;
+    } else if (input[index] === "\r") {
+      line++;
+      if (input[index + 1] === "\n") index++;
+    }
+  }
+  return line;
+}
+
+function syntaxError(
+  path: string,
+  line: number,
+  messageText: string,
+): SyntaxError {
+  return new SyntaxError(
+    `Invalid .env syntax in ${path} at line ${line}: ${messageText}.`,
+  );
+}
+
+function skipLine(input: string, index: number): number {
+  while (
+    index < input.length &&
+    input[index] !== "\r" &&
+    input[index] !== "\n"
+  ) {
+    index++;
+  }
+  return index;
+}
+
+function readNewline(input: string, index: number): number {
+  if (input[index] === "\r" && input[index + 1] === "\n") return index + 2;
+  if (input[index] === "\r") return index + 1;
+  if (input[index] === "\n") return index + 1;
+  return index;
+}
+
+function skipHorizontalWhitespace(input: string, index: number): number {
+  while (input[index] === " " || input[index] === "\t") index++;
+  return index;
+}
+
+function expandEnvValue(
+  rawValue: string,
+  lookup: EnvSource,
+  substitute: EnvFileSubstitute | undefined,
+  options: {
+    readonly path: string;
+    readonly startLine: number;
+    readonly interpretEscapes: boolean;
+    readonly allowSubstitution: boolean;
+  },
+): string {
+  let output = "";
+  for (let index = 0; index < rawValue.length; index++) {
+    const character = rawValue[index];
+    if (options.interpretEscapes && character === "\\") {
+      const next = rawValue[++index];
+      if (next === undefined) {
+        output += "\\";
+      } else if (next === "n") {
+        output += "\n";
+      } else if (next === "r") {
+        output += "\r";
+      } else if (next === "t") {
+        output += "\t";
+      } else {
+        output += next;
+      }
+      continue;
+    }
+    if (!options.allowSubstitution) {
+      output += character;
+      continue;
+    }
+    if (character === "`") {
+      const end = rawValue.indexOf("`", index + 1);
+      if (end < 0) {
+        throw syntaxError(
+          options.path,
+          options.startLine,
+          "unterminated command substitution",
+        );
+      }
+      const command = rawValue.slice(index + 1, end);
+      output += substitute?.(command) ?? "";
+      index = end;
+      continue;
+    }
+    if (character !== "$") {
+      output += character;
+      continue;
+    }
+    if (rawValue[index + 1] === "(") {
+      const end = rawValue.indexOf(")", index + 2);
+      if (end < 0) {
+        throw syntaxError(
+          options.path,
+          options.startLine,
+          "unterminated command substitution",
+        );
+      }
+      const command = rawValue.slice(index + 2, end);
+      output += substitute?.(command) ?? "";
+      index = end;
+      continue;
+    }
+    if (rawValue[index + 1] === "{") {
+      const end = rawValue.indexOf("}", index + 2);
+      if (end < 0) {
+        throw syntaxError(
+          options.path,
+          options.startLine,
+          "unterminated variable expansion",
+        );
+      }
+      const key = rawValue.slice(index + 2, end);
+      output += lookup(key) ?? "";
+      index = end;
+      continue;
+    }
+    const nameStart = rawValue[index + 1];
+    if (nameStart === undefined || !isEnvNameStart(nameStart)) {
+      output += character;
+      continue;
+    }
+    let end = index + 2;
+    while (end < rawValue.length && isEnvNamePart(rawValue[end])) end++;
+    const key = rawValue.slice(index + 1, end);
+    output += lookup(key) ?? "";
+    index = end - 1;
+  }
+  return output;
+}
+
+function parseQuotedEnvValue(
+  input: string,
+  index: number,
+  quote: "'" | '"',
+  path: string,
+  line: number,
+  lookup: EnvSource,
+  substitute: EnvFileSubstitute | undefined,
+): { readonly value: string; readonly nextIndex: number } {
+  const valueStart = index + 1;
+  let cursor = valueStart;
+  while (cursor < input.length) {
+    const character = input[cursor];
+    if (character === "\\" && quote === '"') {
+      cursor += 2;
+      continue;
+    }
+    if (character === quote) {
+      const rawValue = input.slice(valueStart, cursor);
+      const nextIndex = cursor + 1;
+      return {
+        value: quote === "'"
+          ? rawValue
+          : expandEnvValue(rawValue, lookup, substitute, {
+            path,
+            startLine: line,
+            interpretEscapes: true,
+            allowSubstitution: true,
+          }),
+        nextIndex,
+      };
+    }
+    cursor++;
+  }
+  throw syntaxError(path, line, "unterminated quoted value");
+}
+
+function parseUnquotedEnvValue(
+  input: string,
+  index: number,
+  path: string,
+  line: number,
+  lookup: EnvSource,
+  substitute: EnvFileSubstitute | undefined,
+): { readonly value: string; readonly nextIndex: number } {
+  let cursor = index;
+  while (
+    cursor < input.length &&
+    input[cursor] !== "\r" &&
+    input[cursor] !== "\n"
+  ) {
+    if (
+      input[cursor] === "#" &&
+      (cursor === index || /\s/u.test(input[cursor - 1]))
+    ) {
+      break;
+    }
+    cursor++;
+  }
+  const rawValue = input.slice(index, cursor).trimEnd();
+  return {
+    value: expandEnvValue(rawValue, lookup, substitute, {
+      path,
+      startLine: line,
+      interpretEscapes: false,
+      allowSubstitution: true,
+    }),
+    nextIndex: cursor,
+  };
+}
+
+function parseEnvFile(
+  input: string,
+  path: string,
+  lookup: EnvSource,
+  substitute: EnvFileSubstitute | undefined,
+): Record<string, string> {
+  const values: Record<string, string> = {};
+  let index = input.charCodeAt(0) === 0xfeff ? 1 : 0;
+  while (index < input.length) {
+    const line = getLineNumber(input, index);
+    index = skipHorizontalWhitespace(input, index);
+    if (input[index] === "\r" || input[index] === "\n") {
+      index = readNewline(input, index);
+      continue;
+    }
+    if (input[index] === "#") {
+      index = readNewline(input, skipLine(input, index));
+      continue;
+    }
+    if (
+      input.startsWith("export", index) &&
+      /\s/u.test(input[index + "export".length] ?? "")
+    ) {
+      index = skipHorizontalWhitespace(input, index + "export".length);
+    }
+    const keyStart = index;
+    if (!isEnvNameStart(input[index] ?? "")) {
+      throw syntaxError(path, line, "expected KEY=VALUE");
+    }
+    index++;
+    while (index < input.length && isEnvNamePart(input[index])) index++;
+    const key = input.slice(keyStart, index);
+    index = skipHorizontalWhitespace(input, index);
+    if (input[index] !== "=") {
+      throw syntaxError(path, line, "expected KEY=VALUE");
+    }
+    index = skipHorizontalWhitespace(input, index + 1);
+    const lineLookup: EnvSource = (lookupKey) =>
+      lookup(lookupKey) ??
+        values[lookupKey];
+    const parsed = input[index] === "'" || input[index] === '"'
+      ? parseQuotedEnvValue(
+        input,
+        index,
+        input[index] as "'" | '"',
+        path,
+        line,
+        lineLookup,
+        substitute,
+      )
+      : parseUnquotedEnvValue(input, index, path, line, lineLookup, substitute);
+    values[key] = parsed.value;
+    index = skipHorizontalWhitespace(input, parsed.nextIndex);
+    if (input[index] === "#") {
+      index = skipLine(input, index);
+    } else if (
+      index < input.length &&
+      input[index] !== "\r" &&
+      input[index] !== "\n"
+    ) {
+      throw syntaxError(path, line, "unexpected content after value");
+    }
+    index = readNewline(input, index);
+  }
+  return values;
+}
+
+function loadEnvFileValues(
+  options: NormalizedEnvFileOptions,
+  source: EnvSource,
+): Record<string, string> {
+  const values: Record<string, string> = {};
+  for (const path of options.paths) {
+    const absolutePath = resolvePath(path);
+    try {
+      const contents = readFileSync(absolutePath, "utf8");
+      Object.assign(
+        values,
+        parseEnvFile(
+          contents,
+          absolutePath,
+          (key) => source(key) ?? values[key],
+          options.substitute,
+        ),
+      );
+    } catch (error) {
+      if (isErrnoException(error) && error.code === "ENOENT") continue;
+      throw error;
+    }
+  }
+  return values;
 }
 
 /**
@@ -121,29 +558,25 @@ export function createEnvContext(options: EnvContextOptions = {}): EnvContext {
   const rawSource = options.source;
   if (rawSource !== undefined && typeof rawSource !== "function") {
     throw new TypeError(
-      `Expected source to be a function, but got: ${
-        rawSource === null
-          ? "null"
-          : Array.isArray(rawSource)
-          ? "array"
-          : typeof rawSource
-      }.`,
+      `Expected source to be a function, but got: ${getTypeName(rawSource)}.`,
     );
   }
-  const source = rawSource ?? defaultEnvSource;
+  const baseSource = rawSource ?? defaultEnvSource;
   const rawPrefix = options.prefix;
   if (rawPrefix !== undefined && typeof rawPrefix !== "string") {
     throw new TypeError(
-      `Expected prefix to be a string, but got: ${
-        rawPrefix === null
-          ? "null"
-          : Array.isArray(rawPrefix)
-          ? "array"
-          : typeof rawPrefix
-      }.`,
+      `Expected prefix to be a string, but got: ${getTypeName(rawPrefix)}.`,
     );
   }
   const prefix = rawPrefix ?? "";
+  const envFileOptions = normalizeEnvFileOptions(options.envFile);
+  const envFileValues = loadEnvFileValues(envFileOptions, baseSource);
+  const source: EnvSource = (key) => {
+    const value = baseSource(key) as unknown;
+    return value === undefined ? envFileValues[key] : value as
+      | string
+      | undefined;
+  };
 
   return {
     id: contextId,

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -42,6 +42,8 @@ export type EnvSource = (key: string) => string | undefined;
 /**
  * Function type for command substitution in `.env` file values.
  *
+ * @param command Command text captured from `$(...)` or backtick substitution.
+ * @returns Replacement text, or `undefined` to substitute an empty string.
  * @since 1.1.0
  */
 export type EnvFileSubstitute = (command: string) => string | undefined;
@@ -442,8 +444,9 @@ function parseEnvFile(
   path: string,
   lookup: EnvSource,
   substitute: EnvFileSubstitute | undefined,
-): Record<string, string> {
-  const values: Record<string, string> = {};
+  outerValues: ReadonlyMap<string, string> = new Map(),
+): Map<string, string> {
+  const values = new Map<string, string>();
   let index = input.charCodeAt(0) === 0xfeff ? 1 : 0;
   while (index < input.length) {
     const line = getLineNumber(input, index);
@@ -476,7 +479,8 @@ function parseEnvFile(
     index = skipHorizontalWhitespace(input, index + 1);
     const lineLookup: EnvSource = (lookupKey) =>
       lookup(lookupKey) ??
-        values[lookupKey];
+        values.get(lookupKey) ??
+        outerValues.get(lookupKey);
     const parsed = input[index] === "'" || input[index] === '"'
       ? parseQuotedEnvValue(
         input,
@@ -488,7 +492,7 @@ function parseEnvFile(
         substitute,
       )
       : parseUnquotedEnvValue(input, index, path, line, lineLookup, substitute);
-    values[key] = parsed.value;
+    values.set(key, parsed.value);
     index = skipHorizontalWhitespace(input, parsed.nextIndex);
     if (input[index] === "#") {
       index = skipLine(input, index);
@@ -507,21 +511,20 @@ function parseEnvFile(
 function loadEnvFileValues(
   options: NormalizedEnvFileOptions,
   source: EnvSource,
-): Record<string, string> {
-  const values: Record<string, string> = {};
+): ReadonlyMap<string, string> {
+  const values = new Map<string, string>();
   for (const path of options.paths) {
     const absolutePath = resolvePath(path);
     try {
       const contents = readFileSync(absolutePath, "utf8");
-      Object.assign(
+      const parsedValues = parseEnvFile(
+        contents,
+        absolutePath,
+        source,
+        options.substitute,
         values,
-        parseEnvFile(
-          contents,
-          absolutePath,
-          (key) => source(key) ?? values[key],
-          options.substitute,
-        ),
       );
+      for (const [key, value] of parsedValues) values.set(key, value);
     } catch (error) {
       if (isErrnoException(error) && error.code === "ENOENT") continue;
       throw error;
@@ -551,6 +554,10 @@ function loadEnvFileValues(
  * @returns A context that provides environment source annotations.
  * @throws {TypeError} If `prefix` is not a string.
  * @throws {TypeError} If `source` is not a function.
+ * @throws {TypeError} If `envFile` has an invalid shape.
+ * @throws {SyntaxError} If an `.env` file contains invalid syntax.
+ * @throws {Error} If an `.env` file cannot be read for a reason other than
+ * a missing file.
  * @since 1.0.0
  */
 export function createEnvContext(options: EnvContextOptions = {}): EnvContext {
@@ -573,7 +580,7 @@ export function createEnvContext(options: EnvContextOptions = {}): EnvContext {
   const envFileValues = loadEnvFileValues(envFileOptions, baseSource);
   const source: EnvSource = (key) => {
     const value = baseSource(key) as unknown;
-    return value === undefined ? envFileValues[key] : value as
+    return value === undefined ? envFileValues.get(key) : value as
       | string
       | undefined;
   };

--- a/packages/env/tsdown.config.ts
+++ b/packages/env/tsdown.config.ts
@@ -6,5 +6,5 @@ export default defineConfig({
   ],
   dts: true,
   format: ["esm", "cjs"],
-  platform: "neutral",
+  platform: "node",
 });


### PR DESCRIPTION
Summary
-------

This PR adds `EnvContextOptions.envFile` to `@optique/env`. An env context can now load *.env* files as an internal fallback layer, after the configured environment source and before `bindEnv()` defaults.

The loaded values stay inside the Optique env context. They are not written back to `process.env` or `Deno.env`, so applications can opt into file-backed fallbacks without changing process-global state.

Fixes #822.


Behavior
--------

`envFile: true` loads only *.env* from the current working directory. A string loads one explicit file, and an array loads files in order, with later files overriding earlier file values. Missing files are skipped.

The built-in parser supports common dotenv syntax: comments, optional `export` prefixes, unquoted values, quoted values, multiline quoted values, inline comments after unquoted values, and `$VAR`/`${VAR}` expansion.

Single-quoted values are literal. Optique does not expand variables, perform command substitution, or interpret escape sequences inside single quotes.

Command substitution is opt-in. Optique recognizes `$(...)` and backtick forms, but it never executes commands by itself. Applications can provide `envFile.substitute` to handle those forms; without a hook result, the substitution expands to an empty string.


Documentation
-------------

The new option is documented in *docs/integrations/env.md* and *packages/env/README.md*. *CHANGES.md* also includes the release note with links to issue #822 and this PR.


Testing
-------

I added coverage for:

 -  fallback priority between CLI values, real environment values, *.env* values, and defaults
 -  path arrays, missing files, and `envFile: true`
 -  common dotenv syntax, quoted values, multiline values, comments, and carriage-return-only line endings
 -  variable expansion and opt-in command substitution
 -  literal single-quoted values with no substitution or escape handling
 -  invalid syntax and invalid option shapes

Verified with:

~~~~ bash
deno test --allow-read --allow-write --allow-env packages/env/src/index.test.ts
pnpm --filter @optique/env test-all
MISE_JOBS=1 mise test
cd docs && pnpm build
~~~~
