### PR TITLE
`keyValue()` value parser

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -135,11 +135,11 @@ To be released.
     [[#821], [#826]]
 
  -  Added `keyValue()` for parsing `KEY=VALUE` option values into readonly
-    key-value tuples.  The parser supports custom separators, first-or-last
+    key–value tuples.  The parser supports custom separators, first-or-last
     split policy, empty-key and empty-value controls, child key and value
     parsers with preserved type inference, custom error messages,
     `format()`, fallback `validate()`, and best-effort composed completion
-    suggestions.  The key-value cookbook pattern now uses the built-in
+    suggestions.  The key–value cookbook pattern now uses the built-in
     parser instead of a custom implementation.  [[#828], [#833]]
 
  -  Added IPv6 support to `socketAddress()`.  It now accepts bracketed IPv6

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -134,6 +134,14 @@ To be released.
     dependency-derived value parsers are rejected at construction time.
     [[#821], [#826]]
 
+ -  Added `keyValue()` for parsing `KEY=VALUE` option values into readonly
+    key-value tuples.  The parser supports custom separators, first-or-last
+    split policy, empty-key and empty-value controls, child key and value
+    parsers with preserved type inference, custom error messages,
+    `format()`, fallback `validate()`, and best-effort composed completion
+    suggestions.  The key-value cookbook pattern now uses the built-in
+    parser instead of a custom implementation.  [[#828], [#833]]
+
  -  Added IPv6 support to `socketAddress()`.  It now accepts bracketed IPv6
     endpoints such as `[::1]:8080`, host-only IPv6 literals when a
     `defaultPort` is configured, IP version filtering through `host.version`,
@@ -161,8 +169,10 @@ To be released.
 [#823]: https://github.com/dahlia/optique/issues/823
 [#825]: https://github.com/dahlia/optique/pull/825
 [#826]: https://github.com/dahlia/optique/pull/826
+[#828]: https://github.com/dahlia/optique/issues/828
 [#829]: https://github.com/dahlia/optique/issues/829
 [#832]: https://github.com/dahlia/optique/pull/832
+[#833]: https://github.com/dahlia/optique/pull/833
 
 ### @optique/zod
 

--- a/docs/concepts/extend.md
+++ b/docs/concepts/extend.md
@@ -47,7 +47,7 @@ Optique solves this with two systems:
 
 ### Which system to use
 
-If you are building a new data source (for example, a remote key-value store
+If you are building a new data source (for example, a remote key–value store
 or a secrets manager), start with *source contexts*. They handle two-phase
 parsing, priority ordering, and cleanup automatically. Use *annotations*
 directly only if you need to inject runtime data into a parser without the

--- a/docs/concepts/valueparsers.md
+++ b/docs/concepts/valueparsers.md
@@ -167,7 +167,8 @@ const labelResult = label.parse("app:web");
 labelResult;
 // ^?
 
-const overrideResult = override.parse("image.repository=ghcr.io/example/app");
+const overrideResult = override.parse("image.repository=ghcr.io=example/app");
+// Parsed as ["image.repository=ghcr.io", "example/app"].
 overrideResult;
 // ^?
 ~~~~

--- a/docs/concepts/valueparsers.md
+++ b/docs/concepts/valueparsers.md
@@ -31,6 +31,7 @@ with Optique's type system.
 | Parser                           | Module              | Return type                    | Description                                         |
 | -------------------------------- | ------------------- | ------------------------------ | --------------------------------------------------- |
 | `string()`                       | *@optique/core*     | `string`                       | Any string, with optional pattern validation        |
+| `keyValue()`                     | *@optique/core*     | readonly `[key, value]`        | Key-value pair such as `KEY=VALUE`                  |
 | `integer()`                      | *@optique/core*     | `number` or `bigint`           | Integer with range validation                       |
 | `float()`                        | *@optique/core*     | `number`                       | Floating-point number                               |
 | `fileSize()`                     | *@optique/core*     | `number` or `bigint`           | Human-readable data size (bytes)                    |
@@ -115,6 +116,105 @@ Error: Expected a string matching pattern ^\d+\.\d+\.\d+$, but got 1.2.
 
 The `string()` parser uses `"STRING"` as its default metavar, which appears in
 help text to indicate what kind of input is expected.
+
+
+`keyValue()` parser
+-------------------
+
+The `keyValue()` parser accepts a single command-line value shaped like
+`KEY=VALUE` and returns a readonly tuple.  It is useful for Docker-style
+environment variables, Kubernetes or Helm `--set` values, build-time defines,
+labels, and other repeated configuration overrides.
+
+~~~~ typescript twoslash
+import { object } from "@optique/core/constructs";
+import { map, multiple } from "@optique/core/modifiers";
+import { option } from "@optique/core/primitives";
+import { keyValue } from "@optique/core/valueparser";
+
+const parser = object({
+  env: map(
+    multiple(option("-e", "--env", keyValue())),
+    (pairs) => Object.fromEntries(pairs),
+  ),
+  set: map(
+    multiple(option("--set", keyValue())),
+    (pairs) => Object.fromEntries(pairs),
+  ),
+});
+~~~~
+
+By default, `keyValue()`:
+
+ -  uses `=` as the separator;
+ -  rejects input without the separator;
+ -  rejects an empty key such as `=VALUE`;
+ -  allows an empty value such as `KEY=`;
+ -  splits repeated separators at the first separator, so `A=B=C` becomes
+    `["A", "B=C"]`;
+ -  does not trim whitespace.
+
+Use `separator` for other key-value styles and `split: "last"` when the last
+separator should divide the key from the value:
+
+~~~~ typescript twoslash
+import { keyValue } from "@optique/core/valueparser";
+
+const label = keyValue({ separator: ":" });
+const override = keyValue({ split: "last" });
+
+const labelResult = label.parse("app:web");
+labelResult;
+// ^?
+
+const overrideResult = override.parse("image.repository=ghcr.io/example/app");
+overrideResult;
+// ^?
+~~~~
+
+The `key` and `value` options accept normal value parsers.  Their result types
+are preserved in the tuple, so a constrained key or numeric value remains
+visible to TypeScript:
+
+~~~~ typescript twoslash
+import { choice, integer, keyValue } from "@optique/core/valueparser";
+
+const portSetting = keyValue({
+  key: choice(["port"] as const),
+  value: integer({ min: 1, max: 65535 }),
+});
+
+const parsed = portSetting.parse("port=5432");
+if (parsed.success) {
+  parsed.value;
+  //     ^?
+}
+~~~~
+
+For string policies, use child `string()` parsers:
+
+~~~~ typescript twoslash
+import { keyValue, string } from "@optique/core/valueparser";
+
+const label = keyValue({
+  key: string({
+    metavar: "KEY",
+    pattern: /^[a-z][a-z0-9_.-]*$/,
+  }),
+  value: string({ metavar: "VALUE" }),
+});
+~~~~
+
+`format([key, value])` formats both sides through their child parsers before
+joining them with the separator.  Completion suggestions are composed when
+the child parsers provide suggestions: key suggestions get the separator
+appended, and value suggestions are prefixed with the already typed key and
+separator.
+
+Shell escaping and quote handling happen before Optique receives arguments.
+For example, a shell may pass `--set name="hello world"` to Optique as one
+token whose value is `name=hello world`; `keyValue()` then splits that token.
+It does not parse dotenv files, nested paths, or shell syntax.
 
 
 `integer()` parser

--- a/docs/concepts/valueparsers.md
+++ b/docs/concepts/valueparsers.md
@@ -31,7 +31,7 @@ with Optique's type system.
 | Parser                           | Module              | Return type                    | Description                                         |
 | -------------------------------- | ------------------- | ------------------------------ | --------------------------------------------------- |
 | `string()`                       | *@optique/core*     | `string`                       | Any string, with optional pattern validation        |
-| `keyValue()`                     | *@optique/core*     | readonly `[key, value]`        | Key-value pair such as `KEY=VALUE`                  |
+| `keyValue()`                     | *@optique/core*     | readonly `[key, value]`        | Key–value pair such as `KEY=VALUE`                  |
 | `integer()`                      | *@optique/core*     | `number` or `bigint`           | Integer with range validation                       |
 | `float()`                        | *@optique/core*     | `number`                       | Floating-point number                               |
 | `fileSize()`                     | *@optique/core*     | `number` or `bigint`           | Human-readable data size (bytes)                    |
@@ -154,7 +154,7 @@ By default, `keyValue()`:
     `["A", "B=C"]`;
  -  does not trim whitespace.
 
-Use `separator` for other key-value styles and `split: "last"` when the last
+Use `separator` for other key–value styles and `split: "last"` when the last
 separator should divide the key from the value:
 
 ~~~~ typescript twoslash

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -1,7 +1,7 @@
 ---
 description: >-
   Practical recipes for common command-line interface patterns using Optique:
-  subcommands, dependent options, mutually exclusive flags, key-value pairs,
+  subcommands, dependent options, mutually exclusive flags, key–value pairs,
   and more complex CLI designs with detailed explanations.
 ---
 
@@ -15,7 +15,7 @@ you understand how to adapt these techniques to your own applications.
 
 The examples focus on real-world CLI patterns you'll encounter when building
 command-line tools: handling mutually exclusive options, implementing dependent
-flags, parsing key-value pairs, and organizing complex subcommand structures.
+flags, parsing key–value pairs, and organizing complex subcommand structures.
 
 
 Core patterns
@@ -779,7 +779,7 @@ if ("env" in config) {
 
 This pattern demonstrates several advanced techniques:
 
-### Built-in key-value parser
+### Built-in key–value parser
 
 The built-in `keyValue()` parser:
 
@@ -1613,7 +1613,7 @@ function keyValue(separator = "="): ValueParser<"sync", [string, string]> {
   };
 }
 // ---cut-before---
-// Combining subcommands with dependent options and key-value pairs
+// Combining subcommands with dependent options and key–value pairs
 const deployCommand = command("deploy", merge(
   object({
     action: constant("deploy"),
@@ -1633,7 +1633,7 @@ const deployCommand = command("deploy", merge(
 This creates a deploy command that:
 
  -  Requires an environment argument
- -  Supports key-value variables
+ -  Supports key–value variables
  -  Has optional dry-run mode
  -  Uses dependent confirmation when not in dry-run mode
 

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -717,41 +717,10 @@ tools and configuration management systems.
 import { object, or } from "@optique/core/constructs";
 import { map, multiple } from "@optique/core/modifiers";
 import { option } from "@optique/core/primitives";
-import { message, text } from "@optique/core/message";
-import {
-  type ValueParser,
-  type ValueParserResult,
-} from "@optique/core/valueparser";
+import { message } from "@optique/core/message";
+import { keyValue } from "@optique/core/valueparser";
 import { print, run } from "@optique/run";
 // ---cut-before---
-/**
- * Custom value parser for key-value pairs with configurable separator
- */
-function keyValue(separator = "="): ValueParser<"sync", [string, string]> {
-  return {
-    mode: "sync",
-    metavar: `KEY${separator}VALUE`,
-    placeholder: ["", ""] as [string, string],
-    parse(input: string): ValueParserResult<[string, string]> {
-      const index = input.indexOf(separator);
-      if (index === -1 || index === 0) {
-        return {
-          success: false,
-          error: message`Invalid format. Expected KEY${
-            text(separator)
-          }VALUE, got ${input}`,
-        };
-      }
-      const key = input.slice(0, index);
-      const value = input.slice(index + separator.length);
-      return { success: true, value: [key, value] };
-    },
-    format([key, value]: [string, string]): string {
-      return `${key}${separator}${value}`;
-    },
-  };
-}
-
 // Docker-style environment variables
 const dockerParser = object({
   env: map(
@@ -759,7 +728,7 @@ const dockerParser = object({
     (pairs) => Object.fromEntries(pairs),
   ),
   labels: map(
-    multiple(option("-l", "--label", keyValue(":"))),
+    multiple(option("-l", "--label", keyValue({ separator: ":" }))),
     (pairs) => Object.fromEntries(pairs),
   ),
 });
@@ -771,7 +740,7 @@ const k8sParser = object({
     (pairs) => Object.fromEntries(pairs),
   ),
   values: map(
-    multiple(option("--values", keyValue(":"))),
+    multiple(option("--values", keyValue({ separator: ":" }))),
     (pairs) => Object.fromEntries(pairs),
   ),
 });
@@ -810,14 +779,17 @@ if ("env" in config) {
 
 This pattern demonstrates several advanced techniques:
 
-### Custom value parser
+### Built-in key-value parser
 
-The `keyValue()` function creates a reusable value parser that:
+The built-in `keyValue()` parser:
 
  -  *Validates format*: Ensures the input contains the separator
  -  *Splits correctly*: Handles the separator appearing in values
- -  *Provides meaningful errors*: Shows expected format when parsing fails
+ -  *Allows empty values*: Accepts values such as `KEY=` by default, which is
+    useful for environment variables and build defines
  -  *Supports different separators*: Configurable for different use cases
+ -  *Narrows either side*: Accepts child `key` and `value` parsers for stricter
+    validation and type inference
 
 ### Multiple collection
 
@@ -831,7 +803,8 @@ myapp -e DATABASE_URL=postgres://... -e DEBUG=true -l app:web -l version:1.0
 ### Type transformation with `map()`
 
 The example uses [`map()`](./concepts/modifiers.md#map-parser) to transform
-the parsed `[string, string][]` array directly into a `Record<string, string>`.
+the parsed `readonly [string, string][]` array directly into a
+`Record<string, string>`.
 
 This transformation happens at parse time, so your application receives
 structured objects rather than arrays of tuples. The type system correctly
@@ -840,6 +813,24 @@ and type safety.
 
 This pattern is powerful because it bridges the gap between command-line
 interfaces and structured configuration data.
+
+For stricter domains, pass child value parsers to `keyValue()`:
+
+~~~~ typescript twoslash
+import { choice, integer, keyValue } from "@optique/core/valueparser";
+
+const portSetting = keyValue({
+  key: choice(["port"] as const),
+  value: integer({ min: 1, max: 65535 }),
+});
+
+const result = portSetting.parse("port=5432");
+//    ^?
+~~~~
+
+Shell escaping and quotes are handled before Optique receives an argv token.
+For example, `--set name="hello world"` normally arrives as the single value
+`name=hello world`, and `keyValue()` splits only that final token.
 
 ### Verbosity levels
 

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -1597,21 +1597,7 @@ The cookbook patterns can be combined to create sophisticated CLI interfaces:
 import { merge, object } from "@optique/core/constructs";
 import { multiple, withDefault } from "@optique/core/modifiers";
 import { argument, command, constant, flag, option } from "@optique/core/primitives";
-import { string, type ValueParser,
-         type ValueParserResult } from "@optique/core/valueparser";
-function keyValue(separator = "="): ValueParser<"sync", [string, string]> {
-  return {
-    mode: "sync",
-    metavar: `KEY${separator}VALUE`,
-    placeholder: ["", ""] as [string, string],
-    parse(input: string): ValueParserResult<[string, string]> {
-      return { success: true, value: ["", ""] };
-    },
-    format([key, value]: [string, string]): string {
-      return "";
-    },
-  };
-}
+import { keyValue, string } from "@optique/core/valueparser";
 // ---cut-before---
 // Combining subcommands with dependent options and key–value pairs
 const deployCommand = command("deploy", merge(

--- a/examples/patterns/key-value-options.ts
+++ b/examples/patterns/key-value-options.ts
@@ -1,5 +1,5 @@
 /**
- * Key-Value Options Pattern
+ * Key–value options pattern
  *
  * Demonstrates how to parse key=value pairs commonly used in CLI tools
  * like Docker (-e KEY=VALUE) or Kubernetes (--set key=value).
@@ -7,40 +7,8 @@
 import { object, or } from "@optique/core/constructs";
 import { map, multiple } from "@optique/core/modifiers";
 import { option } from "@optique/core/primitives";
-import { message, text } from "@optique/core/message";
-import {
-  type ValueParser,
-  type ValueParserResult,
-} from "@optique/core/valueparser";
+import { keyValue } from "@optique/core/valueparser";
 import { run } from "@optique/run";
-
-/**
- * Custom value parser for key-value pairs with configurable separator
- */
-function keyValue(separator = "="): ValueParser<"sync", [string, string]> {
-  return {
-    mode: "sync",
-    metavar: `KEY${separator}VALUE`,
-    placeholder: ["", ""] as [string, string],
-    parse(input: string): ValueParserResult<[string, string]> {
-      const index = input.indexOf(separator);
-      if (index === -1 || index === 0) {
-        return {
-          success: false,
-          error: message`Invalid format. Expected KEY${
-            text(separator)
-          }VALUE, got ${input}`,
-        };
-      }
-      const key = input.slice(0, index);
-      const value = input.slice(index + separator.length);
-      return { success: true, value: [key, value] };
-    },
-    format([key, value]: [string, string]): string {
-      return `${key}${separator}${value}`;
-    },
-  };
-}
 
 // Docker-style environment variables
 const dockerParser = object({
@@ -49,7 +17,7 @@ const dockerParser = object({
     (pairs) => Object.fromEntries(pairs),
   ),
   labels: map(
-    multiple(option("-l", "--label", keyValue(":"))),
+    multiple(option("-l", "--label", keyValue({ separator: ":" }))),
     (pairs) => Object.fromEntries(pairs),
   ),
 });
@@ -61,7 +29,7 @@ const k8sParser = object({
     (pairs) => Object.fromEntries(pairs),
   ),
   values: map(
-    multiple(option("--values", keyValue(":"))),
+    multiple(option("--values", keyValue({ separator: ":" }))),
     (pairs) => Object.fromEntries(pairs),
   ),
 });

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -19182,6 +19182,27 @@ describe("keyValue", () => {
       assert.deepEqual(suggestions, [{ kind: "literal", text: "mode=debug" }]);
     });
 
+    it("should not suggest values when the key parser rejects the key", () => {
+      const parser = keyValue({
+        key: choice(["mode"] as const),
+        value: choice(["debug"] as const),
+      });
+
+      const suggestions = [...parser.suggest?.("moed=d") ?? []];
+
+      assert.deepEqual(suggestions, []);
+    });
+
+    it("should not suggest values for an empty key by default", () => {
+      const parser = keyValue({
+        value: choice(["debug"] as const),
+      });
+
+      const suggestions = [...parser.suggest?.("=d") ?? []];
+
+      assert.deepEqual(suggestions, []);
+    });
+
     it("should preserve file suggestions after the separator", () => {
       const value: ValueParser<"sync", string> = {
         mode: "sync",

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -19279,7 +19279,7 @@ describe("keyValue", () => {
 
       const normalized = parser.normalize?.(tuple);
 
-      assert.equal(normalized, tuple);
+      assert.strictEqual(normalized, tuple);
     });
   });
 

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -19433,6 +19433,24 @@ describe("keyValue", () => {
       assert.deepEqual(suggestions, []);
     });
 
+    it("should keep suggesting split-last keys after a separator", () => {
+      const parser = keyValue({
+        split: "last",
+        key: choice(["A=B"] as const),
+        value: choice(["C"] as const),
+      });
+
+      const partialSuggestions = [...parser.suggest?.("A=") ?? []];
+      const completeKeySuggestions = [...parser.suggest?.("A=B") ?? []];
+
+      assert.deepEqual(partialSuggestions, [
+        { kind: "literal", text: "A=B=" },
+      ]);
+      assert.deepEqual(completeKeySuggestions, [
+        { kind: "literal", text: "A=B=" },
+      ]);
+    });
+
     it("should preserve file suggestions after the separator", () => {
       const value: ValueParser<"sync", string> = {
         mode: "sync",

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -20,6 +20,7 @@ import {
   type Json,
   json,
   type JsonOptions,
+  keyValue,
   locale,
   macAddress,
   type NonEmptyString,
@@ -18683,6 +18684,510 @@ describe("json()", () => {
 
     it("custom placeholder is respected", () => {
       assert.equal(json({ placeholder: 123 }).placeholder, 123);
+    });
+  });
+});
+
+describe("keyValue", () => {
+  describe("parsing", () => {
+    it("should parse KEY=VALUE as a readonly tuple", () => {
+      const parser = keyValue();
+
+      const result = parser.parse("DATABASE_URL=postgres://localhost/app");
+
+      assert.ok(result.success);
+      assert.deepEqual(result.value, [
+        "DATABASE_URL",
+        "postgres://localhost/app",
+      ]);
+    });
+
+    it("should allow an empty value by default", () => {
+      const parser = keyValue();
+
+      const result = parser.parse("DEBUG=");
+
+      assert.ok(result.success);
+      assert.deepEqual(result.value, ["DEBUG", ""]);
+    });
+
+    it("should reject an empty key by default", () => {
+      const parser = keyValue();
+
+      const result = parser.parse("=enabled");
+
+      assert.ok(!result.success);
+      assert.deepStrictEqual(result.error, [
+        { type: "text", text: "Expected a non-empty key in " },
+        { type: "value", value: "=enabled" },
+        { type: "text", text: "." },
+      ]);
+    });
+
+    it("should reject input without the separator", () => {
+      const parser = keyValue();
+
+      const result = parser.parse("DEBUG");
+
+      assert.ok(!result.success);
+      assert.deepStrictEqual(result.error, [
+        { type: "text", text: "Expected " },
+        { type: "value", value: "=" },
+        { type: "text", text: " in " },
+        { type: "value", value: "DEBUG" },
+        { type: "text", text: "." },
+      ]);
+    });
+
+    it("should support custom separators", () => {
+      const parser = keyValue({ separator: ":" });
+
+      const result = parser.parse("app:web");
+
+      assert.ok(result.success);
+      assert.deepEqual(result.value, ["app", "web"]);
+      assert.equal(parser.metavar, "KEY:VALUE");
+    });
+
+    it("should split repeated separators at the first separator by default", () => {
+      const parser = keyValue();
+
+      const result = parser.parse("A=B=C");
+
+      assert.ok(result.success);
+      assert.deepEqual(result.value, ["A", "B=C"]);
+    });
+
+    it("should split repeated separators at the last separator when configured", () => {
+      const parser = keyValue({ split: "last" });
+
+      const result = parser.parse("A=B=C");
+
+      assert.ok(result.success);
+      assert.deepEqual(result.value, ["A=B", "C"]);
+    });
+
+    it("should preserve whitespace instead of trimming input", () => {
+      const parser = keyValue();
+
+      const result = parser.parse(" KEY = VALUE ");
+
+      assert.ok(result.success);
+      assert.deepEqual(result.value, [" KEY ", " VALUE "]);
+    });
+
+    it("should validate keys and values with child parsers", () => {
+      const parser = keyValue({
+        key: choice(["host", "port"] as const),
+        value: integer({ min: 1 }),
+      });
+
+      const result = parser.parse("port=5432");
+
+      assert.ok(result.success);
+      assert.deepEqual(result.value, ["port", 5432]);
+    });
+
+    it("should wrap key parser failures as invalid-key errors", () => {
+      const parser = keyValue({
+        key: choice(["host", "port"] as const),
+        value: integer(),
+      });
+
+      const result = parser.parse("user=100");
+
+      assert.ok(!result.success);
+      assert.deepStrictEqual(result.error, [
+        { type: "text", text: "Invalid key: " },
+        { type: "text", text: "Expected one of " },
+        { type: "value", value: "host" },
+        { type: "text", text: " and " },
+        { type: "value", value: "port" },
+        { type: "text", text: ", but got " },
+        { type: "value", value: "user" },
+        { type: "text", text: "." },
+      ]);
+    });
+
+    it("should wrap value parser failures as invalid-value errors", () => {
+      const parser = keyValue({
+        key: choice(["port"] as const),
+        value: integer({ min: 1 }),
+      });
+
+      const result = parser.parse("port=0");
+
+      assert.ok(!result.success);
+      assert.deepStrictEqual(result.error, [
+        { type: "text", text: "Invalid value: " },
+        {
+          type: "text",
+          text: "Expected a value greater than or equal to ",
+        },
+        { type: "text", text: "1" },
+        { type: "text", text: ", but got " },
+        { type: "value", value: "0" },
+        { type: "text", text: "." },
+      ]);
+    });
+  });
+
+  describe("empty fields", () => {
+    it("should allow an empty key when configured", () => {
+      const parser = keyValue({ allowEmptyKey: true });
+
+      const result = parser.parse("=default");
+
+      assert.ok(result.success);
+      assert.deepEqual(result.value, ["", "default"]);
+    });
+
+    it("should reject an empty value when configured", () => {
+      const parser = keyValue({ allowEmptyValue: false });
+
+      const result = parser.parse("DEBUG=");
+
+      assert.ok(!result.success);
+      assert.deepStrictEqual(result.error, [
+        { type: "text", text: "Expected a non-empty value in " },
+        { type: "value", value: "DEBUG=" },
+        { type: "text", text: "." },
+      ]);
+    });
+  });
+
+  describe("format", () => {
+    it("should format through the key and value parsers", () => {
+      const parser = keyValue({
+        key: choice(["port"] as const),
+        value: integer(),
+      });
+
+      assert.equal(parser.format(["port", 5432]), "port=5432");
+    });
+
+    it("should use a custom separator when formatting", () => {
+      const parser = keyValue({ separator: ":" });
+
+      assert.equal(parser.format(["app", "web"]), "app:web");
+    });
+  });
+
+  describe("validate", () => {
+    it("should validate fallback tuples through child parsers", () => {
+      const parser = keyValue({
+        key: choice(["host", "port"] as const),
+        value: integer({ min: 1 }),
+      });
+
+      const result = parser.validate?.(["port", 5432]);
+
+      assert.ok(result?.success);
+      assert.deepEqual(result.value, ["port", 5432]);
+    });
+
+    it("should reject fallback tuples that violate child parsers", () => {
+      const parser = keyValue({
+        key: choice(["port"] as const),
+        value: integer({ min: 1 }),
+      });
+
+      const result = parser.validate?.(["port", 0]);
+
+      assert.ok(result);
+      assert.ok(!result.success);
+      assert.equal(
+        formatMessage(result.error),
+        "Invalid value: " +
+          'Expected a value greater than or equal to 1, but got "0".',
+      );
+    });
+
+    it("should reject fallback keys that cannot round-trip with first split", () => {
+      const parser = keyValue();
+
+      const result = parser.validate?.(["A=B", "C"]);
+
+      assert.ok(result);
+      assert.ok(!result.success);
+      assert.equal(
+        formatMessage(result.error),
+        'Invalid key: Expected a key without "=", but got "A=B".',
+      );
+    });
+
+    it("should reject fallback values that cannot round-trip with last split", () => {
+      const parser = keyValue({ split: "last" });
+
+      const result = parser.validate?.(["A", "B=C"]);
+
+      assert.ok(result);
+      assert.ok(!result.success);
+      assert.equal(
+        formatMessage(result.error),
+        'Invalid value: Expected a value without "=", but got "B=C".',
+      );
+    });
+
+    it("should not throw when a child parser cannot format a fallback", () => {
+      const value: ValueParser<"sync", string> = {
+        mode: "sync",
+        metavar: "VALUE",
+        placeholder: "",
+        parse: (input) => ({ success: true, value: input }),
+        format: (input) => {
+          if (input === "sentinel") {
+            throw new TypeError("Sentinel values cannot be formatted.");
+          }
+          return input;
+        },
+      };
+      const parser = keyValue({ value });
+
+      const result = parser.validate?.(["key", "sentinel"]);
+
+      assert.ok(result?.success);
+      assert.deepEqual(result.value, ["key", "sentinel"]);
+    });
+
+    it("should be used by option() fallback validation", () => {
+      const parser = option(
+        "--define",
+        keyValue({
+          key: choice(["port"] as const),
+          value: integer({ min: 1 }),
+        }),
+      );
+
+      const result = parser.validateValue?.(["port", 0]);
+
+      assert.ok(result);
+      assert.ok(!result.success);
+    });
+  });
+
+  describe("suggest", () => {
+    it("should suggest keys with the separator appended before the separator", () => {
+      const parser = keyValue({ key: choice(["host", "port"] as const) });
+
+      const suggestions = [...parser.suggest?.("h") ?? []];
+
+      assert.deepEqual(suggestions, [{ kind: "literal", text: "host=" }]);
+    });
+
+    it("should suggest values with the key and separator prepended", () => {
+      const parser = keyValue({
+        key: choice(["mode"] as const),
+        value: choice(["debug", "info"] as const),
+      });
+
+      const suggestions = [...parser.suggest?.("mode=d") ?? []];
+
+      assert.deepEqual(suggestions, [{ kind: "literal", text: "mode=debug" }]);
+    });
+  });
+
+  describe("deferred metadata", () => {
+    it("should mark the tuple as deferred when a child parser is deferred", () => {
+      const key: ValueParser<"sync", string> = {
+        mode: "sync",
+        metavar: "KEY",
+        placeholder: "",
+        parse: (input) => ({
+          success: true,
+          value: input,
+          deferred: true,
+        }),
+        format: (value) => value,
+      };
+      const parser = keyValue({ key });
+
+      const result = parser.parse("USER=alice");
+
+      assert.ok(result.success);
+      assert.equal(result.deferred, true);
+      assert.deepEqual(result.deferredKeys, new Map([[0, null]]));
+    });
+
+    it("should preserve nested deferred keys from child parsers", () => {
+      const nestedDeferredKeys = new Map<PropertyKey, null>([
+        ["name", null],
+      ]);
+      const value: ValueParser<"sync", { readonly name: string }> = {
+        mode: "sync",
+        metavar: "VALUE",
+        placeholder: { name: "" },
+        parse: (input) => ({
+          success: true,
+          value: { name: input },
+          deferred: true,
+          deferredKeys: nestedDeferredKeys,
+        }),
+        format: (value) => value.name,
+      };
+      const parser = keyValue({ value });
+
+      const result = parser.parse("user=alice");
+
+      assert.ok(result.success);
+      assert.equal(result.deferred, true);
+      assert.deepEqual(
+        result.deferredKeys,
+        new Map<PropertyKey, ReadonlyMap<PropertyKey, null> | null>([
+          [1, nestedDeferredKeys],
+        ]),
+      );
+    });
+  });
+
+  describe("custom errors", () => {
+    it("should use static custom errors", () => {
+      const custom = message`Use KEY=VALUE.`;
+      const parser = keyValue({
+        allowEmptyValue: false,
+        errors: {
+          missingSeparator: custom,
+          emptyKey: custom,
+          emptyValue: custom,
+          invalidKey: custom,
+          invalidValue: custom,
+        },
+        key: choice(["host"] as const),
+        value: integer(),
+      });
+
+      for (const input of ["host", "=value", "host=", "port=1", "host=x"]) {
+        const result = parser.parse(input);
+        assert.ok(!result.success);
+        assert.deepEqual(result.error, custom);
+      }
+    });
+
+    it("should pass context to custom error callbacks", () => {
+      const parser = keyValue({
+        allowEmptyValue: false,
+        errors: {
+          missingSeparator: (input, separator) =>
+            message`Missing ${separator} in ${text(input)}.`,
+          emptyKey: (input) => message`Empty key in ${text(input)}.`,
+          emptyValue: (input) => message`Empty value in ${text(input)}.`,
+          invalidKey: (error) => [text("Bad key: "), ...error],
+          invalidValue: (error) => [text("Bad value: "), ...error],
+        },
+        key: choice(["host"] as const),
+        value: integer(),
+      });
+
+      const missing = parser.parse("host");
+      assert.ok(!missing.success);
+      assert.equal(formatMessage(missing.error), 'Missing "=" in host.');
+
+      const emptyKey = parser.parse("=localhost");
+      assert.ok(!emptyKey.success);
+      assert.equal(formatMessage(emptyKey.error), "Empty key in =localhost.");
+
+      const emptyValue = parser.parse("host=");
+      assert.ok(!emptyValue.success);
+      assert.equal(formatMessage(emptyValue.error), "Empty value in host=.");
+
+      const invalidKey = parser.parse("port=80");
+      assert.ok(!invalidKey.success);
+      assert.equal(
+        formatMessage(invalidKey.error),
+        'Bad key: Expected one of "host", but got "port".',
+      );
+
+      const invalidValue = parser.parse("host=http");
+      assert.ok(!invalidValue.success);
+      assert.equal(
+        formatMessage(invalidValue.error),
+        'Bad value: Expected a valid integer, but got "http".',
+      );
+    });
+  });
+
+  describe("types", () => {
+    it("should infer key and value parser result types", () => {
+      const parser = keyValue({
+        key: choice(["host", "port"] as const),
+        value: integer(),
+      });
+      parser satisfies ValueParser<
+        "sync",
+        readonly ["host" | "port", number]
+      >;
+
+      const result = parser.parse("port=5432");
+      assert.ok(result.success);
+      const value: readonly ["host" | "port", number] = result.value;
+      assert.deepEqual(value, ["port", 5432]);
+    });
+  });
+
+  describe("properties", () => {
+    it("property: strings with one separator parse into original sides", () => {
+      fc.assert(
+        fc.property(
+          fc.string().map((value) => value.replaceAll("=", "_") || "KEY"),
+          fc.string().map((value) => value.replaceAll("=", "_")),
+          (key, value) => {
+            const parser = keyValue();
+
+            const result = parser.parse(`${key}=${value}`);
+
+            assert.ok(result.success);
+            assert.deepEqual(result.value, [key, value]);
+          },
+        ),
+        propertyParameters,
+      );
+    });
+  });
+
+  describe("construction errors", () => {
+    it("should reject an empty separator", () => {
+      assert.throws(
+        () => keyValue({ separator: "" }),
+        {
+          name: "TypeError",
+          message: "Expected a non-empty string.",
+        },
+      );
+    });
+
+    it("should reject async child parsers", () => {
+      const asyncParser: ValueParser<"async", string> = {
+        mode: "async",
+        metavar: "ASYNC",
+        placeholder: "",
+        parse: (input) => Promise.resolve({ success: true, value: input }),
+        format: (value) => value,
+      };
+
+      assert.throws(
+        // @ts-expect-error: keyValue() only accepts sync key parsers.
+        () => keyValue({ key: asyncParser }),
+        TypeError,
+      );
+      assert.throws(
+        // @ts-expect-error: keyValue() only accepts sync value parsers.
+        () => keyValue({ value: asyncParser }),
+        TypeError,
+      );
+    });
+
+    it("should reject dependency-derived child parsers", () => {
+      const mode = dependency(choice(["dev", "prod"]));
+      const derived = mode.derive({
+        metavar: "LEVEL",
+        mode: "sync",
+        factory: (m) =>
+          choice(m === "dev" ? ["debug", "info"] : ["warn", "error"]),
+        defaultValue: () => "dev",
+      });
+
+      assert.throws(() => keyValue({ key: derived }), TypeError);
+      assert.throws(() => keyValue({ value: derived }), TypeError);
     });
   });
 });

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -18903,6 +18903,27 @@ describe("keyValue", () => {
       );
     });
 
+    it("should reject fallback values that are not key-value tuples", () => {
+      const parser = keyValue();
+
+      for (
+        const value of [
+          "admin",
+          ["key"],
+          ["key", "value", "extra"],
+        ]
+      ) {
+        const result = parser.validate?.(value as never);
+
+        assert.ok(result);
+        assert.ok(!result.success);
+        assert.equal(
+          formatMessage(result.error),
+          "Expected a key-value tuple.",
+        );
+      }
+    });
+
     it("should reject fallback keys that cannot round-trip with first split", () => {
       const parser = keyValue();
 
@@ -18916,6 +18937,19 @@ describe("keyValue", () => {
       );
     });
 
+    it("should reject fallback keys that overlap a multi-character separator", () => {
+      const parser = keyValue({ separator: "==" });
+
+      const result = parser.validate?.(["A=", "B"]);
+
+      assert.ok(result);
+      assert.ok(!result.success);
+      assert.equal(
+        formatMessage(result.error),
+        'Invalid key: Expected a key that round-trips with "==", but got "A=".',
+      );
+    });
+
     it("should reject fallback values that cannot round-trip with last split", () => {
       const parser = keyValue({ split: "last" });
 
@@ -18926,6 +18960,19 @@ describe("keyValue", () => {
       assert.equal(
         formatMessage(result.error),
         'Invalid value: Expected a value without "=", but got "B=C".',
+      );
+    });
+
+    it("should reject fallback values that overlap a multi-character separator", () => {
+      const parser = keyValue({ separator: "==", split: "last" });
+
+      const result = parser.validate?.(["A", "=B"]);
+
+      assert.ok(result);
+      assert.ok(!result.success);
+      assert.equal(
+        formatMessage(result.error),
+        'Invalid value: Expected a value that round-trips with "==", but got "=B".',
       );
     });
 

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -19232,7 +19232,10 @@ describe("keyValue", () => {
         mode: "sync",
         metavar: "KEY",
         placeholder: "",
-        parse: (input) => ({ success: true, value: input }),
+        parse: (input) => ({
+          success: true,
+          value: input === "" ? null : input,
+        }),
         format: (input) => input ?? "",
         normalize: () => null,
       };
@@ -19240,15 +19243,43 @@ describe("keyValue", () => {
         mode: "sync",
         metavar: "VALUE",
         placeholder: "",
-        parse: (input) => ({ success: true, value: input }),
+        parse: (input) => ({
+          success: true,
+          value: input === "" ? undefined : input,
+        }),
         format: (input) => input ?? "",
         normalize: () => undefined,
       };
-      const parser = keyValue({ key, value });
+      const parser = keyValue({ allowEmptyKey: true, key, value });
 
       const normalized = parser.normalize?.(["host", "localhost"]);
 
       assert.deepEqual(normalized, [null, undefined]);
+    });
+
+    it("should preserve tuples when normalized parts fail validation", () => {
+      const key: ValueParser<"sync", string> = {
+        mode: "sync",
+        metavar: "KEY",
+        placeholder: "KEY",
+        parse: (input) => ({ success: true, value: input }),
+        format: (input) => input,
+        normalize: () => "",
+      };
+      const value: ValueParser<"sync", string> = {
+        mode: "sync",
+        metavar: "VALUE",
+        placeholder: "VALUE",
+        parse: (input) => ({ success: true, value: input }),
+        format: (input) => input,
+        normalize: (input) => input.trim(),
+      };
+      const parser = keyValue({ key, value });
+      const tuple = ["host", " localhost "] as const;
+
+      const normalized = parser.normalize?.(tuple);
+
+      assert.equal(normalized, tuple);
     });
   });
 
@@ -19421,6 +19452,34 @@ describe("keyValue", () => {
         { kind: "literal", text: "out=src/" },
       ]);
     });
+
+    it("should preserve file suggestions with non-parseable patterns", () => {
+      const value: ValueParser<"sync", string> = {
+        mode: "sync",
+        metavar: "PATH",
+        placeholder: "",
+        parse: (input) =>
+          input.endsWith(".json")
+            ? { success: true, value: input }
+            : { success: false, error: message`Expected a JSON file.` },
+        format: (input) => input,
+        *suggest(prefix) {
+          yield {
+            kind: "file",
+            type: "file",
+            extensions: [".json"],
+            pattern: prefix,
+          };
+        },
+      };
+      const parser = keyValue({ value });
+
+      const suggestions = [...parser.suggest?.("out=src/") ?? []];
+
+      assert.deepEqual(suggestions, [
+        { kind: "literal", text: "out=src/" },
+      ]);
+    });
   });
 
   describe("deferred metadata", () => {
@@ -19441,7 +19500,7 @@ describe("keyValue", () => {
       const result = parser.parse("USER=alice");
 
       assert.ok(result.success);
-      assert.equal(result.deferred, true);
+      assert.ok(result.deferred);
       assert.deepEqual(result.deferredKeys, new Map([[0, null]]));
     });
 
@@ -19466,13 +19525,34 @@ describe("keyValue", () => {
       const result = parser.parse("user=alice");
 
       assert.ok(result.success);
-      assert.equal(result.deferred, true);
+      assert.ok(result.deferred);
       assert.deepEqual(
         result.deferredKeys,
         new Map<PropertyKey, ReadonlyMap<PropertyKey, null> | null>([
           [1, nestedDeferredKeys],
         ]),
       );
+    });
+
+    it("should mark fully deferred object children in deferredKeys", () => {
+      const value: ValueParser<"sync", { readonly name: string }> = {
+        mode: "sync",
+        metavar: "VALUE",
+        placeholder: { name: "" },
+        parse: (input) => ({
+          success: true,
+          value: { name: input },
+          deferred: true,
+        }),
+        format: (value) => value.name,
+      };
+      const parser = keyValue({ value });
+
+      const result = parser.parse("user=alice");
+
+      assert.ok(result.success);
+      assert.ok(result.deferred);
+      assert.deepEqual(result.deferredKeys, new Map([[1, null]]));
     });
   });
 
@@ -19660,12 +19740,18 @@ describe("keyValue", () => {
       assert.throws(
         // @ts-expect-error: keyValue() only accepts sync key parsers.
         () => keyValue({ key: asyncParser }),
-        TypeError,
+        {
+          name: "TypeError",
+          message: /only supports sync key parsers/u,
+        },
       );
       assert.throws(
         // @ts-expect-error: keyValue() only accepts sync value parsers.
         () => keyValue({ value: asyncParser }),
-        TypeError,
+        {
+          name: "TypeError",
+          message: /only supports sync value parsers/u,
+        },
       );
     });
 
@@ -19679,8 +19765,20 @@ describe("keyValue", () => {
         defaultValue: () => "dev",
       });
 
-      assert.throws(() => keyValue({ key: derived }), TypeError);
-      assert.throws(() => keyValue({ value: derived }), TypeError);
+      assert.throws(
+        () => keyValue({ key: derived }),
+        {
+          name: "TypeError",
+          message: /dependency-derived key parsers/u,
+        },
+      );
+      assert.throws(
+        () => keyValue({ value: derived }),
+        {
+          name: "TypeError",
+          message: /dependency-derived value parsers/u,
+        },
+      );
     });
   });
 });

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -19648,7 +19648,7 @@ describe("keyValue", () => {
         readonly [string, string]
       >;
 
-      const typedOptions: KeyValueOptions<string, number> = {};
+      const typedOptions: KeyValueOptions = {};
       const parser = keyValue(typedOptions);
       parser satisfies ValueParser<"sync", readonly [string, string]>;
 
@@ -19656,6 +19656,25 @@ describe("keyValue", () => {
       assert.ok(result.success);
       const value: readonly [string, string] = result.value;
       assert.deepEqual(value, ["port", "5432"]);
+
+      const missingValueParser =
+        // @ts-expect-error: non-string value types require a value parser.
+        {} satisfies KeyValueOptions<string, number>;
+      assert.deepEqual(missingValueParser, {});
+    });
+
+    it("should preserve result types from typed options objects", () => {
+      const options: KeyValueOptions<"port", number> = {
+        key: choice(["port"] as const),
+        value: integer(),
+      };
+      const parser = keyValue(options);
+      parser satisfies ValueParser<"sync", readonly ["port", number]>;
+
+      const result = parser.parse("port=5432");
+      assert.ok(result.success);
+      const value: readonly ["port", number] = result.value;
+      assert.deepEqual(value, ["port", 5432]);
     });
 
     it("should accept optional options objects", () => {

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -19467,7 +19467,7 @@ describe("keyValue", () => {
       const suggestions = [...parser.suggest?.("out=src/") ?? []];
 
       assert.deepEqual(suggestions, [
-        { kind: "literal", text: "out=src/" },
+        { kind: "file", type: "file", pattern: "out=src/" },
       ]);
     });
 
@@ -19495,7 +19495,12 @@ describe("keyValue", () => {
       const suggestions = [...parser.suggest?.("out=src/") ?? []];
 
       assert.deepEqual(suggestions, [
-        { kind: "literal", text: "out=src/" },
+        {
+          kind: "file",
+          type: "file",
+          extensions: [".json"],
+          pattern: "out=src/",
+        },
       ]);
     });
   });

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -19119,6 +19119,49 @@ describe("keyValue", () => {
     });
   });
 
+  describe("normalize", () => {
+    it("should preserve non-tuple sentinel values", () => {
+      const value: ValueParser<"sync", string> = {
+        mode: "sync",
+        metavar: "VALUE",
+        placeholder: "",
+        parse: (input) => ({ success: true, value: input }),
+        format: (input) => input,
+        normalize: (input) => input,
+      };
+      const parser = keyValue({ value });
+      const sentinel = { kind: "default" } as const;
+
+      const normalized = parser.normalize?.(sentinel as never);
+
+      assert.equal(normalized, sentinel);
+    });
+
+    it("should preserve nullish child-normalized tuple parts", () => {
+      const key: ValueParser<"sync", string | null> = {
+        mode: "sync",
+        metavar: "KEY",
+        placeholder: "",
+        parse: (input) => ({ success: true, value: input }),
+        format: (input) => input ?? "",
+        normalize: () => null,
+      };
+      const value: ValueParser<"sync", string | undefined> = {
+        mode: "sync",
+        metavar: "VALUE",
+        placeholder: "",
+        parse: (input) => ({ success: true, value: input }),
+        format: (input) => input ?? "",
+        normalize: () => undefined,
+      };
+      const parser = keyValue({ key, value });
+
+      const normalized = parser.normalize?.(["host", "localhost"]);
+
+      assert.deepEqual(normalized, [null, undefined]);
+    });
+  });
+
   describe("suggest", () => {
     it("should suggest keys with the separator appended before the separator", () => {
       const parser = keyValue({ key: choice(["host", "port"] as const) });

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -18904,6 +18904,52 @@ describe("keyValue", () => {
       );
     });
 
+    it("should reject raw empty fallback keys before child validation", () => {
+      const key: ValueParser<"sync", string> = {
+        mode: "sync",
+        metavar: "KEY",
+        placeholder: "KEY",
+        parse: (input) => ({
+          success: true,
+          value: input === "" ? "default" : input,
+        }),
+        format: (input) => input,
+      };
+      const parser = keyValue({ key });
+
+      const result = parser.validate?.(["", "value"]);
+
+      assert.ok(result);
+      assert.ok(!result.success);
+      assert.equal(
+        formatMessage(result.error),
+        'Expected a non-empty key in "=value".',
+      );
+    });
+
+    it("should reject raw empty fallback values before child validation", () => {
+      const value: ValueParser<"sync", string> = {
+        mode: "sync",
+        metavar: "VALUE",
+        placeholder: "VALUE",
+        parse: (input) => ({
+          success: true,
+          value: input === "" ? "default" : input,
+        }),
+        format: (input) => input,
+      };
+      const parser = keyValue({ allowEmptyValue: false, value });
+
+      const result = parser.validate?.(["key", ""]);
+
+      assert.ok(result);
+      assert.ok(!result.success);
+      assert.equal(
+        formatMessage(result.error),
+        'Expected a non-empty value in "key=".',
+      );
+    });
+
     it("should reject fallback tuple parts that cannot format as strings", () => {
       const parser = keyValue();
 

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -18789,6 +18789,96 @@ describe("keyValue", () => {
       assert.deepEqual(result.value, ["port", 5432]);
     });
 
+    it("should reject parsed keys that canonicalize to empty strings", () => {
+      const key: ValueParser<"sync", string> = {
+        mode: "sync",
+        metavar: "KEY",
+        placeholder: "KEY",
+        parse: (input) => ({
+          success: true,
+          value: input === "default" ? "" : input,
+        }),
+        format: (input) => input,
+      };
+      const parser = keyValue({ key });
+
+      const result = parser.parse("default=enabled");
+
+      assert.ok(!result.success);
+      assert.deepStrictEqual(result.error, [
+        { type: "text", text: "Expected a non-empty key in " },
+        { type: "value", value: "default=enabled" },
+        { type: "text", text: "." },
+      ]);
+    });
+
+    it("should reject parsed values that canonicalize to empty strings", () => {
+      const value: ValueParser<"sync", string> = {
+        mode: "sync",
+        metavar: "VALUE",
+        placeholder: "VALUE",
+        parse: (input) => ({
+          success: true,
+          value: input === "default" ? "" : input,
+        }),
+        format: (input) => input,
+      };
+      const parser = keyValue({ allowEmptyValue: false, value });
+
+      const result = parser.parse("mode=default");
+
+      assert.ok(!result.success);
+      assert.deepStrictEqual(result.error, [
+        { type: "text", text: "Expected a non-empty value in " },
+        { type: "value", value: "mode=default" },
+        { type: "text", text: "." },
+      ]);
+    });
+
+    it("should reject parsed keys that cannot round-trip", () => {
+      const key: ValueParser<"sync", string> = {
+        mode: "sync",
+        metavar: "KEY",
+        placeholder: "KEY",
+        parse: (input) => ({
+          success: true,
+          value: input === "default" ? "A=B" : input,
+        }),
+        format: (input) => input,
+      };
+      const parser = keyValue({ key });
+
+      const result = parser.parse("default=C");
+
+      assert.ok(!result.success);
+      assert.equal(
+        formatMessage(result.error),
+        'Invalid key: Expected a key without "=", but got "A=B".',
+      );
+    });
+
+    it("should reject parsed values that cannot round-trip", () => {
+      const value: ValueParser<"sync", string> = {
+        mode: "sync",
+        metavar: "VALUE",
+        placeholder: "VALUE",
+        parse: (input) => ({
+          success: true,
+          value: input === "default" ? "B=C" : input,
+        }),
+        format: (input) => input,
+      };
+      const parser = keyValue({ split: "last", value });
+
+      const result = parser.parse("A=default");
+
+      assert.ok(!result.success);
+      assert.equal(
+        formatMessage(result.error),
+        'Invalid value: Expected a value without "=", but got "B=C".',
+      );
+    });
+
     it("should wrap key parser failures as invalid-key errors", () => {
       const parser = keyValue({
         key: choice(["host", "port"] as const),
@@ -19199,6 +19289,27 @@ describe("keyValue", () => {
       });
 
       const suggestions = [...parser.suggest?.("=d") ?? []];
+
+      assert.deepEqual(suggestions, []);
+    });
+
+    it("should not suggest values when the key canonicalizes to empty", () => {
+      const key: ValueParser<"sync", string> = {
+        mode: "sync",
+        metavar: "KEY",
+        placeholder: "KEY",
+        parse: (input) => ({
+          success: true,
+          value: input === "default" ? "" : input,
+        }),
+        format: (input) => input,
+      };
+      const parser = keyValue({
+        key,
+        value: choice(["debug"] as const),
+      });
+
+      const suggestions = [...parser.suggest?.("default=d") ?? []];
 
       assert.deepEqual(suggestions, []);
     });

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -19001,6 +19001,19 @@ describe("keyValue", () => {
       );
     });
 
+    it("should reject invalid fallback keys when values cannot format", () => {
+      const parser = keyValue({ value: integer() });
+
+      const result = parser.validate?.(["A=B", undefined] as never);
+
+      assert.ok(result);
+      assert.ok(!result.success);
+      assert.equal(
+        formatMessage(result.error),
+        'Invalid key: Expected a key without "=", but got "A=B".',
+      );
+    });
+
     it("should reject fallback values that overlap a multi-character separator", () => {
       const parser = keyValue({ separator: "==", split: "last" });
 
@@ -19078,6 +19091,26 @@ describe("keyValue", () => {
       const suggestions = [...parser.suggest?.("mode=d") ?? []];
 
       assert.deepEqual(suggestions, [{ kind: "literal", text: "mode=debug" }]);
+    });
+
+    it("should preserve file suggestions after the separator", () => {
+      const value: ValueParser<"sync", string> = {
+        mode: "sync",
+        metavar: "PATH",
+        placeholder: "",
+        parse: (input) => ({ success: true, value: input }),
+        format: (input) => input,
+        *suggest(prefix) {
+          yield { kind: "file", type: "file", pattern: prefix };
+        },
+      };
+      const parser = keyValue({ value });
+
+      const suggestions = [...parser.suggest?.("out=src/") ?? []];
+
+      assert.deepEqual(suggestions, [
+        { kind: "literal", text: "out=src/" },
+      ]);
     });
   });
 

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -19314,6 +19314,25 @@ describe("keyValue", () => {
       const value: readonly [string, string] = result.value;
       assert.deepEqual(value, ["port", "5432"]);
     });
+
+    it("should accept optional options objects", () => {
+      const explicitUndefinedParser = keyValue(undefined);
+      explicitUndefinedParser satisfies ValueParser<
+        "sync",
+        readonly [string, string]
+      >;
+
+      const makeParser = (options: KeyValueOptions | undefined) =>
+        keyValue(options);
+
+      const parser = makeParser(undefined);
+      parser satisfies ValueParser<"sync", readonly [string, string]>;
+
+      const result = parser.parse("port=5432");
+      assert.ok(result.success);
+      const value: readonly [string, string] = result.value;
+      assert.deepEqual(value, ["port", "5432"]);
+    });
   });
 
   describe("properties", () => {

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -18904,6 +18904,43 @@ describe("keyValue", () => {
       );
     });
 
+    it("should reject fallback tuple parts that cannot format as strings", () => {
+      const parser = keyValue();
+
+      const result = parser.validate?.(["PORT", 5432] as never);
+
+      assert.ok(result);
+      assert.ok(!result.success);
+      assert.match(
+        formatMessage(result.error),
+        /^Invalid value: Expected a value formatted as a string/u,
+      );
+    });
+
+    it("should reject validated tuple parts that cannot format as strings", () => {
+      const value: ValueParser<"sync", string> = {
+        mode: "sync",
+        metavar: "VALUE",
+        placeholder: "",
+        parse: (input) => ({ success: true, value: input }),
+        format: (input) => input,
+        validate: (input) => ({ success: true, value: input }),
+      };
+      Object.defineProperty(value, "format", {
+        value: () => 5432,
+      });
+      const parser = keyValue({ value });
+
+      const result = parser.validate?.(["PORT", "5432"]);
+
+      assert.ok(result);
+      assert.ok(!result.success);
+      assert.equal(
+        formatMessage(result.error),
+        "Invalid value: Expected a value formatted as a string.",
+      );
+    });
+
     it("should reject fallback values that are not key-value tuples", () => {
       const parser = keyValue();
 
@@ -19008,6 +19045,15 @@ describe("keyValue", () => {
       );
 
       const result = parser.validateValue?.(["port", 0]);
+
+      assert.ok(result);
+      assert.ok(!result.success);
+    });
+
+    it("should reject non-string tuple parts through option fallback validation", () => {
+      const parser = option("--define", keyValue());
+
+      const result = parser.validateValue?.(["PORT", 5432] as never);
 
       assert.ok(result);
       assert.ok(!result.success);

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -21,6 +21,7 @@ import {
   json,
   type JsonOptions,
   keyValue,
+  type KeyValueOptions,
   locale,
   macAddress,
   type NonEmptyString,
@@ -19168,6 +19169,25 @@ describe("keyValue", () => {
       assert.ok(result.success);
       const value: readonly ["host" | "port", number] = result.value;
       assert.deepEqual(value, ["port", 5432]);
+    });
+
+    it("should default omitted child parser result types to string", () => {
+      const explicitTypeArguments =
+        // @ts-expect-error: keyValue() derives types from child parsers.
+        keyValue<string, number>();
+      explicitTypeArguments satisfies ValueParser<
+        "sync",
+        readonly [string, string]
+      >;
+
+      const typedOptions: KeyValueOptions<string, number> = {};
+      const parser = keyValue(typedOptions);
+      parser satisfies ValueParser<"sync", readonly [string, string]>;
+
+      const result = parser.parse("port=5432");
+      assert.ok(result.success);
+      const value: readonly [string, string] = result.value;
+      assert.deepEqual(value, ["port", "5432"]);
     });
   });
 

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -19314,6 +19314,94 @@ describe("keyValue", () => {
       assert.deepEqual(suggestions, []);
     });
 
+    it("should not suggest keys that cannot round-trip", () => {
+      const parser = keyValue({ key: choice(["A=B"] as const) });
+
+      const suggestions = [...parser.suggest?.("A") ?? []];
+
+      assert.deepEqual(suggestions, []);
+    });
+
+    it("should not suggest keys that overlap a multi-character separator", () => {
+      const parser = keyValue({
+        separator: "==",
+        key: choice(["A="] as const),
+      });
+
+      const suggestions = [...parser.suggest?.("A") ?? []];
+
+      assert.deepEqual(suggestions, []);
+    });
+
+    it("should not suggest raw keys that canonicalize away separators", () => {
+      const key: ValueParser<"sync", string> = {
+        mode: "sync",
+        metavar: "KEY",
+        placeholder: "KEY",
+        parse: (input) => ({
+          success: true,
+          value: input === "A=B" ? "AB" : input,
+        }),
+        format: (input) => input,
+        *suggest(prefix) {
+          if ("A=B".startsWith(prefix)) {
+            yield { kind: "literal", text: "A=B" };
+          }
+        },
+      };
+      const parser = keyValue({ key });
+
+      const suggestions = [...parser.suggest?.("A") ?? []];
+
+      assert.deepEqual(suggestions, []);
+    });
+
+    it("should not suggest values that cannot round-trip", () => {
+      const parser = keyValue({
+        split: "last",
+        value: choice(["B=C"] as const),
+      });
+
+      const suggestions = [...parser.suggest?.("A=B") ?? []];
+
+      assert.deepEqual(suggestions, []);
+    });
+
+    it("should not suggest values that overlap a multi-character separator", () => {
+      const parser = keyValue({
+        separator: "==",
+        split: "last",
+        value: choice(["=B"] as const),
+      });
+
+      const suggestions = [...parser.suggest?.("A==") ?? []];
+
+      assert.deepEqual(suggestions, []);
+    });
+
+    it("should not suggest raw values that canonicalize away separators", () => {
+      const value: ValueParser<"sync", string> = {
+        mode: "sync",
+        metavar: "VALUE",
+        placeholder: "VALUE",
+        parse: (input) => ({
+          success: true,
+          value: input === "B=C" ? "BC" : input,
+        }),
+        format: (input) => input,
+        *suggest(prefix) {
+          if ("B=C".startsWith(prefix)) {
+            yield { kind: "literal", text: "B=C" };
+          }
+        },
+      };
+      const parser = keyValue({ split: "last", value });
+
+      const suggestions = [...parser.suggest?.("A=B") ?? []];
+
+      assert.deepEqual(suggestions, []);
+    });
+
     it("should preserve file suggestions after the separator", () => {
       const value: ValueParser<"sync", string> = {
         mode: "sync",
@@ -19507,6 +19595,25 @@ describe("keyValue", () => {
       assert.ok(result.success);
       const value: readonly [string, string] = result.value;
       assert.deepEqual(value, ["port", "5432"]);
+    });
+
+    it("should include default string types when optional options are undefined", () => {
+      const options = Math.random() > 0.5 ? { value: integer() } : undefined;
+      const parser = keyValue(options);
+      parser satisfies ValueParser<
+        "sync",
+        readonly [string, number] | readonly [string, string]
+      >;
+
+      const result = parser.parse("port=5432");
+      assert.ok(result.success);
+      const value:
+        | readonly [string, number]
+        | readonly [string, string] = result.value;
+      assert.equal(value[0], "port");
+      // @ts-expect-error: optional undefined options use default string parsers.
+      const numericOnly: readonly [string, number] = result.value;
+      assert.deepEqual(numericOnly[0], "port");
     });
   });
 

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -1127,6 +1127,12 @@ export function keyValue(
     return makeKeyValueSuccess(keyResult, valueResult);
   }
 
+  function fallbackInput(key: unknown, value: unknown): string {
+    return `${typeof key === "string" ? key : ""}${separator}${
+      typeof value === "string" ? value : ""
+    }`;
+  }
+
   return {
     mode: "sync",
     metavar,
@@ -1155,6 +1161,18 @@ export function keyValue(
         return {
           success: false,
           error: message`Expected a key-value tuple.`,
+        };
+      }
+      if (!allowEmptyKey && value[0] === "") {
+        return {
+          success: false,
+          error: emptyKeyError(fallbackInput(value[0], value[1])),
+        };
+      }
+      if (!allowEmptyValue && value[1] === "") {
+        return {
+          success: false,
+          error: emptyValueError(fallbackInput(value[0], value[1])),
         };
       }
       const keyResult = validateValueParserValue(keyParser, value[0]);

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -1124,20 +1124,136 @@ export function keyValue(
     if (!valueResult.success) {
       return { success: false, error: invalidValueError(valueResult.error) };
     }
-    return makeKeyValueSuccess(keyResult, valueResult);
+    return validateResultParts(input, keyResult, valueResult);
   }
 
   function validateKeyForSuggestion(key: string): boolean {
     if (!allowEmptyKey && key === "") {
       return false;
     }
-    return keyParser.parse(key).success;
+    const keyResult = keyParser.parse(key);
+    if (!keyResult.success) {
+      return false;
+    }
+    if (!allowEmptyKey && keyResult.value === "") {
+      return false;
+    }
+    const formattedKeyResult = formatValueParserValue(
+      keyParser,
+      keyResult.value,
+    );
+    if (!formattedKeyResult.success) {
+      return false;
+    }
+    const formattedKey = formattedKeyResult.value;
+    return split !== "first" ||
+      formattedKey == null ||
+      !formattedKey.includes(separator);
   }
 
   function fallbackInput(key: unknown, value: unknown): string {
     return `${typeof key === "string" ? key : ""}${separator}${
       typeof value === "string" ? value : ""
     }`;
+  }
+
+  function validateResultParts(
+    input: string,
+    keyResult: Extract<
+      ValueParserResult<unknown>,
+      { readonly success: true }
+    >,
+    valueResult: Extract<
+      ValueParserResult<unknown>,
+      { readonly success: true }
+    >,
+  ): ValueParserResult<readonly [unknown, unknown]> {
+    if (!allowEmptyKey && keyResult.value === "") {
+      return { success: false, error: emptyKeyError(input) };
+    }
+    if (!allowEmptyValue && valueResult.value === "") {
+      return { success: false, error: emptyValueError(input) };
+    }
+
+    const formattedKeyResult = formatValueParserValue(
+      keyParser,
+      keyResult.value,
+    );
+    if (!formattedKeyResult.success) {
+      return {
+        success: false,
+        error: invalidKeyError(formattedKeyResult.error),
+      };
+    }
+    const formattedValueResult = formatValueParserValue(
+      valueParser,
+      valueResult.value,
+    );
+    if (!formattedValueResult.success) {
+      return {
+        success: false,
+        error: invalidValueError(formattedValueResult.error),
+      };
+    }
+    const formattedKey = formattedKeyResult.value;
+    const formattedValue = formattedValueResult.value;
+    const formattedInput = `${formattedKey ?? ""}${separator}${
+      formattedValue ?? ""
+    }`;
+    if (!allowEmptyKey && formattedKey === "") {
+      return { success: false, error: emptyKeyError(input) };
+    }
+    if (!allowEmptyValue && formattedValue === "") {
+      return { success: false, error: emptyValueError(input) };
+    }
+    if (
+      split === "first" &&
+      formattedKey != null &&
+      formattedKey.includes(separator)
+    ) {
+      return {
+        success: false,
+        error: invalidKeyError(
+          message`Expected a key without ${separator}, but got ${formattedKey}.`,
+        ),
+      };
+    }
+    if (
+      split === "last" &&
+      formattedValue != null &&
+      formattedValue.includes(separator)
+    ) {
+      return {
+        success: false,
+        error: invalidValueError(
+          message`Expected a value without ${separator}, but got ${formattedValue}.`,
+        ),
+      };
+    }
+    if (formattedKey != null && formattedValue != null) {
+      const index = findSeparator(formattedInput);
+      const roundTripKey = formattedInput.slice(0, index);
+      const roundTripValue = formattedInput.slice(index + separator.length);
+      if (
+        roundTripKey !== formattedKey ||
+        roundTripValue !== formattedValue
+      ) {
+        return split === "first"
+          ? {
+            success: false,
+            error: invalidKeyError(
+              message`Expected a key that round-trips with ${separator}, but got ${formattedKey}.`,
+            ),
+          }
+          : {
+            success: false,
+            error: invalidValueError(
+              message`Expected a value that round-trips with ${separator}, but got ${formattedValue}.`,
+            ),
+          };
+      }
+    }
+    return makeKeyValueSuccess(keyResult, valueResult);
   }
 
   return {
@@ -1191,83 +1307,11 @@ export function keyValue(
         return { success: false, error: invalidValueError(valueResult.error) };
       }
 
-      const formattedKeyResult = formatValueParserValue(
-        keyParser,
-        keyResult.value,
+      return validateResultParts(
+        fallbackInput(value[0], value[1]),
+        keyResult,
+        valueResult,
       );
-      if (!formattedKeyResult.success) {
-        return {
-          success: false,
-          error: invalidKeyError(formattedKeyResult.error),
-        };
-      }
-      const formattedValueResult = formatValueParserValue(
-        valueParser,
-        valueResult.value,
-      );
-      if (!formattedValueResult.success) {
-        return {
-          success: false,
-          error: invalidValueError(formattedValueResult.error),
-        };
-      }
-      const formattedKey = formattedKeyResult.value;
-      const formattedValue = formattedValueResult.value;
-      const input = `${formattedKey ?? ""}${separator}${formattedValue ?? ""}`;
-      if (!allowEmptyKey && formattedKey === "") {
-        return { success: false, error: emptyKeyError(input) };
-      }
-      if (!allowEmptyValue && formattedValue === "") {
-        return { success: false, error: emptyValueError(input) };
-      }
-      if (
-        split === "first" &&
-        formattedKey != null &&
-        formattedKey.includes(separator)
-      ) {
-        return {
-          success: false,
-          error: invalidKeyError(
-            message`Expected a key without ${separator}, but got ${formattedKey}.`,
-          ),
-        };
-      }
-      if (
-        split === "last" &&
-        formattedValue != null &&
-        formattedValue.includes(separator)
-      ) {
-        return {
-          success: false,
-          error: invalidValueError(
-            message`Expected a value without ${separator}, but got ${formattedValue}.`,
-          ),
-        };
-      }
-      if (formattedKey != null && formattedValue != null) {
-        const index = findSeparator(input);
-        const roundTripKey = input.slice(0, index);
-        const roundTripValue = input.slice(index + separator.length);
-        if (
-          roundTripKey !== formattedKey ||
-          roundTripValue !== formattedValue
-        ) {
-          return split === "first"
-            ? {
-              success: false,
-              error: invalidKeyError(
-                message`Expected a key that round-trips with ${separator}, but got ${formattedKey}.`,
-              ),
-            }
-            : {
-              success: false,
-              error: invalidValueError(
-                message`Expected a value that round-trips with ${separator}, but got ${formattedValue}.`,
-              ),
-            };
-        }
-      }
-      return makeKeyValueSuccess(keyResult, valueResult);
     },
     ...(hasNormalize
       ? {

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -902,13 +902,7 @@ export function string(
   };
 }
 
-/**
- * Options for creating a {@link keyValue} parser.
- * @template K The parsed key type.
- * @template V The parsed value type.
- * @since 1.1.0
- */
-export interface KeyValueOptions<K = string, V = string> {
+interface KeyValueOptionsBase {
   /**
    * The metavariable name for this parser.  Used in help messages to
    * indicate the expected key–value shape.
@@ -921,18 +915,6 @@ export interface KeyValueOptions<K = string, V = string> {
    * @default `"="`
    */
   readonly separator?: string;
-
-  /**
-   * Parser used to validate and transform the key side.
-   * @default `string({ placeholder: "KEY" })`
-   */
-  readonly key?: ValueParser<"sync", K>;
-
-  /**
-   * Parser used to validate and transform the value side.
-   * @default `string()`
-   */
-  readonly value?: ValueParser<"sync", V>;
 
   /**
    * If `true`, accepts an empty key before the separator.
@@ -987,6 +969,62 @@ export interface KeyValueOptions<K = string, V = string> {
   };
 }
 
+type IsDefaultString<T> = [T] extends [string] ? [string] extends [T] ? true
+  : false
+  : false;
+
+type KeyValueKeyOption<K> = IsDefaultString<K> extends true ? {
+    /**
+     * Parser used to validate and transform the key side.
+     * @default `string({ placeholder: "KEY" })`
+     */
+    readonly key?: ValueParser<"sync", K>;
+  }
+  : {
+    /**
+     * Parser used to validate and transform the key side.
+     * @default `string({ placeholder: "KEY" })`
+     */
+    readonly key: ValueParser<"sync", K>;
+  };
+
+type KeyValueValueOption<V> = IsDefaultString<V> extends true ? {
+    /**
+     * Parser used to validate and transform the value side.
+     * @default `string()`
+     */
+    readonly value?: ValueParser<"sync", V>;
+  }
+  : {
+    /**
+     * Parser used to validate and transform the value side.
+     * @default `string()`
+     */
+    readonly value: ValueParser<"sync", V>;
+  };
+
+/**
+ * Options for creating a {@link keyValue} parser.
+ *
+ * The default key and value parsers produce strings.  If {@link K} or
+ * {@link V} is anything other than the default `string` type, the
+ * corresponding child parser is required so the option object cannot promise
+ * a type that the default parser would not produce.
+ *
+ * @template K The parsed key type.
+ * @template V The parsed value type.
+ * @since 1.1.0
+ */
+export type KeyValueOptions<K = string, V = string> =
+  & KeyValueOptionsBase
+  & KeyValueKeyOption<K>
+  & KeyValueValueOption<V>;
+
+type KeyValueOptionsInput = KeyValueOptionsBase & {
+  readonly key?: ValueParser<"sync", unknown>;
+  readonly value?: ValueParser<"sync", unknown>;
+};
+
 type KeyValueKeyType<Options> = Options extends {
   readonly key: ValueParser<"sync", infer K>;
 } ? K
@@ -997,8 +1035,7 @@ type KeyValueValueType<Options> = Options extends {
 } ? V
   : string;
 
-type KeyValueResultType<Options> = Options extends
-  KeyValueOptions<unknown, unknown>
+type KeyValueResultType<Options> = Options extends KeyValueOptionsInput
   ? readonly [KeyValueKeyType<Options>, KeyValueValueType<Options>]
   : readonly [string, string];
 
@@ -1020,12 +1057,12 @@ type KeyValueResultType<Options> = Options extends
  */
 export function keyValue(): ValueParser<"sync", readonly [string, string]>;
 export function keyValue<
-  const Options extends KeyValueOptions<unknown, unknown> | undefined,
+  const Options extends KeyValueOptionsInput | undefined,
 >(
   options: Options,
 ): ValueParser<"sync", KeyValueResultType<Options>>;
 export function keyValue(
-  options: KeyValueOptions<unknown, unknown> = {},
+  options: KeyValueOptionsInput = {},
 ): ValueParser<"sync", readonly [unknown, unknown]> {
   const separator = options.separator ?? "=";
   if (typeof separator !== "string") {

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -1153,6 +1153,13 @@ export function keyValue(
     return formattedKey == null || partsRoundTrip(formattedKey, "");
   }
 
+  function validateKeyPatternForSuggestion(key: string): boolean {
+    if (!allowEmptyKey && key === "") {
+      return false;
+    }
+    return partsRoundTrip(key, "");
+  }
+
   function fallbackInput(key: unknown, value: unknown): string {
     return `${typeof key === "string" ? key : ""}${separator}${
       typeof value === "string" ? value : ""
@@ -1259,6 +1266,37 @@ export function keyValue(
     return makeKeyValueSuccess(keyResult, valueResult);
   }
 
+  function validateTuple(
+    value: readonly [unknown, unknown],
+  ): ValueParserResult<readonly [unknown, unknown]> {
+    if (!allowEmptyKey && value[0] === "") {
+      return {
+        success: false,
+        error: emptyKeyError(fallbackInput(value[0], value[1])),
+      };
+    }
+    if (!allowEmptyValue && value[1] === "") {
+      return {
+        success: false,
+        error: emptyValueError(fallbackInput(value[0], value[1])),
+      };
+    }
+    const keyResult = validateValueParserValue(keyParser, value[0]);
+    if (!keyResult.success) {
+      return { success: false, error: invalidKeyError(keyResult.error) };
+    }
+    const valueResult = validateValueParserValue(valueParser, value[1]);
+    if (!valueResult.success) {
+      return { success: false, error: invalidValueError(valueResult.error) };
+    }
+
+    return validateResultParts(
+      fallbackInput(value[0], value[1]),
+      keyResult,
+      valueResult,
+    );
+  }
+
   return {
     mode: "sync",
     metavar,
@@ -1289,32 +1327,7 @@ export function keyValue(
           error: message`Expected a key-value tuple.`,
         };
       }
-      if (!allowEmptyKey && value[0] === "") {
-        return {
-          success: false,
-          error: emptyKeyError(fallbackInput(value[0], value[1])),
-        };
-      }
-      if (!allowEmptyValue && value[1] === "") {
-        return {
-          success: false,
-          error: emptyValueError(fallbackInput(value[0], value[1])),
-        };
-      }
-      const keyResult = validateValueParserValue(keyParser, value[0]);
-      if (!keyResult.success) {
-        return { success: false, error: invalidKeyError(keyResult.error) };
-      }
-      const valueResult = validateValueParserValue(valueParser, value[1]);
-      if (!valueResult.success) {
-        return { success: false, error: invalidValueError(valueResult.error) };
-      }
-
-      return validateResultParts(
-        fallbackInput(value[0], value[1]),
-        keyResult,
-        valueResult,
-      );
+      return validateTuple(value);
     },
     ...(hasNormalize
       ? {
@@ -1324,7 +1337,7 @@ export function keyValue(
           if (!isKeyValueTuple(value)) {
             return value;
           }
-          return [
+          const normalized = [
             typeof keyParser.normalize === "function"
               ? keyParser.normalize(value[0])
               : value[0],
@@ -1332,6 +1345,7 @@ export function keyValue(
               ? valueParser.normalize(value[1])
               : value[1],
           ] as const;
+          return validateTuple(normalized).success ? normalized : value;
         },
       }
       : {}),
@@ -1344,7 +1358,13 @@ export function keyValue(
             const suggestions: Suggestion[] = [];
             for (const suggestion of keyParser.suggest(prefix)) {
               const key = suggestionTextValue(suggestion);
-              if (!validateKeyForSuggestion(key)) continue;
+              if (
+                suggestion.kind === "literal"
+                  ? !validateKeyForSuggestion(key)
+                  : !validateKeyPatternForSuggestion(key)
+              ) {
+                continue;
+              }
               suggestions.push(
                 prefixKeyValueSuggestion(suggestion, "", separator),
               );
@@ -1364,6 +1384,7 @@ export function keyValue(
               continue;
             }
             if (
+              suggestion.kind === "literal" &&
               !validateParts(`${key}${separator}${value}`, key, value).success
             ) {
               continue;
@@ -1510,9 +1531,7 @@ function collectKeyValueDeferredKeys<T>(
   }
   if (result.deferred !== true) return;
   markDeferred();
-  if (result.value == null || typeof result.value !== "object") {
-    deferredKeys.set(index, null);
-  }
+  deferredKeys.set(index, null);
 }
 
 /**

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -1529,6 +1529,9 @@ function prefixKeyValueSuggestion(
 ): Suggestion {
   const textValue = suggestionTextValue(suggestion);
   const text = `${prefix}${textValue}${suffix}`;
+  if (suggestion.kind === "file" && suffix === "") {
+    return { ...suggestion, pattern: text };
+  }
   return suggestion.description == null
     ? { kind: "literal", text }
     : { kind: "literal", text, description: suggestion.description };

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -1390,45 +1390,55 @@ export function keyValue(
       ? {
         *suggest(prefix: string): Iterable<Suggestion> {
           const index = findSeparator(prefix);
-          if (index < 0) {
-            if (typeof keyParser.suggest !== "function") return;
-            const suggestions: Suggestion[] = [];
-            for (const suggestion of keyParser.suggest(prefix)) {
-              const key = suggestionTextValue(suggestion);
-              if (
-                suggestion.kind === "literal"
-                  ? !validateKeyForSuggestion(key)
-                  : !validateKeyPatternForSuggestion(key)
-              ) {
-                continue;
+          const suggestions: Suggestion[] = [];
+          if (index < 0 || split === "last") {
+            if (typeof keyParser.suggest === "function") {
+              for (const suggestion of keyParser.suggest(prefix)) {
+                const key = suggestionTextValue(suggestion);
+                if (
+                  suggestion.kind === "literal"
+                    ? !validateKeyForSuggestion(key)
+                    : !validateKeyPatternForSuggestion(key)
+                ) {
+                  continue;
+                }
+                suggestions.push(
+                  prefixKeyValueSuggestion(suggestion, "", separator),
+                );
               }
-              suggestions.push(
-                prefixKeyValueSuggestion(suggestion, "", separator),
-              );
             }
+          }
+          if (index < 0) {
             yield* deduplicateSuggestions(suggestions);
             return;
           }
 
-          if (typeof valueParser.suggest !== "function") return;
-          const key = prefix.slice(0, index);
-          if (!validateKeyForSuggestion(key)) return;
-          const valuePrefix = prefix.slice(index + separator.length);
-          const suggestions: Suggestion[] = [];
-          for (const suggestion of valueParser.suggest(valuePrefix)) {
-            const value = suggestionTextValue(suggestion);
-            if (!partsRoundTrip(key, value)) {
-              continue;
+          if (typeof valueParser.suggest === "function") {
+            const key = prefix.slice(0, index);
+            if (!validateKeyForSuggestion(key)) {
+              yield* deduplicateSuggestions(suggestions);
+              return;
             }
-            if (
-              suggestion.kind === "literal" &&
-              !validateParts(`${key}${separator}${value}`, key, value).success
-            ) {
-              continue;
+            const valuePrefix = prefix.slice(index + separator.length);
+            for (const suggestion of valueParser.suggest(valuePrefix)) {
+              const value = suggestionTextValue(suggestion);
+              if (!partsRoundTrip(key, value)) {
+                continue;
+              }
+              if (
+                suggestion.kind === "literal" &&
+                !validateParts(
+                  `${key}${separator}${value}`,
+                  key,
+                  value,
+                ).success
+              ) {
+                continue;
+              }
+              suggestions.push(
+                prefixKeyValueSuggestion(suggestion, `${key}${separator}`),
+              );
             }
-            suggestions.push(
-              prefixKeyValueSuggestion(suggestion, `${key}${separator}`),
-            );
           }
           yield* deduplicateSuggestions(suggestions);
         },

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -987,6 +987,20 @@ export interface KeyValueOptions<K = string, V = string> {
   };
 }
 
+type KeyValueKeyType<Options> = Options extends {
+  readonly key: ValueParser<"sync", infer K>;
+} ? K
+  : string;
+
+type KeyValueValueType<Options> = Options extends {
+  readonly value: ValueParser<"sync", infer V>;
+} ? V
+  : string;
+
+type KeyValueResultType<
+  Options extends KeyValueOptions<unknown, unknown>,
+> = readonly [KeyValueKeyType<Options>, KeyValueValueType<Options>];
+
 /**
  * Creates a value parser for strings shaped like `KEY=VALUE`.
  *
@@ -995,8 +1009,7 @@ export interface KeyValueOptions<K = string, V = string> {
  * value parsers can narrow or transform either side while preserving the
  * inferred tuple type.
  *
- * @template K The parsed key type.
- * @template V The parsed value type.
+ * @template Options The option object type used to infer child parser results.
  * @param options Configuration options for the key-value parser.
  * @returns A sync value parser producing readonly key-value tuples.
  * @throws {TypeError} If `separator` or `metavar` is empty, if
@@ -1004,9 +1017,15 @@ export interface KeyValueOptions<K = string, V = string> {
  *   `"first"` or `"last"`, or if `key` or `value` is not a sync value parser.
  * @since 1.1.0
  */
-export function keyValue<K = string, V = string>(
-  options: KeyValueOptions<K, V> = {},
-): ValueParser<"sync", readonly [K, V]> {
+export function keyValue(): ValueParser<"sync", readonly [string, string]>;
+export function keyValue<
+  const Options extends KeyValueOptions<unknown, unknown>,
+>(
+  options: Options,
+): ValueParser<"sync", KeyValueResultType<Options>>;
+export function keyValue(
+  options: KeyValueOptions<unknown, unknown> = {},
+): ValueParser<"sync", readonly [unknown, unknown]> {
   const separator = options.separator ?? "=";
   if (typeof separator !== "string") {
     throw new TypeError(
@@ -1032,8 +1051,8 @@ export function keyValue<K = string, V = string>(
     string({ placeholder: allowEmptyValue ? "" : "VALUE" });
   checkKeyValueChildParser("key", rawKeyParser);
   checkKeyValueChildParser("value", rawValueParser);
-  const keyParser = rawKeyParser as ValueParser<"sync", K>;
-  const valueParser = rawValueParser as ValueParser<"sync", V>;
+  const keyParser = rawKeyParser as ValueParser<"sync", unknown>;
+  const valueParser = rawValueParser as ValueParser<"sync", unknown>;
   const hasNormalize = typeof keyParser.normalize === "function" ||
     typeof valueParser.normalize === "function";
   const hasSuggest = typeof keyParser.suggest === "function" ||
@@ -1089,7 +1108,7 @@ export function keyValue<K = string, V = string>(
     input: string,
     key: string,
     value: string,
-  ): ValueParserResult<readonly [K, V]> {
+  ): ValueParserResult<readonly [unknown, unknown]> {
     if (!allowEmptyKey && key === "") {
       return { success: false, error: emptyKeyError(input) };
     }
@@ -1115,7 +1134,7 @@ export function keyValue<K = string, V = string>(
       keyParser.placeholder,
       valueParser.placeholder,
     ] as const,
-    parse(input: string): ValueParserResult<readonly [K, V]> {
+    parse(input: string): ValueParserResult<readonly [unknown, unknown]> {
       const index = findSeparator(input);
       if (index < 0) {
         return { success: false, error: missingSeparatorError(input) };
@@ -1124,12 +1143,14 @@ export function keyValue<K = string, V = string>(
       const value = input.slice(index + separator.length);
       return validateParts(input, key, value);
     },
-    format(value: readonly [K, V]): string {
+    format(value: readonly [unknown, unknown]): string {
       return `${keyParser.format(value[0])}${separator}${
         valueParser.format(value[1])
       }`;
     },
-    validate(value: readonly [K, V]): ValueParserResult<readonly [K, V]> {
+    validate(
+      value: readonly [unknown, unknown],
+    ): ValueParserResult<readonly [unknown, unknown]> {
       if (!isKeyValueTuple(value)) {
         return {
           success: false,
@@ -1204,7 +1225,9 @@ export function keyValue<K = string, V = string>(
     },
     ...(hasNormalize
       ? {
-        normalize(value: readonly [K, V]): readonly [K, V] {
+        normalize(
+          value: readonly [unknown, unknown],
+        ): readonly [unknown, unknown] {
           return [
             keyParser.normalize?.(value[0]) ?? value[0],
             valueParser.normalize?.(value[1]) ?? value[1],

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -1021,7 +1021,7 @@ export function keyValue(): ValueParser<"sync", readonly [string, string]>;
 export function keyValue<
   const Options extends KeyValueOptions<unknown, unknown>,
 >(
-  options: Options,
+  options: Options | undefined,
 ): ValueParser<"sync", KeyValueResultType<Options>>;
 export function keyValue(
   options: KeyValueOptions<unknown, unknown> = {},

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -911,7 +911,7 @@ export function string(
 export interface KeyValueOptions<K = string, V = string> {
   /**
    * The metavariable name for this parser.  Used in help messages to
-   * indicate the expected key-value shape.
+   * indicate the expected key–value shape.
    * @default `"KEY=VALUE"` with the configured separator.
    */
   readonly metavar?: NonEmptyString;
@@ -954,7 +954,7 @@ export interface KeyValueOptions<K = string, V = string> {
   readonly split?: "first" | "last";
 
   /**
-   * Custom error messages for key-value parsing failures.
+   * Custom error messages for key–value parsing failures.
    * @since 1.1.0
    */
   readonly errors?: {
@@ -1010,8 +1010,8 @@ type KeyValueResultType<
  * inferred tuple type.
  *
  * @template Options The option object type used to infer child parser results.
- * @param options Configuration options for the key-value parser.
- * @returns A sync value parser producing readonly key-value tuples.
+ * @param options Configuration options for the key–value parser.
+ * @returns A sync value parser producing readonly key–value tuples.
  * @throws {TypeError} If `separator` or `metavar` is empty, if
  *   `allowEmptyKey` or `allowEmptyValue` is not a boolean, if `split` is not
  *   `"first"` or `"last"`, or if `key` or `value` is not a sync value parser.

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -997,9 +997,10 @@ type KeyValueValueType<Options> = Options extends {
 } ? V
   : string;
 
-type KeyValueResultType<
-  Options extends KeyValueOptions<unknown, unknown>,
-> = readonly [KeyValueKeyType<Options>, KeyValueValueType<Options>];
+type KeyValueResultType<Options> = Options extends
+  KeyValueOptions<unknown, unknown>
+  ? readonly [KeyValueKeyType<Options>, KeyValueValueType<Options>]
+  : readonly [string, string];
 
 /**
  * Creates a value parser for strings shaped like `KEY=VALUE`.
@@ -1019,9 +1020,9 @@ type KeyValueResultType<
  */
 export function keyValue(): ValueParser<"sync", readonly [string, string]>;
 export function keyValue<
-  const Options extends KeyValueOptions<unknown, unknown>,
+  const Options extends KeyValueOptions<unknown, unknown> | undefined,
 >(
-  options: Options | undefined,
+  options: Options,
 ): ValueParser<"sync", KeyValueResultType<Options>>;
 export function keyValue(
   options: KeyValueOptions<unknown, unknown> = {},
@@ -1131,6 +1132,9 @@ export function keyValue(
     if (!allowEmptyKey && key === "") {
       return false;
     }
+    if (!partsRoundTrip(key, "")) {
+      return false;
+    }
     const keyResult = keyParser.parse(key);
     if (!keyResult.success) {
       return false;
@@ -1146,15 +1150,23 @@ export function keyValue(
       return false;
     }
     const formattedKey = formattedKeyResult.value;
-    return split !== "first" ||
-      formattedKey == null ||
-      !formattedKey.includes(separator);
+    return formattedKey == null || partsRoundTrip(formattedKey, "");
   }
 
   function fallbackInput(key: unknown, value: unknown): string {
     return `${typeof key === "string" ? key : ""}${separator}${
       typeof value === "string" ? value : ""
     }`;
+  }
+
+  function partsRoundTrip(key: string, value: string): boolean {
+    const input = `${key}${separator}${value}`;
+    const index = findSeparator(input);
+    if (index < 0) {
+      return false;
+    }
+    return input.slice(0, index) === key &&
+      input.slice(index + separator.length) === value;
   }
 
   function validateResultParts(
@@ -1197,9 +1209,6 @@ export function keyValue(
     }
     const formattedKey = formattedKeyResult.value;
     const formattedValue = formattedValueResult.value;
-    const formattedInput = `${formattedKey ?? ""}${separator}${
-      formattedValue ?? ""
-    }`;
     if (!allowEmptyKey && formattedKey === "") {
       return { success: false, error: emptyKeyError(input) };
     }
@@ -1231,13 +1240,7 @@ export function keyValue(
       };
     }
     if (formattedKey != null && formattedValue != null) {
-      const index = findSeparator(formattedInput);
-      const roundTripKey = formattedInput.slice(0, index);
-      const roundTripValue = formattedInput.slice(index + separator.length);
-      if (
-        roundTripKey !== formattedKey ||
-        roundTripValue !== formattedValue
-      ) {
+      if (!partsRoundTrip(formattedKey, formattedValue)) {
         return split === "first"
           ? {
             success: false,
@@ -1340,6 +1343,8 @@ export function keyValue(
             if (typeof keyParser.suggest !== "function") return;
             const suggestions: Suggestion[] = [];
             for (const suggestion of keyParser.suggest(prefix)) {
+              const key = suggestionTextValue(suggestion);
+              if (!validateKeyForSuggestion(key)) continue;
               suggestions.push(
                 prefixKeyValueSuggestion(suggestion, "", separator),
               );
@@ -1354,6 +1359,15 @@ export function keyValue(
           const valuePrefix = prefix.slice(index + separator.length);
           const suggestions: Suggestion[] = [];
           for (const suggestion of valueParser.suggest(valuePrefix)) {
+            const value = suggestionTextValue(suggestion);
+            if (!partsRoundTrip(key, value)) {
+              continue;
+            }
+            if (
+              !validateParts(`${key}${separator}${value}`, key, value).success
+            ) {
+              continue;
+            }
             suggestions.push(
               prefixKeyValueSuggestion(suggestion, `${key}${separator}`),
             );
@@ -1434,14 +1448,18 @@ function stringFormatError(): Message {
   return message`Expected a value formatted as a string.`;
 }
 
+function suggestionTextValue(suggestion: Suggestion): string {
+  return suggestion.kind === "literal"
+    ? suggestion.text
+    : suggestion.pattern ?? "";
+}
+
 function prefixKeyValueSuggestion(
   suggestion: Suggestion,
   prefix: string,
   suffix = "",
 ): Suggestion {
-  const textValue = suggestion.kind === "literal"
-    ? suggestion.text
-    : suggestion.pattern ?? "";
+  const textValue = suggestionTextValue(suggestion);
   const text = `${prefix}${textValue}${suffix}`;
   return suggestion.description == null
     ? { kind: "literal", text }

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -1130,6 +1130,12 @@ export function keyValue<K = string, V = string>(
       }`;
     },
     validate(value: readonly [K, V]): ValueParserResult<readonly [K, V]> {
+      if (!isKeyValueTuple(value)) {
+        return {
+          success: false,
+          error: message`Expected a key-value tuple.`,
+        };
+      }
       const keyResult = validateValueParserValue(keyParser, value[0]);
       if (!keyResult.success) {
         return { success: false, error: invalidKeyError(keyResult.error) };
@@ -1175,6 +1181,24 @@ export function keyValue<K = string, V = string>(
             message`Expected a value without ${separator}, but got ${formattedValue}.`,
           ),
         };
+      }
+      const index = findSeparator(input);
+      const roundTripKey = input.slice(0, index);
+      const roundTripValue = input.slice(index + separator.length);
+      if (roundTripKey !== formattedKey || roundTripValue !== formattedValue) {
+        return split === "first"
+          ? {
+            success: false,
+            error: invalidKeyError(
+              message`Expected a key that round-trips with ${separator}, but got ${formattedKey}.`,
+            ),
+          }
+          : {
+            success: false,
+            error: invalidValueError(
+              message`Expected a value that round-trips with ${separator}, but got ${formattedValue}.`,
+            ),
+          };
       }
       return makeKeyValueSuccess(keyResult, valueResult);
     },
@@ -1267,6 +1291,13 @@ function validateValueParserValue<T>(
     return { success: true, value };
   }
   return parser.parse(formatted);
+}
+
+function isKeyValueTuple(value: unknown): value is readonly [unknown, unknown] {
+  return Array.isArray(value) &&
+    value.length === 2 &&
+    0 in value &&
+    1 in value;
 }
 
 function makeKeyValueSuccess<K, V>(

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -1127,6 +1127,13 @@ export function keyValue(
     return makeKeyValueSuccess(keyResult, valueResult);
   }
 
+  function validateKeyForSuggestion(key: string): boolean {
+    if (!allowEmptyKey && key === "") {
+      return false;
+    }
+    return keyParser.parse(key).success;
+  }
+
   function fallbackInput(key: unknown, value: unknown): string {
     return `${typeof key === "string" ? key : ""}${separator}${
       typeof value === "string" ? value : ""
@@ -1299,6 +1306,7 @@ export function keyValue(
 
           if (typeof valueParser.suggest !== "function") return;
           const key = prefix.slice(0, index);
+          if (!validateKeyForSuggestion(key)) return;
           const valuePrefix = prefix.slice(index + separator.length);
           const suggestions: Suggestion[] = [];
           for (const suggestion of valueParser.suggest(valuePrefix)) {

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -903,6 +903,415 @@ export function string(
 }
 
 /**
+ * Options for creating a {@link keyValue} parser.
+ * @template K The parsed key type.
+ * @template V The parsed value type.
+ * @since 1.1.0
+ */
+export interface KeyValueOptions<K = string, V = string> {
+  /**
+   * The metavariable name for this parser.  Used in help messages to
+   * indicate the expected key-value shape.
+   * @default `"KEY=VALUE"` with the configured separator.
+   */
+  readonly metavar?: NonEmptyString;
+
+  /**
+   * The separator between key and value.
+   * @default `"="`
+   */
+  readonly separator?: string;
+
+  /**
+   * Parser used to validate and transform the key side.
+   * @default `string({ placeholder: "KEY" })`
+   */
+  readonly key?: ValueParser<"sync", K>;
+
+  /**
+   * Parser used to validate and transform the value side.
+   * @default `string()`
+   */
+  readonly value?: ValueParser<"sync", V>;
+
+  /**
+   * If `true`, accepts an empty key before the separator.
+   * @default `false`
+   */
+  readonly allowEmptyKey?: boolean;
+
+  /**
+   * If `true`, accepts an empty value after the separator.
+   * @default `true`
+   */
+  readonly allowEmptyValue?: boolean;
+
+  /**
+   * Chooses which separator occurrence is used when input contains the
+   * separator more than once.
+   * @default `"first"`
+   */
+  readonly split?: "first" | "last";
+
+  /**
+   * Custom error messages for key-value parsing failures.
+   * @since 1.1.0
+   */
+  readonly errors?: {
+    /**
+     * Custom error when the input does not contain the separator.
+     */
+    readonly missingSeparator?:
+      | Message
+      | ((input: string, separator: string) => Message);
+
+    /**
+     * Custom error when the key side is empty and empty keys are disabled.
+     */
+    readonly emptyKey?: Message | ((input: string) => Message);
+
+    /**
+     * Custom error when the value side is empty and empty values are disabled.
+     */
+    readonly emptyValue?: Message | ((input: string) => Message);
+
+    /**
+     * Custom error wrapper for key parser failures.
+     */
+    readonly invalidKey?: Message | ((error: Message) => Message);
+
+    /**
+     * Custom error wrapper for value parser failures.
+     */
+    readonly invalidValue?: Message | ((error: Message) => Message);
+  };
+}
+
+/**
+ * Creates a value parser for strings shaped like `KEY=VALUE`.
+ *
+ * The default parser splits on the first `=`, rejects empty keys, allows
+ * empty values, and returns a readonly `[key, value]` tuple.  Custom key and
+ * value parsers can narrow or transform either side while preserving the
+ * inferred tuple type.
+ *
+ * @template K The parsed key type.
+ * @template V The parsed value type.
+ * @param options Configuration options for the key-value parser.
+ * @returns A sync value parser producing readonly key-value tuples.
+ * @throws {TypeError} If `separator` or `metavar` is empty, if
+ *   `allowEmptyKey` or `allowEmptyValue` is not a boolean, if `split` is not
+ *   `"first"` or `"last"`, or if `key` or `value` is not a sync value parser.
+ * @since 1.1.0
+ */
+export function keyValue<K = string, V = string>(
+  options: KeyValueOptions<K, V> = {},
+): ValueParser<"sync", readonly [K, V]> {
+  const separator = options.separator ?? "=";
+  if (typeof separator !== "string") {
+    throw new TypeError(
+      `Expected separator to be a string, but got ${typeof separator}: ${
+        String(separator)
+      }.`,
+    );
+  }
+  ensureNonEmptyString(separator);
+
+  checkBooleanOption(options, "allowEmptyKey");
+  checkBooleanOption(options, "allowEmptyValue");
+  checkEnumOption(options, "split", ["first", "last"]);
+
+  const split = options.split ?? "first";
+  const allowEmptyKey = options.allowEmptyKey ?? false;
+  const allowEmptyValue = options.allowEmptyValue ?? true;
+  const metavar = options.metavar ?? `KEY${separator}VALUE`;
+  ensureNonEmptyString(metavar);
+
+  const rawKeyParser = options.key ?? string({ placeholder: "KEY" });
+  const rawValueParser = options.value ??
+    string({ placeholder: allowEmptyValue ? "" : "VALUE" });
+  checkKeyValueChildParser("key", rawKeyParser);
+  checkKeyValueChildParser("value", rawValueParser);
+  const keyParser = rawKeyParser as ValueParser<"sync", K>;
+  const valueParser = rawValueParser as ValueParser<"sync", V>;
+  const hasNormalize = typeof keyParser.normalize === "function" ||
+    typeof valueParser.normalize === "function";
+  const hasSuggest = typeof keyParser.suggest === "function" ||
+    typeof valueParser.suggest === "function";
+
+  function findSeparator(input: string): number {
+    return split === "last"
+      ? input.lastIndexOf(separator)
+      : input.indexOf(separator);
+  }
+
+  function emptyKeyError(input: string): Message {
+    const custom = options.errors?.emptyKey;
+    if (custom != null) {
+      return typeof custom === "function" ? custom(input) : custom;
+    }
+    return message`Expected a non-empty key in ${input}.`;
+  }
+
+  function emptyValueError(input: string): Message {
+    const custom = options.errors?.emptyValue;
+    if (custom != null) {
+      return typeof custom === "function" ? custom(input) : custom;
+    }
+    return message`Expected a non-empty value in ${input}.`;
+  }
+
+  function missingSeparatorError(input: string): Message {
+    const custom = options.errors?.missingSeparator;
+    if (custom != null) {
+      return typeof custom === "function" ? custom(input, separator) : custom;
+    }
+    return message`Expected ${separator} in ${input}.`;
+  }
+
+  function invalidKeyError(error: Message): Message {
+    const custom = options.errors?.invalidKey;
+    if (custom != null) {
+      return typeof custom === "function" ? custom(error) : custom;
+    }
+    return [text("Invalid key: "), ...cloneMessage(error)];
+  }
+
+  function invalidValueError(error: Message): Message {
+    const custom = options.errors?.invalidValue;
+    if (custom != null) {
+      return typeof custom === "function" ? custom(error) : custom;
+    }
+    return [text("Invalid value: "), ...cloneMessage(error)];
+  }
+
+  function validateParts(
+    input: string,
+    key: string,
+    value: string,
+  ): ValueParserResult<readonly [K, V]> {
+    if (!allowEmptyKey && key === "") {
+      return { success: false, error: emptyKeyError(input) };
+    }
+    if (!allowEmptyValue && value === "") {
+      return { success: false, error: emptyValueError(input) };
+    }
+
+    const keyResult = keyParser.parse(key);
+    if (!keyResult.success) {
+      return { success: false, error: invalidKeyError(keyResult.error) };
+    }
+    const valueResult = valueParser.parse(value);
+    if (!valueResult.success) {
+      return { success: false, error: invalidValueError(valueResult.error) };
+    }
+    return makeKeyValueSuccess(keyResult, valueResult);
+  }
+
+  return {
+    mode: "sync",
+    metavar,
+    placeholder: [
+      keyParser.placeholder,
+      valueParser.placeholder,
+    ] as const,
+    parse(input: string): ValueParserResult<readonly [K, V]> {
+      const index = findSeparator(input);
+      if (index < 0) {
+        return { success: false, error: missingSeparatorError(input) };
+      }
+      const key = input.slice(0, index);
+      const value = input.slice(index + separator.length);
+      return validateParts(input, key, value);
+    },
+    format(value: readonly [K, V]): string {
+      return `${keyParser.format(value[0])}${separator}${
+        valueParser.format(value[1])
+      }`;
+    },
+    validate(value: readonly [K, V]): ValueParserResult<readonly [K, V]> {
+      const keyResult = validateValueParserValue(keyParser, value[0]);
+      if (!keyResult.success) {
+        return { success: false, error: invalidKeyError(keyResult.error) };
+      }
+      const valueResult = validateValueParserValue(valueParser, value[1]);
+      if (!valueResult.success) {
+        return { success: false, error: invalidValueError(valueResult.error) };
+      }
+
+      let formattedKey: string;
+      let formattedValue: string;
+      try {
+        formattedKey = keyParser.format(keyResult.value);
+        formattedValue = valueParser.format(valueResult.value);
+      } catch {
+        return makeKeyValueSuccess(keyResult, valueResult);
+      }
+      if (
+        typeof formattedKey !== "string" ||
+        typeof formattedValue !== "string"
+      ) {
+        return makeKeyValueSuccess(keyResult, valueResult);
+      }
+      const input = `${formattedKey}${separator}${formattedValue}`;
+      if (!allowEmptyKey && formattedKey === "") {
+        return { success: false, error: emptyKeyError(input) };
+      }
+      if (!allowEmptyValue && formattedValue === "") {
+        return { success: false, error: emptyValueError(input) };
+      }
+      if (split === "first" && formattedKey.includes(separator)) {
+        return {
+          success: false,
+          error: invalidKeyError(
+            message`Expected a key without ${separator}, but got ${formattedKey}.`,
+          ),
+        };
+      }
+      if (split === "last" && formattedValue.includes(separator)) {
+        return {
+          success: false,
+          error: invalidValueError(
+            message`Expected a value without ${separator}, but got ${formattedValue}.`,
+          ),
+        };
+      }
+      return makeKeyValueSuccess(keyResult, valueResult);
+    },
+    ...(hasNormalize
+      ? {
+        normalize(value: readonly [K, V]): readonly [K, V] {
+          return [
+            keyParser.normalize?.(value[0]) ?? value[0],
+            valueParser.normalize?.(value[1]) ?? value[1],
+          ] as const;
+        },
+      }
+      : {}),
+    ...(hasSuggest
+      ? {
+        *suggest(prefix: string): Iterable<Suggestion> {
+          const index = findSeparator(prefix);
+          if (index < 0) {
+            if (typeof keyParser.suggest !== "function") return;
+            const suggestions: Suggestion[] = [];
+            for (const suggestion of keyParser.suggest(prefix)) {
+              if (suggestion.kind === "literal") {
+                suggestions.push({
+                  ...suggestion,
+                  text: `${suggestion.text}${separator}`,
+                });
+              }
+            }
+            yield* deduplicateSuggestions(suggestions);
+            return;
+          }
+
+          if (typeof valueParser.suggest !== "function") return;
+          const key = prefix.slice(0, index);
+          const valuePrefix = prefix.slice(index + separator.length);
+          const suggestions: Suggestion[] = [];
+          for (const suggestion of valueParser.suggest(valuePrefix)) {
+            if (suggestion.kind === "literal") {
+              suggestions.push({
+                ...suggestion,
+                text: `${key}${separator}${suggestion.text}`,
+              });
+            }
+          }
+          yield* deduplicateSuggestions(suggestions);
+        },
+      }
+      : {}),
+  };
+}
+
+function checkKeyValueChildParser(
+  role: "key" | "value",
+  parser: unknown,
+): asserts parser is ValueParser<"sync", unknown> {
+  if (!isValueParser(parser)) {
+    throw new TypeError(
+      `The ${role} option for keyValue() must be a value parser.`,
+    );
+  }
+  if (parser.mode !== "sync") {
+    throw new TypeError(
+      `keyValue() only supports sync ${role} parsers, ` +
+        "but an async one was given.",
+    );
+  }
+  if (isDerivedValueParser(parser)) {
+    throw new TypeError(
+      `keyValue() does not support dependency-derived ${role} parsers ` +
+        "(created via deriveFrom() or dependency().derive()); pass the " +
+        "derived parser directly to option() or argument() instead.",
+    );
+  }
+}
+
+function validateValueParserValue<T>(
+  parser: ValueParser<"sync", T>,
+  value: T,
+): ValueParserResult<T> {
+  if (typeof parser.validate === "function") {
+    return parser.validate(value);
+  }
+  let formatted: string;
+  try {
+    formatted = parser.format(value);
+  } catch {
+    return { success: true, value };
+  }
+  if (typeof formatted !== "string") {
+    return { success: true, value };
+  }
+  return parser.parse(formatted);
+}
+
+function makeKeyValueSuccess<K, V>(
+  keyResult: Extract<ValueParserResult<K>, { readonly success: true }>,
+  valueResult: Extract<ValueParserResult<V>, { readonly success: true }>,
+): ValueParserResult<readonly [K, V]> {
+  const deferredKeys = new Map<PropertyKey, DeferredMap | null>();
+  let hasDeferred = false;
+  collectKeyValueDeferredKeys(deferredKeys, 0, keyResult, () => {
+    hasDeferred = true;
+  });
+  collectKeyValueDeferredKeys(deferredKeys, 1, valueResult, () => {
+    hasDeferred = true;
+  });
+  return {
+    success: true,
+    value: [keyResult.value, valueResult.value] as const,
+    ...(hasDeferred
+      ? {
+        deferred: true as const,
+        ...(deferredKeys.size > 0 ? { deferredKeys } : {}),
+      }
+      : {}),
+  };
+}
+
+function collectKeyValueDeferredKeys<T>(
+  deferredKeys: Map<PropertyKey, DeferredMap | null>,
+  index: 0 | 1,
+  result: Extract<ValueParserResult<T>, { readonly success: true }>,
+  markDeferred: () => void,
+): void {
+  if (result.deferredKeys != null) {
+    markDeferred();
+    deferredKeys.set(index, result.deferredKeys);
+    return;
+  }
+  if (result.deferred !== true) return;
+  markDeferred();
+  if (result.value == null || typeof result.value !== "object") {
+    deferredKeys.set(index, null);
+  }
+}
+
+/**
  * Options for creating an integer parser that returns a JavaScript `number`.
  *
  * This interface is used when you want to parse integers as regular JavaScript

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -1166,19 +1166,25 @@ export function keyValue(
         return { success: false, error: invalidValueError(valueResult.error) };
       }
 
-      let formattedKey: string;
-      let formattedValue: string;
+      let formattedKey: unknown;
+      let formattedValue: unknown;
       try {
         formattedKey = keyParser.format(keyResult.value);
         formattedValue = valueParser.format(valueResult.value);
       } catch {
         return makeKeyValueSuccess(keyResult, valueResult);
       }
-      if (
-        typeof formattedKey !== "string" ||
-        typeof formattedValue !== "string"
-      ) {
-        return makeKeyValueSuccess(keyResult, valueResult);
+      if (typeof formattedKey !== "string") {
+        return {
+          success: false,
+          error: invalidKeyError(stringFormatError()),
+        };
+      }
+      if (typeof formattedValue !== "string") {
+        return {
+          success: false,
+          error: invalidValueError(stringFormatError()),
+        };
       }
       const input = `${formattedKey}${separator}${formattedValue}`;
       if (!allowEmptyKey && formattedKey === "") {
@@ -1304,16 +1310,23 @@ function validateValueParserValue<T>(
   if (typeof parser.validate === "function") {
     return parser.validate(value);
   }
-  let formatted: string;
+  let formatted: unknown;
   try {
     formatted = parser.format(value);
   } catch {
     return { success: true, value };
   }
   if (typeof formatted !== "string") {
-    return { success: true, value };
+    return {
+      success: false,
+      error: stringFormatError(),
+    };
   }
   return parser.parse(formatted);
+}
+
+function stringFormatError(): Message {
+  return message`Expected a value formatted as a string.`;
 }
 
 function isKeyValueTuple(value: unknown): value is readonly [unknown, unknown] {

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -1166,34 +1166,40 @@ export function keyValue(
         return { success: false, error: invalidValueError(valueResult.error) };
       }
 
-      let formattedKey: unknown;
-      let formattedValue: unknown;
-      try {
-        formattedKey = keyParser.format(keyResult.value);
-        formattedValue = valueParser.format(valueResult.value);
-      } catch {
-        return makeKeyValueSuccess(keyResult, valueResult);
-      }
-      if (typeof formattedKey !== "string") {
+      const formattedKeyResult = formatValueParserValue(
+        keyParser,
+        keyResult.value,
+      );
+      if (!formattedKeyResult.success) {
         return {
           success: false,
-          error: invalidKeyError(stringFormatError()),
+          error: invalidKeyError(formattedKeyResult.error),
         };
       }
-      if (typeof formattedValue !== "string") {
+      const formattedValueResult = formatValueParserValue(
+        valueParser,
+        valueResult.value,
+      );
+      if (!formattedValueResult.success) {
         return {
           success: false,
-          error: invalidValueError(stringFormatError()),
+          error: invalidValueError(formattedValueResult.error),
         };
       }
-      const input = `${formattedKey}${separator}${formattedValue}`;
+      const formattedKey = formattedKeyResult.value;
+      const formattedValue = formattedValueResult.value;
+      const input = `${formattedKey ?? ""}${separator}${formattedValue ?? ""}`;
       if (!allowEmptyKey && formattedKey === "") {
         return { success: false, error: emptyKeyError(input) };
       }
       if (!allowEmptyValue && formattedValue === "") {
         return { success: false, error: emptyValueError(input) };
       }
-      if (split === "first" && formattedKey.includes(separator)) {
+      if (
+        split === "first" &&
+        formattedKey != null &&
+        formattedKey.includes(separator)
+      ) {
         return {
           success: false,
           error: invalidKeyError(
@@ -1201,7 +1207,11 @@ export function keyValue(
           ),
         };
       }
-      if (split === "last" && formattedValue.includes(separator)) {
+      if (
+        split === "last" &&
+        formattedValue != null &&
+        formattedValue.includes(separator)
+      ) {
         return {
           success: false,
           error: invalidValueError(
@@ -1209,23 +1219,28 @@ export function keyValue(
           ),
         };
       }
-      const index = findSeparator(input);
-      const roundTripKey = input.slice(0, index);
-      const roundTripValue = input.slice(index + separator.length);
-      if (roundTripKey !== formattedKey || roundTripValue !== formattedValue) {
-        return split === "first"
-          ? {
-            success: false,
-            error: invalidKeyError(
-              message`Expected a key that round-trips with ${separator}, but got ${formattedKey}.`,
-            ),
-          }
-          : {
-            success: false,
-            error: invalidValueError(
-              message`Expected a value that round-trips with ${separator}, but got ${formattedValue}.`,
-            ),
-          };
+      if (formattedKey != null && formattedValue != null) {
+        const index = findSeparator(input);
+        const roundTripKey = input.slice(0, index);
+        const roundTripValue = input.slice(index + separator.length);
+        if (
+          roundTripKey !== formattedKey ||
+          roundTripValue !== formattedValue
+        ) {
+          return split === "first"
+            ? {
+              success: false,
+              error: invalidKeyError(
+                message`Expected a key that round-trips with ${separator}, but got ${formattedKey}.`,
+              ),
+            }
+            : {
+              success: false,
+              error: invalidValueError(
+                message`Expected a value that round-trips with ${separator}, but got ${formattedValue}.`,
+              ),
+            };
+        }
       }
       return makeKeyValueSuccess(keyResult, valueResult);
     },
@@ -1249,12 +1264,9 @@ export function keyValue(
             if (typeof keyParser.suggest !== "function") return;
             const suggestions: Suggestion[] = [];
             for (const suggestion of keyParser.suggest(prefix)) {
-              if (suggestion.kind === "literal") {
-                suggestions.push({
-                  ...suggestion,
-                  text: `${suggestion.text}${separator}`,
-                });
-              }
+              suggestions.push(
+                prefixKeyValueSuggestion(suggestion, "", separator),
+              );
             }
             yield* deduplicateSuggestions(suggestions);
             return;
@@ -1265,12 +1277,9 @@ export function keyValue(
           const valuePrefix = prefix.slice(index + separator.length);
           const suggestions: Suggestion[] = [];
           for (const suggestion of valueParser.suggest(valuePrefix)) {
-            if (suggestion.kind === "literal") {
-              suggestions.push({
-                ...suggestion,
-                text: `${key}${separator}${suggestion.text}`,
-              });
-            }
+            suggestions.push(
+              prefixKeyValueSuggestion(suggestion, `${key}${separator}`),
+            );
           }
           yield* deduplicateSuggestions(suggestions);
         },
@@ -1325,8 +1334,41 @@ function validateValueParserValue<T>(
   return parser.parse(formatted);
 }
 
+function formatValueParserValue<T>(
+  parser: ValueParser<"sync", T>,
+  value: T,
+): ValueParserResult<string | undefined> {
+  let formatted: unknown;
+  try {
+    formatted = parser.format(value);
+  } catch {
+    return { success: true, value: undefined };
+  }
+  if (typeof formatted !== "string") {
+    return {
+      success: false,
+      error: stringFormatError(),
+    };
+  }
+  return { success: true, value: formatted };
+}
+
 function stringFormatError(): Message {
   return message`Expected a value formatted as a string.`;
+}
+
+function prefixKeyValueSuggestion(
+  suggestion: Suggestion,
+  prefix: string,
+  suffix = "",
+): Suggestion {
+  const textValue = suggestion.kind === "literal"
+    ? suggestion.text
+    : suggestion.pattern ?? "";
+  const text = `${prefix}${textValue}${suffix}`;
+  return suggestion.description == null
+    ? { kind: "literal", text }
+    : { kind: "literal", text, description: suggestion.description };
 }
 
 function isKeyValueTuple(value: unknown): value is readonly [unknown, unknown] {

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -1267,9 +1267,16 @@ export function keyValue(
         normalize(
           value: readonly [unknown, unknown],
         ): readonly [unknown, unknown] {
+          if (!isKeyValueTuple(value)) {
+            return value;
+          }
           return [
-            keyParser.normalize?.(value[0]) ?? value[0],
-            valueParser.normalize?.(value[1]) ?? value[1],
+            typeof keyParser.normalize === "function"
+              ? keyParser.normalize(value[0])
+              : value[0],
+            typeof valueParser.normalize === "function"
+              ? valueParser.normalize(value[1])
+              : value[1],
           ] as const;
         },
       }


### PR DESCRIPTION
This adds `keyValue()` to *@optique/core* for option values shaped like `KEY=VALUE`.  It returns a readonly key–value tuple, uses `=` by default, rejects missing separators and empty keys, and allows empty values for cases such as environment variables and build defines.

The parser supports custom separators, first-or-last splitting, custom empty field policy, child key/value parsers, custom errors, `format()`, fallback `validate()`, `normalize()`, and composed completion suggestions. Child parser result types are preserved in the returned tuple, while omitted children still default to `string`.

The implementation lives in *packages/core/src/valueparser.ts*, with regression coverage in *packages/core/src/valueparser.test.ts*.  The docs in *docs/concepts/valueparsers.md* now cover the parser directly, and the cookbook plus *examples/patterns/key-value-options.ts* use the built-in parser instead of a local custom parser.  *CHANGES.md* records the change for PR #833.

Fixes #828.