### PR TITLE
Add IPv6 support to `socketAddress()`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -139,7 +139,8 @@ To be released.
     `defaultPort` is configured, IP version filtering through `host.version`,
     separate `host.ipv4`/`host.ipv6` restrictions, and bracketed formatting
     for IPv6 hosts.  Existing `host.ip` options remain as an IPv4
-    compatibility alias.  [[#829], [#832]]
+    compatibility alias and keep IPv4-only behavior unless callers opt into
+    the new IP version options.  [[#829], [#832]]
 
 [Semantic Versioning 2.0.0]: https://semver.org/
 [#801]: https://github.com/dahlia/optique/issues/801

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -138,9 +138,9 @@ To be released.
     endpoints such as `[::1]:8080`, host-only IPv6 literals when a
     `defaultPort` is configured, IP version filtering through `host.version`,
     separate `host.ipv4`/`host.ipv6` restrictions, and bracketed formatting
-    for IPv6 hosts.  Existing `host.ip` options remain as an IPv4
-    compatibility alias and keep IPv4-only behavior unless callers opt into
-    the new IP version options.  [[#829], [#832]]
+    and normalization for IPv6 hosts.  Existing `host.ip` options remain as
+    an IPv4 compatibility alias and keep IPv4-only behavior unless callers
+    opt into the new IP version options.  [[#829], [#832]]
 
 [Semantic Versioning 2.0.0]: https://semver.org/
 [#801]: https://github.com/dahlia/optique/issues/801

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -134,6 +134,13 @@ To be released.
     dependency-derived value parsers are rejected at construction time.
     [[#821], [#826]]
 
+ -  Added IPv6 support to `socketAddress()`.  It now accepts bracketed IPv6
+    endpoints such as `[::1]:8080`, host-only IPv6 literals when a
+    `defaultPort` is configured, IP version filtering through `host.version`,
+    separate `host.ipv4`/`host.ipv6` restrictions, and bracketed formatting
+    for IPv6 hosts.  Existing `host.ip` options remain as an IPv4
+    compatibility alias.  [[#829], [#832]]
+
 [Semantic Versioning 2.0.0]: https://semver.org/
 [#801]: https://github.com/dahlia/optique/issues/801
 [#802]: https://github.com/dahlia/optique/pull/802
@@ -153,6 +160,8 @@ To be released.
 [#823]: https://github.com/dahlia/optique/issues/823
 [#825]: https://github.com/dahlia/optique/pull/825
 [#826]: https://github.com/dahlia/optique/pull/826
+[#829]: https://github.com/dahlia/optique/issues/829
+[#832]: https://github.com/dahlia/optique/pull/832
 
 ### @optique/zod
 

--- a/docs/concepts/valueparsers.md
+++ b/docs/concepts/valueparsers.md
@@ -1797,9 +1797,10 @@ The parser uses `"EMAIL"` as its default metavar.
 ------------------------
 
 The `socketAddress()` parser validates socket addresses in “host:port” format.
-It supports both hostnames and IPv4 addresses, configurable separators, default
-ports, and comprehensive host/port validation options. The parser returns a
-`SocketAddressValue` object containing both the host and port components.
+It supports hostnames, IPv4 addresses, and IPv6 literals, configurable
+separators, default ports, and comprehensive host/port validation options. The
+parser returns a `SocketAddressValue` object containing both the host and port
+components.
 
 ~~~~ typescript twoslash
 import { socketAddress } from "@optique/core/valueparser";
@@ -1813,7 +1814,7 @@ const server = socketAddress({ defaultPort: 80 });
 // IP addresses only
 const bind = socketAddress({
   defaultPort: 8080,
-  host: { type: "ip" },
+  host: { type: "ip", version: "both" },
 });
 
 // Non-privileged ports only
@@ -1828,10 +1829,20 @@ const listen = socketAddress({
 The parser accepts addresses in the following format:
 
  -  With port: `host:port` (e.g., `"localhost:3000"`, `"192.168.1.1:80"`)
+ -  With an IPv6 literal and port: `[host]:port` (e.g., `"[::1]:8080"`,
+    `"[2001:db8::1]:443"`)
  -  Without port: `host` (only when `defaultPort` is set, e.g., `"example.com"`)
+ -  Without port for IPv6: `host` or `[host]` (only when `defaultPort` is set,
+    e.g., `"::1"` or `"[::1]"`)
+
+When the separator is the default `":"`, IPv6 host-and-port values use bracket
+notation so the parser can distinguish colons inside the address from the port
+separator.  Bare IPv6 literals such as `"::1"` and `"2001:db8::1"` are accepted
+only when `defaultPort` supplies the port.
 
 The separator between host and port can be customized using the `separator`
-option.
+option.  Custom separators keep the ordinary split behavior; bracket notation
+is intended for the default `":"` separator.
 
 ### Port requirements
 
@@ -1878,8 +1889,14 @@ $ example --server "example.com"      # Uses default port 80
 The `host.type` option controls what types of hosts are accepted:
 
  -  `"hostname"`: Accept only valid hostnames
- -  `"ip"`: Accept only IP addresses (currently IPv4 only)
+ -  `"ip"`: Accept only IP addresses
  -  `"both"`: Accept both hostnames and IP addresses (default)
+
+For IP hosts, `host.version` controls which IP versions are accepted:
+
+ -  `4`: Accept IPv4 only
+ -  `6`: Accept IPv6 only
+ -  `"both"`: Accept IPv4 and IPv6 (default)
 
 ~~~~ typescript twoslash
 import { socketAddress } from "@optique/core/valueparser";
@@ -1890,20 +1907,21 @@ const bind = option(
   "--bind",
   socketAddress({
     defaultPort: 8080,
-    host: { type: "ip" },
+    host: { type: "ip", version: "both" },
   })
 );
 ~~~~
 
 ~~~~ bash
-$ example --bind "0.0.0.0:8080"     # Valid
+$ example --bind "0.0.0.0:8080"     # Valid IPv4
+$ example --bind "[::1]:8080"       # Valid IPv6
 $ example --bind "localhost:8080"   # Error: hostname not allowed
 ~~~~
 
 ### Host validation options
 
-Pass options to the underlying hostname or IP parser using `host.hostname` or
-`host.ip`:
+Pass options to the underlying hostname or IP parser using `host.hostname`,
+`host.ipv4`, or `host.ipv6`:
 
 ~~~~ typescript twoslash
 import { socketAddress } from "@optique/core/valueparser";
@@ -1927,7 +1945,9 @@ $ example --remote "localhost:80"     # Error: localhost not allowed
 $ example --remote "example.com:80"   # Valid
 ~~~~
 
-For IP addresses, use `host.ip` to pass options like `allowPrivate`:
+For IPv4 addresses, use `host.ipv4` to pass options like `allowPrivate`.
+The older `host.ip` field is still accepted as a compatibility alias for IPv4
+options:
 
 ~~~~ typescript twoslash
 import { socketAddress } from "@optique/core/valueparser";
@@ -1940,7 +1960,28 @@ const publicServer = option(
     defaultPort: 443,
     host: {
       type: "ip",
-      ip: { allowPrivate: false },
+      version: 4,
+      ipv4: { allowPrivate: false },
+    },
+  })
+);
+~~~~
+
+For IPv6 addresses, use `host.ipv6`:
+
+~~~~ typescript twoslash
+import { socketAddress } from "@optique/core/valueparser";
+import { option } from "@optique/core";
+// ---cut-before---
+// IPv6 addresses only, excluding loopback
+const publicV6 = option(
+  "--listen-v6",
+  socketAddress({
+    defaultPort: 443,
+    host: {
+      type: "ip",
+      version: 6,
+      ipv6: { allowLoopback: false },
     },
   })
 );
@@ -2030,6 +2071,22 @@ if (result.success) {
 }
 ~~~~
 
+IPv6 hosts are normalized with the same canonicalization behavior as
+`ipv6()`.  Formatting a socket address with an IPv6 host and the default
+separator emits bracket notation:
+
+~~~~ typescript twoslash
+import { socketAddress } from "@optique/core/valueparser";
+// ---cut-before---
+const parser = socketAddress();
+
+parser.format({ host: "::1", port: 8080 });  // "[::1]:8080"
+parser.format({
+  host: "2001:0db8:0:0:0:0:0:1",
+  port: 443,
+});  // "[2001:db8::1]:443"
+~~~~
+
 ### Custom error messages
 
 Customize error messages for validation failures:
@@ -2091,7 +2148,7 @@ import { socketAddress } from "@optique/core/valueparser";
 // Bind to IP addresses only, non-privileged ports
 const bind = socketAddress({
   defaultPort: 8080,
-  host: { type: "ip" },
+  host: { type: "ip", version: "both" },
   port: { min: 1024 },
 });
 ~~~~

--- a/docs/concepts/valueparsers.md
+++ b/docs/concepts/valueparsers.md
@@ -1898,6 +1898,10 @@ For IP hosts, `host.version` controls which IP versions are accepted:
  -  `6`: Accept IPv6 only
  -  `"both"`: Accept IPv4 and IPv6 (default)
 
+For compatibility with earlier versions, configurations that use only the
+legacy `host.ip` field keep the previous IPv4-only behavior unless
+`host.version` or the new `host.ipv4`/`host.ipv6` fields are also set.
+
 ~~~~ typescript twoslash
 import { socketAddress } from "@optique/core/valueparser";
 import { option } from "@optique/core";

--- a/docs/concepts/valueparsers.md
+++ b/docs/concepts/valueparsers.md
@@ -1838,7 +1838,9 @@ The parser accepts addresses in the following format:
 When the separator is the default `":"`, IPv6 host-and-port values use bracket
 notation so the parser can distinguish colons inside the address from the port
 separator.  Bare IPv6 literals such as `"::1"` and `"2001:db8::1"` are accepted
-only when `defaultPort` supplies the port.
+only when `defaultPort` supplies the port.  Unbracketed forms such as
+`"::1:8080"` are treated as bare IPv6 hosts, not as host-and-port pairs; use
+`"[::1]:8080"` when the port is explicit.
 
 The separator between host and port can be customized using the `separator`
 option.  Custom separators keep the ordinary split behavior; bracket notation
@@ -2075,9 +2077,9 @@ if (result.success) {
 }
 ~~~~
 
-IPv6 hosts are normalized with the same canonicalization behavior as
-`ipv6()`.  Formatting a socket address with an IPv6 host and the default
-separator emits bracket notation:
+Parsed IPv6 hosts are normalized with the same canonicalization behavior as
+`ipv6()`.  When formatting, the default `":"` separator emits bracket notation
+for IPv6 hosts:
 
 ~~~~ typescript twoslash
 import { socketAddress } from "@optique/core/valueparser";

--- a/packages/core/src/modifiers.test.ts
+++ b/packages/core/src/modifiers.test.ts
@@ -63,6 +63,7 @@ import {
   domain,
   integer,
   macAddress,
+  socketAddress,
   string,
   type ValueParser,
   type ValueParserResult,
@@ -2034,6 +2035,25 @@ describe("withDefault", () => {
     assert.ok(result.success);
     if (result.success) {
       assert.equal(result.value, "example.com");
+    }
+  });
+
+  it("should normalize socketAddress IPv6 default hosts", () => {
+    const parser = withDefault(
+      option("--endpoint", socketAddress()),
+      { host: "2001:0db8:0:0:0:0:0:1", port: 443 },
+    );
+
+    const omitted = parse(parser, []);
+    assert.ok(omitted.success);
+    const provided = parse(parser, [
+      "--endpoint",
+      "[2001:0db8:0:0:0:0:0:1]:443",
+    ]);
+    assert.ok(provided.success);
+    if (omitted.success && provided.success) {
+      assert.deepEqual(omitted.value, { host: "2001:db8::1", port: 443 });
+      assert.deepEqual(omitted.value, provided.value);
     }
   });
 

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -9381,6 +9381,21 @@ describe("socketAddress()", () => {
       assert.ok(!parser.parse("[::1]:80").success);
       assert.ok(parser.parse("[2001:db8::1]:80").success);
     });
+
+    it("should normalize IPv6 hosts in socket values", () => {
+      const parser = socketAddress();
+
+      assert.deepStrictEqual(
+        parser.normalize!({
+          host: "2001:0db8:0:0:0:0:0:1",
+          port: 443,
+        }),
+        {
+          host: "2001:db8::1",
+          port: 443,
+        },
+      );
+    });
   });
 
   describe("host options propagation", () => {

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -9331,6 +9331,53 @@ describe("socketAddress()", () => {
       assert.ok(!ipv6Only.parse("192.0.2.1:80").success);
     });
 
+    it("should throw TypeError for invalid host.version", () => {
+      assert.throws(
+        () =>
+          socketAddress({
+            host: { type: "ip", version: "ipv46" as never },
+          }),
+        {
+          name: "TypeError",
+          message:
+            'Expected host.version to be 4, 6, or "both", but got string: ipv46.',
+        },
+      );
+      assert.throws(
+        () =>
+          socketAddress({
+            host: { type: "ip", version: "4x" as never },
+          }),
+        {
+          name: "TypeError",
+          message:
+            'Expected host.version to be 4, 6, or "both", but got string: 4x.',
+        },
+      );
+      assert.throws(
+        () =>
+          socketAddress({
+            host: { type: "ip", version: "ipv6" as never },
+          }),
+        {
+          name: "TypeError",
+          message:
+            'Expected host.version to be 4, 6, or "both", but got string: ipv6.',
+        },
+      );
+      assert.throws(
+        () =>
+          socketAddress({
+            host: { type: "ip", version: 5 as never },
+          }),
+        {
+          name: "TypeError",
+          message:
+            'Expected host.version to be 4, 6, or "both", but got number: 5.',
+        },
+      );
+    });
+
     it("should keep legacy host.ip configs IPv4-only by default", () => {
       for (const type of ["ip", "both"] as const) {
         const parser = socketAddress({

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -9365,6 +9365,12 @@ describe("socketAddress()", () => {
       assert.ok(!parser.parse("[192.0.2.1]:80").success);
     });
 
+    it("should reject bracketed IPv6 with zero-width compression", () => {
+      const parser = socketAddress({ requirePort: true });
+
+      assert.ok(!parser.parse("[1:2:3:4:5:6:7::8]:80").success);
+    });
+
     it("should apply IPv4 and IPv6 host restrictions separately", () => {
       const parser = socketAddress({
         defaultPort: 80,
@@ -13124,6 +13130,12 @@ describe("ipv6()", () => {
     it("should reject multiple :: compressions", () => {
       const parser = ipv6();
       const result = parser.parse("2001::db8::1");
+      assert.ok(!result.success);
+    });
+
+    it("should reject zero-width :: compression", () => {
+      const parser = ipv6();
+      const result = parser.parse("1:2:3:4:5:6:7::8");
       assert.ok(!result.success);
     });
 

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -9331,6 +9331,23 @@ describe("socketAddress()", () => {
       assert.ok(!ipv6Only.parse("192.0.2.1:80").success);
     });
 
+    it("should keep legacy host.ip configs IPv4-only by default", () => {
+      for (const type of ["ip", "both"] as const) {
+        const parser = socketAddress({
+          defaultPort: 80,
+          host: {
+            type,
+            ip: { allowLoopback: false, allowPrivate: false },
+          },
+        });
+
+        assert.ok(parser.parse("192.0.2.1:80").success);
+        assert.ok(!parser.parse("127.0.0.1:80").success);
+        assert.ok(!parser.parse("[::1]:80").success);
+        assert.ok(!parser.parse("[2001:db8::1]:80").success);
+      }
+    });
+
     it("should reject IPv6 addresses in hostname mode", () => {
       const parser = socketAddress({
         defaultPort: 80,

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -9252,6 +9252,120 @@ describe("socketAddress()", () => {
     });
   });
 
+  describe("IPv6 support", () => {
+    it("should parse bracketed IPv6 addresses with explicit ports", () => {
+      const parser = socketAddress({ requirePort: true });
+
+      const result1 = parser.parse("[::1]:8080");
+      assert.ok(result1.success);
+      assert.deepStrictEqual(result1.value, { host: "::1", port: 8080 });
+
+      const result2 = parser.parse("[2001:0db8:0:0:0:0:0:1]:443");
+      assert.ok(result2.success);
+      assert.deepStrictEqual(result2.value, {
+        host: "2001:db8::1",
+        port: 443,
+      });
+    });
+
+    it("should accept bare IPv6 addresses with a default port", () => {
+      const parser = socketAddress({ defaultPort: 8080 });
+
+      const result1 = parser.parse("[::1]");
+      assert.ok(result1.success);
+      assert.deepStrictEqual(result1.value, { host: "::1", port: 8080 });
+
+      const result2 = parser.parse("::1");
+      assert.ok(result2.success);
+      assert.deepStrictEqual(result2.value, { host: "::1", port: 8080 });
+
+      const result3 = parser.parse("::1:8080");
+      assert.ok(result3.success);
+      assert.deepStrictEqual(result3.value, {
+        host: "::1:8080",
+        port: 8080,
+      });
+    });
+
+    it("should reject bare IPv6 addresses when a port is required", () => {
+      const parser = socketAddress({ requirePort: true });
+
+      const result1 = parser.parse("[::1]");
+      assert.ok(!result1.success);
+      assert.deepStrictEqual(result1.error, [
+        {
+          type: "text",
+          text: "Port number is required but was not specified.",
+        },
+      ]);
+
+      const result2 = parser.parse("::1");
+      assert.ok(!result2.success);
+      assert.deepStrictEqual(result2.error, result1.error);
+
+      const result3 = parser.parse("::1:8080");
+      assert.ok(!result3.success);
+      assert.deepStrictEqual(result3.error, result1.error);
+    });
+
+    it("should apply IP version filters", () => {
+      const dualStack = socketAddress({
+        defaultPort: 80,
+        host: { type: "ip", version: "both" },
+      });
+      assert.ok(dualStack.parse("192.0.2.1:80").success);
+      assert.ok(dualStack.parse("[2001:db8::1]:80").success);
+
+      const ipv4Only = socketAddress({
+        defaultPort: 80,
+        host: { type: "ip", version: 4 },
+      });
+      assert.ok(ipv4Only.parse("192.0.2.1:80").success);
+      assert.ok(!ipv4Only.parse("[2001:db8::1]:80").success);
+
+      const ipv6Only = socketAddress({
+        defaultPort: 80,
+        host: { type: "ip", version: 6 },
+      });
+      assert.ok(ipv6Only.parse("[2001:db8::1]:80").success);
+      assert.ok(!ipv6Only.parse("192.0.2.1:80").success);
+    });
+
+    it("should reject IPv6 addresses in hostname mode", () => {
+      const parser = socketAddress({
+        defaultPort: 80,
+        host: { type: "hostname" },
+      });
+
+      assert.ok(!parser.parse("[::1]:8080").success);
+      assert.ok(!parser.parse("::1").success);
+    });
+
+    it("should reject bracketed non-IPv6 hosts", () => {
+      const parser = socketAddress({ defaultPort: 80 });
+
+      assert.ok(!parser.parse("[example.com]:80").success);
+      assert.ok(!parser.parse("[192.0.2.1]:80").success);
+    });
+
+    it("should apply IPv4 and IPv6 host restrictions separately", () => {
+      const parser = socketAddress({
+        defaultPort: 80,
+        host: {
+          type: "ip",
+          version: "both",
+          ipv4: { allowPrivate: false },
+          ipv6: { allowLoopback: false },
+        },
+      });
+
+      assert.ok(!parser.parse("192.168.1.1:80").success);
+      assert.ok(parser.parse("192.0.2.1:80").success);
+      assert.ok(!parser.parse("[::1]:80").success);
+      assert.ok(parser.parse("[2001:db8::1]:80").success);
+    });
+  });
+
   describe("host options propagation", () => {
     it("should pass hostname options to hostname parser", () => {
       const parser = socketAddress({
@@ -9384,6 +9498,19 @@ describe("socketAddress()", () => {
 
       const formatted = parser.format({ host: "localhost", port: 3000 });
       assert.strictEqual(formatted, "localhost 3000");
+    });
+
+    it("should wrap IPv6 hosts in brackets with the default separator", () => {
+      const parser = socketAddress({ defaultPort: 80 });
+
+      assert.strictEqual(
+        parser.format({ host: "::1", port: 8080 }),
+        "[::1]:8080",
+      );
+      assert.strictEqual(
+        parser.format({ host: "2001:0db8:0:0:0:0:0:1", port: 443 }),
+        "[2001:db8::1]:443",
+      );
     });
   });
 
@@ -11109,19 +11236,18 @@ describe("socketAddress()", () => {
       }
     });
 
-    it("should use generic format error for repeated default separator", () => {
-      // "::80" splits as host ":" + port 80, but ":" is just a
-      // separator artifact.  The generic format error is correct.
+    it("should treat repeated default separator input as bare IPv6", () => {
+      // "::80" is a valid bare IPv6 literal, not host ":" + port 80.
+      // With requirePort it should therefore fail as a missing port.
       const parser = socketAddress({ requirePort: true });
 
       const result = parser.parse("::80");
       assert.ok(!result.success);
       assert.deepStrictEqual(result.error, [
-        { type: "text", text: "Expected a socket address in format " },
-        { type: "text", text: "host:port" },
-        { type: "text", text: ", but got " },
-        { type: "value", value: "::80" },
-        { type: "text", text: "." },
+        {
+          type: "text",
+          text: "Port number is required but was not specified.",
+        },
       ]);
     });
 

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -7167,7 +7167,7 @@ function parseAndNormalizeIpv6(input: string): string | null {
 
     // Calculate how many zero groups are compressed
     const totalGroups = leftGroups.length + rightGroups.length;
-    if (totalGroups > 8) return null;
+    if (totalGroups >= 8) return null;
 
     const zeroCount = 8 - totalGroups;
     const zeros = Array(zeroCount).fill("0");
@@ -7206,7 +7206,7 @@ function expandIpv6(input: string): string[] | null {
     const rightGroups = parts[1] ? parts[1].split(":").filter((g) => g) : [];
 
     const totalGroups = leftGroups.length + rightGroups.length;
-    if (totalGroups > 8) return null;
+    if (totalGroups >= 8) return null;
 
     const zeroCount = 8 - totalGroups;
     const zeros = Array(zeroCount).fill("0");

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -5289,7 +5289,21 @@ export function socketAddress(
     return makeInvalidFormatError(input);
   }
 
-  return {
+  function isSocketAddressValue(value: unknown): value is SocketAddressValue {
+    return typeof value === "object" && value !== null &&
+      "host" in value && typeof value.host === "string" &&
+      "port" in value && typeof value.port === "number";
+  }
+
+  function formatSocketAddressValue(value: SocketAddressValue): string {
+    const ipv6Host = parseAndNormalizeIpv6(value.host);
+    if (separator === ":" && ipv6Host !== null) {
+      return `[${ipv6Host}]${separator}${value.port}`;
+    }
+    return `${value.host}${separator}${value.port}`;
+  }
+
+  const parser: ValueParser<"sync", SocketAddressValue> = {
     mode: "sync",
     metavar,
     get placeholder() {
@@ -5721,13 +5735,19 @@ export function socketAddress(
       };
     },
     format(value: SocketAddressValue): string {
-      const ipv6Host = parseAndNormalizeIpv6(value.host);
-      if (separator === ":" && ipv6Host !== null) {
-        return `[${ipv6Host}]${separator}${value.port}`;
+      return formatSocketAddressValue(value);
+    },
+    normalize(value: SocketAddressValue): SocketAddressValue {
+      if (!isSocketAddressValue(value)) return value;
+      try {
+        const result = parser.parse(formatSocketAddressValue(value));
+        return result.success ? result.value : value;
+      } catch {
+        return value;
       }
-      return `${value.host}${separator}${value.port}`;
     },
   };
+  return parser;
 }
 
 /**

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -4895,7 +4895,8 @@ export interface SocketAddressOptions {
      * - `6`: IPv6 only
      * - `"both"`: Accept both IPv4 and IPv6
      *
-     * @default `"both"`
+     * @default `"both"` unless only the legacy {@link ip} field is set, in
+     * which case the default is `4` to preserve IPv4-only compatibility.
      * @since 1.1.0
      */
     readonly version?: 4 | 6 | "both";
@@ -4999,7 +5000,12 @@ export function socketAddress(
   const defaultPort = options?.defaultPort;
   const requirePort = options?.requirePort ?? false;
   const hostType = options?.host?.type ?? "both";
-  const hostVersion = options?.host?.version ?? "both";
+  const hasLegacyIpOptions = options?.host?.ip !== undefined;
+  const hasNewIpOptions = options?.host?.version !== undefined ||
+    options?.host?.ipv4 !== undefined ||
+    options?.host?.ipv6 !== undefined;
+  const hostVersion = options?.host?.version ??
+    (hasLegacyIpOptions && !hasNewIpOptions ? 4 : "both");
 
   // Create host parser based on type
   const hostnameParser = hostname({

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -4890,10 +4890,36 @@ export interface SocketAddressOptions {
     readonly hostname?: Omit<HostnameOptions, "metavar" | "errors">;
 
     /**
-     * Options for IP validation (when type is "ip" or "both").
-     * Currently only supports IPv4.
+     * IP version to accept when `type` is `"ip"` or `"both"`.
+     * - `4`: IPv4 only
+     * - `6`: IPv6 only
+     * - `"both"`: Accept both IPv4 and IPv6
+     *
+     * @default `"both"`
+     * @since 1.1.0
+     */
+    readonly version?: 4 | 6 | "both";
+
+    /**
+     * Options for IPv4 validation (when type is "ip" or "both").
+     * This is kept for backwards compatibility; prefer {@link ipv4} for
+     * new code.
      */
     readonly ip?: Omit<Ipv4Options, "metavar" | "errors">;
+
+    /**
+     * Options for IPv4 validation (when type is "ip" or "both").
+     *
+     * @since 1.1.0
+     */
+    readonly ipv4?: Omit<Ipv4Options, "metavar" | "errors">;
+
+    /**
+     * Options for IPv6 validation (when type is "ip" or "both").
+     *
+     * @since 1.1.0
+     */
+    readonly ipv6?: Omit<Ipv6Options, "metavar" | "errors">;
   };
 
   /**
@@ -4923,7 +4949,7 @@ export interface SocketAddressOptions {
  * Creates a value parser for socket addresses in "host:port" format.
  *
  * Validates socket addresses with support for:
- * - Hostnames and IPv4 addresses (IPv6 support coming in future versions)
+ * - Hostnames, IPv4 addresses, and IPv6 addresses
  * - Configurable host:port separator
  * - Optional default port
  * - Host type filtering (hostname only, IP only, or both)
@@ -4973,14 +4999,23 @@ export function socketAddress(
   const defaultPort = options?.defaultPort;
   const requirePort = options?.requirePort ?? false;
   const hostType = options?.host?.type ?? "both";
+  const hostVersion = options?.host?.version ?? "both";
 
   // Create host parser based on type
   const hostnameParser = hostname({
     ...options?.host?.hostname,
     metavar: "HOST",
   });
-  const ipParser = ipv4({
+  const ipv4Options = {
     ...options?.host?.ip,
+    ...options?.host?.ipv4,
+  };
+  const ipv4Parser = ipv4({
+    ...ipv4Options,
+    metavar: "HOST",
+  });
+  const ipv6Parser = ipv6({
+    ...options?.host?.ipv6,
     metavar: "HOST",
   });
 
@@ -5024,6 +5059,18 @@ export function socketAddress(
 
   function looksLikeIpv4(input: string): boolean {
     return /^\d+\.\d+\.\d+\.\d+$/.test(input);
+  }
+
+  function looksLikeIpv6(input: string): boolean {
+    const colonCount = input.match(/:/g)?.length ?? 0;
+    return colonCount >= 2 &&
+      (input.includes("::") || /^[0-9a-fA-F:.]+$/.test(input));
+  }
+
+  function looksLikeBareIpv6(input: string): boolean {
+    if (!looksLikeIpv6(input)) return false;
+    if (parseAndNormalizeIpv6(input) !== null) return true;
+    return input.includes("::") || !input.includes(".");
   }
 
   function looksLikeAltIpv4Literal(input: string): boolean {
@@ -5080,6 +5127,31 @@ export function socketAddress(
     return false;
   }
 
+  function parseIpHost(hostInput: string): ValueParserResult<string> {
+    if (hostVersion === 4) return ipv4Parser.parse(hostInput);
+
+    if (hostVersion === 6) return ipv6Parser.parse(hostInput);
+
+    if (looksLikeIpv6(hostInput)) {
+      const result = ipv6Parser.parse(hostInput);
+      if (result.success) {
+        const mappedOctets = extractIpv4FromMapped(result.value);
+        if (mappedOctets !== null) {
+          const restrictionError = checkIpv4MappedRestrictions(
+            mappedOctets,
+            result.value,
+            ipv4Options,
+            undefined,
+          );
+          if (restrictionError !== null) return restrictionError;
+        }
+      }
+      return result;
+    }
+
+    return ipv4Parser.parse(hostInput);
+  }
+
   function parseHost(hostInput: string): ValueParserResult<string> {
     if (hostType === "hostname") {
       // Reject IP-shaped input when type is "hostname".
@@ -5101,7 +5173,7 @@ export function socketAddress(
       }
       return hostnameParser.parse(hostInput);
     } else if (hostType === "ip") {
-      return ipParser.parse(hostInput);
+      return parseIpHost(hostInput);
     } else {
       // "both" mode: route by lexical form, no fallback.
       // Check alternate forms first so that octal-dotted inputs get
@@ -5115,11 +5187,100 @@ export function socketAddress(
       }
       if (looksLikeIpv4(hostInput)) {
         // IP-shaped input: validate as IP only (enforces restrictions)
-        return ipParser.parse(hostInput);
+        return parseIpHost(hostInput);
+      }
+      if (looksLikeIpv6(hostInput)) {
+        return parseIpHost(hostInput);
       }
       // Non-IP-shaped: validate as hostname only
       return hostnameParser.parse(hostInput);
     }
+  }
+
+  function makeInvalidFormatError(
+    input: string,
+  ): ValueParserResult<SocketAddressValue> {
+    const errorMsg = options?.errors?.invalidFormat;
+    const msg = typeof errorMsg === "function" ? errorMsg(input) : errorMsg ??
+      message`Expected a socket address in format ${
+        text(formatExample)
+      }, but got ${input}.`;
+    return { success: false, error: msg };
+  }
+
+  function makeMissingPortError(
+    input: string,
+  ): ValueParserResult<SocketAddressValue> {
+    const errorMsg = options?.errors?.missingPort;
+    const msg = typeof errorMsg === "function"
+      ? errorMsg(input)
+      : errorMsg ?? message`Port number is required but was not specified.`;
+    return { success: false, error: msg };
+  }
+
+  function parseBracketedHost(
+    input: string,
+    trimmed: string,
+    canOmitPort: boolean,
+  ): ValueParserResult<SocketAddressValue> | undefined {
+    if (!trimmed.startsWith("[")) return undefined;
+
+    const closingBracket = trimmed.indexOf("]");
+    if (closingBracket === -1) return makeInvalidFormatError(input);
+
+    const hostInput = trimmed.slice(1, closingBracket);
+    if (!looksLikeBareIpv6(hostInput)) return makeInvalidFormatError(input);
+
+    const rest = trimmed.slice(closingBracket + 1).trimStart();
+    const hostResult = parseHost(hostInput);
+
+    if (rest === "") {
+      if (!hostResult.success) {
+        if (options?.errors?.invalidFormat) {
+          return makeInvalidFormatError(input);
+        }
+        return { success: false, error: hostResult.error };
+      }
+      if (canOmitPort) {
+        return {
+          success: true,
+          value: { host: hostResult.value, port: defaultPort! },
+        };
+      }
+      return makeMissingPortError(input);
+    }
+
+    if (!rest.startsWith(separator)) return makeInvalidFormatError(input);
+
+    const portPart = rest.slice(separator.length).trim();
+    if (portPart === "") {
+      if (!hostResult.success) {
+        if (options?.errors?.invalidFormat) {
+          return makeInvalidFormatError(input);
+        }
+        return { success: false, error: hostResult.error };
+      }
+      return makeMissingPortError(input);
+    }
+
+    const portResult = portParser.parse(portPart);
+    if (!hostResult.success) {
+      if (options?.errors?.invalidFormat) {
+        return makeInvalidFormatError(input);
+      }
+      return { success: false, error: hostResult.error };
+    }
+    if (portResult.success) {
+      return {
+        success: true,
+        value: { host: hostResult.value, port: portResult.value },
+      };
+    }
+    if (options?.errors?.invalidFormat) return makeInvalidFormatError(input);
+    if (/^[0-9]+$/.test(portPart)) {
+      return { success: false, error: portResult.error };
+    }
+    return makeInvalidFormatError(input);
   }
 
   return {
@@ -5128,7 +5289,7 @@ export function socketAddress(
     get placeholder() {
       return {
         host: hostType === "ip"
-          ? ipParser.placeholder
+          ? hostVersion === 6 ? ipv6Parser.placeholder : ipv4Parser.placeholder
           : hostnameParser.placeholder,
         port: defaultPort ?? portParser.placeholder,
       };
@@ -5140,6 +5301,32 @@ export function socketAddress(
       // before the separator search.
       const searchInput = input.trimStart();
       const canOmitPort = defaultPort !== undefined && !requirePort;
+
+      if (separator === ":") {
+        const bracketedResult = parseBracketedHost(
+          input,
+          trimmed,
+          canOmitPort,
+        );
+        if (bracketedResult !== undefined) return bracketedResult;
+
+        if (looksLikeBareIpv6(trimmed)) {
+          const hostResult = parseHost(trimmed);
+          if (hostResult.success) {
+            if (canOmitPort) {
+              return {
+                success: true,
+                value: { host: hostResult.value, port: defaultPort! },
+              };
+            }
+            return makeMissingPortError(input);
+          }
+          if (options?.errors?.invalidFormat) {
+            return makeInvalidFormatError(input);
+          }
+          return { success: false, error: hostResult.error };
+        }
+      }
 
       // Step 1: Try splitting at separator occurrences, rightmost first.
       // Accept the first split where both host and port are valid.
@@ -5528,6 +5715,10 @@ export function socketAddress(
       };
     },
     format(value: SocketAddressValue): string {
+      const ipv6Host = parseAndNormalizeIpv6(value.host);
+      if (separator === ":" && ipv6Host !== null) {
+        return `[${ipv6Host}]${separator}${value.port}`;
+      }
       return `${value.host}${separator}${value.port}`;
     },
   };

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -4961,6 +4961,8 @@ export interface SocketAddressOptions {
  * @throws {TypeError} If `separator` is an empty string.
  * @throws {TypeError} If `separator` contains digit characters, since digits
  *   in the separator would cause ambiguous splitting of port input.
+ * @throws {TypeError} If `host.version` is provided but is not `4`, `6`, or
+ *   `"both"`.
  * @since 0.10.0
  *
  * @example

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -5000,11 +5000,24 @@ export function socketAddress(
   const defaultPort = options?.defaultPort;
   const requirePort = options?.requirePort ?? false;
   const hostType = options?.host?.type ?? "both";
+  const rawHostVersion: unknown = options?.host?.version;
+  if (
+    rawHostVersion !== undefined &&
+    rawHostVersion !== 4 &&
+    rawHostVersion !== 6 &&
+    rawHostVersion !== "both"
+  ) {
+    throw new TypeError(
+      `Expected host.version to be 4, 6, or "both", but got ${
+        Array.isArray(rawHostVersion) ? "array" : typeof rawHostVersion
+      }: ${String(rawHostVersion)}.`,
+    );
+  }
   const hasLegacyIpOptions = options?.host?.ip !== undefined;
-  const hasNewIpOptions = options?.host?.version !== undefined ||
+  const hasNewIpOptions = rawHostVersion !== undefined ||
     options?.host?.ipv4 !== undefined ||
     options?.host?.ipv6 !== undefined;
-  const hostVersion = options?.host?.version ??
+  const hostVersion = rawHostVersion ??
     (hasLegacyIpOptions && !hasNewIpOptions ? 4 : "both");
 
   // Create host parser based on type


### PR DESCRIPTION
Summary
-------

This PR adds IPv6 support to `socketAddress()` in `@optique/core`. The parser now accepts bracketed IPv6 endpoints such as `[::1]:8080`, as well as bare IPv6 literals when `defaultPort` supplies the port. Formatting also emits bracket notation for IPv6 hosts when the separator is the default `":"`.

The host policy API now has `host.version`, `host.ipv4`, and `host.ipv6` for IPv4/IPv6-specific rules. The existing `host.ip` option remains an IPv4 compatibility alias, and it keeps the previous IPv4-only behavior unless callers opt into the new IP version fields.

The IPv6 parsing path also rejects zero-width `::` compression, for example `1:2:3:4:5:6:7::8`.

Closes #829.


What changed
------------

 -  Added IPv6-aware socket parsing, formatting, and normalization in *packages/core/src/valueparser.ts*.
 -  Added socket address coverage in *packages/core/src/valueparser.test.ts*, including bracketed IPv6, bare IPv6 with `defaultPort`, version filters, legacy `host.ip` behavior, and invalid zero-width compression.
 -  Added default-value normalization coverage in *packages/core/src/modifiers.test.ts*.
 -  Documented the new behavior in *docs/concepts/valueparsers.md* and *CHANGES.md*.


Testing
-------

 -  `deno test -A --env-file=.env.test packages/core/src/valueparser.test.ts`
 -  `mise test`
