### PR TITLE
Static module discovery

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,14 +10,23 @@ To be released.
 
 ### @optique/discover
 
+ -  Added `commandsFromModules()` for bundler-friendly command discovery from
+    static module maps such as eager `import.meta.glob()` results.  The helper
+    derives command paths with the same extension, entry-file, duplicate-path,
+    and explicit `path` validation rules as file-system discovery, and returns
+    command entries that can be passed directly to
+    `runProgram({ commands })`.  [[#830], [#840]]
+
  -  Added executable parent commands to file-system discovery.  Entry files
     such as *stash/index.ts* now map to the containing command path (`stash`),
     root *index.ts* defines the root command, and parent commands can coexist
     with nested commands such as `stash list`.  The `entryFileName` option
     customizes or disables the entry-file rule.  [[#838], [#839]]
 
+[#830]: https://github.com/dahlia/optique/issues/830
 [#838]: https://github.com/dahlia/optique/issues/838
 [#839]: https://github.com/dahlia/optique/pull/839
+[#840]: https://github.com/dahlia/optique/pull/840
 
 
 Version 1.1.0

--- a/docs/concepts/discover.md
+++ b/docs/concepts/discover.md
@@ -23,8 +23,9 @@ man pages and runner integration.
 > Command discovery is a runtime feature, not a static registry.  It reads the
 > command directory and imports matching modules dynamically, so bundlers cannot
 > reliably see which command files are used.  If your CLI depends on tree
-> shaking, static bundling, or single-file executable packaging, import command
-> modules manually and pass them to `runProgram()` with `commands`.
+> shaking, static bundling, or single-file executable packaging, use
+> `commandsFromModules()` with a static module map, or import command modules
+> manually and pass them to `runProgram()` with `commands`.
 
 
 Command modules
@@ -135,12 +136,63 @@ await runProgram({
 ~~~~
 
 
-Running statically imported commands
-------------------------------------
+Running with static module maps
+-------------------------------
 
-When command modules need to be visible to a bundler or single-file packager,
-import them manually and pass them as `commands`.  Each command declares its
-own path:
+Bundlers often provide a static module map API for glob imports.  For example,
+Vite and Rollup-based toolchains can statically see `import.meta.glob()` when
+the pattern is literal.  `commandsFromModules()` turns that module map into the
+same command entries that file-system discovery would have produced:
+
+~~~~ typescript twoslash
+declare global {
+  interface ImportMeta {
+    glob(
+      pattern: string,
+      options: { readonly eager: true },
+    ): Record<string, unknown>;
+  }
+}
+// ---cut-before---
+import { message } from "@optique/core/message";
+import { commandsFromModules, runProgram } from "@optique/discover";
+
+const modules = import.meta.glob("./commands/**/*.ts", { eager: true });
+
+await runProgram({
+  commands: commandsFromModules(modules, {
+    base: "./commands",
+    extensions: [".ts"],
+  }),
+  metadata: {
+    name: "admin",
+    version: "1.0.0",
+    brief: message`Administrative command-line tools.`,
+  },
+});
+~~~~
+
+Each module value must expose a default export created with
+`defineCommand()`.  The module map key is treated like a file path relative to
+`base`, so *./commands/user/add.ts* becomes `user add`.  Entry files keep the
+same meaning as runtime discovery: *./commands/index.ts* defines the root
+command, and *./commands/user/index.ts* defines `user`.
+
+Pass `extensions` when the module map keys keep source file suffixes such as
+*.ts* after bundling.  Compound suffixes are matched with the same precedence
+as dynamic discovery, and TypeScript declaration files such as *.d.ts*,
+*.d.mts*, and *.d.cts* are ignored.
+
+The returned entries can also be passed to `createProgramParser()` when you
+want to build the parser directly instead of using `runProgram()`.
+
+
+Running manually imported commands
+----------------------------------
+
+For a small static command registry, or when you want to assign command paths
+manually, import modules yourself and pass commands as `commands`.  Each
+command declares its own path:
 
 ~~~~ typescript twoslash
 import { object } from "@optique/core/constructs";
@@ -175,14 +227,17 @@ await runProgram({
 
 `commands` and `dir` are mutually exclusive.  Use `commands` when static
 imports matter; use `dir` when the runtime file layout is the command registry.
+Prefer `commandsFromModules()` when you want to keep deriving paths from a
+command directory layout.
 
 
 File names and extensions
 -------------------------
 
 The relative file path becomes the command path after removing the configured
-suffix.  Compound suffixes are supported, so *user/add.cmd.ts* can become
-`user add` when *.cmd.ts* is listed before *.ts*.
+suffix.  `commandsFromModules()` applies the same rule to module map keys after
+stripping its `base` option.  Compound suffixes are supported, so
+*user/add.cmd.ts* can become `user add` when *.cmd.ts* is listed before *.ts*.
 
 By default, an entry file named *index* maps to its containing command path:
 
@@ -284,8 +339,16 @@ Use *@optique/discover* when:
 Use static `commands` with manually imported command modules when:
 
  -  You need tree shaking, static bundling, or single-file executable
+    packaging, and your toolchain does not provide a static module map
+ -  You want to assign command paths by hand instead of deriving them from
+    module paths
+
+Use `commandsFromModules()` with a static module map when:
+
+ -  You need tree shaking, static bundling, or single-file executable
     packaging
- -  You want command modules to be visible through ordinary static imports
+ -  You want command modules to be visible to the bundler while keeping the
+    file layout as the command registry
 
 Use plain *@optique/core* and *@optique/run* when:
 

--- a/packages/discover/README.md
+++ b/packages/discover/README.md
@@ -14,7 +14,8 @@ handler.
 > *@optique/discover* reads command files and imports them dynamically at
 > runtime.  It is a poor fit for CLIs that rely on aggressive tree shaking,
 > static bundling, or single-file executable packaging.  In those cases, use
-> manually imported commands with `runProgram({ commands })`.
+> `commandsFromModules()` with a static module map, or manually imported
+> commands with `runProgram({ commands })`.
 
 
 Installation
@@ -79,32 +80,23 @@ admin --help
 admin completion bash
 ~~~~
 
-For bundlers and single-file packagers, import commands manually and declare
-their paths in the command definitions:
+For bundlers and single-file packagers, turn a static module map into command
+entries:
 
 ~~~~ typescript
 // cli.ts
-import { defineCommand, runProgram } from "@optique/discover";
-import { object } from "@optique/core/constructs";
+import { commandsFromModules, runProgram } from "@optique/discover";
 import { message } from "@optique/core/message";
-import { option } from "@optique/core/primitives";
-import { string } from "@optique/core/valueparser";
 
-const addUser = defineCommand({
-  path: ["user", "add"],
-  parser: object({
-    name: option("--name", string()),
-  }),
-  metadata: {
-    brief: message`Add a user.`,
-  },
-  handler(value) {
-    console.log(`Adding ${value.name}.`);
-  },
+const modules = import.meta.glob("./commands/**/*.ts", {
+  eager: true,
 });
 
 await runProgram({
-  commands: [addUser],
+  commands: commandsFromModules(modules, {
+    base: "./commands",
+    extensions: [".ts"],
+  }),
   metadata: {
     name: "admin",
     version: "1.0.0",
@@ -113,6 +105,11 @@ await runProgram({
 });
 ~~~~
 
+`commandsFromModules()` preserves the file-based command layout while making
+the module list visible to bundlers.  For smaller registries, you can also
+import commands manually, declare `path` in each `defineCommand()` call, and
+pass those commands to `runProgram({ commands })`.
+
 By default, Deno and Bun discover `.ts`, `.mts`, `.js`, and `.mjs` files.
 Node.js discovers `.js`, `.mjs`, and `.cjs` files, plus `.ts`, `.mts`, and
 `.cts` when it reports native TypeScript support or runs with a recognized
@@ -120,7 +117,8 @@ TypeScript loader.  TypeScript declaration files such as `.d.ts` are ignored.
 Entry files named `index` map to their containing command path, so
 `commands/index.ts` defines the root command and `commands/user/index.ts`
 defines `user`.  Use `entryFileName` to choose another entry name or disable
-this rule.
+this rule.  `commandsFromModules()` applies the same path rules to module map
+keys after stripping its `base` option.
 
 For more resources, see the [docs] and the [*examples/*](/examples/)
 directory.

--- a/packages/discover/src/index.test.ts
+++ b/packages/discover/src/index.test.ts
@@ -33,6 +33,7 @@ import { describe, it } from "node:test";
 import { defineCommand } from "#src/command.ts";
 import {
   type CommandPath,
+  commandsFromModules,
   createProgramParser,
   discoverCommands,
   getDefaultExtensions,
@@ -580,6 +581,211 @@ describe("discoverCommands()", () => {
 
     const denoDefaults = getDefaultExtensions({ runtime: "deno" });
     assert.deepEqual(denoDefaults, [".ts", ".mts", ".js", ".mjs"]);
+  });
+});
+
+describe("commandsFromModules()", () => {
+  it("derives command paths from static module map keys", () => {
+    const buildCommand = makeCommand();
+    const addCommand = makeCommand();
+
+    const commands = commandsFromModules({
+      "./commands/user/add.ts": { default: addCommand },
+      "./commands/build.ts": { default: buildCommand },
+    }, {
+      base: "./commands",
+      extensions: [".ts"],
+    });
+
+    assert.deepEqual(commands.map((command) => command.path), [
+      ["build"],
+      ["user", "add"],
+    ]);
+    assert.equal(commands[0]?.command, buildCommand);
+    assert.equal(commands[1]?.command, addCommand);
+  });
+
+  it("maps entry files to containing command paths", () => {
+    const rootCommand = makeCommand();
+    const stashCommand = makeCommand();
+    const listCommand = makeCommand();
+
+    const commands = commandsFromModules({
+      "./commands/stash/list.ts": { default: listCommand },
+      "./commands/index.ts": { default: rootCommand },
+      "./commands/stash/index.ts": { default: stashCommand },
+    }, {
+      base: "./commands",
+      extensions: [".ts"],
+    });
+
+    assert.deepEqual(commands.map((command) => command.path), [
+      [],
+      ["stash"],
+      ["stash", "list"],
+    ]);
+    assert.equal(commands[0]?.command, rootCommand);
+    assert.equal(commands[1]?.command, stashCommand);
+    assert.equal(commands[2]?.command, listCommand);
+  });
+
+  it("matches compound extension precedence and ignores declaration files", () => {
+    const commandCommand = makeCommand();
+    const zzzCommand = makeCommand();
+
+    const commands = commandsFromModules({
+      "./commands/a.d.ts": { default: makeCommand() },
+      "./commands/a.cmd.ts": { default: commandCommand },
+      "./commands/a-zzz.ts": { default: zzzCommand },
+    }, {
+      base: "./commands",
+      extensions: [".ts", ".cmd.ts"],
+    });
+
+    assert.deepEqual(commands.map((command) => command.path), [
+      ["a"],
+      ["a-zzz"],
+    ]);
+    assert.equal(commands[0]?.command, commandCommand);
+    assert.equal(commands[1]?.command, zzzCommand);
+  });
+
+  it("supports custom and disabled entry file names", () => {
+    const modCommands = commandsFromModules({
+      "./commands/mod.ts": { default: makeCommand() },
+      "./commands/stash/mod.ts": { default: makeCommand() },
+    }, {
+      base: "./commands",
+      extensions: [".ts"],
+      entryFileName: "mod",
+    });
+
+    assert.deepEqual(modCommands.map((command) => command.path), [
+      [],
+      ["stash"],
+    ]);
+
+    const indexCommands = commandsFromModules({
+      "./commands/index.ts": { default: makeCommand() },
+      "./commands/stash/index.ts": { default: makeCommand() },
+    }, {
+      base: "./commands",
+      extensions: [".ts"],
+      entryFileName: false,
+    });
+
+    assert.deepEqual(indexCommands.map((command) => command.path), [
+      ["index"],
+      ["stash", "index"],
+    ]);
+  });
+
+  it("rejects duplicate command paths", () => {
+    assert.throws(
+      () =>
+        commandsFromModules({
+          "./commands/build.ts": { default: makeCommand() },
+          "./commands/build.cmd.ts": { default: makeCommand() },
+        }, {
+          base: "./commands",
+          extensions: [".cmd.ts", ".ts"],
+        }),
+      /Duplicate command path "build" from \.\/commands\/build\.cmd\.ts and \.\/commands\/build\.ts\./,
+    );
+  });
+
+  it("rejects modules whose default export is not a command", () => {
+    assert.throws(
+      () =>
+        commandsFromModules({
+          "./commands/bad.ts": {},
+        }, {
+          base: "./commands",
+          extensions: [".ts"],
+        }),
+      {
+        name: "TypeError",
+        message:
+          "Module ./commands/bad.ts default export must be created with defineCommand().",
+      },
+    );
+  });
+
+  it("unwraps CommonJS default-wrapped command exports", () => {
+    const buildCommand = makeCommand();
+
+    const commands = commandsFromModules({
+      "./commands/build.cjs": { default: { default: buildCommand } },
+    }, {
+      base: "./commands",
+      extensions: [".cjs"],
+    });
+
+    assert.deepEqual(commands.map((command) => command.path), [["build"]]);
+    assert.equal(commands[0]?.command, buildCommand);
+  });
+
+  it("rejects declared paths that do not match module-derived paths", () => {
+    assert.throws(
+      () =>
+        commandsFromModules({
+          "./commands/build.ts": {
+            default: defineCommand({
+              path: ["deploy"],
+              parser: object({}),
+              handler() {},
+            }),
+          },
+        }, {
+          base: "./commands",
+          extensions: [".ts"],
+        }),
+      /declares command path "deploy" but module path defines "build"\./,
+    );
+  });
+
+  it("works with createProgramParser() for help and dispatch", async () => {
+    const calls: unknown[] = [];
+    const commands = commandsFromModules({
+      "./commands/index.ts": {
+        default: defineCommand({
+          parser: object({
+            name: option("--name", string()),
+          }),
+          metadata: { brief: message`Create an app.` },
+          handler(value) {
+            calls.push(["root", value]);
+          },
+        }),
+      },
+      "./commands/build.ts": {
+        default: defineCommand({
+          parser: object({}),
+          metadata: { brief: message`Build the app.` },
+          handler(value) {
+            calls.push(["build", value]);
+          },
+        }),
+      },
+    }, {
+      base: "./commands",
+      extensions: [".ts"],
+    });
+    const parser = createProgramParser(commands);
+
+    const page = await getDocPageAsync(parser);
+    assert.ok(page != null);
+    const text = formatDocPage("tool", page);
+    assert.match(text, /--name/);
+    assert.match(text, /build\s+Build the app\./);
+
+    const state = await parseAll(parser, ["build"]);
+    const result = await parser.complete(state);
+    assert.ok(result.success);
+    if (result.success) {
+      await result.value.handler(result.value.value);
+    }
+    assert.deepEqual(calls, [["build", {}]]);
   });
 });
 
@@ -1392,6 +1598,38 @@ describe("runProgram()", () => {
     assert.deepEqual(calls, [{ value: "done" }]);
   });
 
+  it("runs commands converted from a static module map", async () => {
+    const calls: unknown[] = [];
+    const commands = commandsFromModules({
+      "./commands/write.ts": {
+        default: defineCommand({
+          parser: object({
+            value: option("--value", string()),
+          }),
+          handler(value) {
+            calls.push(value);
+          },
+        }),
+      },
+    }, {
+      base: "./commands",
+      extensions: [".ts"],
+    });
+
+    await runProgram({
+      commands,
+      metadata: { name: "tool", version: "1.0.0" },
+      args: ["write", "--value", "done"],
+      stdout() {},
+      stderr() {},
+      onExit(exitCode): never {
+        throw new Error(`Unexpected exit ${exitCode}.`);
+      },
+    });
+
+    assert.deepEqual(calls, [{ value: "done" }]);
+  });
+
   it("runs statically registered root commands", async () => {
     const calls: unknown[] = [];
     const createCommand = defineCommand({
@@ -1821,6 +2059,13 @@ function runtimeModuleUrl(
     runtime.Bun === undefined &&
     runtime.Deno === undefined;
   return moduleUrl(isNode ? nodeRelative : sourceRelative);
+}
+
+function makeCommand() {
+  return defineCommand({
+    parser: object({}),
+    handler() {},
+  });
 }
 
 async function parseAll(

--- a/packages/discover/src/index.ts
+++ b/packages/discover/src/index.ts
@@ -27,7 +27,7 @@ import { type HiddenVisibility, mergeHidden } from "@optique/core/usage";
 import { runAsync } from "@optique/run";
 import type { RunOptions } from "@optique/run";
 import { readdir, realpath, stat } from "node:fs/promises";
-import { relative, resolve, sep } from "node:path";
+import { posix, relative, resolve, sep } from "node:path";
 import process from "node:process";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import {
@@ -75,11 +75,32 @@ export interface ProgramInvocation {
 }
 
 /**
+ * A command paired with its command path.
+ *
+ * `createProgramParser()` accepts command entries directly, and
+ * `runProgram({ commands })` accepts them alongside commands that declare
+ * their own `path` field.
+ *
+ * @since 1.2.0
+ */
+export interface CommandEntry {
+  /**
+   * Command path used to place the command in the program tree.
+   */
+  readonly path: CommandPath;
+
+  /**
+   * The command definition.
+   */
+  readonly command: AnyCommand;
+}
+
+/**
  * A command found on disk.
  *
  * @since 1.1.0
  */
-export interface DiscoveredCommand {
+export interface DiscoveredCommand extends CommandEntry {
   /**
    * Command path derived from the module's relative path.
    */
@@ -95,6 +116,28 @@ export interface DiscoveredCommand {
    */
   readonly command: AnyCommand;
 }
+
+/**
+ * A command loaded from a static module map.
+ *
+ * @since 1.2.0
+ */
+export interface ModuleCommand extends CommandEntry {
+  /**
+   * Module map key used to derive the command path.
+   */
+  readonly modulePath: string;
+}
+
+/**
+ * Static module map accepted by {@link commandsFromModules}.
+ *
+ * This matches eager glob import APIs such as Vite's
+ * `import.meta.glob(..., { eager: true })`.
+ *
+ * @since 1.2.0
+ */
+export type ModuleMap = Readonly<Record<string, unknown>>;
 
 /**
  * Options for {@link discoverCommands}.
@@ -123,6 +166,38 @@ export interface DiscoverCommandsOptions {
    *
    * @default `"index"`
    * @since 1.2.0
+   */
+  readonly entryFileName?: string | false;
+}
+
+/**
+ * Options for {@link commandsFromModules}.
+ *
+ * @since 1.2.0
+ */
+export interface CommandsFromModulesOptions {
+  /**
+   * Base module path to strip before deriving command paths.
+   *
+   * @default `"."`
+   */
+  readonly base?: string;
+
+  /**
+   * Module suffixes to include.  Compound suffixes such as `.cmd.ts` are
+   * supported.
+   *
+   * @default Runtime-aware extension defaults from {@link getDefaultExtensions}
+   */
+  readonly extensions?: readonly string[];
+
+  /**
+   * File name that maps to the containing command path after extension
+   * stripping.  For example, `stash/index.ts` maps to `stash`, and root
+   * `index.ts` maps to the root command.  Pass `false` to treat matching files
+   * as ordinary command names.
+   *
+   * @default `"index"`
    */
   readonly entryFileName?: string | false;
 }
@@ -234,8 +309,11 @@ export interface RunProgramDiscoveryOptions extends RunProgramBaseOptions {
 export interface RunProgramStaticOptions extends RunProgramBaseOptions {
   /**
    * Commands to compose without file-system discovery.
+   *
+   * Pass commands that declare their own `path`, or command entries returned
+   * by {@link commandsFromModules}.
    */
-  readonly commands: readonly AnyStaticCommand[];
+  readonly commands: readonly (AnyStaticCommand | CommandEntry)[];
 
   /**
    * File-system discovery cannot be used together with `commands`.
@@ -329,25 +407,93 @@ export async function discoverCommands(
     const mod = await import(pathToFileURL(filePath).href) as {
       readonly default?: unknown;
     };
-    const commandDefinition = unwrapCommandExport(mod.default);
-    if (commandDefinition == null) {
-      throw new TypeError(
-        `Module ${filePath} default export must be created with defineCommand().`,
-      );
-    }
-    if (
-      commandDefinition.path != null &&
-      commandPathKey(commandDefinition.path) !== commandPathKey(path)
-    ) {
-      throw new TypeError(
-        `Module ${filePath} declares command path "${
-          displayCommandPath(commandDefinition.path)
-        }" but file path defines "${displayCommandPath(path)}".`,
-      );
-    }
+    const commandDefinition = commandFromModuleExport(filePath, mod.default);
+    validateDeclaredCommandPath(
+      commandDefinition,
+      path,
+      filePath,
+      "file path",
+    );
     discovered.push({ path, filePath, command: commandDefinition });
   }
 
+  return sortCommands(discovered);
+}
+
+/**
+ * Converts a static module map into command entries.
+ *
+ * This is useful for bundlers and single-file packagers that can statically
+ * see module maps, such as `import.meta.glob(..., { eager: true })`, while
+ * still deriving command paths from file-like module keys.
+ *
+ * @param modules Static module map keyed by module path.
+ * @param options Module path derivation options.
+ * @returns Command entries sorted by command path.
+ * @throws {TypeError} If options are invalid, no command modules are found,
+ *         command paths are duplicated, a module does not default-export a
+ *         command created with `defineCommand()`, or an explicit command
+ *         `path` does not match the module-derived path.
+ * @since 1.2.0
+ */
+export function commandsFromModules(
+  modules: ModuleMap,
+  options: CommandsFromModulesOptions = {},
+): readonly ModuleCommand[] {
+  if (modules == null || typeof modules !== "object") {
+    throw new TypeError("commandsFromModules() requires a module map object.");
+  }
+  const base = normalizeModuleBase(options.base);
+  const extensions = normalizeExtensions(
+    options.extensions ?? getDefaultExtensions(),
+  );
+  const entryFileName = normalizeEntryFileName(options.entryFileName);
+  const modulePaths = Object.keys(modules).toSorted((a, b) =>
+    a.localeCompare(b)
+  );
+
+  const seen = new Map<string, string>();
+  const discovered: ModuleCommand[] = [];
+  for (const modulePath of modulePaths) {
+    if (
+      isDeclarationFile(posix.basename(modulePath)) ||
+      !extensions.some((ext) => modulePath.endsWith(ext))
+    ) {
+      continue;
+    }
+
+    const path = commandPathFromModulePath(
+      base,
+      modulePath,
+      extensions,
+      entryFileName,
+    );
+    const key = commandPathKey(path);
+    const previous = seen.get(key);
+    if (previous != null) {
+      const displayPath = displayCommandPath(path);
+      throw new TypeError(
+        `Duplicate command path "${displayPath}" from ${previous} and ${modulePath}.`,
+      );
+    }
+    seen.set(key, modulePath);
+
+    const commandDefinition = commandFromModuleExport(
+      modulePath,
+      modules[modulePath],
+    );
+    validateDeclaredCommandPath(
+      commandDefinition,
+      path,
+      modulePath,
+      "module path",
+    );
+    discovered.push({ path, modulePath, command: commandDefinition });
+  }
+
+  if (discovered.length < 1) {
+    throw new TypeError("No command modules found in module map.");
+  }
   return sortCommands(discovered);
 }
 
@@ -362,7 +508,7 @@ export async function discoverCommands(
  * @since 1.1.0
  */
 export function createProgramParser(
-  commands: readonly Pick<DiscoveredCommand, "path" | "command">[],
+  commands: readonly CommandEntry[],
   metadata: ProgramHelpMetadata = {},
 ): Parser<Mode, ProgramInvocation, unknown> {
   if (commands.length < 1) {
@@ -509,6 +655,14 @@ function normalizeEntryFileName(
   return normalized;
 }
 
+function normalizeModuleBase(base: string | undefined): string {
+  if (base === undefined) return ".";
+  if (typeof base !== "string" || base.length < 1) {
+    throw new TypeError(`Module base path must be a non-empty string: ${base}`);
+  }
+  return normalizeModulePath(base);
+}
+
 async function collectCommandFiles(
   dir: string,
   extensions: readonly string[],
@@ -572,15 +726,66 @@ function commandPathFromFile(
   extensions: readonly string[],
   entryFileName: string | false,
 ): CommandPath {
-  const matchedExtension = extensions.find((ext) => filePath.endsWith(ext));
-  if (matchedExtension == null) {
-    throw new TypeError(`No configured extension matches ${filePath}.`);
-  }
-  const withoutExtension = filePath.slice(0, -matchedExtension.length);
+  const withoutExtension = stripCommandExtension(filePath, extensions);
   const relativePath = relative(rootDir, withoutExtension);
   const path = relativePath.split(sep).filter((segment) => segment.length > 0);
+  return commandPathFromSegments(path, filePath, entryFileName);
+}
+
+function commandPathFromModulePath(
+  base: string,
+  modulePath: string,
+  extensions: readonly string[],
+  entryFileName: string | false,
+): CommandPath {
+  const withoutExtension = stripCommandExtension(modulePath, extensions);
+  const relativePath = relativeModulePath(base, withoutExtension, modulePath);
+  const path = relativePath.split("/").filter((segment) => segment.length > 0);
+  return commandPathFromSegments(path, modulePath, entryFileName);
+}
+
+function stripCommandExtension(
+  path: string,
+  extensions: readonly string[],
+): string {
+  const matchedExtension = extensions.find((ext) => path.endsWith(ext));
+  if (matchedExtension == null) {
+    throw new TypeError(`No configured extension matches ${path}.`);
+  }
+  return path.slice(0, -matchedExtension.length);
+}
+
+function relativeModulePath(
+  base: string,
+  modulePath: string,
+  originalModulePath: string,
+): string {
+  const normalizedPath = normalizeModulePath(modulePath);
+  const relativePath = posix.relative(base, normalizedPath);
+  if (
+    relativePath.length < 1 ||
+    relativePath === ".." ||
+    relativePath.startsWith("../") ||
+    posix.isAbsolute(relativePath)
+  ) {
+    throw new TypeError(
+      `Module path ${originalModulePath} is not under base path ${base}.`,
+    );
+  }
+  return relativePath;
+}
+
+function normalizeModulePath(path: string): string {
+  return posix.normalize(path.replaceAll("\\", "/"));
+}
+
+function commandPathFromSegments(
+  path: readonly string[],
+  source: string,
+  entryFileName: string | false,
+): CommandPath {
   if (path.length < 1) {
-    throw new TypeError(`Command file ${filePath} does not define a path.`);
+    throw new TypeError(`Command module ${source} does not define a path.`);
   }
   if (entryFileName !== false && path[path.length - 1] === entryFileName) {
     return path.slice(0, -1);
@@ -640,37 +845,76 @@ function isStaticRunProgramOptions(
 }
 
 function staticCommandsToEntries(
-  commands: readonly AnyStaticCommand[],
-): readonly Pick<DiscoveredCommand, "path" | "command">[] {
-  return commands.map((command) => {
-    if (!isCommand(command)) {
+  commands: readonly (AnyStaticCommand | CommandEntry)[],
+): readonly CommandEntry[] {
+  return commands.map((entry) => {
+    if (isCommandEntry(entry)) return entry;
+    if (!isCommand(entry)) {
       throw new TypeError(
         "Static command entries must be created with defineCommand().",
       );
     }
-    if (!isCommandPath(command.path)) {
+    if (!isCommandPath(entry.path)) {
       throw new TypeError(
         "Static command entries must declare a path.",
       );
     }
     return {
-      path: command.path,
-      command,
+      path: entry.path,
+      command: entry,
     };
   });
 }
 
+function isCommandEntry(value: unknown): value is CommandEntry {
+  return value != null &&
+    typeof value === "object" &&
+    isCommandPath((value as { readonly path?: unknown }).path) &&
+    isCommand((value as { readonly command?: unknown }).command);
+}
+
 function unwrapCommandExport(value: unknown): AnyCommand | undefined {
-  if (isCommand(value)) return value;
-  if (value != null && typeof value === "object") {
-    const nestedDefault = (value as { readonly default?: unknown }).default;
-    if (isCommand(nestedDefault)) return nestedDefault;
+  let current = value;
+  for (let depth = 0; depth < 3; depth++) {
+    if (isCommand(current)) return current;
+    if (current == null || typeof current !== "object") return undefined;
+    const nestedDefault = (current as { readonly default?: unknown }).default;
+    if (Object.is(nestedDefault, current)) return undefined;
+    current = nestedDefault;
   }
   return undefined;
 }
 
+function commandFromModuleExport(source: string, value: unknown): AnyCommand {
+  const commandDefinition = unwrapCommandExport(value);
+  if (commandDefinition == null) {
+    throw new TypeError(
+      `Module ${source} default export must be created with defineCommand().`,
+    );
+  }
+  return commandDefinition;
+}
+
+function validateDeclaredCommandPath(
+  commandDefinition: AnyCommand,
+  path: CommandPath,
+  source: string,
+  sourcePathLabel: "file path" | "module path",
+): void {
+  if (
+    commandDefinition.path != null &&
+    commandPathKey(commandDefinition.path) !== commandPathKey(path)
+  ) {
+    throw new TypeError(
+      `Module ${source} declares command path "${
+        displayCommandPath(commandDefinition.path)
+      }" but ${sourcePathLabel} defines "${displayCommandPath(path)}".`,
+    );
+  }
+}
+
 function buildCommandTree(
-  commands: readonly Pick<DiscoveredCommand, "path" | "command">[],
+  commands: readonly CommandEntry[],
 ): CommandTreeNode {
   const root: CommandTreeNode = { children: new Map() };
   for (const entry of commands) {
@@ -1342,7 +1586,7 @@ function createLeafParser(
 
 function withRootDocs(
   parser: Parser<Mode, ProgramInvocation, unknown>,
-  commands: readonly Pick<DiscoveredCommand, "path" | "command">[],
+  commands: readonly CommandEntry[],
   metadata: ProgramHelpMetadata,
 ): Parser<Mode, ProgramInvocation, unknown> {
   const rootState = parser.initialState;


### PR DESCRIPTION
This adds `commandsFromModules()` to `@optique/discover` for CLIs that need bundler-visible command registration while keeping their command directory as the source of command paths.  It accepts an eager static module map, such as Vite's `import.meta.glob("./commands/**/*.ts", { eager: true })`, and returns command entries that can be passed directly to `runProgram({ commands })` or `createProgramParser()`.

The helper shares the same path rules as file-system discovery.  It strips a configured base path, matches configured extensions, maps entry files such as *commands/index.ts* and *commands/user/index.ts*, ignores TypeScript declaration files, rejects duplicate command paths, rejects invalid default exports, and checks explicit `path` declarations against the path derived from the module key.

The docs now show the static module-map workflow in *docs/concepts/discover.md* and *packages/discover/README.md*.  *CHANGES.md* records the addition for issue #830 and this PR.

Fixes #830.


Testing
-------

 -  Targeted Deno tests for *packages/discover/src/index.test.ts*
 -  `mise check`
 -  `mise test`
 -  `mise test:node`
 -  `mise test:bun`
 -  Documentation build from *docs/* with `pnpm build`
