### PR TITLE
Add async Zod and Valibot parser helpers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -154,6 +154,29 @@ To be released.
 [#825]: https://github.com/dahlia/optique/pull/825
 [#826]: https://github.com/dahlia/optique/pull/826
 
+### @optique/zod
+
+ -  Added `zodAsync()` for Zod schemas that require async parsing, including
+    async refinements and transforms.  The existing `zod()` helper remains
+    synchronous and continues to reject async-only schemas.  The async helper
+    preserves metavar inference, choices, suggestions, Boolean literal
+    conversion, formatting, custom error handling, and fallback validation for
+    values supplied through source contexts such as `bindEnv()` and
+    `bindConfig()`.  [[#827], [#831]]
+
+[#827]: https://github.com/dahlia/optique/issues/827
+[#831]: https://github.com/dahlia/optique/pull/831
+
+### @optique/valibot
+
+ -  Added `valibotAsync()` for Valibot schemas that require async parsing,
+    including `pipeAsync()` and `checkAsync()`.  The existing `valibot()`
+    helper remains synchronous and continues to reject async-only schemas.
+    The async helper preserves metavar inference, choices, suggestions,
+    formatting, custom error handling, and fallback validation for values
+    supplied through source contexts such as `bindEnv()` and `bindConfig()`.
+    [[#827], [#831]]
+
 ### @optique/discover
 
  -  Added the new *@optique/discover* package for runtime-aware command module

--- a/docs/integrations/valibot.md
+++ b/docs/integrations/valibot.md
@@ -141,6 +141,54 @@ const name = valibot(
 ~~~~
 
 
+Async schemas
+-------------
+
+Use `valibotAsync()` when a schema depends on async validations.  The returned
+value parser is async, so run the containing parser with `runAsync()` or
+`await run()`:
+
+~~~~ typescript twoslash
+async function isKnownProject(value: string): Promise<boolean> {
+  return await Promise.resolve(value.startsWith("project-"));
+}
+// ---cut-before---
+import { object } from "@optique/core/constructs";
+import { option } from "@optique/core/primitives";
+import { runAsync } from "@optique/run";
+import { valibotAsync } from "@optique/valibot";
+import * as v from "valibot";
+
+const parser = object({
+  project: option(
+    "--project",
+    valibotAsync(
+      v.pipeAsync(
+        v.string(),
+        v.checkAsync(isKnownProject, "Unknown project."),
+      ),
+      { placeholder: "" },
+    ),
+  ),
+});
+
+const config = await runAsync(parser, {
+  args: ["--project", "project-api"],
+});
+~~~~
+
+The synchronous `valibot()` helper remains synchronous and still rejects
+schemas that require Valibot's async parse path.  `valibotAsync()` preserves
+the same metavar inference, choices, suggestions, formatting, and custom error
+handling as `valibot()`.  Fallback values supplied through `bindEnv()` or
+`bindConfig()` are validated by the same schema before they are accepted.
+
+Async validation may run during fallback resolution and other repeated parser
+paths, including shell completion requests.  Keep remote checks bounded and
+cached when possible, and prefer picklist or literal schemas for completion
+choices so suggestions stay metadata-driven.
+
+
 Custom error messages
 ---------------------
 
@@ -210,9 +258,10 @@ The `@optique/valibot` package currently targets Valibot 1.x.
 Limitations
 -----------
 
- -  *Async validations not supported*: Since Optique's parsing is synchronous,
-    async Valibot features like `pipeAsync()` cannot be used. Perform async
-    validation after parsing if needed.
+ -  *`valibot()` remains synchronous*: Async Valibot features like
+    `pipeAsync()` require `valibotAsync()`.  The sync helper detects schemas
+    that need async parsing when possible and throws a `TypeError` instead of
+    silently skipping validation.
 
 The Valibot integration provides a lightweight yet powerful way to reuse
 validation logic across your entire application while maintaining full type

--- a/docs/integrations/valibot.md
+++ b/docs/integrations/valibot.md
@@ -144,6 +144,8 @@ const name = valibot(
 Async schemas
 -------------
 
+*This API is available since Optique 1.1.0.*
+
 Use `valibotAsync()` when a schema depends on async validations.  The returned
 value parser is async, so run the containing parser with `runAsync()` or
 `await run()`:

--- a/docs/integrations/zod.md
+++ b/docs/integrations/zod.md
@@ -110,6 +110,8 @@ const name = zod(z.string().transform((s) => s.toUpperCase()), { placeholder: ""
 Async schemas
 -------------
 
+*This API is available since Optique 1.1.0.*
+
 Use `zodAsync()` when a schema depends on async refinements or transforms.  The
 returned value parser is async, so run the containing parser with
 `runAsync()` or `await run()`:

--- a/docs/integrations/zod.md
+++ b/docs/integrations/zod.md
@@ -107,6 +107,52 @@ const name = zod(z.string().transform((s) => s.toUpperCase()), { placeholder: ""
 ~~~~
 
 
+Async schemas
+-------------
+
+Use `zodAsync()` when a schema depends on async refinements or transforms.  The
+returned value parser is async, so run the containing parser with
+`runAsync()` or `await run()`:
+
+~~~~ typescript twoslash
+async function isKnownApiKey(value: string): Promise<boolean> {
+  return await Promise.resolve(value.startsWith("live_"));
+}
+// ---cut-before---
+import { object } from "@optique/core/constructs";
+import { option } from "@optique/core/primitives";
+import { runAsync } from "@optique/run";
+import { zodAsync } from "@optique/zod";
+import { z } from "zod";
+
+const parser = object({
+  apiKey: option(
+    "--api-key",
+    zodAsync(
+      z.string().refine(isKnownApiKey, "Unknown API key."),
+      { placeholder: "" },
+    ),
+  ),
+});
+
+const config = await runAsync(parser, {
+  args: ["--api-key", "live_secret"],
+});
+~~~~
+
+The synchronous `zod()` helper remains synchronous and still rejects schemas
+that require Zod's async parse path.  `zodAsync()` preserves the same metavar
+inference, choices, suggestions, Boolean literal conversion, formatting, and
+custom error handling as `zod()`.  Fallback values supplied through
+`bindEnv()` or `bindConfig()` are validated by the same schema before they are
+accepted.
+
+Async validation may run during fallback resolution and other repeated parser
+paths, including shell completion requests.  Keep remote checks bounded and
+cached when possible, and prefer enum or literal schemas for completion choices
+so suggestions stay metadata-driven.
+
+
 Custom error messages
 ---------------------
 
@@ -161,12 +207,10 @@ The `@optique/zod` package supports both Zod v3 (3.25.0+) and Zod v4 (4.0.0+):
 Limitations
 -----------
 
- -  *Async refinements not supported*: Since Optique's parsing is synchronous,
-    async Zod features like `refine(async ...)` cannot be used.  Async boolean
-    schemas are detected when a valid boolean literal is parsed (`"true"`,
-    `"false"`, etc.) and throw a `TypeError`; unrecognized inputs like
-    `"maybe"` return a normal validation error instead.  Perform async
-    validation after parsing if needed.
+ -  *`zod()` remains synchronous*: Async Zod features like
+    `refine(async ...)` and async transforms require `zodAsync()`.  The sync
+    helper detects schemas that need async parsing when possible and throws a
+    `TypeError` instead of silently skipping validation.
 
  -  *Boolean parsing in unions*: The CLI-friendly boolean parsing (accepting
     `true`/`false`, `1`/`0`, `yes`/`no`, `on`/`off`) applies only when the

--- a/packages/valibot/README.md
+++ b/packages/valibot/README.md
@@ -142,6 +142,46 @@ const startDate = argument(
 ~~~~
 
 
+Async schemas
+-------------
+
+Use `valibotAsync()` when a schema depends on async validations, and run the
+containing parser with `runAsync()` or `await run()`:
+
+~~~~ typescript
+import { runAsync } from "@optique/run";
+import { object } from "@optique/core/constructs";
+import { option } from "@optique/core/primitives";
+import { valibotAsync } from "@optique/valibot";
+import * as v from "valibot";
+
+async function checkProject(value: string): Promise<boolean> {
+  return await Promise.resolve(value.startsWith("project-"));
+}
+
+const parser = object({
+  project: option("--project",
+    valibotAsync(
+      v.pipeAsync(v.string(), v.checkAsync(checkProject, "Unknown project.")),
+      { placeholder: "" },
+    ),
+  ),
+});
+
+const cli = await runAsync(parser);
+~~~~
+
+The `valibot()` helper remains synchronous and rejects schemas that require
+Valibot's async parse path.  `valibotAsync()` preserves metavar inference,
+choices, suggestions, formatting, and custom errors.  Fallback values from
+`bindEnv()` or `bindConfig()` are validated by the same schema before they are
+accepted.
+
+Async validation can run during fallback resolution and other repeated parser
+paths, including shell completion requests.  Keep remote checks bounded and
+cached when possible.
+
+
 Custom error messages
 ---------------------
 
@@ -186,25 +226,30 @@ const port = option("-p",
 // const port = option("-p", valibot(v.number()));
 ~~~~
 
-### Async validations are not supported
+### `valibot()` is synchronous
 
-Optique's `ValueParser.parse()` is synchronous, so async Valibot features like
-async validations cannot be supported:
+The `valibot()` helper returns a sync value parser, so async Valibot features
+like `pipeAsync()` require `valibotAsync()`:
 
 ~~~~ typescript
 import { option } from "@optique/core/primitives";
-import { valibot } from "@optique/valibot";
+import { valibot, valibotAsync } from "@optique/valibot";
 import * as v from "valibot";
 
-// ❌ Not supported
-const email = option("--email",
+// ❌ Not supported by valibot()
+const syncEmail = option("--email",
   valibot(v.pipeAsync(v.string(),
     v.checkAsync(async (val) => await checkDB(val))),
     { placeholder: "" }),
 );
-~~~~
 
-If you need async validation, perform it after parsing the CLI arguments.
+// ✅ Use valibotAsync() and runAsync()
+const asyncEmail = option("--email",
+  valibotAsync(v.pipeAsync(v.string(),
+    v.checkAsync(async (val) => await checkDB(val))),
+    { placeholder: "" }),
+);
+~~~~
 
 
 For more resources

--- a/packages/valibot/src/index.test.ts
+++ b/packages/valibot/src/index.test.ts
@@ -1,5 +1,7 @@
-import { message } from "@optique/core/message";
-import { valibot } from "@optique/valibot";
+import { formatMessage, message } from "@optique/core/message";
+import { option } from "@optique/core/primitives";
+import { parseAsync } from "@optique/core/parser";
+import { valibot, valibotAsync } from "@optique/valibot";
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import * as v from "valibot";
@@ -1624,3 +1626,165 @@ describe("valibot()", () => {
     });
   });
 });
+
+describe("valibotAsync()", () => {
+  describe("missing placeholder", () => {
+    it("should throw TypeError when options are omitted", () => {
+      assert.throws(
+        // @ts-expect-error: intentionally omitting required options
+        () => valibotAsync(v.string()),
+        {
+          name: "TypeError",
+          message:
+            "valibotAsync() requires an options object with a placeholder property.",
+        },
+      );
+    });
+
+    it("should throw TypeError when placeholder is missing from options", () => {
+      assert.throws(
+        // @ts-expect-error: intentionally omitting placeholder
+        () => valibotAsync(v.string(), {}),
+        {
+          name: "TypeError",
+          message:
+            "valibotAsync() options must include a placeholder property.",
+        },
+      );
+    });
+  });
+
+  describe("async parsing", () => {
+    it("should parse async validations", async () => {
+      const parser = valibotAsync(
+        v.pipeAsync(
+          v.string(),
+          v.checkAsync(
+            async (value) =>
+              await Promise.resolve(value === "existing-project"),
+            "Project does not exist.",
+          ),
+        ),
+        { placeholder: "" },
+      );
+
+      const validResult = await parser.parse("existing-project");
+      const invalidResult = await parser.parse("missing-project");
+
+      assert.equal(parser.mode, "async");
+      assert.ok(validResult.success);
+      assert.equal(validResult.value, "existing-project");
+      assert.ok(!invalidResult.success);
+      assert.match(
+        formatMessage(invalidResult.error),
+        /Project does not exist/,
+      );
+    });
+
+    it("should parse synchronous schemas through the async helper", async () => {
+      const parser = valibotAsync(
+        v.pipe(
+          v.string(),
+          v.transform(Number),
+          v.number(),
+          v.integer(),
+          v.minValue(1024),
+        ),
+        { placeholder: 1024 },
+      );
+
+      const result = await parser.parse("8080");
+
+      assert.ok(result.success);
+      assert.equal(result.value, 8080);
+    });
+
+    it("should work with parseAsync()", async () => {
+      const schema = v.pipeAsync(
+        v.string(),
+        v.checkAsync(
+          async (value) => await Promise.resolve(value.startsWith("project-")),
+          "Project does not exist.",
+        ),
+      );
+      const parser = option(
+        "--project",
+        valibotAsync(schema, {
+          placeholder: "",
+        }),
+      );
+
+      const result = await parseAsync(parser, ["--project", "project-api"]);
+
+      assert.ok(result.success);
+      assert.equal(result.value, "project-api");
+    });
+
+    it("should validate fallback values through validateValue()", async () => {
+      const schema = v.pipeAsync(
+        v.string(),
+        v.checkAsync(
+          async (value) => await Promise.resolve(value.startsWith("project-")),
+          "Project does not exist.",
+        ),
+      );
+      const parser = option(
+        "--project",
+        valibotAsync(schema, {
+          placeholder: "",
+        }),
+      );
+
+      const validation = await parser.validateValue?.("unknown");
+
+      assert.ok(validation != null);
+      assert.ok(!validation.success);
+      assert.match(formatMessage(validation.error), /Project does not exist/);
+    });
+  });
+
+  describe("choices and suggest", () => {
+    it("should expose choices and suggestions for picklist schemas", async () => {
+      const parser = valibotAsync(
+        v.picklist(["debug", "info", "warn", "error"]),
+        { placeholder: "debug" },
+      );
+
+      const suggestions = await collectAsync(parser.suggest!("i"));
+
+      assert.deepEqual(parser.choices, ["debug", "info", "warn", "error"]);
+      assert.deepEqual(suggestions, [{ kind: "literal", text: "info" }]);
+    });
+  });
+
+  describe("error customization", () => {
+    it("should use custom async schema error callbacks", async () => {
+      const parser = valibotAsync(v.pipe(v.string(), v.email()), {
+        placeholder: "",
+        errors: {
+          valibotError: (_issues, input) =>
+            message`Please provide a valid email address, got ${input}.`,
+        },
+      });
+
+      const result = await parser.parse("not-an-email");
+
+      assert.ok(!result.success);
+      assert.deepEqual(result.error, [
+        { type: "text", text: "Please provide a valid email address, got " },
+        { type: "value", value: "not-an-email" },
+        { type: "text", text: "." },
+      ]);
+    });
+  });
+});
+
+// Helpers
+
+async function collectAsync<T>(iterable: AsyncIterable<T>): Promise<T[]> {
+  const result: T[] = [];
+  for await (const value of iterable) {
+    result.push(value);
+  }
+  return result;
+}

--- a/packages/valibot/src/index.ts
+++ b/packages/valibot/src/index.ts
@@ -6,7 +6,7 @@ import type {
 import { type Message, message } from "@optique/core/message";
 import { ensureNonEmptyString } from "@optique/core/nonempty";
 import type * as v from "valibot";
-import { safeParse } from "valibot";
+import { safeParse, safeParseAsync } from "valibot";
 
 /**
  * Options for creating a Valibot value parser.
@@ -560,6 +560,42 @@ function inferChoices(
   return undefined;
 }
 
+function validateOptions<T>(
+  functionName: string,
+  options: ValibotParserOptions<T>,
+): void {
+  if (options == null || typeof options !== "object") {
+    throw new TypeError(
+      `${functionName}() requires an options object with a placeholder property.`,
+    );
+  }
+  if (!("placeholder" in options)) {
+    throw new TypeError(
+      `${functionName}() options must include a placeholder property.`,
+    );
+  }
+}
+
+function formatValue<T>(value: T, format?: (value: T) => string): string {
+  if (format) return format(value);
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? String(value) : value.toISOString();
+  }
+  if (typeof value !== "object" || value === null) return String(value);
+  if (Array.isArray(value)) return String(value);
+  const str = String(value);
+  if (str !== "[object Object]") return str;
+  const proto = Object.getPrototypeOf(value);
+  if (proto === Object.prototype || proto === null) {
+    try {
+      return JSON.stringify(value) ?? str;
+    } catch {
+      // Falls through to str below
+    }
+  }
+  return str;
+}
+
 /**
  * Creates a value parser from a Valibot schema.
  *
@@ -654,16 +690,7 @@ export function valibot<T>(
   schema: v.BaseSchema<unknown, T, v.BaseIssue<unknown>>,
   options: ValibotParserOptions<T>,
 ): ValueParser<"sync", T> {
-  if (options == null || typeof options !== "object") {
-    throw new TypeError(
-      "valibot() requires an options object with a placeholder property.",
-    );
-  }
-  if (!("placeholder" in options)) {
-    throw new TypeError(
-      "valibot() options must include a placeholder property.",
-    );
-  }
+  validateOptions("valibot", options);
   if (containsAsyncSchema(schema)) {
     throw new TypeError(
       "Async Valibot schemas (e.g., async validations) are not " +
@@ -734,25 +761,94 @@ export function valibot<T>(
     },
 
     format(value: T): string {
-      if (options.format) return options.format(value);
-      if (value instanceof Date) {
-        return Number.isNaN(value.getTime())
-          ? String(value)
-          : value.toISOString();
+      return formatValue(value, options.format);
+    },
+  };
+  return parser;
+}
+
+type AnyValibotSchema<T> =
+  | v.BaseSchema<unknown, T, v.BaseIssue<unknown>>
+  | v.BaseSchemaAsync<unknown, T, v.BaseIssue<unknown>>;
+
+/**
+ * Creates an async value parser from a Valibot schema.
+ *
+ * This parser validates CLI argument strings with Valibot's async safe-parse
+ * path, so schemas using `pipeAsync()`, `checkAsync()`, or other async actions
+ * can be reused directly in asynchronous Optique parsers.
+ *
+ * The metavar, choices, suggestions, formatting, and error customization
+ * follow the same rules as {@link valibot}.  Because the returned parser runs
+ * asynchronously, use it with `parseAsync()`, `run()`, or `runAsync()`.
+ *
+ * @template T The output type of the Valibot schema.
+ * @param schema A Valibot schema to validate input against.
+ * @param options Configuration for the parser, including a required
+ *   `placeholder` value used during deferred prompt resolution.
+ * @returns An async value parser that validates inputs using the provided
+ *   schema.
+ *
+ * @throws {TypeError} If `options` is missing, not an object, or does not
+ *   include `placeholder`.
+ * @throws {TypeError} If the resolved `metavar` is an empty string.
+ * @since 1.1.0
+ */
+export function valibotAsync<T>(
+  schema: AnyValibotSchema<T>,
+  options: ValibotParserOptions<T>,
+): ValueParser<"async", T> {
+  validateOptions("valibotAsync", options);
+  const syncSchema = schema as v.BaseSchema<
+    unknown,
+    unknown,
+    v.BaseIssue<unknown>
+  >;
+  const choices = inferChoices(syncSchema);
+  const metavar = options.metavar ?? inferMetavar(syncSchema);
+  ensureNonEmptyString(metavar);
+  const parser: ValueParser<"async", T> = {
+    mode: "async",
+    metavar,
+    placeholder: options.placeholder,
+    ...(choices != null && choices.length > 0
+      ? {
+        choices: Object.freeze(choices) as readonly T[],
+        async *suggest(prefix: string) {
+          for (const c of choices) {
+            if (c.startsWith(prefix)) {
+              yield { kind: "literal" as const, text: c };
+            }
+          }
+        },
       }
-      if (typeof value !== "object" || value === null) return String(value);
-      if (Array.isArray(value)) return String(value);
-      const str = String(value);
-      if (str !== "[object Object]") return str;
-      const proto = Object.getPrototypeOf(value);
-      if (proto === Object.prototype || proto === null) {
-        try {
-          return JSON.stringify(value) ?? str;
-        } catch {
-          // Falls through to str below
-        }
+      : {}),
+
+    async parse(input: string): Promise<ValueParserResult<T>> {
+      const result = await safeParseAsync(schema, input);
+
+      if (result.success) {
+        return { success: true, value: result.output };
       }
-      return str;
+
+      if (options.errors?.valibotError) {
+        return {
+          success: false,
+          error: typeof options.errors.valibotError === "function"
+            ? options.errors.valibotError(result.issues, input)
+            : options.errors.valibotError,
+        };
+      }
+
+      const firstIssue = result.issues[0];
+      return {
+        success: false,
+        error: message`${firstIssue?.message ?? "Validation failed"}`,
+      };
+    },
+
+    format(value: T): string {
+      return formatValue(value, options.format);
     },
   };
   return parser;

--- a/packages/zod/README.md
+++ b/packages/zod/README.md
@@ -125,6 +125,45 @@ const startDate = argument(
 ~~~~
 
 
+Async schemas
+-------------
+
+Use `zodAsync()` when a schema depends on async refinements or transforms, and
+run the containing parser with `runAsync()` or `await run()`:
+
+~~~~ typescript
+import { runAsync } from "@optique/run";
+import { object } from "@optique/core/constructs";
+import { option } from "@optique/core/primitives";
+import { zodAsync } from "@optique/zod";
+import { z } from "zod";
+
+async function checkApiKey(value: string): Promise<boolean> {
+  return await Promise.resolve(value.startsWith("live_"));
+}
+
+const parser = object({
+  apiKey: option("--api-key",
+    zodAsync(z.string().refine(checkApiKey, "Unknown API key."), {
+      placeholder: "",
+    }),
+  ),
+});
+
+const cli = await runAsync(parser);
+~~~~
+
+The `zod()` helper remains synchronous and rejects schemas that require Zod's
+async parse path.  `zodAsync()` preserves metavar inference, choices,
+suggestions, Boolean literal conversion, formatting, and custom errors.
+Fallback values from `bindEnv()` or `bindConfig()` are validated by the same
+schema before they are accepted.
+
+Async validation can run during fallback resolution and other repeated parser
+paths, including shell completion requests.  Keep remote checks bounded and
+cached when possible.
+
+
 Custom error messages
 ---------------------
 
@@ -167,24 +206,28 @@ const port = option("-p", zod(z.coerce.number(), { placeholder: 0 }));
 // const port = option("-p", zod(z.number()));
 ~~~~
 
-### Async refinements are not supported
+### `zod()` is synchronous
 
-Optique's `ValueParser.parse()` is synchronous, so async Zod features like
-async refinements cannot be supported:
+The `zod()` helper returns a sync value parser, so async Zod features like
+async refinements and transforms require `zodAsync()`:
 
 ~~~~ typescript
 import { option } from "@optique/core/primitives";
-import { zod } from "@optique/zod";
+import { zod, zodAsync } from "@optique/zod";
 import { z } from "zod";
 
-// ❌ Not supported
-const email = option("--email",
+// ❌ Not supported by zod()
+const syncEmail = option("--email",
   zod(z.string().refine(async (val) => await checkDB(val)),
     { placeholder: "" }),
 );
-~~~~
 
-If you need async validation, perform it after parsing the CLI arguments.
+// ✅ Use zodAsync() and runAsync()
+const asyncEmail = option("--email",
+  zodAsync(z.string().refine(async (val) => await checkDB(val)),
+    { placeholder: "" }),
+);
+~~~~
 
 
 Zod version compatibility

--- a/packages/zod/src/index.test.ts
+++ b/packages/zod/src/index.test.ts
@@ -1,5 +1,7 @@
 import { formatMessage, message } from "@optique/core/message";
-import { zod } from "@optique/zod";
+import { option } from "@optique/core/primitives";
+import { parseAsync } from "@optique/core/parser";
+import { zod, zodAsync } from "@optique/zod";
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { z } from "zod";
@@ -1372,6 +1374,152 @@ describe("zod()", () => {
   });
 });
 
+describe("zodAsync()", () => {
+  describe("missing placeholder", () => {
+    it("should throw TypeError when options are omitted", () => {
+      assert.throws(
+        // @ts-expect-error: intentionally omitting required options
+        () => zodAsync(z.string()),
+        {
+          name: "TypeError",
+          message:
+            "zodAsync() requires an options object with a placeholder property.",
+        },
+      );
+    });
+
+    it("should throw TypeError when placeholder is missing from options", () => {
+      assert.throws(
+        // @ts-expect-error: intentionally omitting placeholder
+        () => zodAsync(z.string(), {}),
+        {
+          name: "TypeError",
+          message: "zodAsync() options must include a placeholder property.",
+        },
+      );
+    });
+  });
+
+  describe("async parsing", () => {
+    it("should parse async refinements", async () => {
+      const parser = zodAsync(
+        z.string().refine(
+          async (value) => await Promise.resolve(value === "valid-api-key"),
+          "API key is not valid.",
+        ),
+        { placeholder: "" },
+      );
+
+      const validResult = await parser.parse("valid-api-key");
+      const invalidResult = await parser.parse("invalid-api-key");
+
+      assert.equal(parser.mode, "async");
+      assert.ok(validResult.success);
+      assert.equal(validResult.value, "valid-api-key");
+      assert.ok(!invalidResult.success);
+      assert.match(formatMessage(invalidResult.error), /API key is not valid/);
+    });
+
+    it("should parse synchronous schemas through the async helper", async () => {
+      const parser = zodAsync(z.coerce.number().int().min(1024), {
+        placeholder: 1024,
+      });
+
+      const result = await parser.parse("8080");
+
+      assert.ok(result.success);
+      assert.equal(result.value, 8080);
+    });
+
+    it("should parse async transforms", async () => {
+      const parser = zodAsync(
+        z.string().transform(async (value) =>
+          await Promise.resolve(
+            Number(value),
+          )
+        ),
+        { placeholder: 0 },
+      );
+
+      const result = await parser.parse("42");
+
+      assert.ok(result.success);
+      assert.equal(result.value, 42);
+    });
+
+    it("should work with parseAsync()", async () => {
+      const schema = z.string().refine(
+        async (value) => await Promise.resolve(value.startsWith("live_")),
+        "API key must be live.",
+      );
+      const parser = option("--api-key", zodAsync(schema, { placeholder: "" }));
+
+      const result = await parseAsync(parser, ["--api-key", "live_secret"]);
+
+      assert.ok(result.success);
+      assert.equal(result.value, "live_secret");
+    });
+
+    it("should validate fallback values through validateValue()", async () => {
+      const schema = z.string().refine(
+        async (value) => await Promise.resolve(value.startsWith("live_")),
+        "API key must be live.",
+      );
+      const parser = option("--api-key", zodAsync(schema, { placeholder: "" }));
+
+      const validation = await parser.validateValue?.("test_secret");
+
+      assert.ok(validation != null);
+      assert.ok(!validation.success);
+      assert.match(formatMessage(validation.error), /API key must be live/);
+    });
+  });
+
+  describe("choices and suggest", () => {
+    it("should expose choices and suggestions for enum schemas", async () => {
+      const parser = zodAsync(z.enum(["debug", "info", "warn", "error"]), {
+        placeholder: "debug",
+      });
+
+      const suggestions = await collectAsync(parser.suggest!("i"));
+
+      assert.deepEqual(parser.choices, ["debug", "info", "warn", "error"]);
+      assert.deepEqual(suggestions, [{ kind: "literal", text: "info" }]);
+    });
+
+    it("should preserve CLI-friendly boolean conversion", async () => {
+      const parser = zodAsync(z.boolean(), { placeholder: false });
+
+      const result = await parser.parse("yes");
+
+      assert.deepEqual(parser.choices, [true, false]);
+      assert.ok(result.success);
+      assert.ok(result.value);
+    });
+  });
+
+  describe("error customization", () => {
+    it("should use custom async schema error callbacks", async () => {
+      const parser = zodAsync(z.string().email(), {
+        placeholder: "",
+        errors: {
+          zodError: (_error, input) =>
+            message`Please provide a valid email address, got ${input}.`,
+        },
+      });
+
+      const result = await parser.parse("not-an-email");
+
+      assert.ok(!result.success);
+      assert.deepEqual(result.error, [
+        { type: "text", text: "Please provide a valid email address, got " },
+        { type: "value", value: "not-an-email" },
+        { type: "text", text: "." },
+      ]);
+    });
+  });
+});
+
 describe("inferMetavar()—non-coerce schemas", () => {
   it("should infer BOOLEAN for z.boolean() (non-coerce)", () => {
     // z.boolean() has typeName/type "ZodBoolean"/"boolean"—same branch as coerce
@@ -1754,6 +1902,14 @@ describe("Zod internal compatibility branches", () => {
 });
 
 // Helpers
+
+async function collectAsync<T>(iterable: AsyncIterable<T>): Promise<T[]> {
+  const result: T[] = [];
+  for await (const value of iterable) {
+    result.push(value);
+  }
+  return result;
+}
 
 type FakeZodResult<T> =
   | { readonly success: true; readonly data: T }

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -566,6 +566,42 @@ function inferChoices(
   return undefined;
 }
 
+function validateOptions<T>(
+  functionName: string,
+  options: ZodParserOptions<T>,
+): void {
+  if (options == null || typeof options !== "object") {
+    throw new TypeError(
+      `${functionName}() requires an options object with a placeholder property.`,
+    );
+  }
+  if (!("placeholder" in options)) {
+    throw new TypeError(
+      `${functionName}() options must include a placeholder property.`,
+    );
+  }
+}
+
+function formatValue<T>(value: T, format?: (value: T) => string): string {
+  if (format) return format(value);
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? String(value) : value.toISOString();
+  }
+  if (typeof value !== "object" || value === null) return String(value);
+  if (Array.isArray(value)) return String(value);
+  const str = String(value);
+  if (str !== "[object Object]") return str;
+  const proto = Object.getPrototypeOf(value);
+  if (proto === Object.prototype || proto === null) {
+    try {
+      return JSON.stringify(value) ?? str;
+    } catch {
+      // Falls through to str below
+    }
+  }
+  return str;
+}
+
 /**
  * Creates a value parser from a Zod schema.
  *
@@ -651,16 +687,7 @@ export function zod<T>(
   schema: z.Schema<T>,
   options: ZodParserOptions<T>,
 ): ValueParser<"sync", T> {
-  if (options == null || typeof options !== "object") {
-    throw new TypeError(
-      "zod() requires an options object with a placeholder property.",
-    );
-  }
-  if (!("placeholder" in options)) {
-    throw new TypeError(
-      "zod() options must include a placeholder property.",
-    );
-  }
+  validateOptions("zod", options);
   const choices = inferChoices(schema);
   const boolInfo = analyzeBooleanSchema(schema);
   const metavar = options.metavar ??
@@ -806,25 +833,155 @@ export function zod<T>(
     },
 
     format(value: T): string {
-      if (options.format) return options.format(value);
-      if (value instanceof Date) {
-        return Number.isNaN(value.getTime())
-          ? String(value)
-          : value.toISOString();
+      return formatValue(value, options.format);
+    },
+  };
+  return parser;
+}
+
+/**
+ * Creates an async value parser from a Zod schema.
+ *
+ * This parser validates CLI argument strings with Zod's async parse path, so
+ * schemas using async refinements or transforms can be reused directly in
+ * asynchronous Optique parsers.
+ *
+ * The metavar, choices, suggestions, Boolean input conversion, formatting,
+ * and error customization follow the same rules as {@link zod}.  Because the
+ * returned parser runs asynchronously, use it with `parseAsync()`, `run()`, or
+ * `runAsync()`.
+ *
+ * @template T The output type of the Zod schema.
+ * @param schema A Zod schema to validate input against.
+ * @param options Configuration for the parser, including a required
+ *   `placeholder` value used during deferred prompt resolution.
+ * @returns An async value parser that validates inputs using the provided
+ *   schema.
+ *
+ * @throws {TypeError} If `options` is missing, not an object, or does not
+ *   include `placeholder`.
+ * @throws {TypeError} If the resolved `metavar` is an empty string.
+ * @since 1.1.0
+ */
+export function zodAsync<T>(
+  schema: z.Schema<T>,
+  options: ZodParserOptions<T>,
+): ValueParser<"async", T> {
+  validateOptions("zodAsync", options);
+  const choices = inferChoices(schema);
+  const boolInfo = analyzeBooleanSchema(schema);
+  const metavar = options.metavar ??
+    (boolInfo.isBoolean ? "BOOLEAN" : inferMetavar(schema));
+  ensureNonEmptyString(metavar);
+
+  async function doSafeParse(
+    input: unknown,
+    rawInput: string,
+  ): Promise<ValueParserResult<T>> {
+    const result = await schema.safeParseAsync(input);
+
+    if (result.success) {
+      return { success: true, value: result.data };
+    }
+
+    if (options.errors?.zodError) {
+      return {
+        success: false,
+        error: typeof options.errors.zodError === "function"
+          ? options.errors.zodError(result.error, rawInput)
+          : options.errors.zodError,
+      };
+    }
+
+    const zodModule = schema as ZodSchemaInternal;
+    if (typeof zodModule.constructor?.prettifyError === "function") {
+      try {
+        const pretty = zodModule.constructor.prettifyError(result.error);
+        return { success: false, error: message`${pretty}` };
+      } catch {
+        // Fall through to default error handling
       }
-      if (typeof value !== "object" || value === null) return String(value);
-      if (Array.isArray(value)) return String(value);
-      const str = String(value);
-      if (str !== "[object Object]") return str;
-      const proto = Object.getPrototypeOf(value);
-      if (proto === Object.prototype || proto === null) {
-        try {
-          return JSON.stringify(value) ?? str;
-        } catch {
-          // Falls through to str below
+    }
+
+    const firstError = result.error.issues[0];
+    return {
+      success: false,
+      error: message`${firstError?.message ?? "Validation failed"}`,
+    };
+  }
+
+  async function handleBooleanLiteralError(
+    boolResult: ValueParserResult<boolean>,
+    rawInput: string,
+  ): Promise<ValueParserResult<T>> {
+    if (!boolInfo.isCoerced) {
+      return await doSafeParse(rawInput, rawInput);
+    }
+
+    if (options.errors?.zodError) {
+      if (typeof options.errors.zodError !== "function") {
+        return { success: false, error: options.errors.zodError };
+      }
+      const zodError = new ZodError([{
+        code: "invalid_type",
+        expected: "boolean",
+        message: `Invalid Boolean value: ${rawInput}`,
+        path: [],
+      }]);
+      return {
+        success: false,
+        error: options.errors.zodError(zodError, rawInput),
+      };
+    }
+    return boolResult as ValueParserResult<T>;
+  }
+
+  const parser: ValueParser<"async", T> = {
+    mode: "async",
+    metavar,
+    placeholder: options.placeholder,
+    ...(boolInfo.exposeChoices
+      ? {
+        choices: Object.freeze([true, false]) as readonly T[],
+        async *suggest(prefix: string) {
+          const allLiterals = [
+            ...BOOL_TRUE_LITERALS,
+            ...BOOL_FALSE_LITERALS,
+          ];
+          const normalizedPrefix = prefix.toLowerCase();
+          for (const lit of allLiterals) {
+            if (lit.startsWith(normalizedPrefix)) {
+              yield { kind: "literal" as const, text: lit };
+            }
+          }
+        },
+      }
+      : choices != null && choices.length > 0
+      ? {
+        choices: Object.freeze(choices) as readonly T[],
+        async *suggest(prefix: string) {
+          for (const c of choices) {
+            if (c.startsWith(prefix)) {
+              yield { kind: "literal" as const, text: c };
+            }
+          }
+        },
+      }
+      : {}),
+
+    async parse(input: string): Promise<ValueParserResult<T>> {
+      if (boolInfo.isBoolean) {
+        const boolResult = preConvertBoolean(input);
+        if (!boolResult.success) {
+          return await handleBooleanLiteralError(boolResult, input);
         }
+        return await doSafeParse(boolResult.value, input);
       }
-      return str;
+      return await doSafeParse(input, input);
+    },
+
+    format(value: T): string {
+      return formatValue(value, options.format);
     },
   };
   return parser;


### PR DESCRIPTION
This PR adds async value parser helpers for the Zod and Valibot integrations: `zodAsync()` in *@optique/zod* and `valibotAsync()` in *@optique/valibot*. They let CLI parsers reuse schemas that depend on async validation, such as Zod async refinements or transforms and Valibot `pipeAsync()`/`checkAsync()` pipelines.

The existing `zod()` and `valibot()` helpers stay sync-only. They still reject schemas that need an async parse path, so current callers do not silently cross from sync parsing into async behavior.

The async helpers preserve the integration features already available from the sync helpers: metavar inference, choice metadata, completion suggestions, formatting, custom error messages, and fallback value validation through source contexts such as `bindEnv()` and `bindConfig()`.

Tests were added in *packages/zod/src/index.test.ts* and *packages/valibot/src/index.test.ts*. Documentation was updated in *docs/integrations/zod.md*, *docs/integrations/valibot.md*, *packages/zod/README.md*, *packages/valibot/README.md*, and *CHANGES.md*.

Fixes #827.
