### PR TITLE
Add executable parent commands to discover

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,12 +11,13 @@ To be released.
 ### @optique/discover
 
  -  Added executable parent commands to file-system discovery.  Entry files
-    such as `stash/index.ts` now map to the containing command path (`stash`),
-    root `index.ts` defines the root command, and parent commands can coexist
+    such as *stash/index.ts* now map to the containing command path (`stash`),
+    root *index.ts* defines the root command, and parent commands can coexist
     with nested commands such as `stash list`.  The `entryFileName` option
-    customizes or disables the entry-file rule.  [[#838]]
+    customizes or disables the entry-file rule.  [[#838], [#839]]
 
 [#838]: https://github.com/dahlia/optique/issues/838
+[#839]: https://github.com/dahlia/optique/pull/839
 
 
 Version 1.1.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,16 @@ Version 1.2.0
 
 To be released.
 
+### @optique/discover
+
+ -  Added executable parent commands to file-system discovery.  Entry files
+    such as `stash/index.ts` now map to the containing command path (`stash`),
+    root `index.ts` defines the root command, and parent commands can coexist
+    with nested commands such as `stash list`.  The `entryFileName` option
+    customizes or disables the entry-file rule.  [[#838]]
+
+[#838]: https://github.com/dahlia/optique/issues/838
+
 
 Version 1.1.0
 -------------

--- a/docs/concepts/discover.md
+++ b/docs/concepts/discover.md
@@ -181,10 +181,10 @@ File names and extensions
 -------------------------
 
 The relative file path becomes the command path after removing the configured
-suffix.  Compound suffixes are supported, so `user/add.cmd.ts` can become
-`user add` when `.cmd.ts` is listed before `.ts`.
+suffix.  Compound suffixes are supported, so *user/add.cmd.ts* can become
+`user add` when *.cmd.ts* is listed before *.ts*.
 
-By default, an entry file named `index` maps to its containing command path:
+By default, an entry file named *index* maps to its containing command path:
 
 ~~~~ text
 commands/
@@ -203,15 +203,15 @@ By default, *@optique/discover* chooses extensions for the current runtime:
 
 | Runtime | Default extensions                                  |
 | ------- | --------------------------------------------------- |
-| Deno    | `.ts`, `.mts`, `.js`, `.mjs`                        |
-| Bun     | `.ts`, `.mts`, `.js`, `.mjs`                        |
-| Node.js | `.js`, `.mjs`, `.cjs`, and sometimes TypeScript too |
+| Deno    | *.ts*, *.mts*, *.js*, *.mjs*                        |
+| Bun     | *.ts*, *.mts*, *.js*, *.mjs*                        |
+| Node.js | *.js*, *.mjs*, *.cjs*, and sometimes TypeScript too |
 
-Node.js also includes `.ts`, `.mts`, and `.cts` when it appears to be running
+Node.js also includes *.ts*, *.mts*, and *.cts* when it appears to be running
 with native TypeScript support, a TypeScript loader such as `tsx`, `ts-node`,
 `tsimp`, or `jiti`, or Node's built-in type-stripping flags.
 
-TypeScript declaration files (`.d.ts`, `.d.mts`, and `.d.cts`) are ignored even
+TypeScript declaration files (*.d.ts*, *.d.mts*, and *.d.cts*) are ignored even
 when their suffix matches the configured extension list.
 
 Pass `extensions` when you want an explicit policy:
@@ -226,7 +226,7 @@ await runProgram({
 });
 ~~~~
 
-Pass `entryFileName` to use a different entry filename, such as `mod` for a
+Pass `entryFileName` to use a different entry filename, such as *mod* for a
 Deno-style layout:
 
 ~~~~ typescript twoslash
@@ -240,7 +240,7 @@ await runProgram({
 ~~~~
 
 Pass `entryFileName: false` to disable entry-file handling and treat
-`index.ts` as an ordinary `index` command.
+*index.ts* as an ordinary `index` command.
 
 > [!NOTE]
 > Command modules are imported eagerly during startup.  This keeps discovery
@@ -252,9 +252,9 @@ Duplicate paths
 ---------------
 
 Each discovered file must map to exactly one command path.  Discovery rejects
-duplicate paths, such as `build.ts` and `build.cmd.ts` both becoming `build`.
-It also rejects duplicates introduced by entry files, such as `user.ts` and
-`user/index.ts` both becoming `user`.
+duplicate paths, such as *build.ts* and *build.cmd.ts* both becoming `build`.
+It also rejects duplicates introduced by entry files, such as *user.ts* and
+*user/index.ts* both becoming `user`.
 
 A file and directory with the same name are allowed when they map to distinct
 command paths:
@@ -267,8 +267,8 @@ commands/
 ~~~~
 
 In that layout, `user` is an executable parent command and `user add` is a
-nested command.  You can also write the parent command as `user/index.ts`
-instead of `user.ts`, but not both at once unless you change `entryFileName`.
+nested command.  You can also write the parent command as *user/index.ts*
+instead of *user.ts*, but not both at once unless you change `entryFileName`.
 
 
 When to use command discovery

--- a/docs/concepts/discover.md
+++ b/docs/concepts/discover.md
@@ -58,7 +58,8 @@ export default defineCommand({
 If you change the parser, TypeScript checks the handler against the new shape.
 When commands are passed manually to `runProgram()`, add a `path` field to the
 command definition.  File-based discovery can omit `path`; if it is present,
-it must match the path derived from the file name.
+it must match the path derived from the file name.  An empty path (`[]`)
+defines the root command when commands are passed manually.
 
 
 Running a discovered program
@@ -84,8 +85,10 @@ With this file layout:
 
 ~~~~ text
 commands/
+  index.ts
   build.ts
   user/
+    index.ts
     add.ts
     remove.ts
 ~~~~
@@ -93,7 +96,9 @@ commands/
 the discovered command paths are:
 
 ~~~~ bash
+admin
 admin build
+admin user
 admin user add
 admin user remove
 ~~~~
@@ -179,6 +184,21 @@ The relative file path becomes the command path after removing the configured
 suffix.  Compound suffixes are supported, so `user/add.cmd.ts` can become
 `user add` when `.cmd.ts` is listed before `.ts`.
 
+By default, an entry file named `index` maps to its containing command path:
+
+~~~~ text
+commands/
+  index.ts         # admin
+  stash/
+    index.ts       # admin stash
+    list.ts        # admin stash list
+    pop.ts         # admin stash pop
+~~~~
+
+This is useful for executable parent commands.  In the example above,
+`admin stash` has its own parser and handler, while `admin stash list` and
+`admin stash pop` remain nested commands.
+
 By default, *@optique/discover* chooses extensions for the current runtime:
 
 | Runtime | Default extensions                                  |
@@ -206,29 +226,49 @@ await runProgram({
 });
 ~~~~
 
+Pass `entryFileName` to use a different entry filename, such as `mod` for a
+Deno-style layout:
+
+~~~~ typescript twoslash
+import { runProgram } from "@optique/discover";
+
+await runProgram({
+  dir: new URL("./commands/", import.meta.url),
+  metadata: { name: "admin" },
+  entryFileName: "mod",
+});
+~~~~
+
+Pass `entryFileName: false` to disable entry-file handling and treat
+`index.ts` as an ordinary `index` command.
+
 > [!NOTE]
 > Command modules are imported eagerly during startup.  This keeps discovery
 > simple and makes help, errors, and completion aware of the full command tree.
 > Avoid side effects at module top level other than defining the command.
 
 
-Path conflicts
---------------
+Duplicate paths
+---------------
 
 Each discovered file must map to exactly one command path.  Discovery rejects
 duplicate paths, such as `build.ts` and `build.cmd.ts` both becoming `build`.
-It also rejects file-vs-namespace conflicts such as:
+It also rejects duplicates introduced by entry files, such as `user.ts` and
+`user/index.ts` both becoming `user`.
+
+A file and directory with the same name are allowed when they map to distinct
+command paths:
 
 ~~~~ text
 commands/
-  user.ts
+  user.ts          # user
   user/
-    add.ts
+    add.ts         # user add
 ~~~~
 
-In that layout, `user` would need to be both a leaf command and a namespace for
-`user add`.  Move the shared behavior into a helper module or choose a deeper
-leaf command path instead.
+In that layout, `user` is an executable parent command and `user add` is a
+nested command.  You can also write the parent command as `user/index.ts`
+instead of `user.ts`, but not both at once unless you change `entryFileName`.
 
 
 When to use command discovery

--- a/packages/core/src/internal/parser.ts
+++ b/packages/core/src/internal/parser.ts
@@ -1974,10 +1974,122 @@ function buildDocPage(
     }
   }
   return {
-    usage,
+    usage: revealMatchedCommandUsage(
+      usage,
+      effectiveArgs,
+      commandArgIndices ?? null,
+    ),
     sections,
     ...(brief != null && { brief: cloneMessage(brief) }),
     ...(description != null && { description: cloneMessage(description) }),
     ...(footer != null && { footer: cloneMessage(footer) }),
   };
+}
+
+// Hidden commands stay out of namespace listings, but help reached through a
+// matched hidden command still needs the full command path in its usage line.
+function revealMatchedCommandUsage(
+  usage: Usage,
+  args: readonly string[],
+  matchedCommandArgIndices: ReadonlySet<number> | null,
+): Usage {
+  if (args.length < 1) return usage;
+  const [revealed] = revealMatchedCommandUsageTerms(
+    usage,
+    args,
+    matchedCommandArgIndices,
+    0,
+  );
+  return revealed;
+}
+
+function revealMatchedCommandUsageTerms(
+  usage: Usage,
+  args: readonly string[],
+  matchedCommandArgIndices: ReadonlySet<number> | null,
+  argIndex: number,
+): readonly [Usage, number] {
+  const terms: UsageTerm[] = [];
+  let nextArgIndex = argIndex;
+  for (const term of usage) {
+    const [revealed, afterTermArgIndex] = revealMatchedCommandUsageTerm(
+      term,
+      args,
+      matchedCommandArgIndices,
+      nextArgIndex,
+    );
+    terms.push(revealed);
+    nextArgIndex = afterTermArgIndex;
+  }
+  return [terms, nextArgIndex];
+}
+
+function revealMatchedCommandUsageTerm(
+  term: UsageTerm,
+  args: readonly string[],
+  matchedCommandArgIndices: ReadonlySet<number> | null,
+  argIndex: number,
+): readonly [UsageTerm, number] {
+  if (term.type === "command") {
+    const nextArgIndex = findNextMatchedCommandArgIndex(
+      args,
+      matchedCommandArgIndices,
+      argIndex,
+    );
+    if (
+      nextArgIndex < args.length &&
+      commandTermMatches(term, args[nextArgIndex])
+    ) {
+      const { hidden: _hidden, ...revealed } = term;
+      return [revealed, nextArgIndex + 1];
+    }
+    return [term, argIndex];
+  }
+  if (term.type === "sequence") {
+    const [terms, nextArgIndex] = revealMatchedCommandUsageTerms(
+      term.terms,
+      args,
+      matchedCommandArgIndices,
+      argIndex,
+    );
+    return [{ ...term, terms }, nextArgIndex];
+  }
+  if (term.type === "optional" || term.type === "multiple") {
+    const [terms, nextArgIndex] = revealMatchedCommandUsageTerms(
+      term.terms,
+      args,
+      matchedCommandArgIndices,
+      argIndex,
+    );
+    return [{ ...term, terms }, nextArgIndex];
+  }
+  if (term.type === "exclusive") {
+    return [
+      {
+        ...term,
+        terms: term.terms.map((branch) =>
+          revealMatchedCommandUsageTerms(
+            branch,
+            args,
+            matchedCommandArgIndices,
+            argIndex,
+          )[0]
+        ),
+      },
+      argIndex,
+    ];
+  }
+  return [term, argIndex];
+}
+
+function findNextMatchedCommandArgIndex(
+  args: readonly string[],
+  matchedCommandArgIndices: ReadonlySet<number> | null,
+  start: number,
+): number {
+  if (matchedCommandArgIndices == null) return start;
+  for (let index = start; index < args.length; index++) {
+    if (matchedCommandArgIndices.has(index)) return index;
+  }
+  return args.length;
 }

--- a/packages/core/src/internal/parser.ts
+++ b/packages/core/src/internal/parser.ts
@@ -2064,19 +2064,25 @@ function revealMatchedCommandUsageTerm(
     return [{ ...term, terms }, nextArgIndex];
   }
   if (term.type === "exclusive") {
+    let maxArgIndex = argIndex;
+    const terms = term.terms.map((branch) => {
+      const [revealed, nextArgIndex] = revealMatchedCommandUsageTerms(
+        branch,
+        args,
+        matchedCommandArgIndices,
+        argIndex,
+      );
+      if (nextArgIndex > maxArgIndex) {
+        maxArgIndex = nextArgIndex;
+      }
+      return revealed;
+    });
     return [
       {
         ...term,
-        terms: term.terms.map((branch) =>
-          revealMatchedCommandUsageTerms(
-            branch,
-            args,
-            matchedCommandArgIndices,
-            argIndex,
-          )[0]
-        ),
+        terms,
       },
-      argIndex,
+      maxArgIndex,
     ];
   }
   return [term, argIndex];

--- a/packages/core/src/parser.test.ts
+++ b/packages/core/src/parser.test.ts
@@ -2070,6 +2070,22 @@ describe("getDocPage", () => {
     );
   });
 
+  it("should reveal matched hidden commands after exclusive terms", () => {
+    const parser = seq(
+      or(
+        command("alpha", object({}), { hidden: true }),
+        command("beta", object({}), { hidden: true }),
+      ),
+      command("child", object({}), { hidden: true }),
+    );
+
+    const docPage = getDocPageSync(parser, ["alpha", "child"]);
+
+    assert.ok(docPage);
+    assert.ok(docPage.usage);
+    assert.equal(formatUsage("tool", docPage.usage), "tool alpha child");
+  });
+
   it("should preserve seq command docs after positional prefixes", () => {
     const parser = seq(
       optional(argument(string({ metavar: "PROFILE" }))),

--- a/packages/discover/README.md
+++ b/packages/discover/README.md
@@ -117,6 +117,10 @@ By default, Deno and Bun discover `.ts`, `.mts`, `.js`, and `.mjs` files.
 Node.js discovers `.js`, `.mjs`, and `.cjs` files, plus `.ts`, `.mts`, and
 `.cts` when it reports native TypeScript support or runs with a recognized
 TypeScript loader.  TypeScript declaration files such as `.d.ts` are ignored.
+Entry files named `index` map to their containing command path, so
+`commands/index.ts` defines the root command and `commands/user/index.ts`
+defines `user`.  Use `entryFileName` to choose another entry name or disable
+this rule.
 
 For more resources, see the [docs] and the [*examples/*](/examples/)
 directory.

--- a/packages/discover/src/command.ts
+++ b/packages/discover/src/command.ts
@@ -15,11 +15,13 @@ const commandBrand = Symbol.for("@optique/discover/command");
 export type CommandMetadata = CommandOptions;
 
 /**
- * Non-empty command path used by static command registration.
+ * Command path used by static command registration.
+ *
+ * An empty path represents the root command.
  *
  * @since 1.1.0
  */
-export type CommandPath = readonly [string, ...string[]];
+export type CommandPath = readonly string[];
 
 /**
  * Input accepted by {@link defineCommand}.
@@ -31,6 +33,7 @@ export type CommandPath = readonly [string, ...string[]];
 export interface CommandDefinition<M extends Mode, T> {
   /**
    * Command path used when commands are passed directly to `runProgram()`.
+   * Use an empty path (`[]`) to register the root command.
    *
    * File-based discovery derives the command path from the file name and uses
    * this field only to validate that the declared path matches.
@@ -176,14 +179,13 @@ export function isCommand(value: unknown): value is AnyCommand {
 function validateCommandPath(path: unknown): asserts path is CommandPath {
   if (!isCommandPath(path)) {
     throw new TypeError(
-      "Command path must be a non-empty array of non-empty strings.",
+      "Command path must be an array of non-empty strings.",
     );
   }
 }
 
 function isCommandPath(path: unknown): path is CommandPath {
   return Array.isArray(path) &&
-    path.length > 0 &&
     path.every((segment) => typeof segment === "string" && segment.length > 0);
 }
 

--- a/packages/discover/src/index.test.ts
+++ b/packages/discover/src/index.test.ts
@@ -248,6 +248,49 @@ describe("discoverCommands()", () => {
     }
   });
 
+  it("rejects malformed entry file names", async () => {
+    const dir = await makeTempDir();
+    try {
+      await assert.rejects(
+        () =>
+          discoverCommands({
+            dir,
+            entryFileName: null as never,
+          }),
+        {
+          name: "TypeError",
+          message:
+            "Command entry file name must be a non-empty file name: null",
+        },
+      );
+      await assert.rejects(
+        () =>
+          discoverCommands({
+            dir,
+            entryFileName: "",
+          }),
+        {
+          name: "TypeError",
+          message: "Command entry file name must be a non-empty file name: ",
+        },
+      );
+      await assert.rejects(
+        () =>
+          discoverCommands({
+            dir,
+            entryFileName: "mod/index",
+          }),
+        {
+          name: "TypeError",
+          message:
+            "Command entry file name must be a non-empty file name: mod/index",
+        },
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it("rejects duplicate root entry command paths", async () => {
     const dir = await makeTempDir();
     try {

--- a/packages/discover/src/index.test.ts
+++ b/packages/discover/src/index.test.ts
@@ -1,6 +1,6 @@
 import { object } from "@optique/core/constructs";
 import { formatDocPage } from "@optique/core/doc";
-import { message } from "@optique/core/message";
+import { formatMessage, message } from "@optique/core/message";
 import { withDefault } from "@optique/core/modifiers";
 import { getDocPageAsync } from "@optique/core/parser";
 import { option } from "@optique/core/primitives";
@@ -808,6 +808,86 @@ describe("createProgramParser()", () => {
     const parentText = formatDocPage("git", parentPage);
 
     assert.match(parentText, /Manage saved changes\./);
+  });
+
+  it("dispatches executable parent command aliases", async () => {
+    const calls: unknown[] = [];
+    const parser = createProgramParser([
+      {
+        path: ["stash"],
+        command: defineCommand({
+          parser: object({
+            message: withDefault(option("--message", string()), "parent"),
+          }),
+          metadata: { aliases: ["st"] },
+          handler(value) {
+            calls.push(["stash", value]);
+          },
+        }),
+      },
+      {
+        path: ["stash", "list"],
+        command: defineCommand({
+          parser: object({}),
+          handler(value) {
+            calls.push(["stash list", value]);
+          },
+        }),
+      },
+    ]);
+
+    const parentState = await parseAll(parser, ["st", "--message", "wip"]);
+    const parentResult = await parser.complete(parentState);
+    assert.ok(parentResult.success);
+    if (parentResult.success) {
+      await parentResult.value.handler(parentResult.value.value);
+    }
+
+    const childState = await parseAll(parser, ["st", "list"]);
+    const childResult = await parser.complete(childState);
+    assert.ok(childResult.success);
+    if (childResult.success) {
+      await childResult.value.handler(childResult.value.value);
+    }
+
+    assert.deepEqual(calls, [
+      ["stash", { message: "wip" }],
+      ["stash list", {}],
+    ]);
+  });
+
+  it("uses executable parent command errors for namespaces", async () => {
+    const parser = createProgramParser([
+      {
+        path: ["stash"],
+        command: defineCommand({
+          parser: object({}),
+          metadata: {
+            errors: { notMatched: message`Choose stash.` },
+          },
+          handler() {},
+        }),
+      },
+      {
+        path: ["stash", "list"],
+        command: defineCommand({
+          parser: object({}),
+          handler() {},
+        }),
+      },
+    ]);
+
+    const result = await parser.parse({
+      buffer: ["stahs"],
+      state: parser.initialState,
+      optionsTerminated: false,
+      usage: parser.usage,
+    });
+
+    assert.ok(!result.success);
+    if (!result.success) {
+      assert.equal(formatMessage(result.error), "Choose stash.");
+    }
   });
 
   it("rejects duplicate command paths", () => {

--- a/packages/discover/src/index.test.ts
+++ b/packages/discover/src/index.test.ts
@@ -1110,6 +1110,58 @@ describe("createProgramParser()", () => {
     assert.doesNotMatch(childText, /Manage remotes\./);
   });
 
+  it("wraps executable parent completion with async mode", async () => {
+    const asyncChildParser: Parser<"async", Record<string, never>, undefined> =
+      {
+        $valueType: [],
+        $stateType: [],
+        mode: "async",
+        priority: 0,
+        usage: [],
+        leadingNames: new Set(),
+        acceptingAnyToken: false,
+        initialState: undefined,
+        parse(context) {
+          return Promise.resolve({
+            success: true,
+            consumed: [],
+            next: context,
+          });
+        },
+        complete() {
+          return Promise.resolve({ success: true, value: {} });
+        },
+        async *suggest() {},
+        getDocFragments() {
+          return { fragments: [] };
+        },
+      };
+    const parser = createProgramParser([
+      {
+        path: ["stash"],
+        command: defineCommand({
+          parser: object({}),
+          handler() {},
+        }),
+      },
+      {
+        path: ["stash", "list"],
+        command: defineCommand({
+          parser: asyncChildParser,
+          handler() {},
+        }),
+      },
+    ]);
+
+    assert.equal(parser.mode, "async");
+
+    const parentState = await parseAll(parser, ["stash"]);
+    const result = parser.complete(parentState);
+
+    assert.ok(result instanceof Promise);
+    assert.ok((await result).success);
+  });
+
   it("dispatches executable parent command aliases", async () => {
     const calls: unknown[] = [];
     const parser = createProgramParser([

--- a/packages/discover/src/index.test.ts
+++ b/packages/discover/src/index.test.ts
@@ -1,17 +1,27 @@
 import { object } from "@optique/core/constructs";
 import { getAnnotations } from "@optique/core/annotations";
 import { formatDocPage } from "@optique/core/doc";
-import { defineTraits } from "@optique/core/extension";
+import {
+  defineTraits,
+  inheritAnnotations,
+  injectAnnotations,
+} from "@optique/core/extension";
 import { formatMessage, message } from "@optique/core/message";
 import { withDefault } from "@optique/core/modifiers";
 import {
   getDocPageAsync,
   type Parser,
   type ParserContext,
+  type ParserResult,
 } from "@optique/core/parser";
 import { option } from "@optique/core/primitives";
+import type { OptionName } from "@optique/core/usage";
 import type { SourceContext } from "@optique/core/context";
-import { integer, string } from "@optique/core/valueparser";
+import {
+  integer,
+  string,
+  type ValueParserResult,
+} from "@optique/core/valueparser";
 import assert from "node:assert/strict";
 import { mkdir, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -821,6 +831,137 @@ describe("createProgramParser()", () => {
     ]);
   });
 
+  it("preserves phase-two seeds for executable parent commands", async () => {
+    const sourceId = Symbol("source");
+    const phase2Values: unknown[] = [];
+    const calls: unknown[] = [];
+    const context: SourceContext = {
+      id: Symbol("test-context"),
+      phase: "two-pass",
+      getAnnotations(request) {
+        if (request?.phase !== "phase2") return {};
+        phase2Values.push(request.parsed);
+        const config = request.parsed != null &&
+            typeof request.parsed === "object"
+          ? (request.parsed as { readonly config?: unknown }).config
+          : undefined;
+        return typeof config === "string"
+          ? { [sourceId]: `loaded:${config}` }
+          : {};
+      },
+    };
+
+    await runProgram({
+      commands: [
+        defineCommand({
+          path: ["stash"],
+          parser: object({
+            config: option("--config", string()),
+            source: createSourceBackedOptionParser(sourceId, "--source"),
+          }),
+          handler(value) {
+            calls.push(["stash", value]);
+          },
+        }),
+        defineCommand({
+          path: ["stash", "list"],
+          parser: object({}),
+          handler(value) {
+            calls.push(["stash list", value]);
+          },
+        }),
+      ],
+      metadata: { name: "git" },
+      args: ["stash", "--config", "stash.json"],
+      contexts: [context],
+      stdout() {},
+      stderr() {},
+      onExit(exitCode): never {
+        throw new Error(`Unexpected exit ${exitCode}.`);
+      },
+    });
+
+    assert.deepEqual(calls, [
+      [
+        "stash",
+        { config: "stash.json", source: "loaded:stash.json" },
+      ],
+    ]);
+    assert.equal(phase2Values.length, 1);
+    assert.equal(
+      phase2Values[0] != null && typeof phase2Values[0] === "object"
+        ? (phase2Values[0] as { readonly config?: unknown }).config
+        : undefined,
+      "stash.json",
+    );
+  });
+
+  it("completes source-backed executable parents without CLI tokens", async () => {
+    const sourceId = Symbol("source");
+    const context = createStringSourceContext(sourceId, "from-source");
+    const calls: unknown[] = [];
+    const parser = createProgramParser([
+      {
+        path: [],
+        command: defineCommand({
+          parser: createSourceBackedOptionParser(sourceId, "--source"),
+          handler(value) {
+            calls.push(["root complete", value]);
+          },
+        }),
+      },
+      {
+        path: ["build"],
+        command: defineCommand({
+          parser: object({}),
+          handler(value) {
+            calls.push(["build complete", value]);
+          },
+        }),
+      },
+    ]);
+
+    const result = await parser.complete(
+      injectAnnotations(parser.initialState, { [sourceId]: "from-source" }),
+    );
+    assert.ok(result.success);
+    if (result.success) {
+      await result.value.handler(result.value.value);
+    }
+
+    await runProgram({
+      commands: [
+        defineCommand({
+          path: [],
+          parser: createSourceBackedOptionParser(sourceId, "--source"),
+          handler(value) {
+            calls.push(["root", value]);
+          },
+        }),
+        defineCommand({
+          path: ["build"],
+          parser: object({}),
+          handler(value) {
+            calls.push(["build", value]);
+          },
+        }),
+      ],
+      metadata: { name: "tool" },
+      args: [],
+      contexts: [context],
+      stdout() {},
+      stderr() {},
+      onExit(exitCode): never {
+        throw new Error(`Unexpected exit ${exitCode}.`);
+      },
+    });
+
+    assert.deepEqual(calls, [
+      ["root complete", "from-source"],
+      ["root", "from-source"],
+    ]);
+  });
+
   it("shows leaf command paths in root help", async () => {
     const parser = createProgramParser([
       {
@@ -1579,4 +1720,112 @@ function createSourceBackedParser(
     completesFromSource: true,
   });
   return parser;
+}
+
+interface SourceBackedOptionState {
+  readonly hasCliValue: boolean;
+  readonly cliState?: ValueParserResult<string> | undefined;
+}
+
+function isSourceBackedOptionState(
+  value: unknown,
+): value is SourceBackedOptionState {
+  return value != null &&
+    typeof value === "object" &&
+    typeof (value as { readonly hasCliValue?: unknown }).hasCliValue ===
+      "boolean";
+}
+
+function createSourceBackedOptionParser(
+  sourceId: symbol,
+  name: OptionName,
+): Parser<"sync", string, SourceBackedOptionState | undefined> {
+  const cliParser = option(name, string());
+  const parser: Parser<"sync", string, SourceBackedOptionState | undefined> = {
+    mode: "sync",
+    $valueType: [],
+    $stateType: [],
+    priority: cliParser.priority,
+    usage: cliParser.usage,
+    leadingNames: cliParser.leadingNames,
+    acceptingAnyToken: cliParser.acceptingAnyToken,
+    initialState: undefined,
+    parse(context) {
+      const currentState = isSourceBackedOptionState(context.state)
+        ? context.state.cliState ?? cliParser.initialState
+        : cliParser.initialState;
+      const result = cliParser.parse({ ...context, state: currentState });
+      if (result.success) {
+        return wrapSourceBackedOptionParseResult(context.state, result);
+      }
+      if (result.consumed > 0) {
+        return result;
+      }
+      return {
+        success: true,
+        next: {
+          ...context,
+          state: inheritAnnotations(context.state, { hasCliValue: false }),
+        },
+        consumed: [],
+      };
+    },
+    complete(state, exec) {
+      if (isSourceBackedOptionState(state) && state.hasCliValue) {
+        return cliParser.complete(
+          inheritAnnotations(state, state.cliState ?? cliParser.initialState),
+          exec,
+        );
+      }
+      const value = getAnnotations(state)?.[sourceId];
+      return typeof value === "string"
+        ? { success: true, value }
+        : { success: false, error: message`Missing source value.` };
+    },
+    suggest(context, prefix) {
+      return cliParser.suggest({
+        ...context,
+        state: cliParser.initialState,
+      }, prefix);
+    },
+    getDocFragments(state, defaultValue) {
+      return cliParser.getDocFragments(
+        state.kind === "available" && isSourceBackedOptionState(state.state) &&
+          state.state.hasCliValue
+          ? {
+            kind: "available",
+            state: inheritAnnotations(
+              state.state,
+              state.state.cliState ?? cliParser.initialState,
+            ),
+          }
+          : { kind: "unavailable" },
+        defaultValue,
+      );
+    },
+  };
+  defineTraits(parser, {
+    inheritsAnnotations: true,
+    completesFromSource: true,
+  });
+  return parser;
+}
+
+function wrapSourceBackedOptionParseResult(
+  sourceState: unknown,
+  result: ParserResult<ValueParserResult<string> | undefined>,
+): ParserResult<SourceBackedOptionState | undefined> {
+  if (!result.success) return result;
+  const state: SourceBackedOptionState = result.consumed.length > 0
+    ? { hasCliValue: true, cliState: result.next.state }
+    : { hasCliValue: false };
+  return {
+    success: true,
+    ...(result.provisional ? { provisional: true as const } : {}),
+    next: {
+      ...result.next,
+      state: inheritAnnotations(sourceState, state),
+    },
+    consumed: result.consumed,
+  };
 }

--- a/packages/discover/src/index.test.ts
+++ b/packages/discover/src/index.test.ts
@@ -2,7 +2,7 @@ import { object } from "@optique/core/constructs";
 import { formatDocPage } from "@optique/core/doc";
 import { formatMessage, message } from "@optique/core/message";
 import { withDefault } from "@optique/core/modifiers";
-import { getDocPageAsync } from "@optique/core/parser";
+import { getDocPageAsync, type ParserContext } from "@optique/core/parser";
 import { option } from "@optique/core/primitives";
 import type { SourceContext } from "@optique/core/context";
 import { integer, string } from "@optique/core/valueparser";
@@ -658,6 +658,51 @@ describe("createProgramParser()", () => {
     ]);
   });
 
+  it("does not switch to nested commands after parsing parent arguments", async () => {
+    const calls: unknown[] = [];
+    const parser = createProgramParser([
+      {
+        path: ["stash"],
+        command: defineCommand({
+          parser: object({
+            message: withDefault(option("--message", string()), "parent"),
+          }),
+          handler(value) {
+            calls.push(["stash", value]);
+          },
+        }),
+      },
+      {
+        path: ["stash", "list"],
+        command: defineCommand({
+          parser: object({}),
+          handler(value) {
+            calls.push(["stash list", value]);
+          },
+        }),
+      },
+    ]);
+
+    let context: ParserContext<unknown> = {
+      buffer: ["stash", "--message", "wip", "list"],
+      state: parser.initialState,
+      optionsTerminated: false,
+      usage: parser.usage,
+    };
+    let failed = false;
+    while (context.buffer.length > 0) {
+      const result = await parser.parse(context);
+      if (!result.success) {
+        failed = true;
+        break;
+      }
+      context = result.next;
+    }
+
+    assert.ok(failed);
+    assert.deepEqual(calls, []);
+  });
+
   it("dispatches root commands alongside nested commands", async () => {
     const calls: unknown[] = [];
     const parser = createProgramParser([
@@ -776,6 +821,7 @@ describe("createProgramParser()", () => {
           }),
           metadata: {
             description: message`Manage saved changes.`,
+            footer: message`Use stash list to inspect entries.`,
             hidden: "usage",
             usageLine: [{ type: "literal", value: "stash-usage" }],
           },
@@ -815,6 +861,8 @@ describe("createProgramParser()", () => {
     const usageLineText = formatDocPage("git", usageLinePage);
 
     assert.match(usageLineText, /Usage: git stash stash-usage/);
+    assert.match(usageLineText, /Manage saved changes\./);
+    assert.match(usageLineText, /Use stash list to inspect entries\./);
   });
 
   it("dispatches executable parent command aliases", async () => {

--- a/packages/discover/src/index.test.ts
+++ b/packages/discover/src/index.test.ts
@@ -766,6 +766,50 @@ describe("createProgramParser()", () => {
     assert.doesNotMatch(text, /^\s+Create an app\./m);
   });
 
+  it("keeps executable parent metadata out of nested command help", async () => {
+    const parser = createProgramParser([
+      {
+        path: ["stash"],
+        command: defineCommand({
+          parser: object({
+            message: withDefault(option("--message", string()), "parent"),
+          }),
+          metadata: {
+            description: message`Manage saved changes.`,
+            hidden: "usage",
+          },
+          handler() {},
+        }),
+      },
+      {
+        path: ["stash", "list"],
+        command: defineCommand({
+          parser: object({}),
+          metadata: { brief: message`List saved changes.` },
+          handler() {},
+        }),
+      },
+    ]);
+
+    const page = await getDocPageAsync(parser, ["stash", "list"]);
+    assert.ok(page != null);
+    const text = formatDocPage("git", page);
+
+    assert.match(text, /Usage: git stash list/);
+    assert.match(text, /List saved changes\./);
+    assert.doesNotMatch(text, /Manage saved changes\./);
+
+    const parentPage = await getDocPageAsync(parser, [
+      "stash",
+      "--message",
+      "wip",
+    ]);
+    assert.ok(parentPage != null);
+    const parentText = formatDocPage("git", parentPage);
+
+    assert.match(parentText, /Manage saved changes\./);
+  });
+
   it("rejects duplicate command paths", () => {
     const makeCommand = () =>
       defineCommand({

--- a/packages/discover/src/index.test.ts
+++ b/packages/discover/src/index.test.ts
@@ -1140,6 +1140,13 @@ describe("createProgramParser()", () => {
 
     assert.doesNotMatch(text, /\bremote\b/);
 
+    const rootPage = await getDocPageAsync(parser);
+    assert.ok(rootPage != null);
+    const rootText = formatDocPage("git", rootPage);
+
+    assert.doesNotMatch(rootText, /repo remote add/);
+    assert.doesNotMatch(rootText, /Usage: git repo add/);
+
     const suggestions = await suggestAsync(parser, ["repo", ""]);
     assert.ok(
       !suggestions.some((suggestion) =>

--- a/packages/discover/src/index.test.ts
+++ b/packages/discover/src/index.test.ts
@@ -52,6 +52,17 @@ describe("defineCommand()", () => {
     assert.deepEqual(path, ["user", "add"]);
   });
 
+  it("preserves static root command paths", () => {
+    const staticCommand = defineCommand({
+      path: [],
+      parser: object({}),
+      handler() {},
+    });
+
+    const path: CommandPath = staticCommand.path;
+    assert.deepEqual(path, []);
+  });
+
   it("rejects malformed command definitions", () => {
     assert.throws(
       () =>
@@ -75,25 +86,25 @@ describe("defineCommand()", () => {
     assert.throws(
       () =>
         defineCommand({
-          path: [] as never,
-          parser: object({}),
-          handler() {},
-        }),
-      {
-        name: "TypeError",
-        message: "Command path must be a non-empty array of non-empty strings.",
-      },
-    );
-    assert.throws(
-      () =>
-        defineCommand({
           path: ["build", ""] as never,
           parser: object({}),
           handler() {},
         }),
       {
         name: "TypeError",
-        message: "Command path must be a non-empty array of non-empty strings.",
+        message: "Command path must be an array of non-empty strings.",
+      },
+    );
+    assert.throws(
+      () =>
+        defineCommand({
+          path: [1] as never,
+          parser: object({}),
+          handler() {},
+        }),
+      {
+        name: "TypeError",
+        message: "Command path must be an array of non-empty strings.",
       },
     );
   });
@@ -140,7 +151,7 @@ describe("discoverCommands()", () => {
     }
   });
 
-  it("rejects duplicate command paths and file namespace conflicts", async () => {
+  it("rejects duplicate command paths", async () => {
     const duplicateDir = await makeTempDir();
     try {
       await writeCommand(duplicateDir, ["build.ts"], "build");
@@ -157,18 +168,102 @@ describe("discoverCommands()", () => {
     } finally {
       await rm(duplicateDir, { recursive: true, force: true });
     }
+  });
 
-    const conflictDir = await makeTempDir();
+  it("allows executable parent command files with nested commands", async () => {
+    const dir = await makeTempDir();
     try {
-      await writeCommand(conflictDir, ["user.ts"], "user");
-      await writeCommand(conflictDir, ["user", "add.ts"], "add");
+      await writeCommand(dir, ["user.ts"], "user");
+      await writeCommand(dir, ["user", "add.ts"], "add");
+
+      const commands = await discoverCommands({ dir, extensions: [".ts"] });
+
+      assert.deepEqual(commands.map((command) => command.path), [
+        ["user"],
+        ["user", "add"],
+      ]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("maps entry files to containing command paths", async () => {
+    const dir = await makeTempDir();
+    try {
+      await writeCommand(dir, ["index.ts"], "root");
+      await writeCommand(dir, ["build.ts"], "build");
+      await writeCommand(dir, ["stash", "index.ts"], "stash");
+      await writeCommand(dir, ["stash", "list.ts"], "list");
+
+      const commands = await discoverCommands({ dir, extensions: [".ts"] });
+
+      assert.deepEqual(commands.map((command) => command.path), [
+        [],
+        ["build"],
+        ["stash"],
+        ["stash", "list"],
+      ]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("supports custom and disabled entry file names", async () => {
+    const modDir = await makeTempDir();
+    try {
+      await writeCommand(modDir, ["mod.ts"], "root");
+      await writeCommand(modDir, ["stash", "mod.ts"], "stash");
+
+      const commands = await discoverCommands({
+        dir: modDir,
+        extensions: [".ts"],
+        entryFileName: "mod",
+      });
+
+      assert.deepEqual(commands.map((command) => command.path), [
+        [],
+        ["stash"],
+      ]);
+    } finally {
+      await rm(modDir, { recursive: true, force: true });
+    }
+
+    const indexDir = await makeTempDir();
+    try {
+      await writeCommand(indexDir, ["index.ts"], "index");
+      await writeCommand(indexDir, ["stash", "index.ts"], "stash-index");
+
+      const commands = await discoverCommands({
+        dir: indexDir,
+        extensions: [".ts"],
+        entryFileName: false,
+      });
+
+      assert.deepEqual(commands.map((command) => command.path), [
+        ["index"],
+        ["stash", "index"],
+      ]);
+    } finally {
+      await rm(indexDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects duplicate root entry command paths", async () => {
+    const dir = await makeTempDir();
+    try {
+      await writeCommand(dir, ["index.ts"], "root");
+      await writeCommand(dir, ["index.cmd.ts"], "root");
 
       await assert.rejects(
-        () => discoverCommands({ dir: conflictDir, extensions: [".ts"] }),
-        /Command path "user" conflicts with nested command "user add"\./,
+        () =>
+          discoverCommands({
+            dir,
+            extensions: [".cmd.ts", ".ts"],
+          }),
+        /Duplicate command path "<root>"/,
       );
     } finally {
-      await rm(conflictDir, { recursive: true, force: true });
+      await rm(dir, { recursive: true, force: true });
     }
   });
 
@@ -332,6 +427,42 @@ describe("discoverCommands()", () => {
     }
   });
 
+  it("accepts declared root paths that match entry files", async () => {
+    const dir = await makeTempDir();
+    try {
+      await writeCommand(
+        dir,
+        ["index.ts"],
+        "root",
+        `
+          import { defineCommand } from "${
+          runtimeModuleUrl("command.ts", "../dist/command.js")
+        }";
+          import { object } from "${
+          runtimeModuleUrl(
+            "../../core/src/constructs.ts",
+            "../../core/dist/constructs.js",
+          )
+        }";
+
+          export default defineCommand({
+            path: [],
+            parser: object({}),
+            handler() {},
+          });
+        `,
+      );
+
+      const commands = await discoverCommands({ dir, extensions: [".ts"] });
+
+      assert.deepEqual(commands.map((command) => command.path), [
+        [],
+      ]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it("ignores TypeScript declaration files", async () => {
     const dir = await makeTempDir();
     try {
@@ -430,6 +561,107 @@ describe("createProgramParser()", () => {
     assert.deepEqual(calls, [{ name: "Ada" }]);
   });
 
+  it("dispatches executable parent commands and nested commands", async () => {
+    const calls: unknown[] = [];
+    const parser = createProgramParser([
+      {
+        path: ["stash"],
+        command: defineCommand({
+          parser: object({
+            message: withDefault(option("--message", string()), "parent"),
+          }),
+          metadata: { brief: message`Stash changes.` },
+          handler(value) {
+            calls.push(["stash", value]);
+          },
+        }),
+      },
+      {
+        path: ["stash", "list"],
+        command: defineCommand({
+          parser: object({
+            limit: withDefault(option("--limit", integer()), 10),
+          }),
+          metadata: { brief: message`List stashes.` },
+          handler(value) {
+            calls.push(["stash list", value]);
+          },
+        }),
+      },
+    ]);
+
+    const parentState = await parseAll(parser, ["stash", "--message", "wip"]);
+    const parentResult = await parser.complete(parentState);
+    assert.ok(parentResult.success);
+    if (parentResult.success) {
+      await parentResult.value.handler(parentResult.value.value);
+    }
+
+    const childState = await parseAll(parser, [
+      "stash",
+      "list",
+      "--limit",
+      "3",
+    ]);
+    const childResult = await parser.complete(childState);
+    assert.ok(childResult.success);
+    if (childResult.success) {
+      await childResult.value.handler(childResult.value.value);
+    }
+
+    assert.deepEqual(calls, [
+      ["stash", { message: "wip" }],
+      ["stash list", { limit: 3 }],
+    ]);
+  });
+
+  it("dispatches root commands alongside nested commands", async () => {
+    const calls: unknown[] = [];
+    const parser = createProgramParser([
+      {
+        path: [],
+        command: defineCommand({
+          parser: object({
+            name: option("--name", string()),
+          }),
+          metadata: { brief: message`Create an app.` },
+          handler(value) {
+            calls.push(["root", value]);
+          },
+        }),
+      },
+      {
+        path: ["build"],
+        command: defineCommand({
+          parser: object({}),
+          metadata: { brief: message`Build the app.` },
+          handler(value) {
+            calls.push(["build", value]);
+          },
+        }),
+      },
+    ]);
+
+    const rootState = await parseAll(parser, ["--name", "demo"]);
+    const rootResult = await parser.complete(rootState);
+    assert.ok(rootResult.success);
+    if (rootResult.success) {
+      await rootResult.value.handler(rootResult.value.value);
+    }
+
+    const buildState = await parseAll(parser, ["build"]);
+    const buildResult = await parser.complete(buildState);
+    assert.ok(buildResult.success);
+    if (buildResult.success) {
+      await buildResult.value.handler(buildResult.value.value);
+    }
+
+    assert.deepEqual(calls, [
+      ["root", { name: "demo" }],
+      ["build", {}],
+    ]);
+  });
+
   it("shows leaf command paths in root help", async () => {
     const parser = createProgramParser([
       {
@@ -458,6 +690,37 @@ describe("createProgramParser()", () => {
     assert.match(text, /tool user add/);
     assert.match(text, /build\s+Build the project\./);
     assert.match(text, /user add\s+Add a user\./);
+  });
+
+  it("shows root command options and nested commands in root help", async () => {
+    const parser = createProgramParser([
+      {
+        path: [],
+        command: defineCommand({
+          parser: object({
+            name: option("--name", string()),
+          }),
+          metadata: { brief: message`Create an app.` },
+          handler() {},
+        }),
+      },
+      {
+        path: ["build"],
+        command: defineCommand({
+          parser: object({}),
+          metadata: { brief: message`Build the app.` },
+          handler() {},
+        }),
+      },
+    ], { brief: message`Project tool.` });
+
+    const page = await getDocPageAsync(parser);
+    assert.ok(page != null);
+    const text = formatDocPage("tool", page);
+
+    assert.match(text, /--name/);
+    assert.match(text, /build\s+Build the app\./);
+    assert.doesNotMatch(text, /^\s+Create an app\./m);
   });
 
   it("rejects duplicate command paths", () => {
@@ -521,6 +784,32 @@ describe("runProgram()", () => {
     });
 
     assert.deepEqual(calls, [{ value: "done" }]);
+  });
+
+  it("runs statically registered root commands", async () => {
+    const calls: unknown[] = [];
+    const createCommand = defineCommand({
+      path: [],
+      parser: object({
+        name: option("--name", string()),
+      }),
+      handler(value) {
+        calls.push(value);
+      },
+    });
+
+    await runProgram({
+      commands: [createCommand],
+      metadata: { name: "create-demo", version: "1.0.0" },
+      args: ["--name", "demo"],
+      stdout() {},
+      stderr() {},
+      onExit(exitCode): never {
+        throw new Error(`Unexpected exit ${exitCode}.`);
+      },
+    });
+
+    assert.deepEqual(calls, [{ name: "demo" }]);
   });
 
   it("shows statically registered nested commands in root help", async () => {
@@ -659,7 +948,7 @@ describe("runProgram()", () => {
         }),
       {
         name: "TypeError",
-        message: "Static command entries must declare a non-empty path.",
+        message: "Static command entries must declare a path.",
       },
     );
   });

--- a/packages/discover/src/index.test.ts
+++ b/packages/discover/src/index.test.ts
@@ -777,6 +777,7 @@ describe("createProgramParser()", () => {
           metadata: {
             description: message`Manage saved changes.`,
             hidden: "usage",
+            usageLine: [{ type: "literal", value: "stash-usage" }],
           },
           handler() {},
         }),
@@ -808,6 +809,12 @@ describe("createProgramParser()", () => {
     const parentText = formatDocPage("git", parentPage);
 
     assert.match(parentText, /Manage saved changes\./);
+
+    const usageLinePage = await getDocPageAsync(parser, ["stash"]);
+    assert.ok(usageLinePage != null);
+    const usageLineText = formatDocPage("git", usageLinePage);
+
+    assert.match(usageLineText, /Usage: git stash stash-usage/);
   });
 
   it("dispatches executable parent command aliases", async () => {

--- a/packages/discover/src/index.test.ts
+++ b/packages/discover/src/index.test.ts
@@ -1,8 +1,14 @@
 import { object } from "@optique/core/constructs";
+import { getAnnotations } from "@optique/core/annotations";
 import { formatDocPage } from "@optique/core/doc";
+import { defineTraits } from "@optique/core/extension";
 import { formatMessage, message } from "@optique/core/message";
 import { withDefault } from "@optique/core/modifiers";
-import { getDocPageAsync, type ParserContext } from "@optique/core/parser";
+import {
+  getDocPageAsync,
+  type Parser,
+  type ParserContext,
+} from "@optique/core/parser";
 import { option } from "@optique/core/primitives";
 import type { SourceContext } from "@optique/core/context";
 import { integer, string } from "@optique/core/valueparser";
@@ -750,6 +756,71 @@ describe("createProgramParser()", () => {
     ]);
   });
 
+  it("preserves source annotations for executable parent commands", async () => {
+    const sourceId = Symbol("source");
+    const context = createStringSourceContext(sourceId, "from-source");
+    const calls: unknown[] = [];
+
+    await runProgram({
+      commands: [
+        defineCommand({
+          path: ["stash"],
+          parser: createSourceBackedParser(sourceId),
+          handler(value) {
+            calls.push(["stash", value]);
+          },
+        }),
+        defineCommand({
+          path: ["stash", "list"],
+          parser: object({}),
+          handler(value) {
+            calls.push(["stash list", value]);
+          },
+        }),
+      ],
+      metadata: { name: "git" },
+      args: ["stash"],
+      contexts: [context],
+      stdout() {},
+      stderr() {},
+      onExit(exitCode): never {
+        throw new Error(`Unexpected exit ${exitCode}.`);
+      },
+    });
+
+    await runProgram({
+      commands: [
+        defineCommand({
+          path: [],
+          parser: createSourceBackedParser(sourceId),
+          handler(value) {
+            calls.push(["root", value]);
+          },
+        }),
+        defineCommand({
+          path: ["build"],
+          parser: object({}),
+          handler(value) {
+            calls.push(["build", value]);
+          },
+        }),
+      ],
+      metadata: { name: "tool" },
+      args: [],
+      contexts: [context],
+      stdout() {},
+      stderr() {},
+      onExit(exitCode): never {
+        throw new Error(`Unexpected exit ${exitCode}.`);
+      },
+    });
+
+    assert.deepEqual(calls, [
+      ["stash", "from-source"],
+      ["root", "from-source"],
+    ]);
+  });
+
   it("shows leaf command paths in root help", async () => {
     const parser = createProgramParser([
       {
@@ -1456,4 +1527,56 @@ async function parseAll(
     context = result.next;
   }
   return context.state;
+}
+
+function createStringSourceContext(
+  id: symbol,
+  value: string,
+): SourceContext {
+  return {
+    id,
+    phase: "single-pass",
+    getAnnotations() {
+      return { [id]: value };
+    },
+  };
+}
+
+function createSourceBackedParser(
+  sourceId: symbol,
+): Parser<"sync", string, undefined> {
+  const parser: Parser<"sync", string, undefined> = {
+    mode: "sync",
+    $valueType: [],
+    $stateType: [],
+    priority: 0,
+    usage: [],
+    leadingNames: new Set(),
+    acceptingAnyToken: false,
+    initialState: undefined,
+    parse(context) {
+      return {
+        success: true,
+        next: context,
+        consumed: [],
+      };
+    },
+    complete(state) {
+      const value = getAnnotations(state)?.[sourceId];
+      return typeof value === "string"
+        ? { success: true, value }
+        : { success: false, error: message`Missing source value.` };
+    },
+    suggest() {
+      return [];
+    },
+    getDocFragments() {
+      return { fragments: [] };
+    },
+  };
+  defineTraits(parser, {
+    inheritsAnnotations: true,
+    completesFromSource: true,
+  });
+  return parser;
 }

--- a/packages/discover/src/index.test.ts
+++ b/packages/discover/src/index.test.ts
@@ -1,5 +1,6 @@
 import { object } from "@optique/core/constructs";
 import { getAnnotations } from "@optique/core/annotations";
+import { dependency } from "@optique/core/dependency";
 import { formatDocPage } from "@optique/core/doc";
 import {
   defineTraits,
@@ -19,6 +20,7 @@ import { option } from "@optique/core/primitives";
 import type { OptionName } from "@optique/core/usage";
 import type { SourceContext } from "@optique/core/context";
 import {
+  choice,
   integer,
   string,
   type ValueParserResult,
@@ -961,6 +963,36 @@ describe("createProgramParser()", () => {
       ["root complete", "from-source"],
       ["root", "from-source"],
     ]);
+  });
+
+  it("includes source nodes for uncommitted executable parent completion", async () => {
+    const modeParser = dependency(choice(["dev", "prod"] as const));
+    const parser = createProgramParser([
+      {
+        path: ["stash"],
+        command: defineCommand({
+          parser: object({
+            mode: withDefault(option("--mode", modeParser), "prod" as const),
+          }),
+          handler() {},
+        }),
+      },
+      {
+        path: ["stash", "list"],
+        command: defineCommand({
+          parser: object({}),
+          handler() {},
+        }),
+      },
+    ]);
+
+    const state = await parseAll(parser, ["stash"]);
+    const sourceNode = parser.getSuggestRuntimeNodes?.(state, [])?.find(
+      (node) => node.parser.dependencyMetadata?.source != null,
+    );
+
+    assert.ok(sourceNode);
+    assert.deepEqual(sourceNode.path, ["stash", 1, "mode"]);
   });
 
   it("shows leaf command paths in root help", async () => {

--- a/packages/discover/src/index.test.ts
+++ b/packages/discover/src/index.test.ts
@@ -1077,6 +1077,39 @@ describe("createProgramParser()", () => {
     assert.match(usageLineText, /Use stash list to inspect entries\./);
   });
 
+  it("shows executable parent descriptions in namespace help", async () => {
+    const parser = createProgramParser([
+      {
+        path: ["repo", "remote"],
+        command: defineCommand({
+          parser: object({}),
+          metadata: { description: message`Manage remotes.` },
+          handler() {},
+        }),
+      },
+      {
+        path: ["repo", "remote", "add"],
+        command: defineCommand({
+          parser: object({}),
+          metadata: { brief: message`Add a remote.` },
+          handler() {},
+        }),
+      },
+    ]);
+
+    const page = await getDocPageAsync(parser, ["repo"]);
+    assert.ok(page != null);
+    const text = formatDocPage("git", page);
+
+    assert.match(text, /remote\s+Manage remotes\./);
+
+    const childPage = await getDocPageAsync(parser, ["repo", "remote", "add"]);
+    assert.ok(childPage != null);
+    const childText = formatDocPage("git", childPage);
+
+    assert.doesNotMatch(childText, /Manage remotes\./);
+  });
+
   it("dispatches executable parent command aliases", async () => {
     const calls: unknown[] = [];
     const parser = createProgramParser([

--- a/packages/discover/src/index.test.ts
+++ b/packages/discover/src/index.test.ts
@@ -13,6 +13,7 @@ import {
   type Parser,
   type ParserContext,
   type ParserResult,
+  suggestAsync,
 } from "@optique/core/parser";
 import { option } from "@optique/core/primitives";
 import type { OptionName } from "@optique/core/usage";
@@ -1108,6 +1109,53 @@ describe("createProgramParser()", () => {
     const childText = formatDocPage("git", childPage);
 
     assert.doesNotMatch(childText, /Manage remotes\./);
+  });
+
+  it("keeps hidden executable parent namespaces out of help and suggestions", async () => {
+    const parser = createProgramParser([
+      {
+        path: ["repo", "remote"],
+        command: defineCommand({
+          parser: object({}),
+          metadata: {
+            description: message`Manage remotes.`,
+            hidden: true,
+          },
+          handler() {},
+        }),
+      },
+      {
+        path: ["repo", "remote", "add"],
+        command: defineCommand({
+          parser: object({}),
+          metadata: { brief: message`Add a remote.` },
+          handler() {},
+        }),
+      },
+    ]);
+
+    const page = await getDocPageAsync(parser, ["repo"]);
+    assert.ok(page != null);
+    const text = formatDocPage("git", page);
+
+    assert.doesNotMatch(text, /\bremote\b/);
+
+    const suggestions = await suggestAsync(parser, ["repo", ""]);
+    assert.ok(
+      !suggestions.some((suggestion) =>
+        suggestion.kind === "literal" && suggestion.text === "remote"
+      ),
+    );
+
+    const childPage = await getDocPageAsync(parser, [
+      "repo",
+      "remote",
+      "add",
+    ]);
+    assert.ok(childPage != null);
+    const childText = formatDocPage("git", childPage);
+
+    assert.match(childText, /Usage: git repo remote add/);
   });
 
   it("wraps executable parent completion with async mode", async () => {

--- a/packages/discover/src/index.ts
+++ b/packages/discover/src/index.ts
@@ -5,9 +5,16 @@ import type {
 } from "@optique/core/context";
 import type { DocState } from "@optique/core/parser";
 import type { DocFragment, DocFragments } from "@optique/core/doc";
+import type { RuntimeNode } from "@optique/core/dependency-runtime";
 import { map } from "@optique/core/modifiers";
 import type { Message } from "@optique/core/message";
-import type { Mode, Parser } from "@optique/core/parser";
+import type {
+  ExecutionContext,
+  Mode,
+  Parser,
+  ParserContext,
+  ParserResult,
+} from "@optique/core/parser";
 import type { ProgramMetadata } from "@optique/core/program";
 import { command } from "@optique/core/primitives";
 import { runAsync } from "@optique/run";
@@ -675,17 +682,314 @@ function buildCommandTree(
 function buildNodeParser(
   node: CommandTreeNode,
 ): Parser<Mode, ProgramInvocation, unknown> {
-  const parsers: Parser<Mode, ProgramInvocation, unknown>[] = [];
   const childParser = buildChildrenParser(node);
-  if (childParser != null) parsers.push(childParser);
-  if (node.command != null) {
-    parsers.push(createLeafParser(node.command, childParser != null));
+  if (childParser != null && node.command != null) {
+    return createExecutableNodeParser(childParser, node.command);
   }
-  if (parsers.length === 1) return parsers[0];
-  if (parsers.length < 1) {
-    throw new TypeError("Command tree node must contain a command.");
+  if (childParser != null) return childParser;
+  if (node.command != null) return createLeafParser(node.command);
+  throw new TypeError("Command tree node must contain a command.");
+}
+
+interface ExecutableNodeState {
+  readonly branch: number;
+  readonly result: ParserResult<unknown>;
+  readonly committed: boolean;
+}
+
+type ExecutableNodeParserState = ExecutableNodeState | undefined;
+
+function createExecutableNodeParser(
+  childParser: Parser<Mode, ProgramInvocation, unknown>,
+  commandDefinition: AnyCommand,
+): Parser<Mode, ProgramInvocation, ExecutableNodeParserState> {
+  const leafParser = createLeafParser(commandDefinition, true);
+  const branchParsers = [childParser, leafParser] as const;
+  const parser = longestMatch(
+    childParser,
+    leafParser,
+  ) as Parser<Mode, ProgramInvocation, unknown>;
+  return {
+    ...parser,
+    $valueType: [],
+    $stateType: [],
+    initialState: undefined,
+    parse(context) {
+      const activeState = normalizeExecutableNodeState(context.state);
+      if (activeState?.committed === true && activeState.result.success) {
+        const branchParser = branchParsers[activeState.branch];
+        const result = branchParser.parse(
+          withExecutableNodeChildContext(
+            context,
+            activeState.branch,
+            activeState.result.next.state,
+            branchParser,
+          ),
+        );
+        if (isPromiseLike(result)) {
+          return result.then((resolved) =>
+            wrapBranchParseResult(context, activeState, resolved)
+          );
+        }
+        return wrapBranchParseResult(context, activeState, result);
+      }
+
+      const result = parser.parse({
+        ...context,
+        state: toExclusiveState(activeState),
+      });
+      if (isPromiseLike(result)) {
+        return result.then((resolved) =>
+          wrapInitialParseResult(context, resolved)
+        );
+      }
+      return wrapInitialParseResult(context, result);
+    },
+    complete(state, exec) {
+      const activeState = normalizeExecutableNodeState(state);
+      if (activeState?.result.success === true) {
+        return branchParsers[activeState.branch].complete(
+          activeState.result.next.state,
+          withExecutableNodeChildExecPath(exec, activeState.branch),
+        );
+      }
+      return parser.complete(toExclusiveState(activeState), exec);
+    },
+    suggest(context, prefix) {
+      const activeState = normalizeExecutableNodeState(context.state);
+      if (activeState?.committed === true && activeState.result.success) {
+        const branchParser = branchParsers[activeState.branch];
+        return branchParser.suggest(
+          withExecutableNodeChildContext(
+            context,
+            activeState.branch,
+            activeState.result.next.state,
+            branchParser,
+          ),
+          prefix,
+        );
+      }
+      return parser.suggest({
+        ...context,
+        state: toExclusiveState(activeState),
+      }, prefix);
+    },
+    getSuggestRuntimeNodes(state, path): readonly RuntimeNode[] {
+      const activeState = normalizeExecutableNodeState(state);
+      if (activeState?.result.success !== true) {
+        return parser.getSuggestRuntimeNodes?.(
+          toExclusiveState(activeState),
+          path,
+        ) ?? [];
+      }
+      const branchParser = branchParsers[activeState.branch];
+      const branchPath = [...path, activeState.branch];
+      const branchState = activeState.result.next.state;
+      return branchParser.getSuggestRuntimeNodes?.(branchState, branchPath) ??
+        (branchParser.dependencyMetadata?.source != null
+          ? [{ path: branchPath, parser: branchParser, state: branchState }]
+          : []);
+    },
+    getDocFragments(state, defaultValue) {
+      const activeState = state.kind === "available"
+        ? normalizeExecutableNodeState(state.state)
+        : undefined;
+      const fragments = parser.getDocFragments(
+        state.kind === "available"
+          ? { kind: "available", state: toExclusiveState(activeState) }
+          : state,
+        defaultValue,
+      );
+      if (activeState == null) {
+        return withCommandDocMetadata(fragments, commandDefinition.metadata);
+      }
+      return fragments;
+    },
+  };
+}
+
+function normalizeExecutableNodeState(
+  state: unknown,
+): ExecutableNodeParserState {
+  if (
+    state == null ||
+    typeof state !== "object" ||
+    !("branch" in state) ||
+    !("result" in state)
+  ) {
+    return undefined;
   }
-  return longestMatch(...parsers) as Parser<Mode, ProgramInvocation, unknown>;
+  const branch = (state as { readonly branch?: unknown }).branch;
+  if (branch !== 0 && branch !== 1) return undefined;
+  const result = (state as { readonly result?: unknown }).result;
+  if (
+    result == null ||
+    typeof result !== "object" ||
+    typeof (result as { readonly success?: unknown }).success !== "boolean"
+  ) {
+    return undefined;
+  }
+  return {
+    branch,
+    result: result as ParserResult<unknown>,
+    committed: (state as { readonly committed?: unknown }).committed === true,
+  };
+}
+
+function toExclusiveState(
+  state: ExecutableNodeParserState,
+): undefined | [number, ParserResult<unknown>] {
+  if (state == null) return undefined;
+  return [state.branch, state.result];
+}
+
+function fromExclusiveState(
+  state: unknown,
+): ExecutableNodeParserState {
+  if (
+    !Array.isArray(state) ||
+    state.length !== 2 ||
+    (state[0] !== 0 && state[0] !== 1)
+  ) {
+    return undefined;
+  }
+  return {
+    branch: state[0],
+    result: state[1] as ParserResult<unknown>,
+    committed: isCommittedResult(state[1]),
+  };
+}
+
+function isCommittedResult(result: unknown): boolean {
+  return result != null &&
+    typeof result === "object" &&
+    (result as { readonly success?: unknown }).success === true &&
+    Array.isArray((result as { readonly consumed?: unknown }).consumed) &&
+    (result as { readonly consumed: readonly unknown[] }).consumed.length > 0;
+}
+
+function wrapInitialParseResult(
+  _context: ParserContext<ExecutableNodeParserState>,
+  result: ParserResult<unknown>,
+): ParserResult<ExecutableNodeParserState> {
+  if (!result.success) return result;
+  return {
+    success: true,
+    consumed: result.consumed,
+    provisional: result.provisional,
+    next: {
+      ...result.next,
+      state: fromExclusiveState(result.next.state),
+    },
+  };
+}
+
+function wrapBranchParseResult(
+  context: ParserContext<ExecutableNodeParserState>,
+  activeState: ExecutableNodeState,
+  result: ParserResult<unknown>,
+): ParserResult<ExecutableNodeParserState> {
+  if (!result.success) return result;
+  const mergedExec = mergeExecutableNodeChildExec(
+    context.exec,
+    result.next.exec,
+  );
+  const dependencyRegistry = mergedExec?.dependencyRegistry ??
+    result.next.dependencyRegistry ?? context.dependencyRegistry;
+  return {
+    success: true,
+    consumed: result.consumed,
+    provisional: result.provisional,
+    next: {
+      ...context,
+      buffer: result.next.buffer,
+      optionsTerminated: result.next.optionsTerminated,
+      state: {
+        branch: activeState.branch,
+        result,
+        committed: activeState.committed || result.consumed.length > 0,
+      },
+      ...(mergedExec != null
+        ? { exec: mergedExec, trace: mergedExec.trace }
+        : {}),
+      ...(dependencyRegistry != null ? { dependencyRegistry } : {}),
+    },
+  };
+}
+
+function withExecutableNodeChildContext(
+  context: ParserContext<ExecutableNodeParserState>,
+  branch: number,
+  state: unknown,
+  parser: Parser<Mode, ProgramInvocation, unknown>,
+): ParserContext<unknown> {
+  const exec = withExecutableNodeChildExecPath(context.exec, branch);
+  const dependencyRegistry = context.dependencyRegistry ??
+    exec?.dependencyRegistry;
+  return {
+    ...context,
+    state,
+    usage: parser.usage,
+    ...(exec != null
+      ? {
+        exec: dependencyRegistry === exec.dependencyRegistry
+          ? exec
+          : { ...exec, dependencyRegistry },
+        dependencyRegistry,
+      }
+      : {}),
+  };
+}
+
+function withExecutableNodeChildExecPath(
+  exec: ExecutionContext | undefined,
+  branch: number,
+): ExecutionContext | undefined {
+  if (exec == null) return undefined;
+  return {
+    ...exec,
+    path: [...(exec.path ?? []), branch],
+  };
+}
+
+function mergeExecutableNodeChildExec(
+  parent: ExecutionContext | undefined,
+  child: ExecutionContext | undefined,
+): ExecutionContext | undefined {
+  if (parent == null) return child;
+  if (child == null) return parent;
+  return {
+    ...parent,
+    trace: child.trace ?? parent.trace,
+    dependencyRuntime: child.dependencyRuntime ?? parent.dependencyRuntime,
+    dependencyRegistry: child.dependencyRegistry ?? parent.dependencyRegistry,
+    commandPath: child.commandPath ?? parent.commandPath,
+    preCompletedByParser: child.preCompletedByParser ??
+      parent.preCompletedByParser,
+    excludedSourceFields: child.excludedSourceFields ??
+      parent.excludedSourceFields,
+  };
+}
+
+function isPromiseLike<T>(
+  value: T | Promise<T>,
+): value is Promise<T> {
+  return value != null &&
+    typeof value === "object" &&
+    typeof (value as { readonly then?: unknown }).then === "function";
+}
+
+function withCommandDocMetadata(
+  fragments: DocFragments,
+  metadata: CommandMetadata | undefined,
+): DocFragments {
+  if (metadata == null) return fragments;
+  return {
+    ...fragments,
+    brief: fragments.brief ?? metadata.brief,
+    description: fragments.description ?? metadata.description,
+    footer: fragments.footer ?? metadata.footer,
+  };
 }
 
 function buildChildrenParser(
@@ -738,13 +1042,7 @@ function createLeafParser(
     ...parser,
     getDocFragments(state, defaultValue) {
       const fragments = parser.getDocFragments(state, defaultValue);
-      return {
-        ...fragments,
-        brief: fragments.brief ?? commandDefinition.metadata?.brief,
-        description: fragments.description ??
-          commandDefinition.metadata?.description,
-        footer: fragments.footer ?? commandDefinition.metadata?.footer,
-      };
+      return withCommandDocMetadata(fragments, commandDefinition.metadata);
     },
   };
 }

--- a/packages/discover/src/index.ts
+++ b/packages/discover/src/index.ts
@@ -7,6 +7,7 @@ import type { DocState } from "@optique/core/parser";
 import type { DocFragment, DocFragments } from "@optique/core/doc";
 import type { RuntimeNode } from "@optique/core/dependency-runtime";
 import {
+  dispatchByMode,
   inheritAnnotations,
   mapModeValue,
   wrapForMode,
@@ -758,15 +759,24 @@ function createExecutableNodeParser(
     complete(state, exec) {
       const activeState = normalizeExecutableNodeState(state);
       if (activeState?.result.success === true) {
-        return branchParsers[activeState.branch].complete(
-          inheritAnnotations(state, activeState.result.next.state),
-          withExecutableNodeChildExecPath(exec, activeState.branch),
+        return wrapForMode(
+          parser.mode,
+          branchParsers[activeState.branch].complete(
+            inheritAnnotations(state, activeState.result.next.state),
+            withExecutableNodeChildExecPath(exec, activeState.branch),
+          ),
         );
       }
       if (activeState == null) {
-        return completeExecutableNodeLeaf(state, exec, leafParser);
+        return wrapForMode(
+          parser.mode,
+          completeExecutableNodeLeaf(state, exec, leafParser),
+        );
       }
-      return parser.complete(toExclusiveState(activeState, state), exec);
+      return wrapForMode(
+        parser.mode,
+        parser.complete(toExclusiveState(activeState, state), exec),
+      );
     },
     suggest(context, prefix) {
       const activeState = normalizeExecutableNodeState(context.state);
@@ -871,16 +881,25 @@ function completeExecutableNodeLeaf(
   leafParser: Parser<Mode, ProgramInvocation, unknown>,
 ) {
   const result = parseExecutableNodeLeaf(state, exec, leafParser);
-  if (leafParser.mode === "async") {
-    return Promise.resolve(wrapForMode("async", result)).then((resolved) =>
-      completeParsedExecutableNodeLeaf(state, exec, leafParser, resolved)
-    );
-  }
-  return completeParsedExecutableNodeLeaf(
-    state,
-    exec,
-    leafParser,
-    wrapForMode("sync", result),
+  return dispatchByMode(
+    leafParser.mode,
+    () =>
+      wrapForMode(
+        "sync",
+        completeParsedExecutableNodeLeaf(
+          state,
+          exec,
+          leafParser,
+          wrapForMode("sync", result),
+        ),
+      ),
+    () =>
+      Promise.resolve(wrapForMode("async", result)).then((resolved) =>
+        wrapForMode(
+          "async",
+          completeParsedExecutableNodeLeaf(state, exec, leafParser, resolved),
+        )
+      ),
   );
 }
 
@@ -911,21 +930,24 @@ function extractExecutableNodePhase2Seed(
     return phase2SeedHook.extract(toExclusiveState(activeState, state), exec);
   }
   const result = parseExecutableNodeLeaf(state, exec, leafParser);
-  if (leafParser.mode === "async") {
-    return Promise.resolve(wrapForMode("async", result)).then((resolved) =>
+  return dispatchByMode(
+    leafParser.mode,
+    () =>
       extractParsedExecutableNodePhase2Seed(
         state,
         exec,
-        resolved,
+        wrapForMode("sync", result),
         phase2SeedHook,
-      )
-    );
-  }
-  return extractParsedExecutableNodePhase2Seed(
-    state,
-    exec,
-    wrapForMode("sync", result),
-    phase2SeedHook,
+      ),
+    () =>
+      Promise.resolve(wrapForMode("async", result)).then((resolved) =>
+        extractParsedExecutableNodePhase2Seed(
+          state,
+          exec,
+          resolved,
+          phase2SeedHook,
+        )
+      ),
   );
 }
 

--- a/packages/discover/src/index.ts
+++ b/packages/discover/src/index.ts
@@ -6,6 +6,7 @@ import type {
 import type { DocState } from "@optique/core/parser";
 import type { DocFragment, DocFragments } from "@optique/core/doc";
 import type { RuntimeNode } from "@optique/core/dependency-runtime";
+import { inheritAnnotations } from "@optique/core/extension";
 import { map } from "@optique/core/modifiers";
 import type { Message } from "@optique/core/message";
 import type {
@@ -722,7 +723,7 @@ function createExecutableNodeParser(
           withExecutableNodeChildContext(
             context,
             activeState.branch,
-            activeState.result.next.state,
+            inheritAnnotations(context.state, activeState.result.next.state),
             branchParser,
           ),
         );
@@ -736,7 +737,7 @@ function createExecutableNodeParser(
 
       const result = parser.parse({
         ...context,
-        state: toExclusiveState(activeState),
+        state: toExclusiveState(activeState, context.state),
       });
       if (isPromiseLike(result)) {
         return result.then((resolved) =>
@@ -749,11 +750,11 @@ function createExecutableNodeParser(
       const activeState = normalizeExecutableNodeState(state);
       if (activeState?.result.success === true) {
         return branchParsers[activeState.branch].complete(
-          activeState.result.next.state,
+          inheritAnnotations(state, activeState.result.next.state),
           withExecutableNodeChildExecPath(exec, activeState.branch),
         );
       }
-      return parser.complete(toExclusiveState(activeState), exec);
+      return parser.complete(toExclusiveState(activeState, state), exec);
     },
     suggest(context, prefix) {
       const activeState = normalizeExecutableNodeState(context.state);
@@ -763,7 +764,7 @@ function createExecutableNodeParser(
           withExecutableNodeChildContext(
             context,
             activeState.branch,
-            activeState.result.next.state,
+            inheritAnnotations(context.state, activeState.result.next.state),
             branchParser,
           ),
           prefix,
@@ -771,20 +772,23 @@ function createExecutableNodeParser(
       }
       return parser.suggest({
         ...context,
-        state: toExclusiveState(activeState),
+        state: toExclusiveState(activeState, context.state),
       }, prefix);
     },
     getSuggestRuntimeNodes(state, path): readonly RuntimeNode[] {
       const activeState = normalizeExecutableNodeState(state);
       if (activeState?.result.success !== true) {
         return parser.getSuggestRuntimeNodes?.(
-          toExclusiveState(activeState),
+          toExclusiveState(activeState, state),
           path,
         ) ?? [];
       }
       const branchParser = branchParsers[activeState.branch];
       const branchPath = [...path, activeState.branch];
-      const branchState = activeState.result.next.state;
+      const branchState = inheritAnnotations(
+        state,
+        activeState.result.next.state,
+      );
       return branchParser.getSuggestRuntimeNodes?.(branchState, branchPath) ??
         (branchParser.dependencyMetadata?.source != null
           ? [{ path: branchPath, parser: branchParser, state: branchState }]
@@ -796,7 +800,10 @@ function createExecutableNodeParser(
         : undefined;
       const fragments = parser.getDocFragments(
         state.kind === "available"
-          ? { kind: "available", state: toExclusiveState(activeState) }
+          ? {
+            kind: "available",
+            state: toExclusiveState(activeState, state.state),
+          }
           : state,
         defaultValue,
       );
@@ -829,18 +836,21 @@ function normalizeExecutableNodeState(
   ) {
     return undefined;
   }
-  return {
+  return inheritAnnotations(state, {
     branch,
     result: result as ParserResult<unknown>,
     committed: (state as { readonly committed?: unknown }).committed === true,
-  };
+  });
 }
 
 function toExclusiveState(
   state: ExecutableNodeParserState,
-): undefined | [number, ParserResult<unknown>] {
-  if (state == null) return undefined;
-  return [state.branch, state.result];
+  sourceState: unknown = state,
+): unknown {
+  const exclusiveState = state == null
+    ? undefined
+    : [state.branch, state.result] as [number, ParserResult<unknown>];
+  return inheritAnnotations(sourceState, exclusiveState);
 }
 
 function fromExclusiveState(
@@ -853,11 +863,11 @@ function fromExclusiveState(
   ) {
     return undefined;
   }
-  return {
+  return inheritAnnotations(state, {
     branch: state[0],
     result: state[1] as ParserResult<unknown>,
     committed: isCommittedResult(state[1]),
-  };
+  });
 }
 
 function isCommittedResult(result: unknown): boolean {
@@ -896,6 +906,11 @@ function wrapBranchParseResult(
   );
   const dependencyRegistry = mergedExec?.dependencyRegistry ??
     result.next.dependencyRegistry ?? context.dependencyRegistry;
+  const nextState = inheritAnnotations(result.next.state, {
+    branch: activeState.branch,
+    result,
+    committed: activeState.committed || result.consumed.length > 0,
+  });
   return {
     success: true,
     consumed: result.consumed,
@@ -904,11 +919,7 @@ function wrapBranchParseResult(
       ...context,
       buffer: result.next.buffer,
       optionsTerminated: result.next.optionsTerminated,
-      state: {
-        branch: activeState.branch,
-        result,
-        committed: activeState.committed || result.consumed.length > 0,
-      },
+      state: inheritAnnotations(context.state, nextState),
       ...(mergedExec != null
         ? { exec: mergedExec, trace: mergedExec.trace }
         : {}),

--- a/packages/discover/src/index.ts
+++ b/packages/discover/src/index.ts
@@ -801,6 +801,15 @@ function createExecutableNodeParser(
     },
     getSuggestRuntimeNodes(state, path): readonly RuntimeNode[] {
       const activeState = normalizeExecutableNodeState(state);
+      if (activeState == null) {
+        const branchPath = [...path, 1];
+        const branchState = inheritAnnotations(state, leafParser.initialState);
+        return getExecutableNodeBranchSuggestRuntimeNodes(
+          leafParser,
+          branchState,
+          branchPath,
+        );
+      }
       if (activeState?.result.success !== true) {
         return parser.getSuggestRuntimeNodes?.(
           toExclusiveState(activeState, state),
@@ -813,10 +822,11 @@ function createExecutableNodeParser(
         state,
         activeState.result.next.state,
       );
-      return branchParser.getSuggestRuntimeNodes?.(branchState, branchPath) ??
-        (branchParser.dependencyMetadata?.source != null
-          ? [{ path: branchPath, parser: branchParser, state: branchState }]
-          : []);
+      return getExecutableNodeBranchSuggestRuntimeNodes(
+        branchParser,
+        branchState,
+        branchPath,
+      );
     },
     getDocFragments(state, defaultValue) {
       const activeState = state.kind === "available"
@@ -852,6 +862,17 @@ function createExecutableNodeParser(
     });
   }
   return executableParser;
+}
+
+function getExecutableNodeBranchSuggestRuntimeNodes(
+  parser: Parser<Mode, ProgramInvocation, unknown>,
+  state: unknown,
+  path: readonly PropertyKey[],
+): readonly RuntimeNode[] {
+  return parser.getSuggestRuntimeNodes?.(state, path) ??
+    (parser.dependencyMetadata?.source != null
+      ? [{ path, parser, state }]
+      : []);
 }
 
 interface Phase2SeedHook {

--- a/packages/discover/src/index.ts
+++ b/packages/discover/src/index.ts
@@ -708,10 +708,17 @@ function namespaceCommandMetadata(
   metadata: CommandMetadata | undefined,
 ): CommandMetadata | undefined {
   if (metadata == null) return undefined;
-  if (metadata.aliases == null && metadata.errors == null) return undefined;
+  if (
+    metadata.aliases == null &&
+    metadata.errors == null &&
+    metadata.usageLine == null
+  ) {
+    return undefined;
+  }
   return {
     ...(metadata.aliases != null && { aliases: metadata.aliases }),
     ...(metadata.errors != null && { errors: metadata.errors }),
+    ...(metadata.usageLine != null && { usageLine: metadata.usageLine }),
   };
 }
 

--- a/packages/discover/src/index.ts
+++ b/packages/discover/src/index.ts
@@ -710,7 +710,12 @@ function createExecutableNodeParser(
     childParser,
     leafParser,
   ) as Parser<Mode, ProgramInvocation, unknown>;
-  return {
+  const phase2SeedHook = findPhase2SeedHook(parser);
+  const executableParser: Parser<
+    Mode,
+    ProgramInvocation,
+    ExecutableNodeParserState
+  > = {
     ...parser,
     $valueType: [],
     $stateType: [],
@@ -753,6 +758,9 @@ function createExecutableNodeParser(
           inheritAnnotations(state, activeState.result.next.state),
           withExecutableNodeChildExecPath(exec, activeState.branch),
         );
+      }
+      if (activeState == null) {
+        return completeExecutableNodeLeaf(state, exec, leafParser);
       }
       return parser.complete(toExclusiveState(activeState, state), exec);
     },
@@ -813,6 +821,141 @@ function createExecutableNodeParser(
       return fragments;
     },
   };
+  if (phase2SeedHook != null) {
+    Object.defineProperty(executableParser, phase2SeedHook.key, {
+      value(state: unknown, exec?: ExecutionContext) {
+        return extractExecutableNodePhase2Seed(
+          state,
+          exec,
+          leafParser,
+          phase2SeedHook,
+        );
+      },
+      configurable: true,
+      enumerable: true,
+    });
+  }
+  return executableParser;
+}
+
+interface Phase2SeedHook {
+  readonly key: symbol;
+  readonly extract: (state: unknown, exec?: ExecutionContext) => unknown;
+}
+
+const phase2SeedSymbolDescription = "@optique/core/extractPhase2Seed";
+
+function findPhase2SeedHook(parser: object): Phase2SeedHook | undefined {
+  for (const key of Object.getOwnPropertySymbols(parser)) {
+    if (key.description !== phase2SeedSymbolDescription) continue;
+    const value = Reflect.get(parser, key);
+    if (typeof value !== "function") continue;
+    return {
+      key,
+      extract(state, exec) {
+        const seed: unknown = Reflect.apply(value, parser, [state, exec]);
+        return seed;
+      },
+    };
+  }
+  return undefined;
+}
+
+function completeExecutableNodeLeaf(
+  state: unknown,
+  exec: ExecutionContext | undefined,
+  leafParser: Parser<Mode, ProgramInvocation, unknown>,
+) {
+  const result = parseExecutableNodeLeaf(state, exec, leafParser);
+  if (isPromiseLike(result)) {
+    return result.then((resolved) =>
+      completeParsedExecutableNodeLeaf(state, exec, leafParser, resolved)
+    );
+  }
+  return completeParsedExecutableNodeLeaf(state, exec, leafParser, result);
+}
+
+function completeParsedExecutableNodeLeaf(
+  state: unknown,
+  exec: ExecutionContext | undefined,
+  leafParser: Parser<Mode, ProgramInvocation, unknown>,
+  result: ParserResult<unknown>,
+) {
+  const childExec = withExecutableNodeChildExecPath(exec, 1);
+  const nextExec = result.success
+    ? mergeExecutableNodeChildExec(childExec, result.next.exec)
+    : childExec;
+  const nextState = result.success
+    ? inheritAnnotations(state, result.next.state)
+    : inheritAnnotations(state, leafParser.initialState);
+  return leafParser.complete(nextState, nextExec);
+}
+
+function extractExecutableNodePhase2Seed(
+  state: unknown,
+  exec: ExecutionContext | undefined,
+  leafParser: Parser<Mode, ProgramInvocation, unknown>,
+  phase2SeedHook: Phase2SeedHook,
+) {
+  const activeState = normalizeExecutableNodeState(state);
+  if (activeState != null) {
+    return phase2SeedHook.extract(toExclusiveState(activeState, state), exec);
+  }
+  const result = parseExecutableNodeLeaf(state, exec, leafParser);
+  if (isPromiseLike(result)) {
+    return result.then((resolved) =>
+      extractParsedExecutableNodePhase2Seed(
+        state,
+        exec,
+        resolved,
+        phase2SeedHook,
+      )
+    );
+  }
+  return extractParsedExecutableNodePhase2Seed(
+    state,
+    exec,
+    result,
+    phase2SeedHook,
+  );
+}
+
+function extractParsedExecutableNodePhase2Seed(
+  state: unknown,
+  exec: ExecutionContext | undefined,
+  result: ParserResult<unknown>,
+  phase2SeedHook: Phase2SeedHook,
+) {
+  if (!result.success) {
+    return phase2SeedHook.extract(toExclusiveState(undefined, state), exec);
+  }
+  const executableState = inheritAnnotations(state, {
+    branch: 1,
+    result,
+    committed: false,
+  });
+  return phase2SeedHook.extract(toExclusiveState(executableState, state), exec);
+}
+
+function parseExecutableNodeLeaf(
+  state: unknown,
+  exec: ExecutionContext | undefined,
+  leafParser: Parser<Mode, ProgramInvocation, unknown>,
+) {
+  const childExec = withExecutableNodeChildExecPath(exec, 1);
+  const childContext: ParserContext<unknown> = {
+    buffer: [],
+    optionsTerminated: false,
+    usage: leafParser.usage,
+    state: inheritAnnotations(state, leafParser.initialState),
+    ...(childExec != null
+      ? {
+        exec: childExec,
+        dependencyRegistry: childExec.dependencyRegistry,
+      }
+      : {}),
+  };
+  return leafParser.parse(childContext);
 }
 
 function normalizeExecutableNodeState(

--- a/packages/discover/src/index.ts
+++ b/packages/discover/src/index.ts
@@ -23,6 +23,7 @@ import type {
 } from "@optique/core/parser";
 import type { ProgramMetadata } from "@optique/core/program";
 import { command } from "@optique/core/primitives";
+import { type HiddenVisibility, mergeHidden } from "@optique/core/usage";
 import { runAsync } from "@optique/run";
 import type { RunOptions } from "@optique/run";
 import { readdir, realpath, stat } from "node:fs/promises";
@@ -689,8 +690,9 @@ function buildCommandTree(
 
 function buildNodeParser(
   node: CommandTreeNode,
+  inheritedHidden?: HiddenVisibility,
 ): Parser<Mode, ProgramInvocation, unknown> {
-  const childParser = buildChildrenParser(node);
+  const childParser = buildChildrenParser(node, inheritedHidden);
   if (childParser != null && node.command != null) {
     return createExecutableNodeParser(childParser, node.command);
   }
@@ -1171,16 +1173,35 @@ function withCommandDocMetadata(
 
 function buildChildrenParser(
   node: CommandTreeNode,
+  inheritedHidden?: HiddenVisibility,
 ): Parser<Mode, ProgramInvocation, unknown> | undefined {
   const parsers: Parser<Mode, ProgramInvocation, unknown>[] = [];
   for (const [name, child] of node.children) {
-    const childParser = buildNodeParser(child);
+    const childHidden = mergeHidden(
+      inheritedHidden,
+      child.command?.metadata?.hidden,
+    );
+    const childParser = buildNodeParser(child, childHidden);
     if (child.children.size > 0) {
       parsers.push(
-        createNamespaceCommandParser(name, childParser, child.command),
+        createNamespaceCommandParser(
+          name,
+          childParser,
+          child.command,
+          inheritedHidden,
+        ),
       );
     } else {
-      parsers.push(command(name, childParser, child.command?.metadata));
+      parsers.push(
+        command(
+          name,
+          childParser,
+          commandMetadataWithInheritedHidden(
+            child.command?.metadata,
+            inheritedHidden,
+          ),
+        ),
+      );
     }
   }
   if (parsers.length < 1) return undefined;
@@ -1192,12 +1213,13 @@ function createNamespaceCommandParser(
   name: string,
   childParser: Parser<Mode, ProgramInvocation, unknown>,
   commandDefinition: AnyCommand | undefined,
+  inheritedHidden?: HiddenVisibility,
 ): Parser<Mode, ProgramInvocation, unknown> {
   const metadata = commandDefinition?.metadata;
   const parser: Parser<Mode, ProgramInvocation, unknown> = command(
     name,
     childParser,
-    namespaceCommandMetadata(metadata),
+    namespaceCommandMetadata(metadata, inheritedHidden),
   );
   const description = metadata?.brief ?? metadata?.description;
   if (description == null) return parser;
@@ -1242,21 +1264,37 @@ function withNamespaceListDocDescription(
 
 function namespaceCommandMetadata(
   metadata: CommandMetadata | undefined,
+  inheritedHidden?: HiddenVisibility,
 ): CommandMetadata | undefined {
-  if (metadata == null) return undefined;
+  const hidden = mergeHidden(inheritedHidden, metadata?.hidden);
   if (
-    metadata.aliases == null &&
-    metadata.errors == null &&
-    metadata.hidden == null &&
-    metadata.usageLine == null
+    metadata?.aliases == null &&
+    metadata?.errors == null &&
+    hidden == null &&
+    metadata?.usageLine == null
   ) {
     return undefined;
   }
   return {
-    ...(metadata.aliases != null && { aliases: metadata.aliases }),
-    ...(metadata.errors != null && { errors: metadata.errors }),
-    ...(metadata.hidden != null && { hidden: metadata.hidden }),
-    ...(metadata.usageLine != null && { usageLine: metadata.usageLine }),
+    ...(metadata?.aliases != null && { aliases: metadata.aliases }),
+    ...(metadata?.errors != null && { errors: metadata.errors }),
+    ...(hidden != null && { hidden }),
+    ...(metadata?.usageLine != null && { usageLine: metadata.usageLine }),
+  };
+}
+
+function commandMetadataWithInheritedHidden(
+  metadata: CommandMetadata | undefined,
+  inheritedHidden: HiddenVisibility | undefined,
+): CommandMetadata | undefined {
+  const hidden = mergeHidden(inheritedHidden, metadata?.hidden);
+  if (metadata == null) {
+    return hidden == null ? undefined : { hidden };
+  }
+  if (hidden === metadata.hidden) return metadata;
+  return {
+    ...metadata,
+    ...(hidden != null && { hidden }),
   };
 }
 
@@ -1289,6 +1327,9 @@ function withRootDocs(
   const rootState = parser.initialState;
   const rootCommand = commands.find((entry) => entry.path.length < 1);
   const listedCommands = commands.filter((entry) => entry.path.length > 0);
+  const commandsByPath = new Map(
+    commands.map((entry) => [commandPathKey(entry.path), entry.command]),
+  );
   const rootDocs = (): DocFragments => {
     const fragments: DocFragment[] = [
       ...(rootCommand?.command.parser.getDocFragments({ kind: "unavailable" })
@@ -1301,7 +1342,7 @@ function withRootDocs(
           term: {
             type: "command",
             name: entry.path.join(" "),
-            hidden: entry.command.metadata?.hidden,
+            hidden: commandPathHidden(entry.path, commandsByPath),
           },
           description: entry.command.metadata?.brief ??
             entry.command.metadata?.description,
@@ -1330,6 +1371,21 @@ function withRootDocs(
       return parser.getDocFragments(state, defaultValue);
     },
   };
+}
+
+function commandPathHidden(
+  path: readonly string[],
+  commandsByPath: ReadonlyMap<string, AnyCommand>,
+): HiddenVisibility | undefined {
+  let hidden: HiddenVisibility | undefined;
+  for (let length = 1; length <= path.length; length++) {
+    hidden = mergeHidden(
+      hidden,
+      commandsByPath.get(commandPathKey(path.slice(0, length)))?.metadata
+        ?.hidden,
+    );
+  }
+  return hidden;
 }
 
 function buildRunOptions(options: RunProgramOptions): RunOptions {

--- a/packages/discover/src/index.ts
+++ b/packages/discover/src/index.ts
@@ -677,7 +677,9 @@ function buildNodeParser(
   const parsers: Parser<Mode, ProgramInvocation, unknown>[] = [];
   const childParser = buildChildrenParser(node);
   if (childParser != null) parsers.push(childParser);
-  if (node.command != null) parsers.push(createLeafParser(node.command));
+  if (node.command != null) {
+    parsers.push(createLeafParser(node.command, childParser != null));
+  }
   if (parsers.length === 1) return parsers[0];
   if (parsers.length < 1) {
     throw new TypeError("Command tree node must contain a command.");
@@ -691,7 +693,9 @@ function buildChildrenParser(
   const parsers: Parser<Mode, ProgramInvocation, unknown>[] = [];
   for (const [name, child] of node.children) {
     const childParser = buildNodeParser(child);
-    const metadata = child.command?.metadata;
+    const metadata = child.children.size > 0
+      ? undefined
+      : child.command?.metadata;
     parsers.push(command(name, childParser, metadata));
   }
   if (parsers.length < 1) return undefined;
@@ -701,14 +705,29 @@ function buildChildrenParser(
 
 function createLeafParser(
   commandDefinition: AnyCommand,
+  includeMetadata = false,
 ): Parser<Mode, ProgramInvocation, unknown> {
-  return map(commandDefinition.parser, (value): ProgramInvocation => ({
+  const parser = map(commandDefinition.parser, (value): ProgramInvocation => ({
     command: commandDefinition,
     value,
     handler: commandDefinition.handler as (
       value: unknown,
     ) => void | Promise<void>,
   })) as Parser<Mode, ProgramInvocation, unknown>;
+  if (!includeMetadata) return parser;
+  return {
+    ...parser,
+    getDocFragments(state, defaultValue) {
+      const fragments = parser.getDocFragments(state, defaultValue);
+      return {
+        ...fragments,
+        brief: fragments.brief ?? commandDefinition.metadata?.brief,
+        description: fragments.description ??
+          commandDefinition.metadata?.description,
+        footer: fragments.footer ?? commandDefinition.metadata?.footer,
+      };
+    },
+  };
 }
 
 function withRootDocs(

--- a/packages/discover/src/index.ts
+++ b/packages/discover/src/index.ts
@@ -1,10 +1,10 @@
-import { or } from "@optique/core/constructs";
+import { longestMatch, or } from "@optique/core/constructs";
 import type {
   SourceContext,
   SourceContextRequest,
 } from "@optique/core/context";
 import type { DocState } from "@optique/core/parser";
-import type { DocFragments } from "@optique/core/doc";
+import type { DocFragment, DocFragments } from "@optique/core/doc";
 import { map } from "@optique/core/modifiers";
 import type { Message } from "@optique/core/message";
 import type { Mode, Parser } from "@optique/core/parser";
@@ -99,6 +99,16 @@ export interface DiscoverCommandsOptions {
    * @default Runtime-aware extension defaults from {@link getDefaultExtensions}
    */
   readonly extensions?: readonly string[];
+
+  /**
+   * File name that maps to the containing command path after extension
+   * stripping.  For example, `stash/index.ts` maps to `stash`, and root
+   * `index.ts` maps to the root command.  Pass `false` to treat matching files
+   * as ordinary command names.
+   *
+   * @default `"index"`
+   */
+  readonly entryFileName?: string | false;
 }
 
 /**
@@ -186,6 +196,14 @@ export interface RunProgramDiscoveryOptions extends RunProgramBaseOptions {
   readonly extensions?: readonly string[];
 
   /**
+   * File name that maps to the containing command path after extension
+   * stripping.
+   *
+   * @default `"index"`
+   */
+  readonly entryFileName?: string | false;
+
+  /**
    * Static commands cannot be used together with `dir`.
    */
   readonly commands?: never;
@@ -211,6 +229,11 @@ export interface RunProgramStaticOptions extends RunProgramBaseOptions {
    * File suffixes are only used with file-system discovery.
    */
   readonly extensions?: never;
+
+  /**
+   * Entry file names are only used with file-system discovery.
+   */
+  readonly entryFileName?: never;
 }
 
 /**
@@ -255,8 +278,8 @@ export function getDefaultExtensions(
  * @param options Discovery options.
  * @returns Discovered commands sorted by command path.
  * @throws {TypeError} If options are invalid, discovery finds no commands,
- *         command paths conflict, or a module does not default-export a
- *         command created with `defineCommand()`.
+ *         command paths are duplicated, or a module does not default-export
+ *         a command created with `defineCommand()`.
  * @since 1.1.0
  */
 export async function discoverCommands(
@@ -266,6 +289,7 @@ export async function discoverCommands(
   const extensions = normalizeExtensions(
     options.extensions ?? getDefaultExtensions(),
   );
+  const entryFileName = normalizeEntryFileName(options.entryFileName);
   const files = await collectCommandFiles(dir, extensions);
   if (files.length < 1) {
     throw new TypeError(`No command modules found in ${dir}.`);
@@ -274,11 +298,11 @@ export async function discoverCommands(
   const seen = new Map<string, string>();
   const discovered: DiscoveredCommand[] = [];
   for (const filePath of files) {
-    const path = commandPathFromFile(dir, filePath, extensions);
+    const path = commandPathFromFile(dir, filePath, extensions, entryFileName);
     const key = commandPathKey(path);
     const previous = seen.get(key);
     if (previous != null) {
-      const displayPath = path.join(" ");
+      const displayPath = displayCommandPath(path);
       throw new TypeError(
         `Duplicate command path "${displayPath}" from ${previous} and ${filePath}.`,
       );
@@ -300,14 +324,13 @@ export async function discoverCommands(
     ) {
       throw new TypeError(
         `Module ${filePath} declares command path "${
-          commandDefinition.path.join(" ")
-        }" but file path defines "${path.join(" ")}".`,
+          displayCommandPath(commandDefinition.path)
+        }" but file path defines "${displayCommandPath(path)}".`,
       );
     }
     discovered.push({ path, filePath, command: commandDefinition });
   }
 
-  rejectPathConflicts(discovered);
   return sortCommands(discovered);
 }
 
@@ -317,7 +340,8 @@ export async function discoverCommands(
  * @param commands Commands to compose.
  * @param metadata Optional root documentation metadata.
  * @returns A parser that resolves to an internal command invocation.
- * @throws {TypeError} If no commands are provided or command paths conflict.
+ * @throws {TypeError} If no commands are provided or command paths are
+ *         duplicated.
  * @since 1.1.0
  */
 export function createProgramParser(
@@ -331,13 +355,7 @@ export function createProgramParser(
   rejectDuplicatePaths(
     sortedCommands.map((entry) => ({
       path: entry.path,
-      filePath: entry.path.join("/"),
-    })),
-  );
-  rejectPathConflicts(
-    sortedCommands.map((entry) => ({
-      path: entry.path,
-      filePath: entry.path.join("/"),
+      filePath: displayCommandPath(entry.path),
     })),
   );
   const rootNode = buildCommandTree(sortedCommands);
@@ -362,6 +380,7 @@ export async function runProgram(options: RunProgramOptions): Promise<void> {
     commands = await discoverCommands({
       dir: options.dir,
       extensions: options.extensions,
+      entryFileName: options.entryFileName,
     });
   }
   const parser = createProgramParser(commands, options.metadata);
@@ -450,6 +469,23 @@ function normalizeExtensions(extensions: readonly string[]): readonly string[] {
   );
 }
 
+function normalizeEntryFileName(
+  entryFileName: string | false | undefined,
+): string | false {
+  if (entryFileName === false) return false;
+  const normalized = entryFileName ?? "index";
+  if (
+    normalized.length < 1 ||
+    normalized.includes("/") ||
+    normalized.includes("\\")
+  ) {
+    throw new TypeError(
+      `Command entry file name must be a non-empty file name: ${normalized}`,
+    );
+  }
+  return normalized;
+}
+
 async function collectCommandFiles(
   dir: string,
   extensions: readonly string[],
@@ -511,6 +547,7 @@ function commandPathFromFile(
   rootDir: string,
   filePath: string,
   extensions: readonly string[],
+  entryFileName: string | false,
 ): CommandPath {
   const matchedExtension = extensions.find((ext) => filePath.endsWith(ext));
   if (matchedExtension == null) {
@@ -519,42 +556,26 @@ function commandPathFromFile(
   const withoutExtension = filePath.slice(0, -matchedExtension.length);
   const relativePath = relative(rootDir, withoutExtension);
   const path = relativePath.split(sep).filter((segment) => segment.length > 0);
-  const [first, ...rest] = path;
-  if (first == null) {
+  if (path.length < 1) {
     throw new TypeError(`Command file ${filePath} does not define a path.`);
   }
-  return [first, ...rest];
+  if (entryFileName !== false && path[path.length - 1] === entryFileName) {
+    return path.slice(0, -1);
+  }
+  return path;
 }
 
 function commandPathKey(path: readonly string[]): string {
   return path.join("\0");
 }
 
-function isCommandPath(path: unknown): path is CommandPath {
-  return Array.isArray(path) &&
-    path.length > 0 &&
-    path.every((segment) => typeof segment === "string" && segment.length > 0);
+function displayCommandPath(path: readonly string[]): string {
+  return path.length < 1 ? "<root>" : path.join(" ");
 }
 
-function rejectPathConflicts(
-  commands: readonly Pick<DiscoveredCommand, "path" | "filePath">[],
-): void {
-  const paths = new Map(
-    commands.map((entry) => [commandPathKey(entry.path), entry]),
-  );
-  for (const entry of commands) {
-    for (let i = 1; i < entry.path.length; i++) {
-      const parent = entry.path.slice(0, i);
-      const parentEntry = paths.get(commandPathKey(parent));
-      if (parentEntry != null) {
-        throw new TypeError(
-          `Command path "${parent.join(" ")}" conflicts with nested command "${
-            entry.path.join(" ")
-          }".`,
-        );
-      }
-    }
-  }
+function isCommandPath(path: unknown): path is CommandPath {
+  return Array.isArray(path) &&
+    path.every((segment) => typeof segment === "string" && segment.length > 0);
 }
 
 function rejectDuplicatePaths(
@@ -565,7 +586,7 @@ function rejectDuplicatePaths(
     const key = commandPathKey(entry.path);
     const previous = seen.get(key);
     if (previous != null) {
-      const displayPath = entry.path.join(" ");
+      const displayPath = displayCommandPath(entry.path);
       throw new TypeError(
         `Duplicate command path "${displayPath}" from ${previous} and ${entry.filePath}.`,
       );
@@ -606,7 +627,7 @@ function staticCommandsToEntries(
     }
     if (!isCommandPath(command.path)) {
       throw new TypeError(
-        "Static command entries must declare a non-empty path.",
+        "Static command entries must declare a path.",
       );
     }
     return {
@@ -648,13 +669,26 @@ function buildNodeParser(
   node: CommandTreeNode,
 ): Parser<Mode, ProgramInvocation, unknown> {
   const parsers: Parser<Mode, ProgramInvocation, unknown>[] = [];
+  const childParser = buildChildrenParser(node);
+  if (childParser != null) parsers.push(childParser);
+  if (node.command != null) parsers.push(createLeafParser(node.command));
+  if (parsers.length === 1) return parsers[0];
+  if (parsers.length < 1) {
+    throw new TypeError("Command tree node must contain a command.");
+  }
+  return longestMatch(...parsers) as Parser<Mode, ProgramInvocation, unknown>;
+}
+
+function buildChildrenParser(
+  node: CommandTreeNode,
+): Parser<Mode, ProgramInvocation, unknown> | undefined {
+  const parsers: Parser<Mode, ProgramInvocation, unknown>[] = [];
   for (const [name, child] of node.children) {
-    const childParser = child.command != null
-      ? createLeafParser(child.command)
-      : buildNodeParser(child);
+    const childParser = buildNodeParser(child);
     const metadata = child.command?.metadata;
     parsers.push(command(name, childParser, metadata));
   }
+  if (parsers.length < 1) return undefined;
   if (parsers.length === 1) return parsers[0];
   return or(...parsers) as Parser<Mode, ProgramInvocation, unknown>;
 }
@@ -677,23 +711,34 @@ function withRootDocs(
   metadata: ProgramHelpMetadata,
 ): Parser<Mode, ProgramInvocation, unknown> {
   const rootState = parser.initialState;
-  const rootDocs = (): DocFragments => ({
-    brief: metadata.brief,
-    description: metadata.description,
-    footer: metadata.footer,
-    fragments: [{
-      type: "section",
-      entries: commands.map((entry) => ({
-        term: {
-          type: "command",
-          name: entry.path.join(" "),
-          hidden: entry.command.metadata?.hidden,
-        },
-        description: entry.command.metadata?.brief ??
-          entry.command.metadata?.description,
-      })),
-    }],
-  });
+  const rootCommand = commands.find((entry) => entry.path.length < 1);
+  const listedCommands = commands.filter((entry) => entry.path.length > 0);
+  const rootDocs = (): DocFragments => {
+    const fragments: DocFragment[] = [
+      ...(rootCommand?.command.parser.getDocFragments({ kind: "unavailable" })
+        .fragments ?? []),
+    ];
+    if (listedCommands.length > 0) {
+      fragments.push({
+        type: "section",
+        entries: listedCommands.map((entry) => ({
+          term: {
+            type: "command",
+            name: entry.path.join(" "),
+            hidden: entry.command.metadata?.hidden,
+          },
+          description: entry.command.metadata?.brief ??
+            entry.command.metadata?.description,
+        })),
+      });
+    }
+    return {
+      brief: metadata.brief,
+      description: metadata.description,
+      footer: metadata.footer,
+      fragments,
+    };
+  };
   return {
     ...parser,
     getDocFragments(
@@ -717,6 +762,7 @@ function buildRunOptions(options: RunProgramOptions): RunOptions {
     dir: _dir,
     commands: _commands,
     extensions: _extensions,
+    entryFileName: _entryFileName,
     metadata: _metadata,
     help,
     version,

--- a/packages/discover/src/index.ts
+++ b/packages/discover/src/index.ts
@@ -1247,6 +1247,7 @@ function namespaceCommandMetadata(
   if (
     metadata.aliases == null &&
     metadata.errors == null &&
+    metadata.hidden == null &&
     metadata.usageLine == null
   ) {
     return undefined;
@@ -1254,6 +1255,7 @@ function namespaceCommandMetadata(
   return {
     ...(metadata.aliases != null && { aliases: metadata.aliases }),
     ...(metadata.errors != null && { errors: metadata.errors }),
+    ...(metadata.hidden != null && { hidden: metadata.hidden }),
     ...(metadata.usageLine != null && { usageLine: metadata.usageLine }),
   };
 }

--- a/packages/discover/src/index.ts
+++ b/packages/discover/src/index.ts
@@ -19,6 +19,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import {
   type AnyCommand,
   type AnyStaticCommand,
+  type CommandMetadata,
   type CommandPath,
   isCommand,
 } from "./command.ts";
@@ -694,13 +695,24 @@ function buildChildrenParser(
   for (const [name, child] of node.children) {
     const childParser = buildNodeParser(child);
     const metadata = child.children.size > 0
-      ? undefined
+      ? namespaceCommandMetadata(child.command?.metadata)
       : child.command?.metadata;
     parsers.push(command(name, childParser, metadata));
   }
   if (parsers.length < 1) return undefined;
   if (parsers.length === 1) return parsers[0];
   return or(...parsers) as Parser<Mode, ProgramInvocation, unknown>;
+}
+
+function namespaceCommandMetadata(
+  metadata: CommandMetadata | undefined,
+): CommandMetadata | undefined {
+  if (metadata == null) return undefined;
+  if (metadata.aliases == null && metadata.errors == null) return undefined;
+  return {
+    ...(metadata.aliases != null && { aliases: metadata.aliases }),
+    ...(metadata.errors != null && { errors: metadata.errors }),
+  };
 }
 
 function createLeafParser(

--- a/packages/discover/src/index.ts
+++ b/packages/discover/src/index.ts
@@ -6,7 +6,11 @@ import type {
 import type { DocState } from "@optique/core/parser";
 import type { DocFragment, DocFragments } from "@optique/core/doc";
 import type { RuntimeNode } from "@optique/core/dependency-runtime";
-import { inheritAnnotations } from "@optique/core/extension";
+import {
+  inheritAnnotations,
+  mapModeValue,
+  wrapForMode,
+} from "@optique/core/extension";
 import { map } from "@optique/core/modifiers";
 import type { Message } from "@optique/core/message";
 import type {
@@ -116,6 +120,7 @@ export interface DiscoverCommandsOptions {
    * as ordinary command names.
    *
    * @default `"index"`
+   * @since 1.2.0
    */
   readonly entryFileName?: string | false;
 }
@@ -209,6 +214,7 @@ export interface RunProgramDiscoveryOptions extends RunProgramBaseOptions {
    * stripping.
    *
    * @default `"index"`
+   * @since 1.2.0
    */
   readonly entryFileName?: string | false;
 
@@ -732,24 +738,22 @@ function createExecutableNodeParser(
             branchParser,
           ),
         );
-        if (isPromiseLike(result)) {
-          return result.then((resolved) =>
-            wrapBranchParseResult(context, activeState, resolved)
-          );
-        }
-        return wrapBranchParseResult(context, activeState, result);
+        return mapModeValue(
+          parser.mode,
+          wrapForMode(parser.mode, result),
+          (resolved) => wrapBranchParseResult(context, activeState, resolved),
+        );
       }
 
       const result = parser.parse({
         ...context,
         state: toExclusiveState(activeState, context.state),
       });
-      if (isPromiseLike(result)) {
-        return result.then((resolved) =>
-          wrapInitialParseResult(context, resolved)
-        );
-      }
-      return wrapInitialParseResult(context, result);
+      return mapModeValue(
+        parser.mode,
+        wrapForMode(parser.mode, result),
+        (resolved) => wrapInitialParseResult(context, resolved),
+      );
     },
     complete(state, exec) {
       const activeState = normalizeExecutableNodeState(state);
@@ -867,12 +871,17 @@ function completeExecutableNodeLeaf(
   leafParser: Parser<Mode, ProgramInvocation, unknown>,
 ) {
   const result = parseExecutableNodeLeaf(state, exec, leafParser);
-  if (isPromiseLike(result)) {
-    return result.then((resolved) =>
+  if (leafParser.mode === "async") {
+    return Promise.resolve(wrapForMode("async", result)).then((resolved) =>
       completeParsedExecutableNodeLeaf(state, exec, leafParser, resolved)
     );
   }
-  return completeParsedExecutableNodeLeaf(state, exec, leafParser, result);
+  return completeParsedExecutableNodeLeaf(
+    state,
+    exec,
+    leafParser,
+    wrapForMode("sync", result),
+  );
 }
 
 function completeParsedExecutableNodeLeaf(
@@ -902,8 +911,8 @@ function extractExecutableNodePhase2Seed(
     return phase2SeedHook.extract(toExclusiveState(activeState, state), exec);
   }
   const result = parseExecutableNodeLeaf(state, exec, leafParser);
-  if (isPromiseLike(result)) {
-    return result.then((resolved) =>
+  if (leafParser.mode === "async") {
+    return Promise.resolve(wrapForMode("async", result)).then((resolved) =>
       extractParsedExecutableNodePhase2Seed(
         state,
         exec,
@@ -915,7 +924,7 @@ function extractExecutableNodePhase2Seed(
   return extractParsedExecutableNodePhase2Seed(
     state,
     exec,
-    result,
+    wrapForMode("sync", result),
     phase2SeedHook,
   );
 }
@@ -1125,14 +1134,6 @@ function mergeExecutableNodeChildExec(
   };
 }
 
-function isPromiseLike<T>(
-  value: T | Promise<T>,
-): value is Promise<T> {
-  return value != null &&
-    typeof value === "object" &&
-    typeof (value as { readonly then?: unknown }).then === "function";
-}
-
 function withCommandDocMetadata(
   fragments: DocFragments,
   metadata: CommandMetadata | undefined,
@@ -1152,14 +1153,69 @@ function buildChildrenParser(
   const parsers: Parser<Mode, ProgramInvocation, unknown>[] = [];
   for (const [name, child] of node.children) {
     const childParser = buildNodeParser(child);
-    const metadata = child.children.size > 0
-      ? namespaceCommandMetadata(child.command?.metadata)
-      : child.command?.metadata;
-    parsers.push(command(name, childParser, metadata));
+    if (child.children.size > 0) {
+      parsers.push(
+        createNamespaceCommandParser(name, childParser, child.command),
+      );
+    } else {
+      parsers.push(command(name, childParser, child.command?.metadata));
+    }
   }
   if (parsers.length < 1) return undefined;
   if (parsers.length === 1) return parsers[0];
   return or(...parsers) as Parser<Mode, ProgramInvocation, unknown>;
+}
+
+function createNamespaceCommandParser(
+  name: string,
+  childParser: Parser<Mode, ProgramInvocation, unknown>,
+  commandDefinition: AnyCommand | undefined,
+): Parser<Mode, ProgramInvocation, unknown> {
+  const metadata = commandDefinition?.metadata;
+  const parser: Parser<Mode, ProgramInvocation, unknown> = command(
+    name,
+    childParser,
+    namespaceCommandMetadata(metadata),
+  );
+  const description = metadata?.brief ?? metadata?.description;
+  if (description == null) return parser;
+  return {
+    ...parser,
+    getDocFragments(state, defaultValue) {
+      const fragments = parser.getDocFragments(state, defaultValue);
+      if (
+        state.kind !== "unavailable" &&
+        (state.kind !== "available" ||
+          !Object.is(state.state, parser.initialState))
+      ) {
+        return fragments;
+      }
+      return withNamespaceListDocDescription(fragments, name, description);
+    },
+  };
+}
+
+function withNamespaceListDocDescription(
+  fragments: DocFragments,
+  name: string,
+  description: Message,
+): DocFragments {
+  return {
+    ...fragments,
+    fragments: fragments.fragments.map((fragment): DocFragment => {
+      if (
+        fragment.type !== "entry" ||
+        fragment.term.type !== "command" ||
+        fragment.term.name !== name
+      ) {
+        return fragment;
+      }
+      return {
+        ...fragment,
+        description: fragment.description ?? description,
+      };
+    }),
+  };
 }
 
 function namespaceCommandMetadata(

--- a/packages/discover/src/index.ts
+++ b/packages/discover/src/index.ts
@@ -472,8 +472,14 @@ function normalizeExtensions(extensions: readonly string[]): readonly string[] {
 function normalizeEntryFileName(
   entryFileName: string | false | undefined,
 ): string | false {
+  if (entryFileName === undefined) return "index";
   if (entryFileName === false) return false;
-  const normalized = entryFileName ?? "index";
+  if (typeof entryFileName !== "string") {
+    throw new TypeError(
+      `Command entry file name must be a non-empty file name: ${entryFileName}`,
+    );
+  }
+  const normalized = entryFileName;
   if (
     normalized.length < 1 ||
     normalized.includes("/") ||


### PR DESCRIPTION
This pull request teaches *@optique/discover* to treat entry files as commands for their containing path and to let those commands coexist with nested commands. With the default `entryFileName: "index"`, *commands/index.ts* defines the root command, and *commands/stash/index.ts* defines `stash` while *commands/stash/list.ts* still defines `stash list`. Static registration also accepts `path: []` for root commands.

The parser builder now creates an executable namespace when a tree node has both a command and children. The parent command keeps its own aliases, usage line, errors, docs, and source-backed completion behavior without leaking display metadata into child command pages. It also locks dispatch once parent arguments are consumed, so input like `stash --message wip list` cannot silently switch to `stash list`.

The docs in *docs/concepts/discover.md* and *packages/discover/README.md* describe entry-file mapping, custom `entryFileName` values, disabled entry-file handling, and duplicate path behavior. *CHANGES.md* records the feature.

Closes #838.