### PR TITLE
Command aliases

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,12 @@ To be released.
 
 ### @optique/core
 
+ -  Added command aliases through `command()`'s `aliases` option.  Aliases
+    parse as the same command, appear in shell completion and typo
+    suggestions, stay hidden from usage and help output, and are rejected at
+    construction time when they collide with sibling command names or aliases.
+    [[#823], [#825]]
+
  -  Fixed shell completion suggestions for configured help and version options.
     Completion requests now include root-level meta options such as `--help`
     and `--version`, including plus-prefixed aliases such as `+h`, without
@@ -120,6 +126,8 @@ To be released.
 [#817]: https://github.com/dahlia/optique/pull/817
 [#819]: https://github.com/dahlia/optique/issues/819
 [#820]: https://github.com/dahlia/optique/pull/820
+[#823]: https://github.com/dahlia/optique/issues/823
+[#825]: https://github.com/dahlia/optique/pull/825
 
 ### @optique/discover
 

--- a/docs/concepts/completion.md
+++ b/docs/concepts/completion.md
@@ -165,6 +165,11 @@ suggest(option("-v", "--verbose"), ["--v"]);
 suggest(command("build", parser), ["bu"]);
 // Returns: [{ kind: "literal", text: "build" }]
 
+// Command aliases are suggested too
+suggest(command("install", parser, { aliases: ["i"] }), [""]);
+// Returns: [{ kind: "literal", text: "install" },
+//           { kind: "literal", text: "i" }]
+
 // Argument parsers delegate to their value parsers
 suggest(argument(choice(["start", "stop"])), ["st"]);
 // Returns: [{ kind: "literal", text: "start" }, { kind: "literal", text: "stop" }]

--- a/docs/concepts/primitives.md
+++ b/docs/concepts/primitives.md
@@ -610,6 +610,39 @@ const addCommand = command("add", innerParser, {
 > enabling rich descriptions with semantic components for better help text
 > formatting.
 
+### Command aliases
+
+Use `aliases` when a command should accept shorter or legacy names while keeping
+one canonical display name:
+
+~~~~ typescript twoslash
+import { object } from "@optique/core/constructs";
+import { command, option } from "@optique/core/primitives";
+import { string } from "@optique/core/valueparser";
+
+const installCommand = command("install", object({
+  packageName: option("--package", string())
+}), {
+  aliases: ["i"] // [!code highlight]
+});
+~~~~
+
+Aliases parse exactly like the canonical command name.  They are suggested by
+shell completion, but usage and help output continue to show only the canonical
+name.  This keeps the public help text focused on the preferred command name
+without requiring a duplicate hidden command branch.
+
+Command aliases share the command namespace with sibling commands in
+alternative-style compositions.  Optique throws a `TypeError` when a command
+name or alias collides with another command name or alias among active siblings
+in `or()`, `longestMatch()`, `object()`, or `merge()`.
+
+Ordered compositions such as `tuple()` and `seq()` are different: their child
+parsers are positional parts of the same command line, not alternative commands
+at one position.  In those parsers, the same command name or alias can appear in
+more than one child when the grammar intentionally expects the command token
+more than once.
+
 ### Command usage lines
 
 For command help pages, you can override the usage tail with `usageLine`.

--- a/packages/core/src/constructs.test.ts
+++ b/packages/core/src/constructs.test.ts
@@ -22409,6 +22409,87 @@ describe("seq", () => {
     );
   });
 
+  it("should reject command collisions from parser metadata", () => {
+    const custom = createSyncBranchParser(
+      undefined,
+      () => ({
+        success: false,
+        consumed: 0,
+        error: message`Expected custom command.`,
+      }),
+      "custom",
+      {
+        leadingNames: new Set(["install"]),
+        priority: 15,
+        usage: [],
+      },
+    );
+
+    assert.throws(
+      () => or(custom, command("install", object({}))),
+      {
+        name: "TypeError",
+        message:
+          /Duplicate command name "install".*unique within active parser alternatives\./,
+      },
+    );
+  });
+
+  it("should reject command collisions across or() priorities", () => {
+    const highPriority = createSyncBranchParser(
+      undefined,
+      () => ({
+        success: false,
+        consumed: 0,
+        error: message`Expected high priority command.`,
+      }),
+      "highPriority",
+      {
+        leadingNames: new Set(["install"]),
+        priority: 20,
+        usage: [],
+      },
+    );
+    const lowPriority = createSyncBranchParser(
+      undefined,
+      () => ({
+        success: false,
+        consumed: 0,
+        error: message`Expected low priority command.`,
+      }),
+      "lowPriority",
+      {
+        leadingNames: new Set(["install"]),
+        priority: 10,
+        usage: [],
+      },
+    );
+
+    assert.throws(
+      () => or(highPriority, lowPriority),
+      {
+        name: "TypeError",
+        message:
+          /Duplicate command name "install".*unique within active parser alternatives\./,
+      },
+    );
+  });
+
+  it("should reject option-shaped command collisions", () => {
+    assert.throws(
+      () =>
+        or(
+          command("--help", object({})),
+          command("--help", object({})),
+        ),
+      {
+        name: "TypeError",
+        message:
+          /Duplicate command name "--help".*unique within active parser alternatives\./,
+      },
+    );
+  });
+
   it("should reject command alias collisions in longestMatch()", () => {
     assert.throws(
       () =>

--- a/packages/core/src/constructs.test.ts
+++ b/packages/core/src/constructs.test.ts
@@ -110,6 +110,38 @@ function collectEntries(
   });
 }
 
+function docOnlyCommandEntry(name: string): Parser<"sync", null, undefined> {
+  return {
+    mode: "sync",
+    $valueType: [] as readonly null[],
+    $stateType: [] as readonly undefined[],
+    priority: 0,
+    usage: [],
+    leadingNames: new Set(),
+    acceptingAnyToken: false,
+    initialState: undefined,
+    parse() {
+      return {
+        success: false as const,
+        consumed: 0,
+        error: message`Documentation-only parser.`,
+      };
+    },
+    complete() {
+      return { success: true as const, value: null };
+    },
+    *suggest() {},
+    getDocFragments() {
+      return {
+        fragments: [{
+          type: "entry" as const,
+          term: { type: "command" as const, name },
+        }],
+      };
+    },
+  };
+}
+
 function assertErrorIncludes(error: Message, text: string): void {
   const formatted = formatMessage(error);
   assert.ok(formatted.includes(text));
@@ -957,8 +989,8 @@ describe("or", () => {
 
     it("should deduplicate entries with same command name", () => {
       const orParser = or(
-        command("dup", object({})),
-        command("dup", argument(string())),
+        docOnlyCommandEntry("dup"),
+        docOnlyCommandEntry("dup"),
       );
 
       const fragments = orParser.getDocFragments({
@@ -3192,8 +3224,8 @@ describe("longestMatch()", () => {
 
   it("should deduplicate entries with same command name", () => {
     const parser = longestMatch(
-      command("build", object({})),
-      command("build", argument(string())),
+      docOnlyCommandEntry("build"),
+      docOnlyCommandEntry("build"),
     );
 
     const fragments = parser.getDocFragments({ kind: "unavailable" });
@@ -21723,6 +21755,17 @@ describe("leadingNames", () => {
     assert.deepEqual(parser.leadingNames, new Set(["help", "build"]));
   });
 
+  it("should include command aliases in or() leading names", () => {
+    const parser = or(
+      command("install", object({}), { aliases: ["i"] }),
+      command("remove", object({}), { aliases: ["rm"] }),
+    );
+    assert.deepEqual(
+      parser.leadingNames,
+      new Set(["install", "i", "remove", "rm"]),
+    );
+  });
+
   it("should be the union of all branches for longestMatch()", () => {
     const parser = longestMatch(
       command("help", object({})),
@@ -22349,6 +22392,58 @@ describe("seq", () => {
       success: true,
       value: [{ path: false }, { path: true }],
     });
+  });
+
+  it("should reject command alias collisions in or()", () => {
+    assert.throws(
+      () =>
+        or(
+          command("install", object({}), { aliases: ["i"] }),
+          command("inspect", object({}), { aliases: ["i"] }),
+        ),
+      {
+        name: "TypeError",
+        message:
+          'Duplicate command name "i" found in parsers: 0, 1. Each command name or alias must be unique within active parser alternatives.',
+      },
+    );
+  });
+
+  it("should reject command alias collisions in longestMatch()", () => {
+    assert.throws(
+      () =>
+        longestMatch(
+          command("install", object({}), { aliases: ["i"] }),
+          command("i", object({})),
+        ),
+      TypeError,
+    );
+  });
+
+  it("should reject command alias collisions in object()", () => {
+    assert.throws(
+      () =>
+        object({
+          install: command("install", object({}), { aliases: ["i"] }),
+          inspect: command("inspect", object({}), { aliases: ["i"] }),
+        }),
+      TypeError,
+    );
+  });
+
+  it("should reject command alias collisions in merge()", () => {
+    assert.throws(
+      () =>
+        merge(
+          object({
+            install: command("install", object({}), { aliases: ["i"] }),
+          }),
+          object({
+            inspect: command("inspect", object({}), { aliases: ["i"] }),
+          }),
+        ),
+      TypeError,
+    );
   });
 
   it("should evaluate lazy defaults once during completion", () => {

--- a/packages/core/src/constructs.test.ts
+++ b/packages/core/src/constructs.test.ts
@@ -22439,6 +22439,29 @@ describe("seq", () => {
     );
   });
 
+  it("should allow unreachable command alias collisions in object()", () => {
+    const blocker = createSyncBranchParser(
+      undefined,
+      () => {
+        return {
+          success: false,
+          consumed: 0,
+          error: message`Expected input.`,
+        };
+      },
+      "blocked",
+      { acceptingAnyToken: true, priority: 20 },
+    );
+
+    assert.doesNotThrow(() =>
+      object({
+        blocker,
+        install: command("install", object({}), { aliases: ["i"] }),
+        inspect: command("inspect", object({}), { aliases: ["i"] }),
+      })
+    );
+  });
+
   it("should reject command alias collisions in merge()", () => {
     assert.throws(
       () =>
@@ -22455,6 +22478,33 @@ describe("seq", () => {
         message:
           /Duplicate command name "i".*unique within active parser alternatives\./,
       },
+    );
+  });
+
+  it("should allow unreachable command alias collisions in merge()", () => {
+    const blocker = createSyncBranchParser(
+      undefined,
+      () => {
+        return {
+          success: false,
+          consumed: 0,
+          error: message`Expected input.`,
+        };
+      },
+      "blocked",
+      { acceptingAnyToken: true, priority: 20 },
+    );
+
+    assert.doesNotThrow(() =>
+      merge(
+        object({ blocker }),
+        object({
+          install: command("install", object({}), { aliases: ["i"] }),
+        }),
+        object({
+          inspect: command("inspect", object({}), { aliases: ["i"] }),
+        }),
+      )
     );
   });
 

--- a/packages/core/src/constructs.test.ts
+++ b/packages/core/src/constructs.test.ts
@@ -22421,7 +22421,7 @@ describe("seq", () => {
       {
         leadingNames: new Set(["install"]),
         priority: 15,
-        usage: [],
+        usage: [{ type: "command", name: "install" }],
       },
     );
 
@@ -22433,6 +22433,37 @@ describe("seq", () => {
           /Duplicate command name "install".*unique within active parser alternatives\./,
       },
     );
+  });
+
+  it("should allow duplicate literal leading names without command terms", () => {
+    const http = createSyncBranchParser(
+      undefined,
+      () => ({
+        success: false,
+        consumed: 0,
+        error: message`Expected serve http.`,
+      }),
+      "http",
+      {
+        leadingNames: new Set(["serve"]),
+        usage: [{ type: "argument", metavar: "MODE" }],
+      },
+    );
+    const grpc = createSyncBranchParser(
+      undefined,
+      () => ({
+        success: false,
+        consumed: 0,
+        error: message`Expected serve grpc.`,
+      }),
+      "grpc",
+      {
+        leadingNames: new Set(["serve"]),
+        usage: [{ type: "argument", metavar: "MODE" }],
+      },
+    );
+
+    assert.doesNotThrow(() => or(http, grpc));
   });
 
   it("should reject command collisions across or() priorities", () => {
@@ -22447,7 +22478,7 @@ describe("seq", () => {
       {
         leadingNames: new Set(["install"]),
         priority: 20,
-        usage: [],
+        usage: [{ type: "command", name: "install" }],
       },
     );
     const lowPriority = createSyncBranchParser(
@@ -22461,7 +22492,7 @@ describe("seq", () => {
       {
         leadingNames: new Set(["install"]),
         priority: 10,
-        usage: [],
+        usage: [{ type: "command", name: "install" }],
       },
     );
 

--- a/packages/core/src/constructs.test.ts
+++ b/packages/core/src/constructs.test.ts
@@ -535,6 +535,22 @@ describe("or", () => {
     }
   });
 
+  it("should expand aliases from later sibling command suggestions", () => {
+    const orParser = or(
+      command("install", object({}), { aliases: ["i"] }),
+      command("remove", object({}), { aliases: ["rm"] }),
+    );
+
+    const result = parseSync(orParser, ["rmm"]);
+
+    assert.ok(!result.success);
+    if (!result.success) {
+      assertErrorIncludes(result.error, "Did you mean one of these?");
+      assertErrorIncludes(result.error, "`remove`");
+      assertErrorIncludes(result.error, "`rm`");
+    }
+  });
+
   it("should detect mutually exclusive options", () => {
     const parser1 = option("-a");
     const parser2 = option("-b");

--- a/packages/core/src/constructs.test.ts
+++ b/packages/core/src/constructs.test.ts
@@ -22416,7 +22416,11 @@ describe("seq", () => {
           command("install", object({}), { aliases: ["i"] }),
           command("i", object({})),
         ),
-      TypeError,
+      {
+        name: "TypeError",
+        message:
+          /Duplicate command name "i".*unique within active parser alternatives\./,
+      },
     );
   });
 
@@ -22427,7 +22431,11 @@ describe("seq", () => {
           install: command("install", object({}), { aliases: ["i"] }),
           inspect: command("inspect", object({}), { aliases: ["i"] }),
         }),
-      TypeError,
+      {
+        name: "TypeError",
+        message:
+          /Duplicate command name "i".*unique within active parser alternatives\./,
+      },
     );
   });
 
@@ -22442,7 +22450,11 @@ describe("seq", () => {
             inspect: command("inspect", object({}), { aliases: ["i"] }),
           }),
         ),
-      TypeError,
+      {
+        name: "TypeError",
+        message:
+          /Duplicate command name "i".*unique within active parser alternatives\./,
+      },
     );
   });
 

--- a/packages/core/src/constructs.ts
+++ b/packages/core/src/constructs.ts
@@ -1066,7 +1066,7 @@ function checkDuplicateLeadingCommandNames(
   for (const [source, parser] of parserSources) {
     const commandNames = extractCommandNames(parser.usage, true);
     for (const name of parser.leadingNames) {
-      if (/^(--|[-/+])/.test(name) && !commandNames.has(name)) continue;
+      if (!commandNames.has(name)) continue;
       const sources = commandNameSources.get(name);
       commandNameSources.set(
         name,
@@ -1110,7 +1110,7 @@ function checkDuplicateReachableLeadingCommandNames(
       if (parser.acceptingAnyToken) groupAcceptsAnyToken = true;
       const commandNames = extractCommandNames(parser.usage, true);
       for (const name of parser.leadingNames) {
-        if (/^(--|[-/+])/.test(name) && !commandNames.has(name)) continue;
+        if (!commandNames.has(name)) continue;
         if (positionalBlocked || blockedNames.has(name)) continue;
         groupNames.add(name);
         const sources = commandNameSources.get(name);

--- a/packages/core/src/constructs.ts
+++ b/packages/core/src/constructs.ts
@@ -672,8 +672,11 @@ function createUnexpectedInputErrorWithScopedSuggestions(
     candidates,
     DEFAULT_FIND_SIMILAR_OPTIONS,
   );
+  const aliasUsage: Usage = [
+    { type: "exclusive", terms: parsers.map((parser) => parser.usage) },
+  ];
   const displaySuggestions = expandCommandAliasSuggestions(
-    parsers.flatMap((parser) => parser.usage),
+    aliasUsage,
     suggestions,
   );
   const suggestionMsg = customFormatter

--- a/packages/core/src/constructs.ts
+++ b/packages/core/src/constructs.ts
@@ -31,6 +31,7 @@ import {
   getAnnotations,
   inheritAnnotations,
 } from "./internal/annotations.ts";
+import { allowDuplicateLeadingCommandNamesKey } from "./internal/command-alias.ts";
 import {
   mergeChildExec,
   withChildContext as withSharedChildContext,
@@ -4046,9 +4047,6 @@ export interface LongestMatchOptions {
    */
   errors?: LongestMatchErrorOptions;
 }
-
-const allowDuplicateLeadingCommandNamesKey =
-  "__optiqueAllowDuplicateLeadingCommandNames";
 
 type InternalLongestMatchOptions = LongestMatchOptions & {
   readonly [allowDuplicateLeadingCommandNamesKey]?: true;

--- a/packages/core/src/constructs.ts
+++ b/packages/core/src/constructs.ts
@@ -1057,13 +1057,15 @@ function checkDuplicateOptionNames(
 }
 
 function checkDuplicateLeadingCommandNames(
-  parserSources: ReadonlyArray<readonly [string | symbol, Usage]>,
+  parserSources: ReadonlyArray<
+    readonly [string | symbol, Parser<Mode, unknown, unknown>]
+  >,
 ): void {
   const commandNameSources = new Map<string, (string | symbol)[]>();
 
-  for (const [source, usage] of parserSources) {
-    const names = extractParsableLeadingCommandNames(usage);
-    for (const name of names) {
+  for (const [source, parser] of parserSources) {
+    for (const name of parser.leadingNames) {
+      if (isNonCommandOptionLeadingName(parser, name)) continue;
       const sources = commandNameSources.get(name);
       commandNameSources.set(
         name,
@@ -1085,12 +1087,30 @@ function checkDuplicateReachableLeadingCommandNames(
   >,
 ): void {
   const commandNameSources = new Map<string, (string | symbol)[]>();
+  const sortedSources = parserSources.toSorted(([, parserA], [, parserB]) =>
+    parserB.priority - parserA.priority
+  );
+  const blockedNames = new Set<string>();
   let positionalBlocked = false;
 
-  for (const [source, parser] of parserSources) {
-    if (!positionalBlocked) {
-      const names = extractParsableLeadingCommandNames(parser.usage);
-      for (const name of names) {
+  for (let i = 0; i < sortedSources.length;) {
+    const priority = sortedSources[i][1].priority;
+    const priorityGroup: typeof sortedSources = [];
+    while (
+      i < sortedSources.length && sortedSources[i][1].priority === priority
+    ) {
+      priorityGroup.push(sortedSources[i]);
+      i++;
+    }
+
+    const groupNames = new Set<string>();
+    let groupAcceptsAnyToken = false;
+    for (const [source, parser] of priorityGroup) {
+      if (parser.acceptingAnyToken) groupAcceptsAnyToken = true;
+      for (const name of parser.leadingNames) {
+        if (isNonCommandOptionLeadingName(parser, name)) continue;
+        if (positionalBlocked || blockedNames.has(name)) continue;
+        groupNames.add(name);
         const sources = commandNameSources.get(name);
         commandNameSources.set(
           name,
@@ -1098,7 +1118,8 @@ function checkDuplicateReachableLeadingCommandNames(
         );
       }
     }
-    if (parser.acceptingAnyToken) positionalBlocked = true;
+    for (const name of groupNames) blockedNames.add(name);
+    if (groupAcceptsAnyToken) positionalBlocked = true;
   }
 
   for (const [name, sources] of commandNameSources) {
@@ -1106,6 +1127,14 @@ function checkDuplicateReachableLeadingCommandNames(
       throw new DuplicateCommandNameError(name, sources);
     }
   }
+}
+
+function isNonCommandOptionLeadingName(
+  parser: Parser<Mode, unknown, unknown>,
+  name: string,
+): boolean {
+  if (!/^(--|[-/+])/.test(name)) return false;
+  return !extractCommandNames(parser.usage, true).has(name);
 }
 
 /**
@@ -1117,13 +1146,6 @@ function checkDuplicateReachableLeadingCommandNames(
  */
 function extractParsableOptionNames(usage: Usage): Set<string> {
   return extractOptionNames(usage, true);
-}
-
-function extractParsableLeadingCommandNames(usage: Usage): Set<string> {
-  const options = new Set<string>();
-  const commands = new Set<string>();
-  collectLeadingCandidates(usage, options, commands, true);
-  return commands;
 }
 
 /**
@@ -3152,7 +3174,7 @@ export function or(
   }
   assertParsers(parsers, "or()");
   checkDuplicateLeadingCommandNames(
-    parsers.map((parser, index) => [String(index), parser.usage] as const),
+    parsers.map((parser, index) => [String(index), parser] as const),
   );
 
   // Analyze context once for error message generation
@@ -4350,7 +4372,7 @@ function createLongestMatch(
     options?.[allowDuplicateLeadingCommandNamesKey] === true;
   if (!allowDuplicateLeadingCommandNames) {
     checkDuplicateLeadingCommandNames(
-      parsers.map((parser, index) => [String(index), parser.usage] as const),
+      parsers.map((parser, index) => [String(index), parser] as const),
     );
   }
 

--- a/packages/core/src/constructs.ts
+++ b/packages/core/src/constructs.ts
@@ -1079,6 +1079,35 @@ function checkDuplicateLeadingCommandNames(
   }
 }
 
+function checkDuplicateReachableLeadingCommandNames(
+  parserSources: ReadonlyArray<
+    readonly [string | symbol, Parser<Mode, unknown, unknown>]
+  >,
+): void {
+  const commandNameSources = new Map<string, (string | symbol)[]>();
+  let positionalBlocked = false;
+
+  for (const [source, parser] of parserSources) {
+    if (!positionalBlocked) {
+      const names = extractParsableLeadingCommandNames(parser.usage);
+      for (const name of names) {
+        const sources = commandNameSources.get(name);
+        commandNameSources.set(
+          name,
+          sources == null ? [source] : [...sources, source],
+        );
+      }
+    }
+    if (parser.acceptingAnyToken) positionalBlocked = true;
+  }
+
+  for (const [name, sources] of commandNameSources) {
+    if (sources.length > 1) {
+      throw new DuplicateCommandNameError(name, sources);
+    }
+  }
+}
+
 /**
  * Extracts option names that participate in CLI syntax.
  *
@@ -5748,9 +5777,9 @@ export function object<
       ),
     );
   }
-  checkDuplicateLeadingCommandNames(
+  checkDuplicateReachableLeadingCommandNames(
     parserPairs.map(([field, parser]) =>
-      [field as string | symbol, parser.usage] as const
+      [field as string | symbol, parser] as const
     ),
   );
 
@@ -9951,9 +9980,9 @@ export function merge(
       ),
     );
   }
-  checkDuplicateLeadingCommandNames(
+  checkDuplicateReachableLeadingCommandNames(
     sorted.map(([parser, originalIndex]) =>
-      [String(originalIndex), parser.usage] as const
+      [String(originalIndex), parser] as const
     ),
   );
 

--- a/packages/core/src/constructs.ts
+++ b/packages/core/src/constructs.ts
@@ -636,6 +636,7 @@ import {
   createSuggestionMessage,
   deduplicateSuggestions,
   DEFAULT_FIND_SIMILAR_OPTIONS,
+  expandCommandAliasSuggestions,
   findSimilar,
 } from "./suggestion.ts";
 import {
@@ -670,9 +671,13 @@ function createUnexpectedInputErrorWithScopedSuggestions(
     candidates,
     DEFAULT_FIND_SIMILAR_OPTIONS,
   );
+  const displaySuggestions = expandCommandAliasSuggestions(
+    parsers.flatMap((parser) => parser.usage),
+    suggestions,
+  );
   const suggestionMsg = customFormatter
-    ? customFormatter(suggestions)
-    : createSuggestionMessage(suggestions);
+    ? customFormatter(displaySuggestions)
+    : createSuggestionMessage(displaySuggestions);
 
   return suggestionMsg.length > 0
     ? [...baseError, text("\n\n"), ...suggestionMsg]
@@ -1002,6 +1007,26 @@ export class DuplicateOptionError extends Error {
 }
 
 /**
+ * Error class thrown when duplicate command names or aliases are detected
+ * during parser construction. This is a programmer error, not a user error.
+ */
+class DuplicateCommandNameError extends TypeError {
+  constructor(
+    public readonly commandName: string,
+    public readonly sources: readonly (string | symbol)[],
+  ) {
+    const sourceNames = sources.map((s) =>
+      typeof s === "symbol" ? s.description ?? s.toString() : s
+    );
+    super(
+      `Duplicate command name "${commandName}" found in parsers: ` +
+        `${sourceNames.join(", ")}. Each command name or alias must be ` +
+        `unique within active parser alternatives.`,
+    );
+  }
+}
+
+/**
  * Checks for duplicate option names across parser sources and throws an error
  * if duplicates are found. This should be called at construction time.
  * @param parserSources Array of [source, usage] tuples
@@ -1030,6 +1055,29 @@ function checkDuplicateOptionNames(
   }
 }
 
+function checkDuplicateLeadingCommandNames(
+  parserSources: ReadonlyArray<readonly [string | symbol, Usage]>,
+): void {
+  const commandNameSources = new Map<string, (string | symbol)[]>();
+
+  for (const [source, usage] of parserSources) {
+    const names = extractParsableLeadingCommandNames(usage);
+    for (const name of names) {
+      const sources = commandNameSources.get(name);
+      commandNameSources.set(
+        name,
+        sources == null ? [source] : [...sources, source],
+      );
+    }
+  }
+
+  for (const [name, sources] of commandNameSources) {
+    if (sources.length > 1) {
+      throw new DuplicateCommandNameError(name, sources);
+    }
+  }
+}
+
 /**
  * Extracts option names that participate in CLI syntax.
  *
@@ -1039,6 +1087,13 @@ function checkDuplicateOptionNames(
  */
 function extractParsableOptionNames(usage: Usage): Set<string> {
   return extractOptionNames(usage, true);
+}
+
+function extractParsableLeadingCommandNames(usage: Usage): Set<string> {
+  const options = new Set<string>();
+  const commands = new Set<string>();
+  collectLeadingCandidates(usage, options, commands, true);
+  return commands;
 }
 
 /**
@@ -3066,6 +3121,9 @@ export function or(
     throw new TypeError("or() requires at least one parser argument.");
   }
   assertParsers(parsers, "or()");
+  checkDuplicateLeadingCommandNames(
+    parsers.map((parser, index) => [String(index), parser.usage] as const),
+  );
 
   // Analyze context once for error message generation
   const noMatchContext = analyzeNoMatchContext(parsers);
@@ -3989,6 +4047,13 @@ export interface LongestMatchOptions {
   errors?: LongestMatchErrorOptions;
 }
 
+const allowDuplicateLeadingCommandNamesKey =
+  "__optiqueAllowDuplicateLeadingCommandNames";
+
+type InternalLongestMatchOptions = LongestMatchOptions & {
+  readonly [allowDuplicateLeadingCommandNamesKey]?: true;
+};
+
 /**
  * Options for customizing error messages in the {@link longestMatch} parser.
  * @since 0.5.0
@@ -4224,9 +4289,15 @@ export function longestMatch<
 export function longestMatch(
   ...args: Array<Parser<Mode, unknown, unknown> | LongestMatchOptions>
 ): Parser<Mode, unknown, undefined | [number, ParserResult<unknown>]> {
+  return createLongestMatch(...args);
+}
+
+function createLongestMatch(
+  ...args: Array<Parser<Mode, unknown, unknown> | LongestMatchOptions>
+): Parser<Mode, unknown, undefined | [number, ParserResult<unknown>]> {
   // Extract parsers and options from arguments
   let parsers: Parser<Mode, unknown, unknown>[];
-  let options: LongestMatchOptions | undefined;
+  let options: InternalLongestMatchOptions | undefined;
 
   if (
     args.length > 0 && args[args.length - 1] &&
@@ -4234,7 +4305,7 @@ export function longestMatch(
     !("$valueType" in args[args.length - 1])
   ) {
     // Last argument is options
-    options = args[args.length - 1] as LongestMatchOptions;
+    options = args[args.length - 1] as InternalLongestMatchOptions;
     parsers = args.slice(0, -1) as Parser<Mode, unknown, unknown>[];
   } else {
     // No options provided
@@ -4248,6 +4319,13 @@ export function longestMatch(
     );
   }
   assertParsers(parsers, "longestMatch()");
+  const allowDuplicateLeadingCommandNames =
+    options?.[allowDuplicateLeadingCommandNamesKey] === true;
+  if (!allowDuplicateLeadingCommandNames) {
+    checkDuplicateLeadingCommandNames(
+      parsers.map((parser, index) => [String(index), parser.usage] as const),
+    );
+  }
 
   // Analyze context once for error message generation
   const noMatchContext = analyzeNoMatchContext(parsers);
@@ -5672,6 +5750,11 @@ export function object<
       ),
     );
   }
+  checkDuplicateLeadingCommandNames(
+    parserPairs.map(([field, parser]) =>
+      [field as string | symbol, parser.usage] as const
+    ),
+  );
 
   // Analyze context once for error message generation
   const noMatchContext = analyzeNoMatchContext(
@@ -9870,6 +9953,11 @@ export function merge(
       ),
     );
   }
+  checkDuplicateLeadingCommandNames(
+    sorted.map(([parser, originalIndex]) =>
+      [String(originalIndex), parser.usage] as const
+    ),
+  );
 
   // Collect field parser pairs from all children so that nested merge()
   // can pre-complete dependency source fields at the outer level.

--- a/packages/core/src/constructs.ts
+++ b/packages/core/src/constructs.ts
@@ -1088,7 +1088,7 @@ function checkDuplicateReachableLeadingCommandNames(
   >,
 ): void {
   const commandNameSources = new Map<string, (string | symbol)[]>();
-  const sortedSources = parserSources.toSorted(([, parserA], [, parserB]) =>
+  const sortedSources = [...parserSources].sort(([, parserA], [, parserB]) =>
     parserB.priority - parserA.priority
   );
   const blockedNames = new Set<string>();

--- a/packages/core/src/constructs.ts
+++ b/packages/core/src/constructs.ts
@@ -1064,8 +1064,9 @@ function checkDuplicateLeadingCommandNames(
   const commandNameSources = new Map<string, (string | symbol)[]>();
 
   for (const [source, parser] of parserSources) {
+    const commandNames = extractCommandNames(parser.usage, true);
     for (const name of parser.leadingNames) {
-      if (isNonCommandOptionLeadingName(parser, name)) continue;
+      if (/^(--|[-/+])/.test(name) && !commandNames.has(name)) continue;
       const sources = commandNameSources.get(name);
       commandNameSources.set(
         name,
@@ -1107,8 +1108,9 @@ function checkDuplicateReachableLeadingCommandNames(
     let groupAcceptsAnyToken = false;
     for (const [source, parser] of priorityGroup) {
       if (parser.acceptingAnyToken) groupAcceptsAnyToken = true;
+      const commandNames = extractCommandNames(parser.usage, true);
       for (const name of parser.leadingNames) {
-        if (isNonCommandOptionLeadingName(parser, name)) continue;
+        if (/^(--|[-/+])/.test(name) && !commandNames.has(name)) continue;
         if (positionalBlocked || blockedNames.has(name)) continue;
         groupNames.add(name);
         const sources = commandNameSources.get(name);
@@ -1127,14 +1129,6 @@ function checkDuplicateReachableLeadingCommandNames(
       throw new DuplicateCommandNameError(name, sources);
     }
   }
-}
-
-function isNonCommandOptionLeadingName(
-  parser: Parser<Mode, unknown, unknown>,
-  name: string,
-): boolean {
-  if (!/^(--|[-/+])/.test(name)) return false;
-  return !extractCommandNames(parser.usage, true).has(name);
 }
 
 /**

--- a/packages/core/src/facade.test.ts
+++ b/packages/core/src/facade.test.ts
@@ -4317,7 +4317,7 @@ describe("Subcommand help edge cases (Issue #26 comprehensive coverage)", () => 
       assert.ok(!suggestions.includes("--version"));
     });
 
-    it("should not treat nested command options as current value slots", () => {
+    it("should not treat unmatched nested command options as current value slots", () => {
       const parser = command(
         "outer",
         command("inner", option("--output", string())),
@@ -4446,7 +4446,7 @@ describe("Subcommand help edge cases (Issue #26 comprehensive coverage)", () => 
       assert.ok(!suggestions.includes("--version"));
     });
 
-    it("should not treat nested command options as current value slots", () => {
+    it("should not treat unselected nested command options as current value slots", () => {
       const parser = command(
         "tool",
         or(

--- a/packages/core/src/facade.test.ts
+++ b/packages/core/src/facade.test.ts
@@ -4416,10 +4416,10 @@ describe("Subcommand help edge cases (Issue #26 comprehensive coverage)", () => 
       assert.ok(suggestions.includes("--version"));
     });
 
-    it("should not add meta options while completing an option from a duplicate command branch", () => {
-      const parser = or(
-        command("tool", object({ a: option("--a", string()) })),
-        command("tool", object({ b: option("--b", string()) })),
+    it("should not add meta options while completing a command option value", () => {
+      const parser = command(
+        "tool",
+        object({ b: option("--b", string()) }),
       );
 
       let completionOutput = "";
@@ -4446,10 +4446,13 @@ describe("Subcommand help edge cases (Issue #26 comprehensive coverage)", () => 
       assert.ok(!suggestions.includes("--version"));
     });
 
-    it("should not treat nested duplicate command branch options as current value slots", () => {
-      const parser = or(
-        command("tool", command("deploy", option("--target", string()))),
-        command("tool", command("status", object({}))),
+    it("should not treat nested command options as current value slots", () => {
+      const parser = command(
+        "tool",
+        or(
+          command("deploy", option("--target", string())),
+          command("status", object({})),
+        ),
       );
 
       let completionOutput = "";

--- a/packages/core/src/facade.test.ts
+++ b/packages/core/src/facade.test.ts
@@ -14342,6 +14342,31 @@ describe("branch coverage: facade.ts edge cases", () => {
     );
   });
 
+  it("keeps meta-command aliases out of typo suggestions", () => {
+    const parser = object({ verbose: option("--verbose") });
+
+    let stderrOutput = "";
+    const result = runParser(parser, "myapp", ["asist", "--help"], {
+      help: {
+        command: { names: ["help", "assist"] },
+        option: true,
+        onShow: () => "help-shown",
+      },
+      stdout: () => {},
+      stderr: (text) => {
+        stderrOutput += text + "\n";
+      },
+      onError: (code) => `error-${code}` as never,
+    });
+
+    assert.equal(result, "error-1");
+    assert.ok(stderrOutput.includes("help"));
+    assert.ok(
+      !/\bassist\b/.test(stderrOutput),
+      `hidden help alias should stay out of suggestions, got:\n${stderrOutput}`,
+    );
+  });
+
   it("uses canonical names for meta-command alias help", () => {
     const parser = object({ verbose: option("--verbose") });
 

--- a/packages/core/src/facade.test.ts
+++ b/packages/core/src/facade.test.ts
@@ -11348,8 +11348,7 @@ describe("runWithAsync", () => {
 });
 
 describe("branch coverage: facade.ts edge cases", () => {
-  // Lines 101/149: multi-name help/version commands (i > 0 hidden branch)
-  it("multi-name help command uses hidden:true for i>0 names", () => {
+  it("multi-name help command accepts hidden aliases", () => {
     const parser = object({ verbose: option("--verbose") });
     let helpOutput = "";
     runParser(parser, "test", ["help"], {
@@ -11361,7 +11360,7 @@ describe("branch coverage: facade.ts edge cases", () => {
     assert.ok(helpOutput.length > 0, "help should be shown via 'help' command");
   });
 
-  it("multi-name version command uses hidden:true for i>0 names", () => {
+  it("multi-name version command accepts hidden aliases", () => {
     const parser = object({ verbose: option("--verbose") });
     let versionOutput = "";
     runParser(parser, "test", ["version"], {
@@ -14340,6 +14339,57 @@ describe("branch coverage: facade.ts edge cases", () => {
       !/(?:^|\n)\s+completions\b/m.test(completionOutput) &&
         !/\bmyapp completions\b/.test(completionOutput),
       `hidden completion alias should stay out of help output, got:\n${completionOutput}`,
+    );
+  });
+
+  it("uses canonical names for meta-command alias help", () => {
+    const parser = object({ verbose: option("--verbose") });
+
+    let helpOutput = "";
+    runParser(parser, "myapp", ["h", "--help"], {
+      help: {
+        command: { names: ["help", "h"] },
+        option: true,
+        onShow: () => "help-shown",
+      },
+      stdout: (text) => {
+        helpOutput += text + "\n";
+      },
+    });
+    assert.ok(helpOutput.includes("Usage: myapp help [COMMAND...]"));
+    assert.ok(!helpOutput.includes("Usage: myapp h [COMMAND...]"));
+
+    let versionOutput = "";
+    runParser(parser, "myapp", ["ver", "--help"], {
+      help: { option: true, onShow: () => "help-shown" },
+      version: {
+        command: { names: ["version", "ver"] },
+        value: "1.2.3",
+        onShow: () => "version-shown",
+      },
+      stdout: (text) => {
+        versionOutput += text + "\n";
+      },
+    });
+    assert.ok(versionOutput.includes("Usage: myapp version"));
+    assert.ok(!/^Usage: myapp ver$/m.test(versionOutput));
+
+    let completionOutput = "";
+    runParser(parser, "myapp", ["completions", "--help"], {
+      help: { option: true, onShow: () => "help-shown" },
+      completion: {
+        command: { names: ["completion", "completions"] },
+        onShow: () => "completion-shown",
+      },
+      stdout: (text) => {
+        completionOutput += text + "\n";
+      },
+    });
+    assert.ok(
+      completionOutput.includes("Usage: myapp completion [SHELL] [ARG...]"),
+    );
+    assert.ok(
+      !completionOutput.includes("Usage: myapp completions [SHELL] [ARG...]"),
     );
   });
 

--- a/packages/core/src/facade.ts
+++ b/packages/core/src/facade.ts
@@ -69,7 +69,10 @@ import {
   isInjectedAnnotationWrapper,
   unwrapInjectedAnnotationWrapper,
 } from "./internal/annotations.ts";
-import { allowDuplicateLeadingCommandNamesKey } from "./internal/command-alias.ts";
+import {
+  allowDuplicateLeadingCommandNamesKey,
+  hiddenCommandAliasesKey,
+} from "./internal/command-alias.ts";
 import {
   type MetaEntry,
   validateCommandNames,
@@ -656,7 +659,7 @@ function createHelpParser(
     const aliases = getMetaCommandAliases(names);
     helpCommand = command(names[0], innerParser, {
       description: message`Show help information.`,
-      ...(aliases != null ? { aliases } : {}),
+      ...(aliases != null ? { [hiddenCommandAliasesKey]: aliases } : {}),
       hidden: commandConfig.hidden,
     });
   }
@@ -689,7 +692,7 @@ function createVersionParser(
     const aliases = getMetaCommandAliases(names);
     versionCommand = command(names[0], innerParser, {
       description: message`Show version information.`,
-      ...(aliases != null ? { aliases } : {}),
+      ...(aliases != null ? { [hiddenCommandAliasesKey]: aliases } : {}),
       hidden: commandConfig.hidden,
     });
   }
@@ -859,7 +862,7 @@ function createCompletionParser(
     const aliases = getMetaCommandAliases(names);
     completionCommand = command(names[0], completionInner, {
       ...completionCommandConfig,
-      ...(aliases != null ? { aliases } : {}),
+      ...(aliases != null ? { [hiddenCommandAliasesKey]: aliases } : {}),
       hidden: commandConfig.hidden,
     });
   }

--- a/packages/core/src/facade.ts
+++ b/packages/core/src/facade.ts
@@ -64,6 +64,7 @@ import {
   isInjectedAnnotationWrapper,
   unwrapInjectedAnnotationWrapper,
 } from "./internal/annotations.ts";
+import { allowDuplicateLeadingCommandNamesKey } from "./internal/command-alias.ts";
 import {
   type MetaEntry,
   validateCommandNames,
@@ -77,9 +78,6 @@ import type {
   SourceContext,
   SourceContextRequest,
 } from "./context.ts";
-
-const allowDuplicateLeadingCommandNamesKey =
-  "__optiqueAllowDuplicateLeadingCommandNames";
 
 function longestMatchForMetaCommands(
   ...parsers: Parser<Mode, unknown, unknown>[]

--- a/packages/core/src/facade.ts
+++ b/packages/core/src/facade.ts
@@ -6,7 +6,12 @@ import {
   type ShellCompletion,
   zsh,
 } from "./completion.ts";
-import { group, longestMatch, object } from "./constructs.ts";
+import {
+  group,
+  longestMatch,
+  type LongestMatchOptions,
+  object,
+} from "./constructs.ts";
 import {
   type DocPage,
   type DocSection,
@@ -79,13 +84,21 @@ import type {
   SourceContextRequest,
 } from "./context.ts";
 
+type MetaCommandLongestMatchOptions = LongestMatchOptions & {
+  readonly [allowDuplicateLeadingCommandNamesKey]: true;
+};
+
+/**
+ * Combines built-in meta commands while intentionally bypassing duplicate
+ * leading command name validation in `createLongestMatch()`.
+ */
 function longestMatchForMetaCommands(
   ...parsers: Parser<Mode, unknown, unknown>[]
 ): Parser<Mode, unknown, unknown> {
-  return longestMatch(
-    ...parsers,
-    { [allowDuplicateLeadingCommandNamesKey]: true } as never,
-  );
+  const options: MetaCommandLongestMatchOptions = {
+    [allowDuplicateLeadingCommandNamesKey]: true,
+  };
+  return longestMatch(...parsers, options);
 }
 
 export type { ParserValuePlaceholder, SourceContext, SourceContextRequest };
@@ -1084,14 +1097,10 @@ function combineWithHelpVersion(
     return parsers[0];
   }
 
-  let combined: Parser<Mode, unknown, unknown>;
-  if (parsers.length === 2) {
-    combined = longestMatchForMetaCommands(parsers[0], parsers[1]);
-  } else {
-    // Use variadic longestMatch for all parsers
-    // Our lenient help/version parsers will win because they consume all input
-    combined = longestMatchForMetaCommands(...parsers);
-  }
+  // Our lenient help/version parsers will win because they consume all input.
+  let combined: Parser<Mode, unknown, unknown> = longestMatchForMetaCommands(
+    ...parsers,
+  );
 
   // Reorder the usage so that the main parser's usage appears before
   // meta-command (version/completion/help) usage.  The parsing order
@@ -2728,11 +2737,6 @@ export function runParser<
           // Use longestMatch to combine all parsers
           if (commandParsers.length === 1) {
             helpGeneratorParser = commandParsers[0];
-          } else if (commandParsers.length === 2) {
-            helpGeneratorParser = longestMatchForMetaCommands(
-              commandParsers[0],
-              commandParsers[1],
-            );
           } else {
             helpGeneratorParser = longestMatchForMetaCommands(
               ...commandParsers,

--- a/packages/core/src/facade.ts
+++ b/packages/core/src/facade.ts
@@ -78,6 +78,18 @@ import type {
   SourceContextRequest,
 } from "./context.ts";
 
+const allowDuplicateLeadingCommandNamesKey =
+  "__optiqueAllowDuplicateLeadingCommandNames";
+
+function longestMatchForMetaCommands(
+  ...parsers: Parser<Mode, unknown, unknown>[]
+): Parser<Mode, unknown, unknown> {
+  return longestMatch(
+    ...parsers,
+    { [allowDuplicateLeadingCommandNamesKey]: true } as never,
+  );
+}
+
 export type { ParserValuePlaceholder, SourceContext, SourceContextRequest };
 
 type LiteralSuggestion = Extract<Suggestion, { readonly kind: "literal" }>;
@@ -1076,11 +1088,11 @@ function combineWithHelpVersion(
 
   let combined: Parser<Mode, unknown, unknown>;
   if (parsers.length === 2) {
-    combined = longestMatch(parsers[0], parsers[1]);
+    combined = longestMatchForMetaCommands(parsers[0], parsers[1]);
   } else {
     // Use variadic longestMatch for all parsers
     // Our lenient help/version parsers will win because they consume all input
-    combined = longestMatch(...parsers);
+    combined = longestMatchForMetaCommands(...parsers);
   }
 
   // Reorder the usage so that the main parser's usage appears before
@@ -2719,12 +2731,14 @@ export function runParser<
           if (commandParsers.length === 1) {
             helpGeneratorParser = commandParsers[0];
           } else if (commandParsers.length === 2) {
-            helpGeneratorParser = longestMatch(
+            helpGeneratorParser = longestMatchForMetaCommands(
               commandParsers[0],
               commandParsers[1],
             );
           } else {
-            helpGeneratorParser = longestMatch(...commandParsers);
+            helpGeneratorParser = longestMatchForMetaCommands(
+              ...commandParsers,
+            );
           }
         }
 

--- a/packages/core/src/facade.ts
+++ b/packages/core/src/facade.ts
@@ -628,6 +628,13 @@ interface VersionParsers {
   readonly versionOption: Parser<"sync", boolean, unknown> | null;
 }
 
+function getMetaCommandAliases(
+  names: readonly [string, ...string[]],
+): readonly [string, ...string[]] | undefined {
+  const [, firstAlias, ...restAliases] = names;
+  return firstAlias == null ? undefined : [firstAlias, ...restAliases];
+}
+
 /**
  * Creates help parsers based on the sub-config.
  */
@@ -639,28 +646,19 @@ function createHelpParser(
   let helpOption: HelpParsers["helpOption"] = null;
 
   if (commandConfig) {
-    const names = commandConfig.names ?? ["help"];
+    const names: readonly [string, ...string[]] = commandConfig.names ??
+      ["help"];
     const innerParser = multiple(
       argument(string({ metavar: "COMMAND" }), {
         description: message`Command name to show help for.`,
       }),
     );
-    const commandParsers: Parser<
-      "sync",
-      readonly string[],
-      unknown
-    >[] = [];
-    for (let i = 0; i < names.length; i++) {
-      commandParsers.push(
-        command(names[i], innerParser, {
-          description: message`Show help information.`,
-          hidden: i === 0 ? commandConfig.hidden : true,
-        }),
-      );
-    }
-    helpCommand = commandParsers.length === 1
-      ? commandParsers[0]
-      : longestMatch(...commandParsers);
+    const aliases = getMetaCommandAliases(names);
+    helpCommand = command(names[0], innerParser, {
+      description: message`Show help information.`,
+      ...(aliases != null ? { aliases } : {}),
+      hidden: commandConfig.hidden,
+    });
   }
 
   if (optionConfig) {
@@ -685,24 +683,15 @@ function createVersionParser(
   let versionOption: VersionParsers["versionOption"] = null;
 
   if (commandConfig) {
-    const names = commandConfig.names ?? ["version"];
+    const names: readonly [string, ...string[]] = commandConfig.names ??
+      ["version"];
     const innerParser = object({});
-    const commandParsers: Parser<
-      "sync",
-      Record<PropertyKey, never>,
-      unknown
-    >[] = [];
-    for (let i = 0; i < names.length; i++) {
-      commandParsers.push(
-        command(names[i], innerParser, {
-          description: message`Show version information.`,
-          hidden: i === 0 ? commandConfig.hidden : true,
-        }),
-      );
-    }
-    versionCommand = commandParsers.length === 1
-      ? commandParsers[0]
-      : longestMatch(...commandParsers);
+    const aliases = getMetaCommandAliases(names);
+    versionCommand = command(names[0], innerParser, {
+      description: message`Show version information.`,
+      ...(aliases != null ? { aliases } : {}),
+      hidden: commandConfig.hidden,
+    });
   }
 
   if (optionConfig) {
@@ -842,7 +831,8 @@ function createCompletionParser(
   });
 
   if (commandConfig) {
-    const names = commandConfig.names ?? ["completion"];
+    const names: readonly [string, ...string[]] = commandConfig.names ??
+      ["completion"];
     const displayName = names[0];
 
     const completionCommandConfig = {
@@ -866,23 +856,12 @@ function createCompletionParser(
       }`,
     };
 
-    const commandParsers: Parser<
-      "sync",
-      { shell: string | undefined; args: readonly string[] },
-      unknown
-    >[] = [];
-    for (let i = 0; i < names.length; i++) {
-      commandParsers.push(
-        command(names[i], completionInner, {
-          ...completionCommandConfig,
-          hidden: i === 0 ? commandConfig.hidden : true,
-        }),
-      );
-    }
-
-    completionCommand = commandParsers.length === 1
-      ? commandParsers[0]
-      : longestMatch(...commandParsers);
+    const aliases = getMetaCommandAliases(names);
+    completionCommand = command(names[0], completionInner, {
+      ...completionCommandConfig,
+      ...(aliases != null ? { aliases } : {}),
+      hidden: commandConfig.hidden,
+    });
   }
 
   if (optionConfig) {

--- a/packages/core/src/internal/command-alias.ts
+++ b/packages/core/src/internal/command-alias.ts
@@ -1,3 +1,7 @@
+/**
+ * Internal key used to bypass duplicate leading command name validation when
+ * composing built-in meta commands with user parsers.
+ */
 export const allowDuplicateLeadingCommandNamesKey = Symbol(
   "allowDuplicateLeadingCommandNames",
 );

--- a/packages/core/src/internal/command-alias.ts
+++ b/packages/core/src/internal/command-alias.ts
@@ -5,3 +5,14 @@
 export const allowDuplicateLeadingCommandNamesKey = Symbol(
   "allowDuplicateLeadingCommandNames",
 );
+
+/**
+ * Internal command() option key for aliases that are accepted by parsing but
+ * omitted from completion and typo-suggestion display.
+ */
+export const hiddenCommandAliasesKey = Symbol("hiddenCommandAliases");
+
+/** @internal */
+export interface HiddenCommandAliasOptions {
+  readonly [hiddenCommandAliasesKey]?: readonly [string, ...string[]];
+}

--- a/packages/core/src/internal/command-alias.ts
+++ b/packages/core/src/internal/command-alias.ts
@@ -1,0 +1,2 @@
+export const allowDuplicateLeadingCommandNamesKey =
+  "__optiqueAllowDuplicateLeadingCommandNames";

--- a/packages/core/src/internal/command-alias.ts
+++ b/packages/core/src/internal/command-alias.ts
@@ -1,2 +1,3 @@
-export const allowDuplicateLeadingCommandNamesKey =
-  "__optiqueAllowDuplicateLeadingCommandNames";
+export const allowDuplicateLeadingCommandNamesKey = Symbol(
+  "allowDuplicateLeadingCommandNames",
+);

--- a/packages/core/src/internal/parser.ts
+++ b/packages/core/src/internal/parser.ts
@@ -1498,8 +1498,11 @@ function findCommandInCurrentUsageTerm(
   return null;
 }
 
-function commandTermMatches(term: UsageTerm, commandName: string): boolean {
-  return term.type === "command" &&
+function commandTermMatches(
+  term: UsageTerm | null | undefined,
+  commandName: string,
+): boolean {
+  return term?.type === "command" &&
     (term.name === commandName ||
       term.aliases?.includes(commandName) === true ||
       term.hiddenAliases?.includes(commandName) === true);

--- a/packages/core/src/internal/parser.ts
+++ b/packages/core/src/internal/parser.ts
@@ -1510,7 +1510,7 @@ function collectCommandInputNames(
 ): void {
   for (const term of usage) {
     if (term.type === "command") {
-      if (term.name === commandName) {
+      if (commandTermMatches(term, commandName)) {
         names.add(term.name);
         for (const alias of term.aliases ?? []) names.add(alias);
       }

--- a/packages/core/src/internal/parser.ts
+++ b/packages/core/src/internal/parser.ts
@@ -1483,7 +1483,7 @@ function findCommandInCurrentUsageTerm(
   commandName: string,
   trailingUsage: Usage,
 ): Usage | null {
-  if (term.type === "command" && term.name === commandName) {
+  if (term.type === "command" && commandTermMatches(term, commandName)) {
     return [term, ...trailingUsage];
   }
 
@@ -1498,7 +1498,50 @@ function findCommandInCurrentUsageTerm(
   return null;
 }
 
+function commandTermMatches(term: UsageTerm, commandName: string): boolean {
+  return term.type === "command" &&
+    (term.name === commandName || term.aliases?.includes(commandName) === true);
+}
+
+function collectCommandInputNames(
+  usage: Usage,
+  commandName: string,
+  names: Set<string>,
+): void {
+  for (const term of usage) {
+    if (term.type === "command") {
+      if (term.name === commandName) {
+        names.add(term.name);
+        for (const alias of term.aliases ?? []) names.add(alias);
+      }
+    } else if (term.type === "exclusive") {
+      for (const branch of term.terms) {
+        collectCommandInputNames(branch, commandName, names);
+      }
+    } else if (term.type === "sequence") {
+      collectCommandInputNames(term.terms, commandName, names);
+    } else if (term.type === "optional" || term.type === "multiple") {
+      collectCommandInputNames(term.terms, commandName, names);
+    }
+  }
+}
+
+function findLastCommandInputIndex(
+  consumed: readonly string[],
+  commandName: string,
+  usage: Usage,
+  searchEnd: number,
+): number {
+  const names = new Set([commandName]);
+  collectCommandInputNames(usage, commandName, names);
+  for (let index = searchEnd - 1; index >= 0; index--) {
+    if (names.has(consumed[index])) return index;
+  }
+  return -1;
+}
+
 function recordMatchedCommandArgIndices(
+  usage: Usage,
   consumed: readonly string[],
   previousCommandPath: readonly string[] | undefined,
   nextCommandPath: readonly string[] | undefined,
@@ -1513,7 +1556,12 @@ function recordMatchedCommandArgIndices(
   for (let index = next.length - 1; index >= previousLength; index--) {
     if (searchEnd <= 0) break;
     const commandName = next[index];
-    const localIndex = consumed.lastIndexOf(commandName, searchEnd - 1);
+    const localIndex = findLastCommandInputIndex(
+      consumed,
+      commandName,
+      usage,
+      searchEnd,
+    );
     if (localIndex < 0) continue;
     indices.add(consumedOffset + localIndex);
     searchEnd = localIndex;
@@ -1703,6 +1751,7 @@ function getDocPageSyncImpl(
     context = result.next;
     const consumedCount = previousBuffer.length - context.buffer.length;
     recordMatchedCommandArgIndices(
+      parser.usage,
       previousBuffer.slice(0, consumedCount),
       previousCommandPath,
       context.exec?.commandPath,
@@ -1742,6 +1791,7 @@ async function getDocPageAsyncImpl(
     context = result.next;
     const consumedCount = previousBuffer.length - context.buffer.length;
     recordMatchedCommandArgIndices(
+      parser.usage,
       previousBuffer.slice(0, consumedCount),
       previousCommandPath,
       context.exec?.commandPath,

--- a/packages/core/src/internal/parser.ts
+++ b/packages/core/src/internal/parser.ts
@@ -1500,7 +1500,9 @@ function findCommandInCurrentUsageTerm(
 
 function commandTermMatches(term: UsageTerm, commandName: string): boolean {
   return term.type === "command" &&
-    (term.name === commandName || term.aliases?.includes(commandName) === true);
+    (term.name === commandName ||
+      term.aliases?.includes(commandName) === true ||
+      term.hiddenAliases?.includes(commandName) === true);
 }
 
 function collectCommandInputNames(
@@ -1513,6 +1515,7 @@ function collectCommandInputNames(
       if (commandTermMatches(term, commandName)) {
         names.add(term.name);
         for (const alias of term.aliases ?? []) names.add(alias);
+        for (const alias of term.hiddenAliases ?? []) names.add(alias);
       }
     } else if (term.type === "exclusive") {
       for (const branch of term.terms) {

--- a/packages/core/src/internal/parser.ts
+++ b/packages/core/src/internal/parser.ts
@@ -917,6 +917,7 @@ export function parseSync<T>(
     phase: "complete",
     dependencyRuntime: runtime,
     dependencyRegistry: runtime.registry,
+    commandPath: context.exec?.commandPath ?? exec.commandPath,
     trace: context.exec?.trace ?? context.trace ?? exec.trace,
   };
   const endResult = parser.complete(context.state, completeExec);
@@ -1008,6 +1009,7 @@ export async function parseAsync<T>(
     phase: "complete",
     dependencyRuntime: runtime,
     dependencyRegistry: runtime.registry,
+    commandPath: context.exec?.commandPath ?? exec.commandPath,
     trace: context.exec?.trace ?? context.trace ?? exec.trace,
   };
   const endResult = await parser.complete(context.state, completeExec);

--- a/packages/core/src/internal/parser.ts
+++ b/packages/core/src/internal/parser.ts
@@ -1896,7 +1896,7 @@ function buildDocPage(
   ): void => {
     if (
       term?.type !== "command" ||
-      term.name !== arg ||
+      !commandTermMatches(term, arg) ||
       !isLastArg ||
       term.usageLine == null
     ) {

--- a/packages/core/src/parser.test.ts
+++ b/packages/core/src/parser.test.ts
@@ -2495,6 +2495,51 @@ describe("getDocPage", () => {
     }
   });
 
+  it("should resolve command-specific usage when navigating by alias", () => {
+    const installCommand = command(
+      "install",
+      object({
+        name: option("--name", string()),
+      }),
+      { aliases: ["i"] },
+    );
+
+    const inspectCommand = command(
+      "inspect",
+      object({
+        verbose: option("--verbose"),
+      }),
+    );
+
+    const parser = longestMatch(or(installCommand, inspectCommand));
+
+    const doc = getDocPage(parser, ["i"]);
+    assert.ok(doc);
+    assert.ok(doc.usage && doc.usage.length > 0);
+
+    if (doc.usage) {
+      const firstTerm = doc.usage[0];
+      assert.equal(
+        firstTerm.type,
+        "command",
+        `Expected first usage term to be 'command', got '${firstTerm.type}'`,
+      );
+      if (firstTerm.type === "command") {
+        assert.equal(firstTerm.name, "install");
+      }
+    }
+    assert.ok(
+      doc.usage.some((term) =>
+        term.type === "option" && term.names.includes("--name")
+      ),
+    );
+    assert.ok(
+      !doc.usage.some((term) =>
+        term.type === "option" && term.names.includes("--verbose")
+      ),
+    );
+  });
+
   it("should include choices in formatted help for option with choice()", () => {
     const parser = object({
       format: option("--format", choice(["json", "yaml", "xml"]), {

--- a/packages/core/src/parser.test.ts
+++ b/packages/core/src/parser.test.ts
@@ -2540,6 +2540,48 @@ describe("getDocPage", () => {
     );
   });
 
+  it("should apply command usageLine when navigating by alias", () => {
+    const installCommand = command(
+      "install",
+      object({
+        name: option("--name", string()),
+      }),
+      {
+        aliases: ["i"],
+        usageLine: [{ type: "literal", value: "install-usage" }],
+      },
+    );
+
+    const inspectCommand = command(
+      "inspect",
+      object({
+        verbose: option("--verbose"),
+      }),
+    );
+
+    const parser = longestMatch(or(installCommand, inspectCommand));
+
+    const doc = getDocPage(parser, ["i"]);
+    assert.ok(doc);
+    assert.ok(doc.usage && doc.usage.length > 0);
+
+    assert.ok(
+      doc.usage.some((term) =>
+        term.type === "literal" && term.value === "install-usage"
+      ),
+    );
+    assert.ok(
+      !doc.usage.some((term) =>
+        term.type === "option" && term.names.includes("--name")
+      ),
+    );
+    assert.ok(
+      !doc.usage.some((term) =>
+        term.type === "option" && term.names.includes("--verbose")
+      ),
+    );
+  });
+
   it("should include choices in formatted help for option with choice()", () => {
     const parser = object({
       format: option("--format", choice(["json", "yaml", "xml"]), {

--- a/packages/core/src/primitives.test.ts
+++ b/packages/core/src/primitives.test.ts
@@ -26,6 +26,7 @@ import {
   option,
   passThrough,
 } from "@optique/core/primitives";
+import { formatUsage } from "@optique/core/usage";
 import {
   choice,
   integer,
@@ -3303,6 +3304,95 @@ describe("command", () => {
     }
   });
 
+  it("should parse command aliases", () => {
+    const installParser = command(
+      "install",
+      object({
+        type: constant("install" as const),
+        packageName: argument(string({ metavar: "PACKAGE" })),
+      }),
+      { aliases: ["i"] },
+    );
+
+    const result = parseSync(installParser, ["i", "optique"]);
+
+    assert.ok(result.success);
+    if (result.success) {
+      assert.deepEqual(result.value, {
+        type: "install",
+        packageName: "optique",
+      });
+    }
+  });
+
+  it("should suggest command aliases alongside canonical names", () => {
+    const parser = command("install", object({}), { aliases: ["i"] });
+
+    const suggestions = suggest(parser, [""]);
+
+    assert.deepEqual(suggestions, [
+      { kind: "literal", text: "install" },
+      { kind: "literal", text: "i" },
+    ]);
+  });
+
+  it("should keep command aliases out of usage output", () => {
+    const parser = command("install", object({}), { aliases: ["i"] });
+
+    const usage = formatUsage("mytool", parser.usage);
+
+    assert.match(usage, /\binstall\b/);
+    assert.doesNotMatch(usage, /\bi\b/);
+  });
+
+  it("should preserve the canonical command path when an alias matches", () => {
+    const inner: Parser<"sync", readonly string[], undefined> = {
+      mode: "sync",
+      $valueType: [] as readonly (readonly string[])[],
+      $stateType: [] as readonly undefined[],
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(),
+      acceptingAnyToken: false,
+      initialState: undefined,
+      parse(context) {
+        return { success: true, next: context, consumed: [] };
+      },
+      complete(_state, exec) {
+        return { success: true, value: exec?.commandPath ?? [] };
+      },
+      *suggest() {},
+      getDocFragments() {
+        return { fragments: [] };
+      },
+    };
+    const parser = command("install", inner, { aliases: ["i"] });
+
+    const result = parseSync(parser, ["i"]);
+
+    assert.deepEqual(result, { success: true, value: ["install"] });
+  });
+
+  it("should reject duplicate command aliases", () => {
+    assert.throws(
+      () => command("install", object({}), { aliases: ["i", "i"] }),
+      {
+        name: "TypeError",
+        message: 'Command has a duplicate name: "i".',
+      },
+    );
+  });
+
+  it("should reject aliases that duplicate the canonical command name", () => {
+    assert.throws(
+      () => command("install", object({}), { aliases: ["install"] }),
+      {
+        name: "TypeError",
+        message: 'Command has a duplicate name: "install".',
+      },
+    );
+  });
+
   it("should fail when wrong subcommand is provided", () => {
     const showParser = command(
       "show",
@@ -3926,6 +4016,19 @@ describe("command", () => {
       assertErrorIncludes(result.error, "Expected command `child`");
       assertErrorIncludes(result.error, "Did you mean");
       assertErrorIncludes(result.error, "`child`");
+    }
+  });
+
+  it("should suggest canonical command names and aliases for alias typos", () => {
+    const parser = command("install", object({}), { aliases: ["i"] });
+
+    const result = parse(parser, ["ii"]);
+
+    assert.ok(!result.success);
+    if (!result.success) {
+      assertErrorIncludes(result.error, "Did you mean one of these?");
+      assertErrorIncludes(result.error, "`install`");
+      assertErrorIncludes(result.error, "`i`");
     }
   });
 
@@ -7948,6 +8051,13 @@ describe("leadingNames", () => {
     assert.deepEqual(
       command("help", object({})).leadingNames,
       new Set(["help"]),
+    );
+  });
+
+  it("should contain command aliases for command()", () => {
+    assert.deepEqual(
+      command("install", object({}), { aliases: ["i", "add"] }).leadingNames,
+      new Set(["install", "i", "add"]),
     );
   });
 

--- a/packages/core/src/primitives.test.ts
+++ b/packages/core/src/primitives.test.ts
@@ -3423,6 +3423,16 @@ describe("command", () => {
     );
   });
 
+  it("should reject sparse command aliases arrays", () => {
+    assert.throws(
+      () => command("install", object({}), { aliases: new Array(1) as never }),
+      {
+        name: "TypeError",
+        message: "Command aliases must be a non-empty array of strings.",
+      },
+    );
+  });
+
   it("should fail when wrong subcommand is provided", () => {
     const showParser = command(
       "show",

--- a/packages/core/src/primitives.test.ts
+++ b/packages/core/src/primitives.test.ts
@@ -3393,6 +3393,36 @@ describe("command", () => {
     );
   });
 
+  it("should reject an empty command aliases array", () => {
+    assert.throws(
+      () => command("install", object({}), { aliases: [] as never }),
+      {
+        name: "TypeError",
+        message: "Command aliases must be a non-empty array of strings.",
+      },
+    );
+  });
+
+  it("should reject non-array command aliases", () => {
+    assert.throws(
+      () => command("install", object({}), { aliases: "i" as never }),
+      {
+        name: "TypeError",
+        message: "Command aliases must be a non-empty array of strings.",
+      },
+    );
+  });
+
+  it("should reject non-string command aliases", () => {
+    assert.throws(
+      () => command("install", object({}), { aliases: ["i", 1] as never }),
+      {
+        name: "TypeError",
+        message: "Command aliases must be a non-empty array of strings.",
+      },
+    );
+  });
+
   it("should fail when wrong subcommand is provided", () => {
     const showParser = command(
       "show",

--- a/packages/core/src/primitives.ts
+++ b/packages/core/src/primitives.ts
@@ -231,6 +231,7 @@ import {
   createErrorWithSuggestions,
   createSuggestionMessage,
   DEFAULT_FIND_SIMILAR_OPTIONS,
+  expandCommandAliasSuggestions,
   findSimilar,
 } from "./suggestion.ts";
 import type {
@@ -2803,6 +2804,17 @@ export interface CommandOptions {
   readonly hidden?: HiddenVisibility;
 
   /**
+   * Additional names that invoke this command.
+   *
+   * Aliases are functional at runtime and are suggested by shell completion,
+   * but are hidden from usage and documentation output.  The `name` parameter
+   * passed to {@link command} remains the canonical display name.
+   *
+   * @since 1.1.0
+   */
+  readonly aliases?: readonly [string, ...string[]];
+
+  /**
    * Error messages customization.
    * @since 0.5.0
    */
@@ -2895,10 +2907,28 @@ function appendCommandPath(
   };
 }
 
+function getCommandNames(
+  name: string,
+  options: CommandOptions,
+): readonly string[] {
+  return options.aliases == null ? [name] : [name, ...options.aliases];
+}
+
+function validateUniqueCommandNames(names: readonly string[]): void {
+  const seen = new Set<string>();
+  for (const name of names) {
+    if (seen.has(name)) {
+      throw new TypeError(`Command has a duplicate name: "${name}".`);
+    }
+    seen.add(name);
+  }
+}
+
 function* suggestCommandSync<T, TState>(
   context: ParserContext<CommandState<TState>>,
   prefix: string,
   name: string,
+  aliases: readonly string[],
   parser: Parser<"sync", T, TState>,
   options: CommandOptions,
 ): Generator<Suggestion> {
@@ -2911,12 +2941,14 @@ function* suggestCommandSync<T, TState>(
   // Handle different command states
   if (state === undefined) {
     // Command not yet matched - suggest command name if it matches prefix
-    if (name.startsWith(prefix)) {
-      yield {
-        kind: "literal",
-        text: name,
-        ...(options.description && { description: options.description }),
-      };
+    for (const commandName of [name, ...aliases]) {
+      if (commandName.startsWith(prefix)) {
+        yield {
+          kind: "literal",
+          text: commandName,
+          ...(options.description && { description: options.description }),
+        };
+      }
     }
   } else if (state[0] === "matched") {
     // Command matched but inner parser not started - delegate to inner parser
@@ -2947,6 +2979,7 @@ async function* suggestCommandAsync<T, TState>(
   context: ParserContext<CommandState<TState>>,
   prefix: string,
   name: string,
+  aliases: readonly string[],
   parser: Parser<Mode, T, TState>,
   options: CommandOptions,
 ): AsyncGenerator<Suggestion> {
@@ -2959,12 +2992,14 @@ async function* suggestCommandAsync<T, TState>(
   // Handle different command states
   if (state === undefined) {
     // Command not yet matched - suggest command name if it matches prefix
-    if (name.startsWith(prefix)) {
-      yield {
-        kind: "literal",
-        text: name,
-        ...(options.description && { description: options.description }),
-      };
+    for (const commandName of [name, ...aliases]) {
+      if (commandName.startsWith(prefix)) {
+        yield {
+          kind: "literal",
+          text: commandName,
+          ...(options.description && { description: options.description }),
+        };
+      }
     }
   } else if (state[0] === "matched") {
     // Command matched but inner parser not started - delegate to inner parser
@@ -3018,7 +3053,10 @@ export function command<M extends Mode, T, TState>(
   parser: Parser<M, T, TState>,
   options: CommandOptions = {},
 ): Parser<M, T, CommandState<TState>> {
-  validateCommandNames([name], "Command");
+  const commandNames = getCommandNames(name, options);
+  const aliases = commandNames.slice(1);
+  validateCommandNames(commandNames, "Command");
+  validateUniqueCommandNames(commandNames);
   const isAsync = parser.mode === "async";
   const syncInnerParser = parser as Parser<"sync", T, TState>;
   const asyncInnerParser = parser as Parser<"async", T, TState>;
@@ -3034,12 +3072,13 @@ export function command<M extends Mode, T, TState>(
       {
         type: "command",
         name,
+        ...(aliases.length > 0 && { aliases }),
         ...(options.usageLine != null && { usageLine: options.usageLine }),
         ...(options.hidden != null && { hidden: options.hidden }),
       },
       ...parser.usage,
     ],
-    leadingNames: new Set([name]),
+    leadingNames: new Set(commandNames),
     acceptingAnyToken: false,
     initialState: undefined,
     canSkip(state: CommandState<TState>, exec?: ExecutionContext) {
@@ -3078,7 +3117,10 @@ export function command<M extends Mode, T, TState>(
       // Handle different states
       if (state === undefined) {
         // Check if buffer starts with our command name
-        if (context.buffer.length < 1 || context.buffer[0] !== name) {
+        if (
+          context.buffer.length < 1 ||
+          !commandNames.includes(context.buffer[0])
+        ) {
           const actual = context.buffer.length > 0 ? context.buffer[0] : null;
 
           // Only suggest commands that are valid at the current parse position
@@ -3086,9 +3128,13 @@ export function command<M extends Mode, T, TState>(
           // commands that the user has not yet entered.
           // See: https://github.com/dahlia/optique/issues/117
           const leadingCmds = extractLeadingCommandNames(context.usage);
-          const suggestions = actual
+          const rawSuggestions = actual
             ? findSimilar(actual, leadingCmds, DEFAULT_FIND_SIMILAR_OPTIONS)
             : [];
+          const suggestions = expandCommandAliasSuggestions(
+            context.usage,
+            rawSuggestions,
+          );
 
           // If custom error is provided, use it
           if (options.errors?.notMatched) {
@@ -3370,6 +3416,7 @@ export function command<M extends Mode, T, TState>(
           context,
           prefix,
           name,
+          aliases,
           parser,
           options,
         );
@@ -3378,6 +3425,7 @@ export function command<M extends Mode, T, TState>(
         context,
         prefix,
         name,
+        aliases,
         parser as Parser<"sync", T, TState>,
         options,
       );

--- a/packages/core/src/primitives.ts
+++ b/packages/core/src/primitives.ts
@@ -2911,7 +2911,21 @@ function getCommandNames(
   name: string,
   options: CommandOptions,
 ): readonly string[] {
-  return options.aliases == null ? [name] : [name, ...options.aliases];
+  const aliases: unknown = options.aliases;
+  if (aliases == null) return [name];
+  if (!isNonEmptyStringArray(aliases)) {
+    throw new TypeError(
+      "Command aliases must be a non-empty array of strings.",
+    );
+  }
+  return [name, ...aliases];
+}
+
+function isNonEmptyStringArray(
+  value: unknown,
+): value is readonly [string, ...string[]] {
+  return Array.isArray(value) && value.length > 0 &&
+    value.every((item) => typeof item === "string");
 }
 
 function validateUniqueCommandNames(names: readonly string[]): void {

--- a/packages/core/src/primitives.ts
+++ b/packages/core/src/primitives.ts
@@ -33,6 +33,10 @@ import {
   completeOrExtractPhase2Seed,
   extractPhase2SeedKey,
 } from "./phase2-seed.ts";
+import {
+  hiddenCommandAliasesKey,
+  type HiddenCommandAliasOptions,
+} from "./internal/command-alias.ts";
 import type { TraceEntry } from "./input-trace.ts";
 import type { DependencyRegistryLike } from "./registry-types.ts";
 import { validateCommandNames, validateOptionNames } from "./validate.ts";
@@ -2911,14 +2915,40 @@ function getCommandNames(
   name: string,
   options: CommandOptions,
 ): readonly string[] {
+  return [
+    name,
+    ...getVisibleCommandAliases(options),
+    ...getHiddenCommandAliases(options),
+  ];
+}
+
+function getVisibleCommandAliases(
+  options: CommandOptions,
+): readonly string[] {
   const aliases: unknown = options.aliases;
-  if (aliases == null) return [name];
+  if (aliases == null) return [];
   if (!isNonEmptyStringArray(aliases)) {
     throw new TypeError(
       "Command aliases must be a non-empty array of strings.",
     );
   }
-  return [name, ...aliases];
+  return aliases;
+}
+
+function getHiddenCommandAliases(
+  options: CommandOptions,
+): readonly string[] {
+  const hiddenAliases: unknown =
+    (options as CommandOptions & HiddenCommandAliasOptions)[
+      hiddenCommandAliasesKey
+    ];
+  if (hiddenAliases == null) return [];
+  if (!isNonEmptyStringArray(hiddenAliases)) {
+    throw new TypeError(
+      "Hidden command aliases must be a non-empty array of strings.",
+    );
+  }
+  return hiddenAliases;
 }
 
 function isNonEmptyStringArray(
@@ -3071,7 +3101,8 @@ export function command<M extends Mode, T, TState>(
   options: CommandOptions = {},
 ): Parser<M, T, CommandState<TState>> {
   const commandNames = getCommandNames(name, options);
-  const aliases = commandNames.slice(1);
+  const aliases = getVisibleCommandAliases(options);
+  const hiddenAliases = getHiddenCommandAliases(options);
   validateCommandNames(commandNames, "Command");
   validateUniqueCommandNames(commandNames);
   const isAsync = parser.mode === "async";
@@ -3090,6 +3121,7 @@ export function command<M extends Mode, T, TState>(
         type: "command",
         name,
         ...(aliases.length > 0 && { aliases }),
+        ...(hiddenAliases.length > 0 && { hiddenAliases }),
         ...(options.usageLine != null && { usageLine: options.usageLine }),
         ...(options.hidden != null && { hidden: options.hidden }),
       },

--- a/packages/core/src/primitives.ts
+++ b/packages/core/src/primitives.ts
@@ -2924,8 +2924,11 @@ function getCommandNames(
 function isNonEmptyStringArray(
   value: unknown,
 ): value is readonly [string, ...string[]] {
-  return Array.isArray(value) && value.length > 0 &&
-    value.every((item) => typeof item === "string");
+  if (!Array.isArray(value) || value.length === 0) return false;
+  for (let i = 0; i < value.length; i++) {
+    if (typeof value[i] !== "string") return false;
+  }
+  return true;
 }
 
 function validateUniqueCommandNames(names: readonly string[]): void {

--- a/packages/core/src/suggestion.test.ts
+++ b/packages/core/src/suggestion.test.ts
@@ -4,6 +4,7 @@ import {
   createErrorWithSuggestions,
   createSuggestionMessage,
   deduplicateSuggestions,
+  expandCommandAliasSuggestions,
   findSimilar,
   levenshteinDistance,
 } from "./suggestion.ts";
@@ -362,6 +363,34 @@ describe("createSuggestionMessage()", () => {
     assert.doesNotMatch(formatted, /`/);
     // Should still have the option name
     assert.match(formatted, /--verbose/);
+  });
+});
+
+describe("expandCommandAliasSuggestions()", () => {
+  it("should ignore nested command aliases when expanding suggestions", () => {
+    const usage: Usage = [
+      {
+        type: "exclusive",
+        terms: [
+          [
+            {
+              type: "sequence",
+              terms: [
+                { type: "command", name: "parent" },
+                { type: "command", name: "nested", aliases: ["run"] },
+              ],
+            },
+          ],
+          [{ type: "command", name: "run", aliases: ["r"] }],
+        ],
+      },
+    ];
+
+    assert.deepEqual(expandCommandAliasSuggestions(usage, ["run"]), ["run"]);
+    assert.deepEqual(expandCommandAliasSuggestions(usage, ["r"]), [
+      "run",
+      "r",
+    ]);
   });
 });
 

--- a/packages/core/src/suggestion.test.ts
+++ b/packages/core/src/suggestion.test.ts
@@ -392,6 +392,40 @@ describe("expandCommandAliasSuggestions()", () => {
       "r",
     ]);
   });
+
+  it("should continue after required multiple terms with skippable children", () => {
+    const usage: Usage = [
+      {
+        type: "multiple",
+        min: 1,
+        terms: [{ type: "optional", terms: [] }],
+      },
+      { type: "command", name: "install", aliases: ["i"] },
+    ];
+
+    assert.deepEqual(expandCommandAliasSuggestions(usage, ["i"]), [
+      "install",
+      "i",
+    ]);
+  });
+
+  it("should continue after exclusive terms with a skippable branch", () => {
+    const usage: Usage = [
+      {
+        type: "exclusive",
+        terms: [
+          [{ type: "option", names: ["--format"] }],
+          [{ type: "optional", terms: [] }],
+        ],
+      },
+      { type: "command", name: "install", aliases: ["i"] },
+    ];
+
+    assert.deepEqual(expandCommandAliasSuggestions(usage, ["i"]), [
+      "install",
+      "i",
+    ]);
+  });
 });
 
 describe("integration: findSimilar + createSuggestionMessage", () => {

--- a/packages/core/src/suggestion.test.ts
+++ b/packages/core/src/suggestion.test.ts
@@ -438,6 +438,16 @@ describe("expandCommandAliasSuggestions()", () => {
       "i",
     ]);
   });
+
+  it("should collapse hidden command aliases to canonical suggestions", () => {
+    const usage: Usage = [
+      { type: "command", name: "help", hiddenAliases: ["assist"] },
+    ];
+
+    assert.deepEqual(expandCommandAliasSuggestions(usage, ["assist"]), [
+      "help",
+    ]);
+  });
 });
 
 describe("integration: findSimilar + createSuggestionMessage", () => {

--- a/packages/core/src/suggestion.test.ts
+++ b/packages/core/src/suggestion.test.ts
@@ -448,6 +448,15 @@ describe("expandCommandAliasSuggestions()", () => {
       "help",
     ]);
   });
+
+  it("should stop before aliases behind non-skippable literal terms", () => {
+    const usage: Usage = [
+      { type: "literal", value: "deploy" },
+      { type: "command", name: "install", aliases: ["i"] },
+    ];
+
+    assert.deepEqual(expandCommandAliasSuggestions(usage, ["i"]), ["i"]);
+  });
 });
 
 describe("integration: findSimilar + createSuggestionMessage", () => {

--- a/packages/core/src/suggestion.test.ts
+++ b/packages/core/src/suggestion.test.ts
@@ -426,6 +426,18 @@ describe("expandCommandAliasSuggestions()", () => {
       "i",
     ]);
   });
+
+  it("should continue past leading options before command aliases", () => {
+    const usage: Usage = [
+      { type: "option", names: ["--verbose"] },
+      { type: "command", name: "install", aliases: ["i"] },
+    ];
+
+    assert.deepEqual(expandCommandAliasSuggestions(usage, ["i"]), [
+      "install",
+      "i",
+    ]);
+  });
 });
 
 describe("integration: findSimilar + createSuggestionMessage", () => {

--- a/packages/core/src/suggestion.ts
+++ b/packages/core/src/suggestion.ts
@@ -313,6 +313,11 @@ function collectCommandAliasTargets(
             targets.set(alias, [term.name, alias]);
           }
         }
+        for (const alias of term.hiddenAliases ?? []) {
+          if (!targets.has(alias)) {
+            targets.set(alias, [term.name]);
+          }
+        }
         return false;
       }
 

--- a/packages/core/src/suggestion.ts
+++ b/packages/core/src/suggestion.ts
@@ -346,6 +346,8 @@ function collectCommandAliasTargets(
         if (anySkippable) continue;
         return false;
       }
+
+      return false;
     }
     return true;
   }

--- a/packages/core/src/suggestion.ts
+++ b/packages/core/src/suggestion.ts
@@ -292,11 +292,15 @@ function collectCommandAliasTargets(
 ): Map<string, readonly string[]> {
   const targets = new Map<string, readonly string[]>();
 
-  function traverse(terms: Usage): void {
-    if (!terms || !Array.isArray(terms)) return;
+  function traverse(terms: Usage): boolean {
+    if (!terms || !Array.isArray(terms)) return true;
     for (const term of terms) {
+      if (term.type === "option" || term.type === "argument") {
+        return false;
+      }
+
       if (term.type === "command") {
-        if (isSuggestionHidden(term.hidden)) continue;
+        if (isSuggestionHidden(term.hidden)) return false;
         if (!targets.has(term.name)) {
           targets.set(term.name, [term.name]);
         }
@@ -305,19 +309,36 @@ function collectCommandAliasTargets(
             targets.set(alias, [term.name, alias]);
           }
         }
-        continue;
+        return false;
       }
-      if (
-        term.type === "optional" || term.type === "multiple" ||
-        term.type === "sequence"
-      ) {
+
+      if (term.type === "optional") {
         traverse(term.terms);
         continue;
       }
+
+      if (term.type === "multiple") {
+        traverse(term.terms);
+        if (term.min === 0) continue;
+        return false;
+      }
+
+      if (term.type === "sequence") {
+        if (traverse(term.terms)) continue;
+        return false;
+      }
+
       if (term.type === "exclusive") {
-        for (const branch of term.terms) traverse(branch);
+        let allSkippable = true;
+        for (const branch of term.terms) {
+          const branchSkippable = traverse(branch);
+          allSkippable = allSkippable && branchSkippable;
+        }
+        if (allSkippable) continue;
+        return false;
       }
     }
+    return true;
   }
 
   traverse(usage);

--- a/packages/core/src/suggestion.ts
+++ b/packages/core/src/suggestion.ts
@@ -295,7 +295,11 @@ function collectCommandAliasTargets(
   function traverse(terms: Usage): boolean {
     if (!terms || !Array.isArray(terms)) return true;
     for (const term of terms) {
-      if (term.type === "option" || term.type === "argument") {
+      if (term.type === "option") {
+        continue;
+      }
+
+      if (term.type === "argument") {
         return false;
       }
 

--- a/packages/core/src/suggestion.ts
+++ b/packages/core/src/suggestion.ts
@@ -271,6 +271,8 @@ export function expandCommandAliasSuggestions(
   usage: Usage,
   suggestions: readonly string[],
 ): readonly string[] {
+  if (suggestions.length === 0) return suggestions;
+
   const commandAliasTargets = collectCommandAliasTargets(usage);
   const expanded: string[] = [];
   const seen = new Set<string>();

--- a/packages/core/src/suggestion.ts
+++ b/packages/core/src/suggestion.ts
@@ -318,8 +318,8 @@ function collectCommandAliasTargets(
       }
 
       if (term.type === "multiple") {
-        traverse(term.terms);
-        if (term.min === 0) continue;
+        const termsSkippable = traverse(term.terms);
+        if (term.min === 0 || termsSkippable) continue;
         return false;
       }
 
@@ -329,12 +329,12 @@ function collectCommandAliasTargets(
       }
 
       if (term.type === "exclusive") {
-        let allSkippable = true;
+        let anySkippable = false;
         for (const branch of term.terms) {
           const branchSkippable = traverse(branch);
-          allSkippable = allSkippable && branchSkippable;
+          anySkippable = anySkippable || branchSkippable;
         }
-        if (allSkippable) continue;
+        if (anySkippable) continue;
         return false;
       }
     }

--- a/packages/core/src/suggestion.ts
+++ b/packages/core/src/suggestion.ts
@@ -2,7 +2,11 @@ import type { Message, MessageTerm } from "./message.ts";
 import { message, optionName, text } from "./message.ts";
 import type { Suggestion } from "./parser.ts";
 import type { Usage } from "./usage.ts";
-import { extractCommandNames, extractOptionNames } from "./usage.ts";
+import {
+  extractCommandNames,
+  extractOptionNames,
+  isSuggestionHidden,
+} from "./usage.ts";
 
 /**
  * Calculates the Levenshtein distance between two strings.
@@ -255,6 +259,70 @@ export function createSuggestionMessage(
 }
 
 /**
+ * Expands command alias suggestions so an alias typo can point at both the
+ * canonical command and the alias that matched.
+ *
+ * @param usage Usage terms that define command aliases.
+ * @param suggestions Candidate suggestions returned by {@link findSimilar}.
+ * @returns Suggestions with alias hits expanded to canonical name + alias.
+ * @internal
+ */
+export function expandCommandAliasSuggestions(
+  usage: Usage,
+  suggestions: readonly string[],
+): readonly string[] {
+  const commandAliasTargets = collectCommandAliasTargets(usage);
+  const expanded: string[] = [];
+  const seen = new Set<string>();
+  for (const suggestion of suggestions) {
+    const targets = commandAliasTargets.get(suggestion) ?? [suggestion];
+    for (const target of targets) {
+      if (seen.has(target)) continue;
+      seen.add(target);
+      expanded.push(target);
+    }
+  }
+  return expanded;
+}
+
+function collectCommandAliasTargets(
+  usage: Usage,
+): Map<string, readonly string[]> {
+  const targets = new Map<string, readonly string[]>();
+
+  function traverse(terms: Usage): void {
+    if (!terms || !Array.isArray(terms)) return;
+    for (const term of terms) {
+      if (term.type === "command") {
+        if (isSuggestionHidden(term.hidden)) continue;
+        if (!targets.has(term.name)) {
+          targets.set(term.name, [term.name]);
+        }
+        for (const alias of term.aliases ?? []) {
+          if (!targets.has(alias)) {
+            targets.set(alias, [term.name, alias]);
+          }
+        }
+        continue;
+      }
+      if (
+        term.type === "optional" || term.type === "multiple" ||
+        term.type === "sequence"
+      ) {
+        traverse(term.terms);
+        continue;
+      }
+      if (term.type === "exclusive") {
+        for (const branch of term.terms) traverse(branch);
+      }
+    }
+  }
+
+  traverse(usage);
+  return targets;
+}
+
+/**
  * Creates an error message with suggestions for similar options or commands.
  *
  * This is a convenience function that combines the functionality of
@@ -310,10 +378,13 @@ export function createErrorWithSuggestions(
     candidates,
     DEFAULT_FIND_SIMILAR_OPTIONS,
   );
+  const displaySuggestions = type === "option"
+    ? suggestions
+    : expandCommandAliasSuggestions(usage, suggestions);
 
   const suggestionMsg = customFormatter
-    ? customFormatter(suggestions)
-    : createSuggestionMessage(suggestions);
+    ? customFormatter(displaySuggestions)
+    : createSuggestionMessage(displaySuggestions);
 
   return suggestionMsg.length > 0
     ? [...baseError, text("\n\n"), ...suggestionMsg]

--- a/packages/core/src/usage-internals.ts
+++ b/packages/core/src/usage-internals.ts
@@ -46,6 +46,9 @@ export function collectLeadingCandidates(
         for (const alias of term.aliases ?? []) {
           commandNames.add(alias);
         }
+        for (const alias of term.hiddenAliases ?? []) {
+          commandNames.add(alias);
+        }
       }
       return false;
     }

--- a/packages/core/src/usage-internals.ts
+++ b/packages/core/src/usage-internals.ts
@@ -43,6 +43,9 @@ export function collectLeadingCandidates(
     if (term.type === "command") {
       if (includeHidden || !isSuggestionHidden(term.hidden)) {
         commandNames.add(term.name);
+        for (const alias of term.aliases ?? []) {
+          commandNames.add(alias);
+        }
       }
       return false;
     }

--- a/packages/core/src/usage.test.ts
+++ b/packages/core/src/usage.test.ts
@@ -3103,6 +3103,23 @@ describe("extractCommandNames hidden filtering", () => {
       new Set(["usage-only", "doc-only", "help-only"]),
     );
   });
+
+  it("should include command aliases", () => {
+    const usage: Usage = [
+      { type: "command", name: "install", aliases: ["i"] },
+      { type: "command", name: "remove", aliases: ["rm"] },
+    ];
+    const result = extractCommandNames(usage);
+    assert.deepEqual(result, new Set(["install", "i", "remove", "rm"]));
+  });
+
+  it("should skip aliases of fully hidden commands", () => {
+    const usage: Usage = [
+      { type: "command", name: "install", aliases: ["i"], hidden: true },
+    ];
+    const result = extractCommandNames(usage);
+    assert.deepEqual(result, new Set());
+  });
 });
 
 describe("extractOptionNames includeHidden", () => {

--- a/packages/core/src/usage.ts
+++ b/packages/core/src/usage.ts
@@ -148,6 +148,13 @@ export type UsageTerm =
      */
     readonly aliases?: readonly string[];
     /**
+     * Additional command names that invoke the same parser but are not
+     * rendered or suggested.  They are still available to parsers and
+     * suggestion matchers so alias typos can resolve to the canonical command.
+     * @since 1.1.0
+     */
+    readonly hiddenAliases?: readonly string[];
+    /**
      * Optional usage line override for this command's own help page.
      * This affects help/documentation rendering only.
      * @since 1.0.0
@@ -380,6 +387,11 @@ export function extractCommandNames(
         names.add(term.name);
         for (const alias of term.aliases ?? []) {
           names.add(alias);
+        }
+        if (includeHidden) {
+          for (const alias of term.hiddenAliases ?? []) {
+            names.add(alias);
+          }
         }
       } else if (
         term.type === "optional" || term.type === "multiple" ||
@@ -779,11 +791,17 @@ export function cloneUsageTerm(term: UsageTerm): UsageTerm {
         return {
           ...term,
           ...(term.aliases != null ? { aliases: [...term.aliases] } : {}),
+          ...(term.hiddenAliases != null
+            ? { hiddenAliases: [...term.hiddenAliases] }
+            : {}),
         };
       }
       return {
         ...term,
         ...(term.aliases != null ? { aliases: [...term.aliases] } : {}),
+        ...(term.hiddenAliases != null
+          ? { hiddenAliases: [...term.hiddenAliases] }
+          : {}),
         usageLine: term.usageLine.map(cloneUsageTerm),
       };
     }

--- a/packages/core/src/usage.ts
+++ b/packages/core/src/usage.ts
@@ -141,6 +141,13 @@ export type UsageTerm =
      */
     readonly name: string;
     /**
+     * Additional command names that invoke the same parser.
+     * These aliases participate in parsing, completion, and typo
+     * suggestions, but are not rendered in usage or documentation output.
+     * @since 1.1.0
+     */
+    readonly aliases?: readonly string[];
+    /**
      * Optional usage line override for this command's own help page.
      * This affects help/documentation rendering only.
      * @since 1.0.0
@@ -371,6 +378,9 @@ export function extractCommandNames(
       if (term.type === "command") {
         if (!includeHidden && isSuggestionHidden(term.hidden)) continue;
         names.add(term.name);
+        for (const alias of term.aliases ?? []) {
+          names.add(alias);
+        }
       } else if (
         term.type === "optional" || term.type === "multiple" ||
         term.type === "sequence"
@@ -766,9 +776,16 @@ export function cloneUsageTerm(term: UsageTerm): UsageTerm {
       return { ...term, names: [...term.names] };
     case "command": {
       if (term.usageLine == null || typeof term.usageLine === "function") {
-        return { ...term };
+        return {
+          ...term,
+          ...(term.aliases != null ? { aliases: [...term.aliases] } : {}),
+        };
       }
-      return { ...term, usageLine: term.usageLine.map(cloneUsageTerm) };
+      return {
+        ...term,
+        ...(term.aliases != null ? { aliases: [...term.aliases] } : {}),
+        usageLine: term.usageLine.map(cloneUsageTerm),
+      };
     }
     case "optional":
       return { type: "optional", terms: term.terms.map(cloneUsageTerm) };


### PR DESCRIPTION
Summary
-------

This PR adds command aliases to `command()`, so a parser can accept short or legacy command names while keeping one canonical command path and display name. Aliases are accepted during parsing, included in shell completion and typo suggestions, and kept out of usage, help, and documentation output.

Fixes #823.


What changed
------------

 -  Added `aliases` to `CommandOptions` in *@optique/core*.
 -  Preserved canonical command paths even when the input uses an alias.
 -  Included aliases in completion and typo suggestions.
 -  Rejected command name and alias collisions among active sibling alternatives in `or()`, `longestMatch()`, `object()`, and `merge()`.
 -  Kept ordered compositions such as `tuple()` and `seq()` positional, and documented why duplicate aliases are allowed there.
 -  Updated *docs/concepts/primitives.md*, *docs/concepts/completion.md*, and *CHANGES.md*.


Validation
----------

 -  `deno test packages/core/src/facade.test.ts packages/core/src/primitives.test.ts packages/core/src/constructs.test.ts packages/core/src/usage.test.ts`
 -  `mise check`
 -  `cd docs && pnpm build`
 -  `mise test`
 -  `deno fmt --check`
 -  `git diff --check`
