### PR TITLE
`firstOf()` value parser combinator

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -293,6 +293,29 @@ in a single, well-documented location.
 
  -  Test files are co-located with source files using `.test.ts` suffix.
 
+ -  Node.js executes TypeScript directly in type-stripping mode, which
+    rejects TypeScript syntax that requires transformation: parameter
+    properties (`constructor(readonly id: string)`), `enum`, `namespace`,
+    and the like.  Deno and Bun accept such syntax, so the breakage only
+    shows up in `mise test:node` as `ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX`.
+    Declare class fields explicitly and assign them in the constructor
+    instead:
+
+    ~~~~ typescript
+    // Wrong: parameter property fails under Node.js type stripping
+    class UserId {
+      constructor(readonly id: string) {}
+    }
+
+    // Correct: explicit field declaration and assignment
+    class UserId {
+      readonly id: string;
+      constructor(id: string) {
+        this.id = id;
+      }
+    }
+    ~~~~
+
  -  Avoid the `assert.equal(..., true)` or `assert.equal(..., false)` patterns.
     Use `assert.ok(...)` and `assert.ok(!...)` instead.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -111,6 +111,25 @@ To be released.
     determine whether a child can finish without more CLI input.
     [[#819], [#820]]
 
+ -  Added an optional `validate()` method to the `ValueParser` interface.
+    When present, `option()` and `argument()` use it to validate fallback
+    values (e.g. from `bindEnv()`/`bindConfig()`) instead of the generic
+    `format()`+`parse()` round-trip, which cannot express validation
+    failures for value parsers whose constituents produce overlapping
+    string representations.  [[#821]]
+
+ -  Added `firstOf()` value parser combinator that tries multiple sync value
+    parsers in declaration order and returns the first successful result,
+    with the result type inferred as the union of the constituent types
+    (e.g., `firstOf(choice(["auto"]), integer({ min: 1 }))` produces
+    `"auto" | number`).  The default metavar joins the constituent metavars
+    with `|` and can be overridden via the `metavar` option.  Choices are
+    merged when every constituent enumerates them, completion suggestions
+    are merged and deduplicated across constituents, and `format()`,
+    `normalize()`, and `validate()` dispatch to the constituent that owns
+    the value.  When every constituent fails, the error lists each
+    constituent's error on its own line.  [[#821]]
+
 [Semantic Versioning 2.0.0]: https://semver.org/
 [#801]: https://github.com/dahlia/optique/issues/801
 [#802]: https://github.com/dahlia/optique/pull/802
@@ -126,6 +145,7 @@ To be released.
 [#817]: https://github.com/dahlia/optique/pull/817
 [#819]: https://github.com/dahlia/optique/issues/819
 [#820]: https://github.com/dahlia/optique/pull/820
+[#821]: https://github.com/dahlia/optique/issues/821
 [#823]: https://github.com/dahlia/optique/issues/823
 [#825]: https://github.com/dahlia/optique/pull/825
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -128,7 +128,8 @@ To be released.
     are merged and deduplicated across constituents, and `format()`,
     `normalize()`, and `validate()` dispatch to the constituent that owns
     the value.  When every constituent fails, the error lists each
-    constituent's error on its own line.  [[#821]]
+    constituent's error on its own line; the `errors.noMatch` option
+    customizes this message.  [[#821]]
 
 [Semantic Versioning 2.0.0]: https://semver.org/
 [#801]: https://github.com/dahlia/optique/issues/801

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -129,8 +129,10 @@ To be released.
     `normalize()`, and `validate()` dispatch to the constituent that owns
     the value.  When every constituent fails, the error lists each
     constituent's error on its own line; the `errors.noMatch` option
-    customizes this message.  Async and dependency-derived value parsers
-    are rejected at construction time.  [[#821]]
+    customizes this message.  Dynamically built parser lists can be passed
+    as a single array (`firstOf(parsers, options?)`).  Async and
+    dependency-derived value parsers are rejected at construction time.
+    [[#821]]
 
 [Semantic Versioning 2.0.0]: https://semver.org/
 [#801]: https://github.com/dahlia/optique/issues/801

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -116,7 +116,7 @@ To be released.
     values (e.g. from `bindEnv()`/`bindConfig()`) instead of the generic
     `format()`+`parse()` round-trip, which cannot express validation
     failures for value parsers whose constituents produce overlapping
-    string representations.  [[#821]]
+    string representations.  [[#821], [#826]]
 
  -  Added `firstOf()` value parser combinator that tries multiple sync value
     parsers in declaration order and returns the first successful result,
@@ -132,7 +132,7 @@ To be released.
     customizes this message.  Dynamically built parser lists can be passed
     as a single array (`firstOf(parsers, options?)`).  Async and
     dependency-derived value parsers are rejected at construction time.
-    [[#821]]
+    [[#821], [#826]]
 
 [Semantic Versioning 2.0.0]: https://semver.org/
 [#801]: https://github.com/dahlia/optique/issues/801
@@ -152,6 +152,7 @@ To be released.
 [#821]: https://github.com/dahlia/optique/issues/821
 [#823]: https://github.com/dahlia/optique/issues/823
 [#825]: https://github.com/dahlia/optique/pull/825
+[#826]: https://github.com/dahlia/optique/pull/826
 
 ### @optique/discover
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -129,7 +129,8 @@ To be released.
     `normalize()`, and `validate()` dispatch to the constituent that owns
     the value.  When every constituent fails, the error lists each
     constituent's error on its own line; the `errors.noMatch` option
-    customizes this message.  [[#821]]
+    customizes this message.  Async and dependency-derived value parsers
+    are rejected at construction time.  [[#821]]
 
 [Semantic Versioning 2.0.0]: https://semver.org/
 [#801]: https://github.com/dahlia/optique/issues/801

--- a/docs/concepts/valueparsers.md
+++ b/docs/concepts/valueparsers.md
@@ -647,7 +647,10 @@ const count = firstOf(choice(["auto"]), integer({ min: 1 }), {
 > [!NOTE]
 > `firstOf()` only supports synchronous value parsers.  Passing an async
 > value parser (such as the Git parsers from *@optique/git*) throws a
-> `TypeError` at construction time.
+> `TypeError` at construction time.  Dependency-derived value parsers
+> (created via `deriveFrom()` or `dependency().derive()`) are rejected the
+> same way: invoked through `firstOf()` they would parse with default
+> dependency values instead of the ones resolved during the current parse.
 
 
 `json()` parser

--- a/docs/concepts/valueparsers.md
+++ b/docs/concepts/valueparsers.md
@@ -617,6 +617,30 @@ multiple `choice()` parsers), the merged list is also exposed for the
 `showChoices` display option; if any constituent is open-ended, no choice
 list is shown.
 
+### Dynamic parser lists
+
+The variadic form requires at least two statically known arguments.  When
+the constituents are built dynamically, pass them as a single array
+instead:
+
+~~~~ typescript twoslash
+import {
+  choice,
+  firstOf,
+  integer,
+  type ValueParser,
+} from "@optique/core/valueparser";
+// ---cut-before---
+const parsers: ValueParser<"sync", "auto" | number>[] = [
+  choice(["auto"]),
+  integer({ min: 1 }),
+];
+const count = firstOf(parsers, { metavar: "COUNT" });
+~~~~
+
+The array must still contain at least two parsers; shorter arrays are
+rejected with a `TypeError` at construction time.
+
 ### Error messages
 
 When every constituent fails, the error lists each constituent's error on

--- a/docs/concepts/valueparsers.md
+++ b/docs/concepts/valueparsers.md
@@ -3458,8 +3458,8 @@ handling and help text generation as built-in parsers.
 
 ### ValueParser interface
 
-The `ValueParser<M, T>` interface defines three required properties plus a mode
-marker:
+The `ValueParser<M, T>` interface defines four required properties plus a mode
+marker, and two optional methods:
 
 ~~~~ typescript twoslash
 import type { Mode, ModeValue, NonEmptyString, ValueParserResult } from "@optique/core/valueparser";
@@ -3471,6 +3471,7 @@ interface ValueParser<M extends Mode, T> {
   parse(input: string): ModeValue<M, ValueParserResult<T>>;
   format(value: T): string;
   normalize?(value: T): T;
+  validate?(value: T): ValueParserResult<T>;
 }
 ~~~~
 
@@ -3518,6 +3519,19 @@ interface ValueParser<M extends Mode, T> {
     > Exclusive combinators (`or()`, `longestMatch()`) and multi-source
     > combinators (`merge()`) intentionally do not forward normalization
     > because the active branch or key ownership is unknown at default time.
+
+`validate()`
+:   Optional.  *Available since Optique 1.1.0.*  Validates a value of type
+    `T` as if it had been parsed from CLI input, returning a success result
+    with the possibly canonicalized value or a failure with an error
+    message.  When present, `option()` and `argument()` use this method to
+    validate fallback values (e.g. from `bindEnv()`/`bindConfig()`) instead
+    of the generic `format()`+`parse()` round-trip.  Most parsers do not
+    need it: implement it only when the round-trip cannot faithfully
+    express validation for some values, as with `firstOf()` whose
+    constituents may produce overlapping string representations.  Like
+    `normalize()`, this method is synchronous regardless of the parser's
+    mode.
 
 ### Basic custom parser
 

--- a/docs/concepts/valueparsers.md
+++ b/docs/concepts/valueparsers.md
@@ -36,6 +36,7 @@ with Optique's type system.
 | `fileSize()`                     | *@optique/core*     | `number` or `bigint`           | Human-readable data size (bytes)                    |
 | `color()`                        | *@optique/core*     | `Color`                        | CSS color (hex, rgb, hsl, or named)                 |
 | `choice()`                       | *@optique/core*     | string or number literal union | Enumerated values                                   |
+| `firstOf()`                      | *@optique/core*     | union of constituent types     | First-match union of value parsers                  |
 | `json()`                         | *@optique/core*     | `Json`                         | Any JSON value, with optional root type restriction |
 | `url()`                          | *@optique/core*     | `URL`                          | URL with protocol filtering                         |
 | `locale()`                       | *@optique/core*     | `Intl.Locale`                  | BCP 47 locale identifier                            |
@@ -554,6 +555,99 @@ const depth = choice([8, 10, 12]);
 > option in your runner configuration.  See the
 > [choice display](./runners.md#choice-display) section in the runners guide
 > for details.
+
+
+`firstOf()` combinator
+----------------------
+
+*This combinator is available since Optique 1.1.0.*
+
+Some options accept values of multiple incompatible types: a `--count` that
+takes either a number or the literal `auto`, an `--output` that is either a
+file path or `-` for standard output, a `--log-level` that accepts both named
+levels and numeric verbosity.  The `firstOf()` combinator composes existing
+value parsers into such a union.  It tries each constituent parser in
+declaration order and returns the result of the first one that succeeds:
+
+~~~~ typescript twoslash
+import { choice, firstOf, integer } from "@optique/core/valueparser";
+
+const count = firstOf(choice(["auto"]), integer({ min: 1 }));
+//    ^?
+~~~~
+
+The result type is inferred as the union of the constituent types, so the
+example above produces `"auto" | number` without manual type annotations or
+hand-written parsing logic.  Each constituent keeps its own validation and
+error messages, which is the main advantage over parsing with `string()` and
+converting the result in a `map()`.
+
+### Declaration order
+
+The first constituent that accepts the input wins.  When inputs overlap (for
+example, `choice(["1"])` and `integer()` both accept the input `1`), the
+earlier constituent claims them, so put more specific parsers first:
+
+~~~~ typescript twoslash
+import { choice, firstOf, string } from "@optique/core/valueparser";
+// ---cut-before---
+// Correct: the specific alias list comes before the catch-all string()
+const target = firstOf(choice(["production", "staging"]), string());
+
+// Wrong: string() accepts everything, so choice() never gets a chance
+const broken = firstOf(string(), choice(["production", "staging"]));
+~~~~
+
+### Help text
+
+The default metavar joins the constituent metavars with `|` (for the example
+above, `TYPE|INTEGER`), and the `metavar` option overrides it:
+
+~~~~ typescript twoslash
+import { choice, firstOf, integer } from "@optique/core/valueparser";
+// ---cut-before---
+const count = firstOf(choice(["auto"]), integer({ min: 1 }), {
+  metavar: "COUNT",
+});
+~~~~
+
+Completion suggestions are merged across all constituents that provide them.
+When every constituent enumerates its valid values (e.g. a `firstOf()` of
+multiple `choice()` parsers), the merged list is also exposed for the
+`showChoices` display option; if any constituent is open-ended, no choice
+list is shown.
+
+### Error messages
+
+When every constituent fails, the error lists each constituent's error on
+its own line:
+
+~~~~ bash
+$ myapp --count abc
+Error: `--count`: Expected one of the following:
+- Expected one of "auto", but got "abc".
+- Expected a valid integer, but got "abc".
+~~~~
+
+The `errors.noMatch` option replaces this combined message with a static
+message or one computed from the input and the constituent errors:
+
+~~~~ typescript twoslash
+import { message } from "@optique/core/message";
+import { choice, firstOf, integer } from "@optique/core/valueparser";
+// ---cut-before---
+const count = firstOf(choice(["auto"]), integer({ min: 1 }), {
+  errors: {
+    noMatch: (input) =>
+      message`Expected ${"auto"} or a positive integer, but got ${input}.`,
+  },
+});
+~~~~
+
+> [!NOTE]
+> `firstOf()` only supports synchronous value parsers.  Passing an async
+> value parser (such as the Git parsers from *@optique/git*) throws a
+> `TypeError` at construction time.
 
 
 `json()` parser

--- a/packages/core/src/primitives.ts
+++ b/packages/core/src/primitives.ts
@@ -1456,14 +1456,7 @@ export function option<M extends Mode, T>(
         // that a generic format()+parse() round-trip cannot (e.g. values
         // whose string form an earlier overlapping constituent claims).
         if (typeof vp.validate === "function") {
-          return dispatchByMode(
-            mode,
-            () =>
-              wrapParseResult(
-                (vp as ValueParser<"sync", T>).validate!(v as T),
-              ),
-            async () => wrapParseResult(await vp.validate!(v as T)),
-          );
+          return wrapForMode(mode, wrapParseResult(vp.validate(v as T)));
         }
         let stringified: string;
         try {
@@ -2718,13 +2711,9 @@ export function argument<M extends Mode, T>(
         // that a generic format()+parse() round-trip cannot (e.g. values
         // whose string form an earlier overlapping constituent claims).
         if (typeof vp.validate === "function") {
-          return dispatchByMode<M, ValueParserResult<T>>(
+          return wrapForMode<M, ValueParserResult<T>>(
             vpMode,
-            () =>
-              wrapParseResult(
-                (vp as ValueParser<"sync", T>).validate!(v),
-              ),
-            async () => wrapParseResult(await vp.validate!(v)),
+            wrapParseResult(vp.validate(v)),
           );
         }
         let stringified: string;

--- a/packages/core/src/primitives.ts
+++ b/packages/core/src/primitives.ts
@@ -1451,6 +1451,20 @@ export function option<M extends Mode, T>(
       value(
         v: T | boolean,
       ): ModeValue<M, ValueParserResult<T | boolean>> {
+        // Prefer the value parser's own validate() hook when present:
+        // combinators like firstOf() can express validation failures
+        // that a generic format()+parse() round-trip cannot (e.g. values
+        // whose string form an earlier overlapping constituent claims).
+        if (typeof vp.validate === "function") {
+          return dispatchByMode(
+            mode,
+            () =>
+              wrapParseResult(
+                (vp as ValueParser<"sync", T>).validate!(v as T),
+              ),
+            async () => wrapParseResult(await vp.validate!(v as T)),
+          );
+        }
         let stringified: string;
         try {
           stringified = vp.format(v as T);
@@ -2699,6 +2713,20 @@ export function argument<M extends Mode, T>(
         : { success: false, error: formatInvalidValueError(parsed.error) };
     Object.defineProperty(result, "validateValue", {
       value(v: T): ModeValue<M, ValueParserResult<T>> {
+        // Prefer the value parser's own validate() hook when present:
+        // combinators like firstOf() can express validation failures
+        // that a generic format()+parse() round-trip cannot (e.g. values
+        // whose string form an earlier overlapping constituent claims).
+        if (typeof vp.validate === "function") {
+          return dispatchByMode<M, ValueParserResult<T>>(
+            vpMode,
+            () =>
+              wrapParseResult(
+                (vp as ValueParser<"sync", T>).validate!(v),
+              ),
+            async () => wrapParseResult(await vp.validate!(v)),
+          );
+        }
         let stringified: string;
         try {
           stringified = vp.format(v);

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -18924,6 +18924,47 @@ describe("firstOf", () => {
     });
   });
 
+  describe("array form", () => {
+    it("should accept a dynamically built array of parsers", () => {
+      const parsers: ValueParser<"sync", "auto" | number>[] = [
+        choice(["auto"]),
+        integer({ min: 1 }),
+      ];
+      const parser = firstOf(parsers);
+      const autoResult = parser.parse("auto");
+      assert.ok(autoResult.success);
+      assert.equal(autoResult.value, "auto");
+      const intResult = parser.parse("5");
+      assert.ok(intResult.success);
+      assert.equal(intResult.value, 5);
+      assert.equal(parser.metavar, "TYPE|INTEGER");
+    });
+
+    it("should accept options with the array form", () => {
+      const parser = firstOf([choice(["auto"]), integer()], {
+        metavar: "COUNT",
+      });
+      assert.equal(parser.metavar, "COUNT");
+    });
+
+    it("should snapshot the parser array at construction time", () => {
+      const parsers: ValueParser<"sync", "auto" | number>[] = [
+        choice(["auto"]),
+        integer(),
+      ];
+      const parser = firstOf(parsers);
+      parsers.length = 0;
+      const result = parser.parse("5");
+      assert.ok(result.success);
+      assert.equal(result.value, 5);
+    });
+
+    it("should throw TypeError for arrays with fewer than two parsers", () => {
+      assert.throws(() => firstOf([integer()]), TypeError);
+      assert.throws(() => firstOf([]), TypeError);
+    });
+  });
+
   describe("custom errors", () => {
     it("should use a static noMatch message", () => {
       const parser = firstOf(choice(["auto"]), integer({ min: 1 }), {
@@ -18978,6 +19019,9 @@ describe("firstOf", () => {
         "sync",
         "a" | "b" | "c" | "d" | "e" | number
       >;
+
+      const fromArray = firstOf([choice(["auto"]), integer({ min: 1 })]);
+      fromArray satisfies ValueParser<"sync", "auto" | number>;
 
       const result = pair.parse("auto");
       assert.ok(result.success);

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -18738,6 +18738,25 @@ describe("firstOf", () => {
       assert.ok(Object.is(zeroResult.value, 0));
     });
 
+    it("should accept fallbacks canonicalized beyond case folding", () => {
+      // Built-in parsers like email({ allowDisplayName: true }) and
+      // semVer({ allowPrefix: true }) canonicalize during parse() without
+      // exposing normalize().  When no constituent owns the value more
+      // faithfully, a same-primitive-type round trip is the same
+      // canonicalization the constituent alone would apply to a fallback.
+      const mail = firstOf(email({ allowDisplayName: true }), integer());
+      const mailResult = mail.validate?.("John Doe <john@example.com>");
+      assert.ok(mailResult?.success);
+      assert.equal(mailResult.value, "john@example.com");
+
+      const version = firstOf(semVer({ allowPrefix: true }), integer());
+      // The v-prefixed form is outside the SemVerString literal type but
+      // arrives at runtime from config/env fallbacks:
+      const versionResult = version.validate?.("v1.2.3" as never);
+      assert.ok(versionResult?.success);
+      assert.equal(versionResult.value, "1.2.3");
+    });
+
     it("should not treat arbitrary same-type round trips as ownership", () => {
       // A parser whose format() clamps values to its range round-trips
       // 15 into 10.  That is data loss, not canonicalization: it must

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -36,12 +36,15 @@ import {
 } from "@optique/core/valueparser";
 import {
   formatMessage,
+  type Message,
   message,
   type MessageTerm,
   text,
   values,
 } from "@optique/core/message";
-import { argument } from "#src/primitives.ts";
+import { argument, option } from "#src/primitives.ts";
+import { withDefault } from "#src/modifiers.ts";
+import { parse } from "#src/parser.ts";
 import assert from "node:assert/strict";
 import * as fc from "fast-check";
 import { describe, it } from "node:test";
@@ -18781,6 +18784,158 @@ describe("firstOf", () => {
         suggestions.map((s) => s.kind === "literal" ? s.text : s.kind),
         ["auto", "max", "min"],
       );
+    });
+  });
+
+  describe("custom errors", () => {
+    it("should use a static noMatch message", () => {
+      const parser = firstOf(choice(["auto"]), integer({ min: 1 }), {
+        errors: { noMatch: message`Custom error.` },
+      });
+      const result = parser.parse("abc");
+      assert.ok(!result.success);
+      assert.deepEqual(result.error, message`Custom error.`);
+    });
+
+    it("should pass input and constituent errors to a noMatch function", () => {
+      let seenInput: string | undefined;
+      let seenErrors: readonly Message[] | undefined;
+      const parser = firstOf(choice(["auto"]), integer({ min: 1 }), {
+        errors: {
+          noMatch: (input, errors) => {
+            seenInput = input;
+            seenErrors = errors;
+            return message`No match for ${input}.`;
+          },
+        },
+      });
+      const result = parser.parse("abc");
+      assert.ok(!result.success);
+      assert.deepEqual(result.error, message`No match for ${"abc"}.`);
+      assert.equal(seenInput, "abc");
+      assert.equal(seenErrors?.length, 2);
+      assert.ok(formatMessage(seenErrors[0]).includes("auto"));
+      assert.ok(formatMessage(seenErrors[1]).includes("integer"));
+    });
+  });
+
+  describe("types", () => {
+    it("should infer the union of constituent types", () => {
+      const pair = firstOf(choice(["auto"]), integer({ min: 1 }));
+      pair satisfies ValueParser<"sync", "auto" | number>;
+
+      const withOptions = firstOf(choice(["auto"]), integer(), {
+        metavar: "COUNT",
+      });
+      withOptions satisfies ValueParser<"sync", "auto" | number>;
+
+      const variadic = firstOf(
+        choice(["a"]),
+        choice(["b"]),
+        choice(["c"]),
+        choice(["d"]),
+        choice(["e"]),
+        integer(),
+      );
+      variadic satisfies ValueParser<
+        "sync",
+        "a" | "b" | "c" | "d" | "e" | number
+      >;
+
+      const result = pair.parse("auto");
+      assert.ok(result.success);
+      const value: "auto" | number = result.value;
+      assert.equal(value, "auto");
+    });
+  });
+
+  describe("properties", () => {
+    it("property: every constituent's values parse to themselves", () => {
+      fc.assert(
+        fc.property(
+          fc.uniqueArray(lowercaseWordArbitrary, { minLength: 1 }),
+          safeIntegerArbitrary,
+          (words, num) => {
+            const parser = firstOf(choice(words), integer());
+            for (const word of words) {
+              const result = parser.parse(word);
+              assert.ok(result.success);
+              assert.equal(result.value, word);
+            }
+            const numResult = parser.parse(String(num));
+            assert.ok(numResult.success);
+            assert.equal(numResult.value, num);
+          },
+        ),
+        propertyParameters,
+      );
+    });
+
+    it("property: parse(format(v)) round-trips union values", () => {
+      fc.assert(
+        fc.property(
+          fc.uniqueArray(lowercaseWordArbitrary, { minLength: 1 }),
+          safeIntegerArbitrary,
+          (words, num) => {
+            const parser = firstOf(choice(words), integer());
+            for (const value of [...words, num]) {
+              const result = parser.parse(parser.format(value));
+              assert.ok(result.success);
+              assert.equal(result.value, value);
+            }
+          },
+        ),
+        propertyParameters,
+      );
+    });
+
+    it("property: declaration order determines the winning branch", () => {
+      fc.assert(
+        fc.property(safeIntegerArbitrary, (num) => {
+          const numText = String(num);
+          const stringFirst = firstOf(choice([numText]), integer());
+          const stringResult = stringFirst.parse(numText);
+          assert.ok(stringResult.success);
+          assert.equal(stringResult.value, numText);
+
+          const integerFirst = firstOf(integer(), choice([numText]));
+          const integerResult = integerFirst.parse(numText);
+          assert.ok(integerResult.success);
+          assert.equal(integerResult.value, num);
+        }),
+        propertyParameters,
+      );
+    });
+  });
+
+  describe("integration", () => {
+    it("should parse option values through option()", () => {
+      const parser = option(
+        "--count",
+        firstOf(choice(["auto"]), integer({ min: 1 })),
+      );
+
+      const auto = parse(parser, ["--count", "auto"]);
+      assert.ok(auto.success);
+      assert.equal(auto.value, "auto");
+
+      const five = parse(parser, ["--count", "5"]);
+      assert.ok(five.success);
+      assert.equal(five.value, 5);
+
+      const invalid = parse(parser, ["--count", "0"]);
+      assert.ok(!invalid.success);
+    });
+
+    it("should normalize withDefault() defaults via the owning constituent", () => {
+      const mac = macAddress({ outputSeparator: ":" });
+      const parser = withDefault(
+        option("--mac", firstOf(mac, choice(["none"]))),
+        "AA-BB-CC-DD-EE-FF",
+      );
+      const result = parse(parser, []);
+      assert.ok(result.success);
+      assert.equal(result.value, mac.normalize?.("AA-BB-CC-DD-EE-FF"));
     });
   });
 

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -18868,6 +18868,63 @@ describe("firstOf", () => {
       assert.deepEqual(result.value, { a: 1 });
     });
 
+    it("should let class instances with public fields own their values", () => {
+      // A hookless custom parser may round-trip a class instance through
+      // its enumerable own fields without overriding toString().  Two
+      // structurally equal instances of the same class must compare as
+      // equal, or the parser could never own its own round-tripped
+      // values and fallback validation would reject them.
+      class UserId {
+        constructor(readonly id: string) {}
+      }
+      const userId: ValueParser<"sync", UserId> = {
+        mode: "sync",
+        metavar: "USER",
+        placeholder: new UserId(""),
+        parse: (input) =>
+          /^[a-z]+$/.test(input)
+            ? { success: true, value: new UserId(input) }
+            : { success: false, error: message`Expected a user ID.` },
+        format: (value) => value.id,
+      };
+      const parser = firstOf(integer(), userId);
+      const result = parser.validate?.(new UserId("alice"));
+      assert.ok(result?.success);
+      assert.ok(result.value instanceof UserId);
+      assert.equal(result.value.id, "alice");
+    });
+
+    it("should require matching serialization when toString() is overridden", () => {
+      // A class may expose some state through enumerable fields and keep
+      // the rest in private fields that only its toString() serializes.
+      // Structural key equality alone must not let a lossy parser claim
+      // such a value when the serializations disagree.
+      class Token {
+        readonly #scope: string;
+        constructor(readonly id: string, scope: string) {
+          this.#scope = scope;
+        }
+        toString(): string {
+          return `${this.id}:${this.#scope}`;
+        }
+      }
+      const token: ValueParser<"sync", Token> = {
+        mode: "sync",
+        metavar: "TOKEN",
+        placeholder: new Token("", ""),
+        parse: (input) => ({
+          success: true,
+          value: new Token(input, "parsed"),
+        }),
+        // Lossy: drops the private scope.
+        format: (value) => value.id,
+      };
+      const parser = firstOf(token, choice(["none"]));
+      const result = parser.validate?.(new Token("alice", "original"));
+      assert.ok(result);
+      assert.ok(!result.success);
+    });
+
     it("should treat a throwing constituent validate() as non-ownership", () => {
       // A custom parser's validate() hook is typed for its own T, so it
       // may reasonably use string-only operations that throw when handed

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -18702,6 +18702,40 @@ describe("firstOf", () => {
       assert.equal(stringResult.value, "0");
     });
 
+    it("should accept fallback values canonicalized by parse()", () => {
+      // choice() with caseInsensitive canonicalizes during parse() but
+      // does not expose normalize(), so the round trip yields "info" for
+      // the fallback "INFO".  A same-type primitive canonicalization is
+      // still ownership: the constituent alone would accept the same
+      // fallback through its format()+parse() round-trip validation.
+      const parser = firstOf(
+        choice(["info", "warn"], { caseInsensitive: true }),
+        integer(),
+      );
+      // Config/env fallback values are runtime-typed, so they can carry
+      // representations outside the inferred literal union:
+      const result = parser.validate?.("INFO" as never);
+      assert.ok(result?.success);
+      assert.equal(result.value, "info");
+
+      // Same for number canonicalization: choice([0]) parses "-0" as 0.
+      const zero = firstOf(choice([0]), string());
+      const zeroResult = zero.validate?.(-0);
+      assert.ok(zeroResult?.success);
+      assert.ok(Object.is(zeroResult.value, 0));
+    });
+
+    it("should canonicalize parse-normalized fallbacks through option()", () => {
+      const parser = option(
+        "--level",
+        firstOf(choice(["info"], { caseInsensitive: true }), integer()),
+      );
+      const result = parser.validateValue?.("INFO" as never);
+      assert.ok(result);
+      assert.ok(result.success);
+      assert.equal(result.value, "info");
+    });
+
     it("should canonicalize values through the owning constituent", () => {
       const mac = macAddress({ outputSeparator: ":" });
       const parser = firstOf(mac, choice(["none"]));

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -18855,6 +18855,35 @@ describe("firstOf", () => {
       assert.deepEqual(result.value, { a: 1 });
     });
 
+    it("should treat a throwing constituent validate() as non-ownership", () => {
+      // A custom parser's validate() hook is typed for its own T, so it
+      // may reasonably use string-only operations that throw when handed
+      // a foreign value from another branch of the union.  Such throws
+      // must count as "not this constituent's value", letting later
+      // branches claim it, just like throwing format() does.
+      const word: ValueParser<"sync", string> = {
+        mode: "sync",
+        metavar: "WORD",
+        placeholder: "",
+        parse: (input) =>
+          /^[a-z]+$/.test(input)
+            ? { success: true, value: input }
+            : { success: false, error: message`Expected a lowercase word.` },
+        format: (value) => String(value),
+        validate(value) {
+          const lower = value.toLowerCase();
+          return /^[a-z]+$/.test(lower)
+            ? { success: true, value: lower }
+            : { success: false, error: message`Expected a lowercase word.` };
+        },
+      };
+      const parser = firstOf(word, integer());
+      const result = parser.validate?.(1);
+      assert.ok(result?.success);
+      assert.equal(result.value, 1);
+      assert.equal(parser.format(1), "1");
+    });
+
     it("should consult a constituent's validate() for shadowed values", () => {
       // The inner firstOf() cannot round-trip the shadowed integer 1
       // through format()+parse() (the string "1" goes to its choice()

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -18566,6 +18566,19 @@ describe("firstOf", () => {
       assert.deepEqual(parser.choices, ["a", "b", "c"]);
     });
 
+    it("should deduplicate overlapping choices", () => {
+      const parser = firstOf(choice(["a", "b"]), choice(["b", "c"]));
+      assert.deepEqual(parser.choices, ["a", "b", "c"]);
+    });
+
+    it("should keep 0 and -0 distinct when deduplicating", () => {
+      const parser = firstOf(choice([0]), choice([-0, 1]));
+      assert.equal(parser.choices?.length, 3);
+      assert.ok(Object.is(parser.choices?.[0], 0));
+      assert.ok(Object.is(parser.choices?.[1], -0));
+      assert.equal(parser.choices?.[2], 1);
+    });
+
     it("should omit choices when any constituent is open-ended", () => {
       const parser = firstOf(choice(["auto"]), integer());
       assert.equal(parser.choices, undefined);

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -18738,6 +18738,29 @@ describe("firstOf", () => {
       assert.ok(Object.is(zeroResult.value, 0));
     });
 
+    it("should not treat arbitrary same-type round trips as ownership", () => {
+      // A parser whose format() clamps values to its range round-trips
+      // 15 into 10.  That is data loss, not canonicalization: it must
+      // not claim the value ahead of a later constituent that preserves
+      // it exactly.
+      const clamping: ValueParser<"sync", number> = {
+        mode: "sync",
+        metavar: "CLAMPED",
+        placeholder: 1,
+        parse: (input) => {
+          const n = Number(input);
+          return Number.isInteger(n) && n >= 1 && n <= 10
+            ? { success: true, value: n }
+            : { success: false, error: message`Expected 1-10.` };
+        },
+        format: (value) => String(Math.max(1, Math.min(10, value))),
+      };
+      const parser = firstOf(clamping, float());
+      const result = parser.validate?.(15);
+      assert.ok(result?.success);
+      assert.equal(result.value, 15);
+    });
+
     it("should canonicalize parse-normalized fallbacks through option()", () => {
       const parser = option(
         "--level",

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -9,6 +9,7 @@ import {
   email,
   fileSize,
   type FileSizeOptionsBigInt,
+  firstOf,
   float,
   hostname,
   integer,
@@ -31,6 +32,7 @@ import {
   string,
   url,
   uuid,
+  type ValueParser,
 } from "@optique/core/valueparser";
 import {
   formatMessage,
@@ -39,6 +41,7 @@ import {
   text,
   values,
 } from "@optique/core/message";
+import { argument } from "#src/primitives.ts";
 import assert from "node:assert/strict";
 import * as fc from "fast-check";
 import { describe, it } from "node:test";
@@ -18459,6 +18462,363 @@ describe("json()", () => {
 
     it("custom placeholder is respected", () => {
       assert.equal(json({ placeholder: 123 }).placeholder, 123);
+    });
+  });
+});
+
+describe("firstOf", () => {
+  describe("parsing", () => {
+    it("should return the first successful constituent's value", () => {
+      const parser = firstOf(choice(["auto"]), integer({ min: 1 }));
+
+      const autoResult = parser.parse("auto");
+      assert.ok(autoResult.success);
+      assert.equal(autoResult.value, "auto");
+
+      const intResult = parser.parse("5");
+      assert.ok(intResult.success);
+      assert.equal(intResult.value, 5);
+    });
+
+    it("should respect declaration order on overlapping inputs", () => {
+      const parser = firstOf(choice(["1"]), integer());
+      const result = parser.parse("1");
+      assert.ok(result.success);
+      assert.equal(result.value, "1");
+
+      const reversed = firstOf(integer(), choice(["1"]));
+      const reversedResult = reversed.parse("1");
+      assert.ok(reversedResult.success);
+      assert.equal(reversedResult.value, 1);
+    });
+
+    it("should combine all constituent errors when every parser fails", () => {
+      const parser = firstOf(choice(["auto"]), integer({ min: 1 }));
+      const result = parser.parse("abc");
+      assert.ok(!result.success);
+
+      const [header] = result.error;
+      assert.ok(header.type === "text");
+      assert.ok(header.text.includes("Expected one of the following"));
+
+      const lineBreaks = result.error.filter(
+        (term: MessageTerm) => term.type === "lineBreak",
+      );
+      assert.equal(lineBreaks.length, 2);
+
+      const formatted = formatMessage(result.error);
+      assert.ok(formatted.includes("auto"));
+      assert.ok(formatted.includes("integer"));
+      assert.equal(formatted.split("\n").length, 3);
+    });
+
+    it("should propagate the deferred flag from custom constituents", () => {
+      const deferredParser: ValueParser<"sync", string> = {
+        mode: "sync",
+        metavar: "DEFERRED",
+        placeholder: "",
+        parse: (input) => ({ success: true, value: input, deferred: true }),
+        format: (value) => value,
+      };
+      const parser = firstOf(integer(), deferredParser);
+      const result = parser.parse("abc");
+      assert.ok(result.success);
+      assert.equal(result.value, "abc");
+      assert.ok(result.deferred);
+    });
+  });
+
+  describe("metadata", () => {
+    it("should be a sync value parser", () => {
+      const parser = firstOf(choice(["auto"]), integer());
+      assert.equal(parser.mode, "sync");
+      assert.ok(isValueParser(parser));
+    });
+
+    it("should join constituent metavars with | by default", () => {
+      const parser = firstOf(choice(["auto"]), integer());
+      assert.equal(parser.metavar, "TYPE|INTEGER");
+    });
+
+    it("should respect a custom metavar option", () => {
+      const parser = firstOf(choice(["auto"]), integer(), {
+        metavar: "COUNT",
+      });
+      assert.equal(parser.metavar, "COUNT");
+    });
+
+    it("should use the first constituent's placeholder", () => {
+      const parser = firstOf(choice(["auto", "manual"]), integer());
+      assert.equal(parser.placeholder, "auto");
+
+      const reversed = firstOf(integer(), choice(["auto", "manual"]));
+      assert.equal(reversed.placeholder, 0);
+    });
+  });
+
+  describe("choices", () => {
+    it("should merge choices when every constituent defines them", () => {
+      const parser = firstOf(choice(["a", "b"]), choice(["c"]));
+      assert.deepEqual(parser.choices, ["a", "b", "c"]);
+    });
+
+    it("should omit choices when any constituent is open-ended", () => {
+      const parser = firstOf(choice(["auto"]), integer());
+      assert.equal(parser.choices, undefined);
+    });
+  });
+
+  describe("format", () => {
+    it("should format with the constituent that accepts the value", () => {
+      const parser = firstOf(choice(["auto"]), integer({ min: 1 }));
+      assert.equal(parser.format("auto"), "auto");
+      assert.equal(parser.format(5), "5");
+    });
+
+    it("should skip constituents whose format() throws", () => {
+      const throwing: ValueParser<"sync", number> = {
+        mode: "sync",
+        metavar: "ONE",
+        placeholder: 1,
+        parse: (input) =>
+          input === "1"
+            ? { success: true, value: 1 }
+            : { success: false, error: message`Expected ${text("1")}.` },
+        format: (value) => {
+          if (value !== 1) throw new RangeError("Not one.");
+          return "1";
+        },
+      };
+      const parser = firstOf(throwing, integer());
+      assert.equal(parser.format(42), "42");
+      assert.equal(parser.format(1), "1");
+    });
+
+    it("should rethrow when every constituent's format() throws", () => {
+      const throwing: ValueParser<"sync", number> = {
+        mode: "sync",
+        metavar: "ONE",
+        placeholder: 1,
+        parse: () => ({ success: false, error: message`Nope.` }),
+        format: () => {
+          throw new RangeError("Cannot format.");
+        },
+      };
+      const parser = firstOf(throwing, throwing);
+      assert.throws(() => parser.format(42), RangeError);
+    });
+
+    it("should fall back to a well-formed string for unclaimed values", () => {
+      const parser = firstOf(choice(["auto"]), integer({ min: 1 }));
+      assert.equal(parser.format(0), "0");
+    });
+
+    it("should not validate out-of-union values through another branch", () => {
+      // Regression: a format()+parse() round-trip (as performed by
+      // validateValue() for bindEnv()/bindConfig() fallbacks) must not
+      // accept values that no constituent accepts.
+      const parser = firstOf(string({ pattern: /^a$/ }), integer({ min: 1 }));
+      const roundTrip = parser.parse(parser.format(0));
+      assert.ok(!roundTrip.success);
+    });
+
+    it("should not let a lossy earlier constituent claim a later one's value", () => {
+      // Regression: color().format() accepts any { r, g, b, a } shape and
+      // color().parse() accepts the result, so a naive success-based
+      // ownership test would drop extra object fields owned by json().
+      const parser = firstOf(color(), json({ rootType: "object" }));
+      const value = { r: 1, g: 2, b: 3, a: 1, extra: "keep" };
+      const roundTrip = parser.parse(parser.format(value));
+      assert.ok(roundTrip.success);
+      assert.deepEqual(roundTrip.value, value);
+    });
+
+    it("should format overlapping values for display", () => {
+      // format() is a display-oriented best effort; precise fallback
+      // validation goes through validate() instead.
+      const parser = firstOf(choice(["1"]), integer());
+      assert.equal(parser.format("1"), "1");
+      assert.equal(parser.format(1), "1");
+    });
+
+    it("should format through a constituent that normalizes the value", () => {
+      const mac = macAddress({ outputSeparator: ":" });
+      const parser = firstOf(mac, choice(["none"]));
+      assert.equal(
+        parser.format("AA-BB-CC-DD-EE-FF"),
+        mac.format("AA-BB-CC-DD-EE-FF"),
+      );
+    });
+  });
+
+  describe("validate", () => {
+    it("should accept values owned by a constituent", () => {
+      const parser = firstOf(choice(["auto"]), integer({ min: 1 }));
+      const autoResult = parser.validate?.("auto");
+      assert.ok(autoResult?.success);
+      assert.equal(autoResult.value, "auto");
+      const intResult = parser.validate?.(5);
+      assert.ok(intResult?.success);
+      assert.equal(intResult.value, 5);
+    });
+
+    it("should accept values shadowed by an earlier overlapping branch", () => {
+      // The integer 1 cannot be produced by parsing (its string form "1"
+      // always goes to the choice() branch), but it is still a valid
+      // integer() value, so fallback validation must accept it unchanged.
+      const parser = firstOf(choice(["1"]), integer());
+      const result = parser.validate?.(1);
+      assert.ok(result?.success);
+      assert.equal(result.value, 1);
+    });
+
+    it("should reject values that no constituent accepts", () => {
+      // The number 0 violates integer({ min: 1 }), and the choice() branch
+      // only accepts the *string* "0".  A format()+parse() round-trip
+      // cannot express this failure ("0" parses fine into the choice
+      // branch), which is exactly what validate() is for.
+      const parser = firstOf(choice(["0"]), integer({ min: 1 }));
+      const result = parser.validate?.(0);
+      assert.ok(result);
+      assert.ok(!result.success);
+      const stringResult = parser.validate?.("0");
+      assert.ok(stringResult?.success);
+      assert.equal(stringResult.value, "0");
+    });
+
+    it("should canonicalize values through the owning constituent", () => {
+      const mac = macAddress({ outputSeparator: ":" });
+      const parser = firstOf(mac, choice(["none"]));
+      const result = parser.validate?.("AA-BB-CC-DD-EE-FF");
+      assert.ok(result?.success);
+      assert.equal(result.value, mac.format("AA-BB-CC-DD-EE-FF"));
+    });
+
+    it("should delegate to a constituent's own validate()", () => {
+      const inner = firstOf(choice(["0"]), integer({ min: 1 }));
+      const parser = firstOf(choice(["x"]), inner);
+      const invalid = parser.validate?.(0);
+      assert.ok(invalid);
+      assert.ok(!invalid.success);
+      const valid = parser.validate?.(5);
+      assert.ok(valid?.success);
+      assert.equal(valid.value, 5);
+    });
+
+    it("should consult a constituent's validate() for shadowed values", () => {
+      // The inner firstOf() cannot round-trip the shadowed integer 1
+      // through format()+parse() (the string "1" goes to its choice()
+      // branch), but its own validate() hook accepts it; the outer
+      // firstOf() must consult that hook instead of only round-tripping.
+      const parser = firstOf(choice(["x"]), firstOf(choice(["1"]), integer()));
+      const result = parser.validate?.(1);
+      assert.ok(result?.success);
+      assert.equal(result.value, 1);
+    });
+
+    it("should be used by option()/argument() fallback validation", () => {
+      const overlapping = argument(firstOf(choice(["1"]), integer()));
+      const shadowed = overlapping.validateValue?.(1);
+      assert.ok(shadowed);
+      assert.ok(shadowed.success);
+      assert.equal(shadowed.value, 1);
+
+      const strict = argument(firstOf(choice(["0"]), integer({ min: 1 })));
+      const rejected = strict.validateValue?.(0);
+      assert.ok(rejected);
+      assert.ok(!rejected.success);
+    });
+  });
+
+  describe("normalize", () => {
+    it("should be undefined when no constituent normalizes", () => {
+      const parser = firstOf(choice(["auto"]), integer());
+      assert.equal(parser.normalize, undefined);
+    });
+
+    it("should dispatch to the constituent that accepts the value", () => {
+      const mac = macAddress({ outputSeparator: ":" });
+      const parser = firstOf(mac, choice(["none"]));
+      assert.equal(
+        parser.normalize?.("AA-BB-CC-DD-EE-FF"),
+        mac.normalize?.("AA-BB-CC-DD-EE-FF"),
+      );
+    });
+
+    it("should return values unchanged for constituents without normalize", () => {
+      const parser = firstOf(macAddress(), choice(["none"]));
+      assert.equal(parser.normalize?.("none"), "none");
+    });
+
+    it("should return unclaimed values unchanged", () => {
+      const parser = firstOf(macAddress(), choice(["none"]));
+      assert.equal(parser.normalize?.("not-a-mac"), "not-a-mac");
+    });
+  });
+
+  describe("suggest", () => {
+    it("should be undefined when no constituent suggests", () => {
+      const parser = firstOf(string(), integer());
+      assert.equal(parser.suggest, undefined);
+    });
+
+    it("should merge suggestions from all constituents in order", () => {
+      const parser = firstOf(
+        choice(["auto", "always"]),
+        choice(["all", "never"]),
+      );
+      const suggestions = [...parser.suggest?.("a") ?? []];
+      assert.deepEqual(
+        suggestions.map((s) => s.kind === "literal" ? s.text : s.kind),
+        ["auto", "always", "all"],
+      );
+    });
+
+    it("should deduplicate identical suggestions across constituents", () => {
+      const parser = firstOf(choice(["auto", "max"]), choice(["auto", "min"]));
+      const suggestions = [...parser.suggest?.("") ?? []];
+      assert.deepEqual(
+        suggestions.map((s) => s.kind === "literal" ? s.text : s.kind),
+        ["auto", "max", "min"],
+      );
+    });
+  });
+
+  describe("construction errors", () => {
+    it("should throw TypeError when fewer than two parsers are given", () => {
+      assert.throws(
+        // @ts-expect-error: firstOf() requires at least two parsers.
+        () => firstOf(integer()),
+        TypeError,
+      );
+      assert.throws(
+        // @ts-expect-error: firstOf() requires at least two parsers.
+        () => firstOf(integer(), { metavar: "COUNT" }),
+        TypeError,
+      );
+    });
+
+    it("should throw TypeError for non-parser arguments", () => {
+      assert.throws(
+        // @ts-expect-error: 42 is not a value parser.
+        () => firstOf(integer(), 42),
+        TypeError,
+      );
+    });
+
+    it("should throw TypeError for async constituents", () => {
+      const asyncParser: ValueParser<"async", string> = {
+        mode: "async",
+        metavar: "ASYNC",
+        placeholder: "",
+        parse: (input) => Promise.resolve({ success: true, value: input }),
+        format: (value) => value,
+      };
+      assert.throws(
+        // @ts-expect-error: firstOf() only accepts sync value parsers.
+        () => firstOf(string(), asyncParser),
+        TypeError,
+      );
     });
   });
 });

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -18709,6 +18709,106 @@ describe("firstOf", () => {
       assert.equal(valid.value, 5);
     });
 
+    it("should not let an opaque-object branch claim another's value", () => {
+      // Mimics firstOf(instant(), zonedDateTime()): both value types are
+      // class instances without enumerable own keys, and the instant-like
+      // parser lossily accepts the zoned string form by stripping the
+      // time zone annotation.  Ownership comparison must not treat two
+      // key-less objects of different types as equal.
+      class FakeInstant {
+        readonly #iso: string;
+        constructor(iso: string) {
+          this.#iso = iso;
+        }
+        toString(): string {
+          return this.#iso;
+        }
+      }
+      class FakeZonedDateTime {
+        readonly #iso: string;
+        readonly #zone: string;
+        constructor(iso: string, zone: string) {
+          this.#iso = iso;
+          this.#zone = zone;
+        }
+        toString(): string {
+          return `${this.#iso}[${this.#zone}]`;
+        }
+      }
+      const instant: ValueParser<"sync", FakeInstant> = {
+        mode: "sync",
+        metavar: "INSTANT",
+        placeholder: new FakeInstant("1970-01-01T00:00:00Z"),
+        parse: (input) => ({
+          success: true,
+          value: new FakeInstant(input.replace(/\[[^\]]*\]$/, "")),
+        }),
+        format: (value) => value.toString(),
+      };
+      const zoned: ValueParser<"sync", FakeZonedDateTime> = {
+        mode: "sync",
+        metavar: "ZONED",
+        placeholder: new FakeZonedDateTime("1970-01-01T00:00:00Z", "UTC"),
+        parse: (input) => {
+          const match = /^(.+)\[([^\]]+)\]$/.exec(input);
+          return match == null
+            ? {
+              success: false,
+              error: message`Expected a time zone annotation.`,
+            }
+            : {
+              success: true,
+              value: new FakeZonedDateTime(match[1], match[2]),
+            };
+        },
+        format: (value) => value.toString(),
+      };
+      const parser = firstOf(instant, zoned);
+      const value = new FakeZonedDateTime("2024-01-01T00:00:00Z", "Asia/Seoul");
+      const result = parser.validate?.(value);
+      assert.ok(result?.success);
+      assert.ok(result.value instanceof FakeZonedDateTime);
+      assert.equal(String(result.value), "2024-01-01T00:00:00Z[Asia/Seoul]");
+    });
+
+    it("should not equate objects when only one side overrides toString()", () => {
+      // Same-prototype opaque objects compare by their toString()
+      // serialization, but only when *both* sides override it: an
+      // instance-level override on the round-tripped value alone must
+      // not make it equal to a value that stringifies generically.
+      class Opaque {}
+      const claiming: ValueParser<"sync", Opaque> = {
+        mode: "sync",
+        metavar: "OPAQUE",
+        placeholder: new Opaque(),
+        parse: (input) => {
+          const value = new Opaque();
+          Object.defineProperty(value, "toString", { value: () => input });
+          return { success: true, value };
+        },
+        format: (value) => String(value),
+      };
+      const parser = firstOf(claiming, choice(["none"]));
+      const result = parser.validate?.(new Opaque());
+      assert.ok(result);
+      assert.ok(!result.success);
+    });
+
+    it("should accept null-prototype objects as plain objects", () => {
+      // JSON values built with Object.create(null) format to the same
+      // JSON text as ordinary object literals and parse back as ordinary
+      // objects; ownership comparison must not distinguish the two
+      // prototypes.
+      const parser = firstOf(json({ rootType: "object" }), choice(["none"]));
+      const value: Record<string, number> = Object.assign(
+        Object.create(null),
+        { a: 1 },
+      );
+      const result = parser.validate?.(value);
+      assert.ok(result?.success);
+      assert.deepEqual(result.value, { a: 1 });
+    });
+
     it("should consult a constituent's validate() for shadowed values", () => {
       // The inner firstOf() cannot round-trip the shadowed integer 1
       // through format()+parse() (the string "1" goes to its choice()

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -18875,7 +18875,10 @@ describe("firstOf", () => {
       // equal, or the parser could never own its own round-tripped
       // values and fallback validation would reject them.
       class UserId {
-        constructor(readonly id: string) {}
+        readonly id: string;
+        constructor(id: string) {
+          this.id = id;
+        }
       }
       const userId: ValueParser<"sync", UserId> = {
         mode: "sync",
@@ -18900,8 +18903,10 @@ describe("firstOf", () => {
       // Structural key equality alone must not let a lossy parser claim
       // such a value when the serializations disagree.
       class Token {
+        readonly id: string;
         readonly #scope: string;
-        constructor(readonly id: string, scope: string) {
+        constructor(id: string, scope: string) {
+          this.id = id;
           this.#scope = scope;
         }
         toString(): string {

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -18637,6 +18637,18 @@ describe("firstOf", () => {
       assert.deepEqual(roundTrip.value, value);
     });
 
+    it("should format values owned via a constituent's validate()", () => {
+      // The inner firstOf() accepts { a: 1 } through its validate() hook,
+      // but the outer round-trip cannot see that ownership: the JSON text
+      // is shadowed by the inner choice() branch, so the combined parse
+      // yields the string instead of the object.  The format path must
+      // consult the hook rather than fall back to an earlier branch's
+      // generic stringification ("[object Object]").
+      const inner = firstOf(choice(['{"a":1}']), json({ rootType: "object" }));
+      const outer = firstOf(choice(["x"]), inner);
+      assert.equal(outer.format({ a: 1 }), '{"a":1}');
+    });
+
     it("should format overlapping values for display", () => {
       // format() is a display-oriented best effort; precise fallback
       // validation goes through validate() instead.

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -18757,6 +18757,30 @@ describe("firstOf", () => {
       const parser = firstOf(macAddress(), choice(["none"]));
       assert.equal(parser.normalize?.("not-a-mac"), "not-a-mac");
     });
+
+    it("should normalize through a constituent's validate() ownership", () => {
+      // The outer firstOf() cannot round-trip 7 through the inner one
+      // (the string "7" goes to the inner choice() branch), but the
+      // inner validate() hook accepts it; normalization ownership must
+      // honor that hook just like validate() does.
+      const evenizer: ValueParser<"sync", number> = {
+        mode: "sync",
+        metavar: "EVEN",
+        placeholder: 0,
+        parse: (input) => {
+          const n = Number(input);
+          return Number.isInteger(n)
+            ? { success: true, value: n - (n % 2) }
+            : { success: false, error: message`Expected a number.` };
+        },
+        format: (value) => String(value),
+        normalize: (value) => value - (value % 2),
+      };
+      const inner = firstOf(choice(["7"]), evenizer);
+      const outer = firstOf(choice(["x"]), inner);
+      assert.equal(inner.normalize?.(7), 6);
+      assert.equal(outer.normalize?.(7), 6);
+    });
   });
 
   describe("suggest", () => {
@@ -18936,6 +18960,29 @@ describe("firstOf", () => {
       const result = parse(parser, []);
       assert.ok(result.success);
       assert.equal(result.value, mac.normalize?.("AA-BB-CC-DD-EE-FF"));
+    });
+
+    it("should normalize withDefault() defaults through nested firstOf()", () => {
+      const evenizer: ValueParser<"sync", number> = {
+        mode: "sync",
+        metavar: "EVEN",
+        placeholder: 0,
+        parse: (input) => {
+          const n = Number(input);
+          return Number.isInteger(n)
+            ? { success: true, value: n - (n % 2) }
+            : { success: false, error: message`Expected a number.` };
+        },
+        format: (value) => String(value),
+        normalize: (value) => value - (value % 2),
+      };
+      const parser = withDefault(
+        option("--n", firstOf(choice(["x"]), firstOf(choice(["7"]), evenizer))),
+        7,
+      );
+      const result = parse(parser, []);
+      assert.ok(result.success);
+      assert.equal(result.value, 6);
     });
   });
 

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -42,6 +42,7 @@ import {
   text,
   values,
 } from "@optique/core/message";
+import { dependency } from "#src/dependency.ts";
 import { argument, option } from "#src/primitives.ts";
 import { withDefault } from "#src/modifiers.ts";
 import { parse } from "#src/parser.ts";
@@ -19006,6 +19007,23 @@ describe("firstOf", () => {
         () => firstOf(integer(), 42),
         TypeError,
       );
+    });
+
+    it("should throw TypeError for dependency-derived constituents", () => {
+      // A derived value parser parses with *default* dependency values when
+      // called directly, and firstOf() cannot forward the derived metadata
+      // that option()/argument() use to re-run it with live values, so
+      // accepting one would silently validate against the wrong branch.
+      const mode = dependency(choice(["dev", "prod"]));
+      const derived = mode.derive({
+        metavar: "LEVEL",
+        mode: "sync",
+        factory: (m) =>
+          choice(m === "dev" ? ["debug", "info"] : ["warn", "error"]),
+        defaultValue: () => "dev",
+      });
+      assert.throws(() => firstOf(derived, choice(["auto"])), TypeError);
+      assert.throws(() => firstOf(choice(["auto"]), derived), TypeError);
     });
 
     it("should throw TypeError for async constituents", () => {

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -18953,6 +18953,33 @@ describe("firstOf", () => {
       assert.ok(!result.success);
     });
 
+    it("should not crash on values with throwing toString getters", () => {
+      // Accessing toString on a hostile or exotic object (Proxy, throwing
+      // getter) must not crash ownership resolution; such objects still
+      // compare through their enumerable own fields.
+      class Weird {
+        readonly id: string;
+        constructor(id: string) {
+          this.id = id;
+        }
+        get toString(): never {
+          throw new Error("boom");
+        }
+      }
+      const weird: ValueParser<"sync", Weird> = {
+        mode: "sync",
+        metavar: "WEIRD",
+        placeholder: new Weird(""),
+        parse: (input) => ({ success: true, value: new Weird(input) }),
+        format: (value) => value.id,
+      };
+      const parser = firstOf(weird, integer());
+      const result = parser.validate?.(new Weird("x"));
+      assert.ok(result?.success);
+      assert.ok(result.value instanceof Weird);
+      assert.equal(result.value.id, "x");
+    });
+
     it("should treat a throwing constituent validate() as non-ownership", () => {
       // A custom parser's validate() hook is typed for its own T, so it
       // may reasonably use string-only operations that throw when handed

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -1,6 +1,16 @@
-import { type Message, message, text, valueSet } from "./message.ts";
+import {
+  cloneMessage,
+  lineBreak,
+  type Message,
+  message,
+  type MessageTerm,
+  metavar as metavarTerm,
+  text,
+  valueSet,
+} from "./message.ts";
 import { ensureNonEmptyString, type NonEmptyString } from "./nonempty.ts";
 import type { Mode, ModeIterable, ModeValue, Suggestion } from "./parser.ts";
+import { deduplicateSuggestions } from "./suggestion.ts";
 
 export {
   ensureNonEmptyString,
@@ -86,6 +96,25 @@ export interface ValueParser<M extends Mode = "sync", T = unknown> {
    * @since 1.0.0
    */
   normalize?(value: T): T;
+
+  /**
+   * Validates a value of type {@link T} as if it had been parsed from CLI
+   * input, returning either a success result (with the possibly
+   * canonicalized value) or a failure with an error message.
+   *
+   * When present, `option()` and `argument()` use this method to validate
+   * fallback values (e.g. from `bindEnv()`/`bindConfig()`) instead of the
+   * generic `format()`+`parse()` round-trip.  Implement it when the
+   * round-trip cannot faithfully express validation for some values, as
+   * with combinators like `firstOf()` whose constituents may produce
+   * overlapping string representations.
+   *
+   * @param value The value to validate.
+   * @returns A {@link ValueParserResult} indicating success or failure.
+   *          In async mode, returns a Promise that resolves to the result.
+   * @since 1.1.0
+   */
+  validate?(value: T): ModeValue<M, ValueParserResult<T>>;
 
   /**
    * Provides completion suggestions for values of this type.
@@ -8668,4 +8697,448 @@ function findNonFiniteNumber(root: Json): number | undefined {
     }
   }
   return undefined;
+}
+
+/**
+ * Options for the {@link firstOf} combinator.
+ * @since 1.1.0
+ */
+export interface FirstOfOptions {
+  /**
+   * The metavariable name for the combined parser.  This is used in help
+   * messages to indicate what kind of value this parser expects.
+   * @default The constituent metavars joined with `|`, e.g. `"auto|INTEGER"`.
+   */
+  readonly metavar?: NonEmptyString;
+}
+
+/**
+ * The trailing options argument of {@link firstOf}.  A {@link ValueParser}
+ * structurally satisfies {@link FirstOfOptions} (its `metavar` field matches
+ * the optional one), so the required `parse` method is excluded to keep
+ * the overloads unambiguous.
+ */
+type FirstOfTailOptions = FirstOfOptions & { readonly parse?: never };
+
+/**
+ * Extracts the result type of a sync {@link ValueParser}.
+ */
+type ValueParserValue<P> = P extends ValueParser<"sync", infer T> ? T : never;
+
+/**
+ * Creates a {@link ValueParser} that tries two value parsers in declaration
+ * order and returns the result of the first one that succeeds.
+ *
+ * The result type is the union of the constituent result types:
+ *
+ * ```typescript
+ * const count = firstOf(choice(["auto"]), integer({ min: 1 }));
+ * // Inferred type: ValueParser<"sync", "auto" | number>
+ * ```
+ *
+ * When every constituent fails, the combined error lists each constituent's
+ * error on its own line.
+ * @template TA The result type of the first parser.
+ * @template TB The result type of the second parser.
+ * @param a The first value parser to try.
+ * @param b The second value parser to try.
+ * @param options Configuration options for the combined parser.
+ * @returns A {@link ValueParser} that accepts values matching any of the
+ *          constituent parsers.
+ * @throws {TypeError} If any constituent is not a sync value parser.
+ * @since 1.1.0
+ */
+export function firstOf<TA, TB>(
+  a: ValueParser<"sync", TA>,
+  b: ValueParser<"sync", TB>,
+  options?: FirstOfTailOptions,
+): ValueParser<"sync", TA | TB>;
+
+/**
+ * Creates a {@link ValueParser} that tries three value parsers in declaration
+ * order and returns the result of the first one that succeeds.
+ * @template TA The result type of the first parser.
+ * @template TB The result type of the second parser.
+ * @template TC The result type of the third parser.
+ * @param a The first value parser to try.
+ * @param b The second value parser to try.
+ * @param c The third value parser to try.
+ * @param options Configuration options for the combined parser.
+ * @returns A {@link ValueParser} that accepts values matching any of the
+ *          constituent parsers.
+ * @throws {TypeError} If any constituent is not a sync value parser.
+ * @since 1.1.0
+ */
+export function firstOf<TA, TB, TC>(
+  a: ValueParser<"sync", TA>,
+  b: ValueParser<"sync", TB>,
+  c: ValueParser<"sync", TC>,
+  options?: FirstOfTailOptions,
+): ValueParser<"sync", TA | TB | TC>;
+
+/**
+ * Creates a {@link ValueParser} that tries four value parsers in declaration
+ * order and returns the result of the first one that succeeds.
+ * @template TA The result type of the first parser.
+ * @template TB The result type of the second parser.
+ * @template TC The result type of the third parser.
+ * @template TD The result type of the fourth parser.
+ * @param a The first value parser to try.
+ * @param b The second value parser to try.
+ * @param c The third value parser to try.
+ * @param d The fourth value parser to try.
+ * @param options Configuration options for the combined parser.
+ * @returns A {@link ValueParser} that accepts values matching any of the
+ *          constituent parsers.
+ * @throws {TypeError} If any constituent is not a sync value parser.
+ * @since 1.1.0
+ */
+export function firstOf<TA, TB, TC, TD>(
+  a: ValueParser<"sync", TA>,
+  b: ValueParser<"sync", TB>,
+  c: ValueParser<"sync", TC>,
+  d: ValueParser<"sync", TD>,
+  options?: FirstOfTailOptions,
+): ValueParser<"sync", TA | TB | TC | TD>;
+
+/**
+ * Creates a {@link ValueParser} that tries five value parsers in declaration
+ * order and returns the result of the first one that succeeds.
+ * @template TA The result type of the first parser.
+ * @template TB The result type of the second parser.
+ * @template TC The result type of the third parser.
+ * @template TD The result type of the fourth parser.
+ * @template TE The result type of the fifth parser.
+ * @param a The first value parser to try.
+ * @param b The second value parser to try.
+ * @param c The third value parser to try.
+ * @param d The fourth value parser to try.
+ * @param e The fifth value parser to try.
+ * @param options Configuration options for the combined parser.
+ * @returns A {@link ValueParser} that accepts values matching any of the
+ *          constituent parsers.
+ * @throws {TypeError} If any constituent is not a sync value parser.
+ * @since 1.1.0
+ */
+export function firstOf<TA, TB, TC, TD, TE>(
+  a: ValueParser<"sync", TA>,
+  b: ValueParser<"sync", TB>,
+  c: ValueParser<"sync", TC>,
+  d: ValueParser<"sync", TD>,
+  e: ValueParser<"sync", TE>,
+  options?: FirstOfTailOptions,
+): ValueParser<"sync", TA | TB | TC | TD | TE>;
+
+/**
+ * Creates a {@link ValueParser} that tries any number of value parsers in
+ * declaration order and returns the result of the first one that succeeds.
+ * @template TParsers The tuple of constituent value parsers.
+ * @param args The value parsers to try, followed by configuration options.
+ * @returns A {@link ValueParser} that accepts values matching any of the
+ *          constituent parsers.
+ * @throws {TypeError} If any constituent is not a sync value parser.
+ * @since 1.1.0
+ */
+export function firstOf<
+  const TParsers extends readonly [
+    ValueParser<"sync", unknown>,
+    ValueParser<"sync", unknown>,
+    ...ValueParser<"sync", unknown>[],
+  ],
+>(
+  ...args: [...parsers: TParsers, options: FirstOfTailOptions]
+): ValueParser<"sync", ValueParserValue<TParsers[number]>>;
+
+/**
+ * Creates a {@link ValueParser} that tries any number of value parsers in
+ * declaration order and returns the result of the first one that succeeds.
+ * @template TParsers The tuple of constituent value parsers.
+ * @param parsers The value parsers to try.
+ * @returns A {@link ValueParser} that accepts values matching any of the
+ *          constituent parsers.
+ * @throws {TypeError} If any constituent is not a sync value parser.
+ * @since 1.1.0
+ */
+export function firstOf<
+  const TParsers extends readonly [
+    ValueParser<"sync", unknown>,
+    ValueParser<"sync", unknown>,
+    ...ValueParser<"sync", unknown>[],
+  ],
+>(
+  ...parsers: TParsers
+): ValueParser<"sync", ValueParserValue<TParsers[number]>>;
+
+/**
+ * Implementation of the {@link firstOf} combinator.
+ */
+export function firstOf(
+  ...rawArgs: readonly (
+    | ValueParser<"sync", unknown>
+    | FirstOfTailOptions
+    | undefined
+  )[]
+): ValueParser<"sync", unknown> {
+  // The fixed-arity overloads declare the trailing options as optional,
+  // so an explicit `undefined` may arrive as the last argument:
+  const args = rawArgs.length > 0 && rawArgs.at(-1) === undefined
+    ? rawArgs.slice(0, -1)
+    : rawArgs;
+  let parsers: readonly ValueParser<"sync", unknown>[];
+  let options: FirstOfOptions;
+  const last = args.at(-1);
+  if (
+    args.length > 0 && typeof last === "object" && last != null &&
+    !isValueParser(last)
+  ) {
+    options = last as FirstOfOptions;
+    parsers = args.slice(0, -1) as readonly ValueParser<"sync", unknown>[];
+  } else {
+    options = {};
+    parsers = args as readonly ValueParser<"sync", unknown>[];
+  }
+  if (parsers.length < 2) {
+    throw new TypeError("firstOf() requires at least two value parsers.");
+  }
+  for (const parser of parsers) {
+    if (!isValueParser(parser)) {
+      throw new TypeError(
+        "Every firstOf() constituent must be a value parser.",
+      );
+    }
+    if (parser.mode !== "sync") {
+      throw new TypeError(
+        "firstOf() only supports sync value parsers, " +
+          "but an async one was given.",
+      );
+    }
+  }
+  const metavar = options.metavar ??
+    parsers.map((parser) => parser.metavar).join("|");
+  ensureNonEmptyString(metavar);
+
+  // A merged choices list is only meaningful when it is exhaustive, i.e.,
+  // when every constituent enumerates its valid values.  Concatenation
+  // (rather than Set-based deduplication) preserves values like 0 and -0
+  // that choice() deliberately distinguishes.
+  const mergedChoices = parsers.every((parser) => parser.choices != null)
+    ? Object.freeze(parsers.flatMap((parser) => [...parser.choices!]))
+    : undefined;
+
+  // Finds the constituent that produced the given value by round-tripping
+  // each constituent's format() through its own parse().  Constituents whose
+  // format() throws or returns a non-string for a foreign value are skipped,
+  // as are lossy claims where the round-tripped value no longer equals the
+  // original (or the constituent's own normalization of it).
+  function findOwner(
+    value: unknown,
+  ): ValueParser<"sync", unknown> | undefined {
+    for (const parser of parsers) {
+      let formatted: string;
+      try {
+        formatted = parser.format(value);
+      } catch {
+        continue;
+      }
+      if (typeof formatted !== "string") continue;
+      const result = parser.parse(formatted);
+      if (
+        result.success && ownsRoundTrippedValue(parser, result.value, value)
+      ) {
+        return parser;
+      }
+    }
+    return undefined;
+  }
+
+  const hasNormalize = parsers.some(
+    (parser) => typeof parser.normalize === "function",
+  );
+  const hasSuggest = parsers.some(
+    (parser) => typeof parser.suggest === "function",
+  );
+
+  return {
+    mode: "sync",
+    metavar,
+    placeholder: parsers[0].placeholder,
+    ...(mergedChoices != null ? { choices: mergedChoices } : {}),
+    parse(input: string): ValueParserResult<unknown> {
+      const errors: Message[] = [];
+      for (const parser of parsers) {
+        const result = parser.parse(input);
+        if (result.success) return result;
+        errors.push(result.error);
+      }
+      return { success: false, error: firstOfNoMatchError(errors) };
+    },
+    format(value: unknown): string {
+      // format() is a display-oriented best effort: precise fallback
+      // validation goes through validate() below, so this method only
+      // needs to pick the most faithful string representation available.
+      let fallback: string | undefined;
+      let firstError: unknown;
+      let hasError = false;
+      for (const parser of parsers) {
+        let formatted: string;
+        try {
+          formatted = parser.format(value);
+        } catch (e) {
+          if (!hasError) {
+            firstError = e;
+            hasError = true;
+          }
+          continue;
+        }
+        // A constituent's format() may return a non-string when handed a
+        // value from another branch of the union; such results are not
+        // usable as CLI input and must not be returned.
+        if (typeof formatted !== "string") continue;
+        const result = parser.parse(formatted);
+        if (
+          result.success && ownsRoundTrippedValue(parser, result.value, value)
+        ) {
+          return formatted;
+        }
+        fallback ??= formatted;
+      }
+      if (fallback !== undefined) return fallback;
+      if (hasError) throw firstError;
+      throw new TypeError(
+        "No constituent parser could format the given value.",
+      );
+    },
+    validate(value: unknown): ValueParserResult<unknown> {
+      for (const parser of parsers) {
+        // A constituent's own validate() hook decides membership
+        // authoritatively: it can accept values that its format()+parse()
+        // round-trip cannot express, such as a nested firstOf() whose
+        // valid value is shadowed by an earlier overlapping branch.
+        if (typeof parser.validate === "function") {
+          const result = parser.validate(value);
+          if (result.success) return result;
+          continue;
+        }
+        let formatted: string;
+        try {
+          formatted = parser.format(value);
+        } catch {
+          continue;
+        }
+        if (typeof formatted !== "string") continue;
+        const result = parser.parse(formatted);
+        if (
+          result.success && ownsRoundTrippedValue(parser, result.value, value)
+        ) {
+          return { success: true, value: result.value };
+        }
+      }
+      return {
+        success: false,
+        error: message`Expected a value matching ${metavarTerm(metavar)}.`,
+      };
+    },
+    ...(hasNormalize
+      ? {
+        normalize(value: unknown): unknown {
+          const owner = findOwner(value);
+          if (owner == null || typeof owner.normalize !== "function") {
+            return value;
+          }
+          return owner.normalize(value);
+        },
+      }
+      : {}),
+    ...(hasSuggest
+      ? {
+        *suggest(prefix: string): Iterable<Suggestion> {
+          const collected: Suggestion[] = [];
+          for (const parser of parsers) {
+            if (typeof parser.suggest !== "function") continue;
+            for (const suggestion of parser.suggest(prefix)) {
+              collected.push(suggestion);
+            }
+          }
+          yield* deduplicateSuggestions(collected);
+        },
+      }
+      : {}),
+  };
+}
+
+/**
+ * Builds the default error message for {@link firstOf} when every
+ * constituent parser fails: a header followed by each constituent's error
+ * on its own line.
+ */
+function firstOfNoMatchError(errors: readonly Message[]): Message {
+  const terms: MessageTerm[] = [text("Expected one of the following:")];
+  for (const error of errors) {
+    terms.push(lineBreak(), text("- "), ...cloneMessage(error));
+  }
+  return terms;
+}
+
+/**
+ * Determines whether a {@link firstOf} constituent owns a value, given the
+ * result of round-tripping the value through the constituent's `format()`
+ * and `parse()`.  The constituent owns the value when the round-trip
+ * preserves it exactly, or when it yields the constituent's own
+ * normalization of it (e.g. a MAC address parser canonicalizing separators
+ * and case).  A merely *successful* round-trip is not enough: a constituent
+ * with a lossy `format()` (such as `color()` reducing any `{ r, g, b, a }`
+ * shape to a hex string) must not claim values that belong to a later,
+ * more faithful constituent.
+ */
+function ownsRoundTrippedValue(
+  parser: ValueParser<"sync", unknown>,
+  roundTripped: unknown,
+  value: unknown,
+): boolean {
+  if (valuesEqual(roundTripped, value)) return true;
+  if (typeof parser.normalize !== "function") return false;
+  let normalized: unknown;
+  try {
+    normalized = parser.normalize(value);
+  } catch {
+    return false;
+  }
+  return valuesEqual(roundTripped, normalized);
+}
+
+/**
+ * Structural equality for parsed CLI values: primitives compare with
+ * `Object.is` (so `NaN` equals itself and `0` differs from `-0`, matching
+ * the distinction `choice()` makes), `Date` and `URL` instances compare by
+ * time value and href respectively, and arrays and plain objects compare
+ * recursively.  Recursion is bounded by the structure of the second
+ * argument, which in {@link firstOf} is always a freshly parsed (acyclic)
+ * value.
+ */
+function valuesEqual(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) return true;
+  if (
+    typeof a !== "object" || typeof b !== "object" || a == null || b == null
+  ) {
+    return false;
+  }
+  if (Array.isArray(a) || Array.isArray(b)) {
+    return Array.isArray(a) && Array.isArray(b) && a.length === b.length &&
+      a.every((item, i) => valuesEqual(item, b[i]));
+  }
+  if (a instanceof Date || b instanceof Date) {
+    return a instanceof Date && b instanceof Date &&
+      a.getTime() === b.getTime();
+  }
+  if (a instanceof URL || b instanceof URL) {
+    return a instanceof URL && b instanceof URL && a.href === b.href;
+  }
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) return false;
+  const bRecord = b as Record<string, unknown>;
+  return aKeys.every((key) =>
+    Object.hasOwn(b, key) &&
+    valuesEqual((a as Record<string, unknown>)[key], bRecord[key])
+  );
 }

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -8710,6 +8710,22 @@ export interface FirstOfOptions {
    * @default The constituent metavars joined with `|`, e.g. `"auto|INTEGER"`.
    */
   readonly metavar?: NonEmptyString;
+
+  /**
+   * Custom error messages for firstOf parsing failures.
+   * @since 1.1.0
+   */
+  readonly errors?: {
+    /**
+     * Custom error message when every constituent parser fails.  Can be a
+     * static message or a function that receives the input and the
+     * constituent errors in declaration order.
+     * @since 1.1.0
+     */
+    noMatch?:
+      | Message
+      | ((input: string, errors: readonly Message[]) => Message);
+  };
 }
 
 /**
@@ -8970,7 +8986,15 @@ export function firstOf(
         if (result.success) return result;
         errors.push(result.error);
       }
-      return { success: false, error: firstOfNoMatchError(errors) };
+      const noMatch = options.errors?.noMatch;
+      return {
+        success: false,
+        error: noMatch == null
+          ? firstOfNoMatchError(errors)
+          : typeof noMatch === "function"
+          ? noMatch(input, errors)
+          : noMatch,
+      };
     },
     format(value: unknown): string {
       // format() is a display-oriented best effort: precise fallback

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -9025,9 +9025,20 @@ export function firstOf(
   // whose valid value is shadowed by an earlier overlapping branch.
   // Hookless constituents are checked by round-tripping their format()
   // through their own parse(); those whose format() throws or returns a
-  // non-string for a foreign value are skipped, as are lossy claims where
-  // the round-tripped value no longer equals the original (or the
-  // constituent's own normalization of it).
+  // non-string for a foreign value are skipped.
+  //
+  // Ownership resolves in two passes.  The first pass requires the
+  // round-tripped value to faithfully preserve the original (exact
+  // equality, the constituent's own normalize() result, or a recognized
+  // canonicalization; see ownsRoundTrippedValue), so a constituent that
+  // preserves the value always beats an earlier lossy one.  Only when no
+  // constituent preserves the value does the second pass accept the first
+  // same-primitive-type round trip as a parse-level canonicalization
+  // (e.g. email({ allowDisplayName: true }) stripping a display name)—
+  // the same acceptance the constituent alone would grant a fallback
+  // value.  Object values are exempt from the second pass: structural
+  // equality is the only way to tell canonicalization from data loss
+  // there, and the first pass already covers it.
   function findOwner(
     value: unknown,
   ):
@@ -9036,6 +9047,12 @@ export function firstOf(
       readonly result: ValueParserResult<unknown>;
     }
     | undefined {
+    let canonicalizing:
+      | {
+        readonly parser: ValueParser<"sync", unknown>;
+        readonly result: ValueParserResult<unknown>;
+      }
+      | undefined;
     for (const parser of parsers) {
       if (typeof parser.validate === "function") {
         // A constituent's validate() hook is typed for its own value
@@ -9059,13 +9076,19 @@ export function firstOf(
       }
       if (typeof formatted !== "string") continue;
       const result = parser.parse(formatted);
-      if (
-        result.success && ownsRoundTrippedValue(parser, result.value, value)
-      ) {
+      if (!result.success) continue;
+      if (ownsRoundTrippedValue(parser, result.value, value)) {
         return { parser, result };
       }
+      if (
+        canonicalizing == null &&
+        value !== null && typeof value !== "object" &&
+        typeof result.value === typeof value
+      ) {
+        canonicalizing = { parser, result };
+      }
     }
-    return undefined;
+    return canonicalizing;
   }
 
   const hasNormalize = parsers.some(
@@ -9101,6 +9124,11 @@ export function firstOf(
       // format() is a display-oriented best effort: precise fallback
       // validation goes through validate() below, so this method only
       // needs to pick the most faithful string representation available.
+      // Ownership mirrors findOwner(): a constituent's own validate()
+      // hook decides authoritatively, faithful round trips win over
+      // same-primitive-type canonicalizing ones, and unclaimed values
+      // fall back to the first well-formed string.
+      let canonicalizing: string | undefined;
       let fallback: string | undefined;
       let firstError: unknown;
       let hasError = false;
@@ -9119,12 +9147,9 @@ export function firstOf(
         // value from another branch of the union; such results are not
         // usable as CLI input and must not be returned.
         if (typeof formatted !== "string") continue;
-        // Ownership mirrors findOwner(): a constituent's own validate()
-        // hook decides authoritatively (a nested firstOf() may accept a
-        // value whose string form its round-trip cannot express), and
-        // only hookless constituents use the round-trip test.  A hook
-        // that throws on a foreign value counts as non-ownership.
         if (typeof parser.validate === "function") {
+          // A hook that throws on a foreign value counts as
+          // non-ownership.
           let owned = false;
           try {
             owned = parser.validate(value).success;
@@ -9134,15 +9159,22 @@ export function firstOf(
           if (owned) return formatted;
         } else {
           const result = parser.parse(formatted);
-          if (
-            result.success &&
-            ownsRoundTrippedValue(parser, result.value, value)
-          ) {
-            return formatted;
+          if (result.success) {
+            if (ownsRoundTrippedValue(parser, result.value, value)) {
+              return formatted;
+            }
+            if (
+              canonicalizing == null &&
+              value !== null && typeof value !== "object" &&
+              typeof result.value === typeof value
+            ) {
+              canonicalizing = formatted;
+            }
           }
         }
         fallback ??= formatted;
       }
+      if (canonicalizing !== undefined) return canonicalizing;
       if (fallback !== undefined) return fallback;
       if (hasError) throw firstError;
       throw new TypeError(

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -9030,7 +9030,16 @@ export function firstOf(
     | undefined {
     for (const parser of parsers) {
       if (typeof parser.validate === "function") {
-        const result = parser.validate(value);
+        // A constituent's validate() hook is typed for its own value
+        // type, so it may throw when handed a foreign value from another
+        // branch of the union; treat that as non-ownership, like a
+        // throwing format().
+        let result: ValueParserResult<unknown>;
+        try {
+          result = parser.validate(value);
+        } catch {
+          continue;
+        }
         if (result.success) return { parser, result };
         continue;
       }
@@ -9105,9 +9114,16 @@ export function firstOf(
         // Ownership mirrors findOwner(): a constituent's own validate()
         // hook decides authoritatively (a nested firstOf() may accept a
         // value whose string form its round-trip cannot express), and
-        // only hookless constituents use the round-trip test.
+        // only hookless constituents use the round-trip test.  A hook
+        // that throws on a foreign value counts as non-ownership.
         if (typeof parser.validate === "function") {
-          if (parser.validate(value).success) return formatted;
+          let owned = false;
+          try {
+            owned = parser.validate(value).success;
+          } catch {
+            // Not this constituent's value.
+          }
+          if (owned) return formatted;
         } else {
           const result = parser.parse(formatted);
           if (

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -9154,10 +9154,11 @@ function ownsRoundTrippedValue(
  * Structural equality for parsed CLI values: primitives compare with
  * `Object.is` (so `NaN` equals itself and `0` differs from `-0`, matching
  * the distinction `choice()` makes), `Date` and `URL` instances compare by
- * time value and href respectively, and arrays and plain objects compare
- * recursively.  Recursion is bounded by the structure of the second
- * argument, which in {@link firstOf} is always a freshly parsed (acyclic)
- * value.
+ * time value and href respectively, arrays and plain objects compare
+ * recursively, and other class instances compare by their overridden
+ * `toString()` serialization.  Recursion is bounded by the structure of
+ * the second argument, which in {@link firstOf} is always a freshly
+ * parsed (acyclic) value.
  */
 function valuesEqual(a: unknown, b: unknown): boolean {
   if (Object.is(a, b)) return true;
@@ -9176,6 +9177,40 @@ function valuesEqual(a: unknown, b: unknown): boolean {
   }
   if (a instanceof URL || b instanceof URL) {
     return a instanceof URL && b instanceof URL && a.href === b.href;
+  }
+  const prototypeA = Object.getPrototypeOf(a);
+  const prototypeB = Object.getPrototypeOf(b);
+  // Object.prototype and null are the same "plain object" category:
+  // a null-prototype object (e.g. built with Object.create(null)) holds
+  // the same JSON-style data as an ordinary object literal.
+  const plainA = prototypeA === Object.prototype || prototypeA === null;
+  const plainB = prototypeB === Object.prototype || prototypeB === null;
+  if (plainA !== plainB) return false;
+  if (!plainA) {
+    if (prototypeA !== prototypeB) return false;
+    // Opaque (non-plain) objects such as Temporal instances can hold
+    // their state in private fields or internal slots that enumerable-key
+    // comparison cannot see, so two key-less objects of the same type are
+    // not necessarily equal.  Compare via their overridden toString()
+    // serialization, and treat objects without one as unequal.  Both
+    // sides must override it: an instance-level toString() on one side
+    // alone (e.g. on a freshly parsed value) must not equate it with an
+    // object that stringifies generically.
+    const toStringA = (a as { toString?: unknown }).toString;
+    const toStringB = (b as { toString?: unknown }).toString;
+    if (
+      typeof toStringA !== "function" ||
+      typeof toStringB !== "function" ||
+      toStringA === Object.prototype.toString ||
+      toStringB === Object.prototype.toString
+    ) {
+      return false;
+    }
+    try {
+      return String(a) === String(b);
+    } catch {
+      return false;
+    }
   }
   const aKeys = Object.keys(a);
   const bKeys = Object.keys(b);

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -9275,30 +9275,47 @@ function valuesEqual(a: unknown, b: unknown): boolean {
   if (plainA !== plainB) return false;
   if (!plainA) {
     if (prototypeA !== prototypeB) return false;
-    // Opaque (non-plain) objects such as Temporal instances can hold
-    // their state in private fields or internal slots that enumerable-key
-    // comparison cannot see, so two key-less objects of the same type are
-    // not necessarily equal.  Compare via their overridden toString()
-    // serialization, and treat objects without one as unequal.  Both
-    // sides must override it: an instance-level toString() on one side
-    // alone (e.g. on a freshly parsed value) must not equate it with an
-    // object that stringifies generically.
-    const toStringA = (a as { toString?: unknown }).toString;
-    const toStringB = (b as { toString?: unknown }).toString;
-    if (
-      typeof toStringA !== "function" ||
-      typeof toStringB !== "function" ||
-      toStringA === Object.prototype.toString ||
-      toStringB === Object.prototype.toString
-    ) {
-      return false;
-    }
+    // Class instances may expose state through enumerable own fields
+    // (e.g. `class UserId { constructor(readonly id: string) {} }`),
+    // through private fields or internal slots that only an overridden
+    // toString() serializes (e.g. Temporal instances), or both.  Compare
+    // whatever channels the objects provide: enumerable fields must match
+    // structurally, and when toString() is overridden, both sides must
+    // override it (an instance-level override on one side alone, e.g. on
+    // a freshly parsed value, must not equate it with an object that
+    // stringifies generically) and the serializations must agree.
+    // Key-less objects without an overridden toString() expose no channel
+    // to compare, so they are conservatively unequal.
+    const overridesA = hasCustomToString(a);
+    const overridesB = hasCustomToString(b);
+    if (overridesA !== overridesB) return false;
+    const hasKeys = Object.keys(a).length > 0 || Object.keys(b).length > 0;
+    if (hasKeys && !plainObjectsEqual(a, b)) return false;
+    if (!overridesA) return hasKeys;
     try {
       return String(a) === String(b);
     } catch {
       return false;
     }
   }
+  return plainObjectsEqual(a, b);
+}
+
+/**
+ * Checks whether an object provides a `toString()` implementation other
+ * than the generic `Object.prototype.toString`.
+ */
+function hasCustomToString(value: object): boolean {
+  const toString = (value as { toString?: unknown }).toString;
+  return typeof toString === "function" &&
+    toString !== Object.prototype.toString;
+}
+
+/**
+ * Compares two objects by their enumerable own keys, recursing into the
+ * values with {@link valuesEqual}.
+ */
+function plainObjectsEqual(a: object, b: object): boolean {
   const aKeys = Object.keys(a);
   const bKeys = Object.keys(b);
   if (aKeys.length !== bKeys.length) return false;

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -9206,17 +9206,20 @@ function firstOfNoMatchError(errors: readonly Message[]): Message {
  * and `parse()`.  The constituent owns the value when the round-trip
  * preserves it exactly, when it yields the constituent's own normalization
  * of it (e.g. a MAC address parser canonicalizing separators and case), or
- * when a primitive value is canonicalized within its own primitive type
- * (e.g. a case-insensitive `choice()` folding `"INFO"` to `"info"`, or a
- * number parser folding `-0` to `0`)—the same acceptance the constituent
- * alone would grant a fallback value through round-trip validation.
- * A merely *successful* round-trip is not enough otherwise: a round-trip
- * that changes the primitive type means the string form belongs to a
- * different branch of the union (e.g. `choice(["1"])` capturing the
- * integer 1), and for object values structural equality is the only way
- * to tell canonicalization from data loss (e.g. a lossy `color()`
- * `format()` dropping fields that belong to a later, more faithful
- * constituent).
+ * when the round-trip is a recognized parse-level canonicalization: a
+ * case-insensitive string match (e.g. a case-insensitive `choice()`
+ * folding `"INFO"` to `"info"`) or numeric equality (a number parser
+ * folding `-0` to `0`)—the same acceptance the constituent alone would
+ * grant a fallback value through round-trip validation.  Parsers with
+ * richer parse-level canonicalization should expose it via `normalize()`.
+ * A merely *successful* round-trip is not enough otherwise: an arbitrary
+ * same-type change means data loss rather than canonicalization (e.g. a
+ * clamping `format()` folding 15 into 10), a round-trip that changes the
+ * primitive type means the string form belongs to a different branch of
+ * the union (e.g. `choice(["1"])` capturing the integer 1), and for
+ * object values structural equality is the only way to tell
+ * canonicalization from data loss (e.g. a lossy `color()` `format()`
+ * dropping fields that belong to a later, more faithful constituent).
  */
 function ownsRoundTrippedValue(
   parser: ValueParser<"sync", unknown>,
@@ -9233,8 +9236,15 @@ function ownsRoundTrippedValue(
     }
     if (valuesEqual(roundTripped, normalized)) return true;
   }
-  return value !== null && typeof value !== "object" &&
-    typeof roundTripped === typeof value;
+  if (typeof value === "string" && typeof roundTripped === "string") {
+    return value.toLowerCase() === roundTripped.toLowerCase();
+  }
+  if (typeof value === "number" && typeof roundTripped === "number") {
+    // Object.is above already handled identical numbers; this only
+    // accepts the remaining ±0 fold.
+    return value === roundTripped;
+  }
+  return false;
 }
 
 /**

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -110,12 +110,15 @@ export interface ValueParser<M extends Mode = "sync", T = unknown> {
    * with combinators like `firstOf()` whose constituents may produce
    * overlapping string representations.
    *
+   * Like {@link normalize}, this method is synchronous regardless of the
+   * parser's mode, so wrappers that spread a sync parser into an async
+   * one inherit it unchanged.
+   *
    * @param value The value to validate.
    * @returns A {@link ValueParserResult} indicating success or failure.
-   *          In async mode, returns a Promise that resolves to the result.
    * @since 1.1.0
    */
-  validate?(value: T): ModeValue<M, ValueParserResult<T>>;
+  validate?(value: T): ValueParserResult<T>;
 
   /**
    * Provides completion suggestions for values of this type.

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -9276,8 +9276,9 @@ function valuesEqual(a: unknown, b: unknown): boolean {
   if (!plainA) {
     if (prototypeA !== prototypeB) return false;
     // Class instances may expose state through enumerable own fields
-    // (e.g. `class UserId { constructor(readonly id: string) {} }`),
-    // through private fields or internal slots that only an overridden
+    // (e.g. a `UserId` wrapper class assigning `this.id` in its
+    // constructor), through private fields or internal slots that only an
+    // overridden
     // toString() serializes (e.g. Temporal instances), or both.  Compare
     // whatever channels the objects provide: enumerable fields must match
     // structurally, and when toString() is overridden, both sides must

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -8902,32 +8902,73 @@ export function firstOf<
 ): ValueParser<"sync", ValueParserValue<TParsers[number]>>;
 
 /**
+ * Creates a {@link ValueParser} that tries the value parsers in the given
+ * array in declaration order and returns the result of the first one that
+ * succeeds.
+ *
+ * Unlike the variadic overloads, which require at least two statically
+ * known arguments, this form accepts a dynamically built array:
+ *
+ * ```typescript
+ * const parsers: ValueParser<"sync", string | number>[] = buildParsers();
+ * const combined = firstOf(parsers);
+ * ```
+ * @template TParsers The array of constituent value parsers.
+ * @param parsers The value parsers to try.  Must contain at least two
+ *                parsers.
+ * @param options Configuration options for the combined parser.
+ * @returns A {@link ValueParser} that accepts values matching any of the
+ *          constituent parsers.
+ * @throws {TypeError} If the array contains fewer than two value parsers.
+ * @throws {TypeError} If any constituent is not a sync value parser.
+ * @throws {TypeError} If any constituent is a dependency-derived value
+ *         parser (created via `deriveFrom()` or `dependency().derive()`).
+ * @since 1.1.0
+ */
+export function firstOf<
+  const TParsers extends readonly ValueParser<"sync", unknown>[],
+>(
+  parsers: TParsers,
+  options?: FirstOfOptions,
+): ValueParser<"sync", ValueParserValue<TParsers[number]>>;
+
+/**
  * Implementation of the {@link firstOf} combinator.
  */
 export function firstOf(
   ...rawArgs: readonly (
     | ValueParser<"sync", unknown>
     | FirstOfTailOptions
+    | FirstOfOptions
+    | readonly ValueParser<"sync", unknown>[]
     | undefined
   )[]
 ): ValueParser<"sync", unknown> {
-  // The fixed-arity overloads declare the trailing options as optional,
-  // so an explicit `undefined` may arrive as the last argument:
+  // The fixed-arity and array overloads declare the trailing options as
+  // optional, so an explicit `undefined` may arrive as the last argument:
   const args = rawArgs.length > 0 && rawArgs.at(-1) === undefined
     ? rawArgs.slice(0, -1)
     : rawArgs;
   let parsers: readonly ValueParser<"sync", unknown>[];
   let options: FirstOfOptions;
-  const last = args.at(-1);
-  if (
-    args.length > 0 && typeof last === "object" && last != null &&
-    !isValueParser(last)
-  ) {
-    options = last as FirstOfOptions;
-    parsers = args.slice(0, -1) as readonly ValueParser<"sync", unknown>[];
+  if (args.length > 0 && Array.isArray(args[0])) {
+    // Snapshot the caller-provided array so later mutations cannot make
+    // the parsing behavior diverge from the construction-time metadata
+    // (metavar, choices, normalize/suggest presence).
+    parsers = [...args[0]] as readonly ValueParser<"sync", unknown>[];
+    options = (args[1] ?? {}) as FirstOfOptions;
   } else {
-    options = {};
-    parsers = args as readonly ValueParser<"sync", unknown>[];
+    const last = args.at(-1);
+    if (
+      args.length > 0 && typeof last === "object" && last != null &&
+      !isValueParser(last)
+    ) {
+      options = last as FirstOfOptions;
+      parsers = args.slice(0, -1) as readonly ValueParser<"sync", unknown>[];
+    } else {
+      options = {};
+      parsers = args as readonly ValueParser<"sync", unknown>[];
+    }
   }
   if (parsers.length < 2) {
     throw new TypeError("firstOf() requires at least two value parsers.");

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -9003,11 +9003,19 @@ export function firstOf(
   ensureNonEmptyString(metavar);
 
   // A merged choices list is only meaningful when it is exhaustive, i.e.,
-  // when every constituent enumerates its valid values.  Concatenation
-  // (rather than Set-based deduplication) preserves values like 0 and -0
-  // that choice() deliberately distinguishes.
+  // when every constituent enumerates its valid values.  Overlapping
+  // choices are deduplicated with Object.is rather than a Set, which
+  // would conflate values like 0 and -0 that choice() deliberately
+  // distinguishes.
   const mergedChoices = parsers.every((parser) => parser.choices != null)
-    ? Object.freeze(parsers.flatMap((parser) => [...parser.choices!]))
+    ? Object.freeze(
+      parsers
+        .flatMap((parser) => [...parser.choices!])
+        .filter(
+          (value, index, all) =>
+            all.findIndex((other) => Object.is(other, value)) === index,
+        ),
+    )
     : undefined;
 
   // Finds the constituent that produced the given value, along with its

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -9180,12 +9180,19 @@ function firstOfNoMatchError(errors: readonly Message[]): Message {
  * Determines whether a {@link firstOf} constituent owns a value, given the
  * result of round-tripping the value through the constituent's `format()`
  * and `parse()`.  The constituent owns the value when the round-trip
- * preserves it exactly, or when it yields the constituent's own
- * normalization of it (e.g. a MAC address parser canonicalizing separators
- * and case).  A merely *successful* round-trip is not enough: a constituent
- * with a lossy `format()` (such as `color()` reducing any `{ r, g, b, a }`
- * shape to a hex string) must not claim values that belong to a later,
- * more faithful constituent.
+ * preserves it exactly, when it yields the constituent's own normalization
+ * of it (e.g. a MAC address parser canonicalizing separators and case), or
+ * when a primitive value is canonicalized within its own primitive type
+ * (e.g. a case-insensitive `choice()` folding `"INFO"` to `"info"`, or a
+ * number parser folding `-0` to `0`)—the same acceptance the constituent
+ * alone would grant a fallback value through round-trip validation.
+ * A merely *successful* round-trip is not enough otherwise: a round-trip
+ * that changes the primitive type means the string form belongs to a
+ * different branch of the union (e.g. `choice(["1"])` capturing the
+ * integer 1), and for object values structural equality is the only way
+ * to tell canonicalization from data loss (e.g. a lossy `color()`
+ * `format()` dropping fields that belong to a later, more faithful
+ * constituent).
  */
 function ownsRoundTrippedValue(
   parser: ValueParser<"sync", unknown>,
@@ -9193,14 +9200,17 @@ function ownsRoundTrippedValue(
   value: unknown,
 ): boolean {
   if (valuesEqual(roundTripped, value)) return true;
-  if (typeof parser.normalize !== "function") return false;
-  let normalized: unknown;
-  try {
-    normalized = parser.normalize(value);
-  } catch {
-    return false;
+  if (typeof parser.normalize === "function") {
+    let normalized: unknown;
+    try {
+      normalized = parser.normalize(value);
+    } catch {
+      return false;
+    }
+    if (valuesEqual(roundTripped, normalized)) return true;
   }
-  return valuesEqual(roundTripped, normalized);
+  return value !== null && typeof value !== "object" &&
+    typeof roundTripped === typeof value;
 }
 
 /**

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -8,6 +8,7 @@ import {
   text,
   valueSet,
 } from "./message.ts";
+import { isDerivedValueParser } from "./internal/dependency.ts";
 import { ensureNonEmptyString, type NonEmptyString } from "./nonempty.ts";
 import type { Mode, ModeIterable, ModeValue, Suggestion } from "./parser.ts";
 import { deduplicateSuggestions } from "./suggestion.ts";
@@ -8762,6 +8763,8 @@ type ValueParserValue<P> = P extends ValueParser<"sync", infer T> ? T : never;
  * @returns A {@link ValueParser} that accepts values matching any of the
  *          constituent parsers.
  * @throws {TypeError} If any constituent is not a sync value parser.
+ * @throws {TypeError} If any constituent is a dependency-derived value
+ *         parser (created via `deriveFrom()` or `dependency().derive()`).
  * @since 1.1.0
  */
 export function firstOf<TA, TB>(
@@ -8783,6 +8786,8 @@ export function firstOf<TA, TB>(
  * @returns A {@link ValueParser} that accepts values matching any of the
  *          constituent parsers.
  * @throws {TypeError} If any constituent is not a sync value parser.
+ * @throws {TypeError} If any constituent is a dependency-derived value
+ *         parser (created via `deriveFrom()` or `dependency().derive()`).
  * @since 1.1.0
  */
 export function firstOf<TA, TB, TC>(
@@ -8807,6 +8812,8 @@ export function firstOf<TA, TB, TC>(
  * @returns A {@link ValueParser} that accepts values matching any of the
  *          constituent parsers.
  * @throws {TypeError} If any constituent is not a sync value parser.
+ * @throws {TypeError} If any constituent is a dependency-derived value
+ *         parser (created via `deriveFrom()` or `dependency().derive()`).
  * @since 1.1.0
  */
 export function firstOf<TA, TB, TC, TD>(
@@ -8834,6 +8841,8 @@ export function firstOf<TA, TB, TC, TD>(
  * @returns A {@link ValueParser} that accepts values matching any of the
  *          constituent parsers.
  * @throws {TypeError} If any constituent is not a sync value parser.
+ * @throws {TypeError} If any constituent is a dependency-derived value
+ *         parser (created via `deriveFrom()` or `dependency().derive()`).
  * @since 1.1.0
  */
 export function firstOf<TA, TB, TC, TD, TE>(
@@ -8853,6 +8862,8 @@ export function firstOf<TA, TB, TC, TD, TE>(
  * @returns A {@link ValueParser} that accepts values matching any of the
  *          constituent parsers.
  * @throws {TypeError} If any constituent is not a sync value parser.
+ * @throws {TypeError} If any constituent is a dependency-derived value
+ *         parser (created via `deriveFrom()` or `dependency().derive()`).
  * @since 1.1.0
  */
 export function firstOf<
@@ -8873,6 +8884,8 @@ export function firstOf<
  * @returns A {@link ValueParser} that accepts values matching any of the
  *          constituent parsers.
  * @throws {TypeError} If any constituent is not a sync value parser.
+ * @throws {TypeError} If any constituent is a dependency-derived value
+ *         parser (created via `deriveFrom()` or `dependency().derive()`).
  * @since 1.1.0
  */
 export function firstOf<
@@ -8926,6 +8939,18 @@ export function firstOf(
       throw new TypeError(
         "firstOf() only supports sync value parsers, " +
           "but an async one was given.",
+      );
+    }
+    // A dependency-derived value parser parses with *default* dependency
+    // values when invoked directly, and firstOf() cannot forward the
+    // derived metadata that option()/argument() use to re-run it with the
+    // dependency values resolved during the current parse.  Accepting one
+    // would silently validate against the wrong branch.
+    if (isDerivedValueParser(parser)) {
+      throw new TypeError(
+        "firstOf() does not support dependency-derived value parsers " +
+          "(created via deriveFrom() or dependency().derive()); pass the " +
+          "derived parser directly to option() or argument() instead.",
       );
     }
   }

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -9061,11 +9061,20 @@ export function firstOf(
         // value from another branch of the union; such results are not
         // usable as CLI input and must not be returned.
         if (typeof formatted !== "string") continue;
-        const result = parser.parse(formatted);
-        if (
-          result.success && ownsRoundTrippedValue(parser, result.value, value)
-        ) {
-          return formatted;
+        // Ownership mirrors findOwner(): a constituent's own validate()
+        // hook decides authoritatively (a nested firstOf() may accept a
+        // value whose string form its round-trip cannot express), and
+        // only hookless constituents use the round-trip test.
+        if (typeof parser.validate === "function") {
+          if (parser.validate(value).success) return formatted;
+        } else {
+          const result = parser.parse(formatted);
+          if (
+            result.success &&
+            ownsRoundTrippedValue(parser, result.value, value)
+          ) {
+            return formatted;
+          }
         }
         fallback ??= formatted;
       }

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -8711,7 +8711,7 @@ export interface FirstOfOptions {
   /**
    * The metavariable name for the combined parser.  This is used in help
    * messages to indicate what kind of value this parser expects.
-   * @default The constituent metavars joined with `|`, e.g. `"auto|INTEGER"`.
+   * @default The constituent metavars joined with `|`, e.g. `"TYPE|INTEGER"`.
    */
   readonly metavar?: NonEmptyString;
 

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -9317,9 +9317,15 @@ function valuesEqual(a: unknown, b: unknown): boolean {
  * than the generic `Object.prototype.toString`.
  */
 function hasCustomToString(value: object): boolean {
-  const toString = (value as { toString?: unknown }).toString;
-  return typeof toString === "function" &&
-    toString !== Object.prototype.toString;
+  // Reading the property can throw for exotic objects (a Proxy or a
+  // throwing getter); treat those as having no usable toString().
+  try {
+    const toString = (value as { toString?: unknown }).toString;
+    return typeof toString === "function" &&
+      toString !== Object.prototype.toString;
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -8941,15 +8941,30 @@ export function firstOf(
     ? Object.freeze(parsers.flatMap((parser) => [...parser.choices!]))
     : undefined;
 
-  // Finds the constituent that produced the given value by round-tripping
-  // each constituent's format() through its own parse().  Constituents whose
-  // format() throws or returns a non-string for a foreign value are skipped,
-  // as are lossy claims where the round-tripped value no longer equals the
-  // original (or the constituent's own normalization of it).
+  // Finds the constituent that produced the given value, along with its
+  // canonical validation result.  A constituent's own validate() hook
+  // decides membership authoritatively: it can accept values that its
+  // format()+parse() round-trip cannot express, such as a nested firstOf()
+  // whose valid value is shadowed by an earlier overlapping branch.
+  // Hookless constituents are checked by round-tripping their format()
+  // through their own parse(); those whose format() throws or returns a
+  // non-string for a foreign value are skipped, as are lossy claims where
+  // the round-tripped value no longer equals the original (or the
+  // constituent's own normalization of it).
   function findOwner(
     value: unknown,
-  ): ValueParser<"sync", unknown> | undefined {
+  ):
+    | {
+      readonly parser: ValueParser<"sync", unknown>;
+      readonly result: ValueParserResult<unknown>;
+    }
+    | undefined {
     for (const parser of parsers) {
+      if (typeof parser.validate === "function") {
+        const result = parser.validate(value);
+        if (result.success) return { parser, result };
+        continue;
+      }
       let formatted: string;
       try {
         formatted = parser.format(value);
@@ -8961,7 +8976,7 @@ export function firstOf(
       if (
         result.success && ownsRoundTrippedValue(parser, result.value, value)
       ) {
-        return parser;
+        return { parser, result };
       }
     }
     return undefined;
@@ -9033,43 +9048,23 @@ export function firstOf(
       );
     },
     validate(value: unknown): ValueParserResult<unknown> {
-      for (const parser of parsers) {
-        // A constituent's own validate() hook decides membership
-        // authoritatively: it can accept values that its format()+parse()
-        // round-trip cannot express, such as a nested firstOf() whose
-        // valid value is shadowed by an earlier overlapping branch.
-        if (typeof parser.validate === "function") {
-          const result = parser.validate(value);
-          if (result.success) return result;
-          continue;
-        }
-        let formatted: string;
-        try {
-          formatted = parser.format(value);
-        } catch {
-          continue;
-        }
-        if (typeof formatted !== "string") continue;
-        const result = parser.parse(formatted);
-        if (
-          result.success && ownsRoundTrippedValue(parser, result.value, value)
-        ) {
-          return { success: true, value: result.value };
-        }
+      const owner = findOwner(value);
+      if (owner == null) {
+        return {
+          success: false,
+          error: message`Expected a value matching ${metavarTerm(metavar)}.`,
+        };
       }
-      return {
-        success: false,
-        error: message`Expected a value matching ${metavarTerm(metavar)}.`,
-      };
+      return owner.result;
     },
     ...(hasNormalize
       ? {
         normalize(value: unknown): unknown {
           const owner = findOwner(value);
-          if (owner == null || typeof owner.normalize !== "function") {
+          if (owner == null || typeof owner.parser.normalize !== "function") {
             return value;
           }
-          return owner.normalize(value);
+          return owner.parser.normalize(value);
         },
       }
       : {}),

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -8726,7 +8726,7 @@ export interface FirstOfOptions {
      * constituent errors in declaration order.
      * @since 1.1.0
      */
-    noMatch?:
+    readonly noMatch?:
       | Message
       | ((input: string, errors: readonly Message[]) => Message);
   };

--- a/packages/env/src/index.test.ts
+++ b/packages/env/src/index.test.ts
@@ -62,9 +62,6 @@ function asyncChoice<const T extends readonly string[]>(
   return {
     ...parser,
     mode: "async",
-    // choice() does not define the sync validate() hook at runtime, but the
-    // spread type carries it over; clear it so the async signature matches.
-    validate: undefined,
     async parse(input: string) {
       return await parser.parse(input);
     },

--- a/packages/env/src/index.test.ts
+++ b/packages/env/src/index.test.ts
@@ -62,6 +62,9 @@ function asyncChoice<const T extends readonly string[]>(
   return {
     ...parser,
     mode: "async",
+    // choice() does not define the sync validate() hook at runtime, but the
+    // spread type carries it over; clear it so the async signature matches.
+    validate: undefined,
     async parse(input: string) {
       return await parser.parse(input);
     },


### PR DESCRIPTION
Closes #821.

This adds `firstOf()`, a value-parser-level union combinator that tries its constituent parsers in declaration order and returns the first successful result. The result type is inferred as the union of the constituent types, so an option that accepts values of multiple incompatible types no longer needs `string()` plus a hand-written `map()`:

~~~~ typescript
const count = option("--count", firstOf(choice(["auto"]), integer({ min: 1 })));
// The option's parsed value type is "auto" | number.
~~~~

The combined parser exposes metadata conservatively. The default metavar joins the constituent metavars with `|` (for the example above, `TYPE|INTEGER`), completion suggestions are merged and deduplicated, and `choices` is forwarded only when every constituent enumerates its values, since a partial list presented as exhaustive in help output would be misleading. When every constituent fails, the error lists each constituent's error on its own line; `errors.noMatch` replaces that message. A dynamically built parser list can be passed as a single array, `firstOf(parsers, options?)`, which is also the only form that type-checks without casts when the constituents are not statically known.

For values that can be attributed to a constituent, `format()` and `normalize()` use that owner; `format()` stays best-effort for display, and precise fallback validation goes through `validate()` instead. Ownership is stricter than a merely successful `format()`+`parse()` round trip: the round-tripped value has to equal the original, the constituent's own `normalize()` result, or a same-primitive-type canonicalization of it (e.g. a case-insensitive `choice()` folding `"INFO"` to `"info"`). Without this, a lossy earlier branch such as `color()` could claim a later `json()` branch's object and silently drop its extra fields.

Overlapping constituents create one case the round trip fundamentally cannot express: with `firstOf(choice(["0"]), integer({ min: 1 }))`, the number `0` is invalid, but its string form parses fine into the choice branch, so fallback validation through `format()`+`parse()` would either replace the value or skip validation entirely. The `ValueParser` interface therefore gains an optional synchronous `validate()` hook that `option()` and `argument()` prefer over the generic round trip when validating `bindEnv()`/`bindConfig()` fallback values. `firstOf()` implements the hook by consulting each constituent's own `validate()` (a hook that throws on a foreign value counts as non-ownership) or round-trip ownership, in declaration order.

Two restrictions are enforced at construction time. Async constituents are rejected because `format()` and `normalize()` are synchronous and cannot round-trip through an async `parse()`. Dependency-derived value parsers are rejected because they parse with default dependency values when invoked directly, and `firstOf()` cannot forward the derived metadata that `option()`/`argument()` use to re-run them with live values.

Documentation lives in a new section of *docs/concepts/valueparsers.md*, and the changelog entries are in *CHANGES.md*. The later commits fix review-found edge cases around fallback validation of shadowed and unowned values, dependency-derived parsers, opaque object equality, parser-array snapshots, parse-level canonicalization, and throwing `validate()` hooks.
