### PR TITLE
`optique-discover`: Static discover generator

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,12 @@ To be released.
     command entries that can be passed directly to
     `runProgram({ commands })`.  [[#830], [#840]]
 
+ -  Added the `optique-discover` command to generate static TypeScript command
+    modules for bundlers and single-file CLI packaging.  The generated module
+    imports discovered command files and default-exports the
+    `commandsFromModules()` result, with `--watch` support for regenerating
+    when command files are added, removed, or renamed.  [[#835], [#841]]
+
  -  Added executable parent commands to file-system discovery.  Entry files
     such as *stash/index.ts* now map to the containing command path (`stash`),
     root *index.ts* defines the root command, and parent commands can coexist
@@ -24,9 +30,11 @@ To be released.
     customizes or disables the entry-file rule.  [[#838], [#839]]
 
 [#830]: https://github.com/dahlia/optique/issues/830
+[#835]: https://github.com/dahlia/optique/issues/835
 [#838]: https://github.com/dahlia/optique/issues/838
 [#839]: https://github.com/dahlia/optique/pull/839
 [#840]: https://github.com/dahlia/optique/pull/840
+[#841]: https://github.com/dahlia/optique/pull/841
 
 
 Version 1.1.0

--- a/docs/concepts/discover.md
+++ b/docs/concepts/discover.md
@@ -187,6 +187,67 @@ The returned entries can also be passed to `createProgramParser()` when you
 want to build the parser directly instead of using `runProgram()`.
 
 
+Generating static module maps
+-----------------------------
+
+If your toolchain does not provide an eager glob API, or you do not want to
+maintain the static module map by hand, use the `optique-discover` command to
+generate a TypeScript module:
+
+~~~~ bash
+optique-discover ./commands --output ./commands.generated.ts --extension .ts
+~~~~
+
+The generated module imports every command file and exports the
+`commandsFromModules()` result as its default export:
+
+~~~~ typescript
+import { commandsFromModules } from "@optique/discover";
+import * as cmd0 from "./commands/build.ts";
+import * as cmd1 from "./commands/user/add.ts";
+
+export default commandsFromModules(
+  {
+    "./commands/build.ts": cmd0,
+    "./commands/user/add.ts": cmd1,
+  },
+  {
+    base: "./commands",
+    extensions: [".ts"],
+  },
+);
+~~~~
+
+Use that generated module from your CLI entry point:
+
+~~~~ typescript
+import { message } from "@optique/core/message";
+import { runProgram } from "@optique/discover";
+import commands from "./commands.generated.ts";
+
+await runProgram({
+  commands,
+  metadata: {
+    name: "admin",
+    version: "1.0.0",
+    brief: message`Administrative command-line tools.`,
+  },
+});
+~~~~
+
+Pass `--watch` during development to regenerate when command files are added,
+removed, or renamed:
+
+~~~~ bash
+optique-discover ./commands --output ./commands.generated.ts \
+  --extension .ts --watch
+~~~~
+
+Watch mode tracks the command file set, not file contents.  Editing a command
+module does not rewrite the generated module because the module map has not
+changed.
+
+
 Running manually imported commands
 ----------------------------------
 
@@ -349,6 +410,13 @@ Use `commandsFromModules()` with a static module map when:
     packaging
  -  You want command modules to be visible to the bundler while keeping the
     file layout as the command registry
+
+Use `optique-discover` when:
+
+ -  You want a checked-in or generated static command module instead of a
+    bundler-specific glob API
+ -  You want watch mode to keep the generated module in sync when command files
+    are added, removed, or renamed
 
 Use plain *@optique/core* and *@optique/run* when:
 

--- a/docs/concepts/discover.md
+++ b/docs/concepts/discover.md
@@ -201,7 +201,9 @@ optique-discover ./commands --output ./commands.generated.ts --extension .ts
 The generated module imports every command file and exports the
 `commandsFromModules()` result as its default export:
 
-~~~~ typescript
+~~~~ typescript twoslash
+// @noErrors: 2307
+// ---cut-before---
 import { commandsFromModules } from "@optique/discover";
 import * as cmd0 from "./commands/build.ts";
 import * as cmd1 from "./commands/user/add.ts";
@@ -220,7 +222,9 @@ export default commandsFromModules(
 
 Use that generated module from your CLI entry point:
 
-~~~~ typescript
+~~~~ typescript twoslash
+// @noErrors: 2307
+// ---cut-before---
 import { message } from "@optique/core/message";
 import { runProgram } from "@optique/discover";
 import commands from "./commands.generated.ts";

--- a/packages/discover/README.md
+++ b/packages/discover/README.md
@@ -110,6 +110,33 @@ the module list visible to bundlers.  For smaller registries, you can also
 import commands manually, declare `path` in each `defineCommand()` call, and
 pass those commands to `runProgram({ commands })`.
 
+If you do not want to maintain the static module map by hand, generate one:
+
+~~~~ bash
+optique-discover ./commands --output ./commands.generated.ts --extension .ts
+~~~~
+
+Then import the generated module from your CLI entry point:
+
+~~~~ typescript
+// cli.ts
+import { runProgram } from "@optique/discover";
+import { message } from "@optique/core/message";
+import commands from "./commands.generated.ts";
+
+await runProgram({
+  commands,
+  metadata: {
+    name: "admin",
+    version: "1.0.0",
+    brief: message`Administrative command-line tools.`,
+  },
+});
+~~~~
+
+Use `--watch` during development to regenerate only when command files are
+added, removed, or renamed.
+
 By default, Deno and Bun discover `.ts`, `.mts`, `.js`, and `.mjs` files.
 Node.js discovers `.js`, `.mjs`, and `.cjs` files, plus `.ts`, `.mts`, and
 `.cts` when it reports native TypeScript support or runs with a recognized

--- a/packages/discover/deno.json
+++ b/packages/discover/deno.json
@@ -5,6 +5,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./command": "./src/command.ts",
+    "./generator": "./src/generator.ts",
     "./cli": "./src/cli.ts"
   },
   "imports": {

--- a/packages/discover/deno.json
+++ b/packages/discover/deno.json
@@ -4,7 +4,8 @@
   "license": "MIT",
   "exports": {
     ".": "./src/index.ts",
-    "./command": "./src/command.ts"
+    "./command": "./src/command.ts",
+    "./cli": "./src/cli.ts"
   },
   "imports": {
     "#src/": "./src/"

--- a/packages/discover/package.json
+++ b/packages/discover/package.json
@@ -58,6 +58,10 @@
       },
       "import": "./dist/command.js",
       "require": "./dist/command.cjs"
+    },
+    "./cli": {
+      "types": "./dist/cli.d.ts",
+      "import": "./dist/cli.js"
     }
   },
   "imports": {
@@ -67,6 +71,9 @@
     }
   },
   "sideEffects": false,
+  "bin": {
+    "optique-discover": "./dist/cli.js"
+  },
   "dependencies": {
     "@optique/core": "workspace:*",
     "@optique/run": "workspace:*"

--- a/packages/discover/package.json
+++ b/packages/discover/package.json
@@ -59,6 +59,14 @@
       "import": "./dist/command.js",
       "require": "./dist/command.cjs"
     },
+    "./generator": {
+      "types": {
+        "import": "./dist/generator.d.ts",
+        "require": "./dist/generator.d.cts"
+      },
+      "import": "./dist/generator.js",
+      "require": "./dist/generator.cjs"
+    },
     "./cli": {
       "types": "./dist/cli.d.ts",
       "import": "./dist/cli.js"

--- a/packages/discover/src/cli.test.ts
+++ b/packages/discover/src/cli.test.ts
@@ -115,6 +115,30 @@ describe("optique-discover CLI", { skip: !hasReliableSubprocess }, () => {
       await rm(dir, { recursive: true, force: true });
     }
   });
+
+  it("should report a missing output option", async () => {
+    if (!hasReliableSubprocess) return;
+
+    const dir = await makeTempDir();
+    try {
+      const commandsDir = join(dir, "commands");
+      await writeText(join(commandsDir, "build.ts"), "");
+
+      const result = await runCli([
+        commandsDir,
+        "--extension",
+        ".ts",
+      ]);
+
+      assert.equal(result.exitCode, 1);
+      assert.equal(result.stdout, "");
+      assert.match(result.stderr, /Usage: optique-discover/);
+      assert.match(result.stderr, /Missing option `-o`\/`--output`\./);
+      assert.doesNotMatch(result.stderr, /TypeError/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("package exports", () => {

--- a/packages/discover/src/cli.test.ts
+++ b/packages/discover/src/cli.test.ts
@@ -17,15 +17,19 @@ interface RunResult {
 }
 
 function isSubprocessReliable(): boolean {
-  const probe = spawnSync(
-    process.execPath,
-    ["-e", "process.stdout.write('ok')"],
-    {
-      encoding: "utf8",
-      timeout: 5000,
-    },
-  );
-  return probe.status === 0 && probe.stdout === "ok";
+  try {
+    const probe = spawnSync(
+      process.execPath,
+      ["-e", "process.stdout.write('ok')"],
+      {
+        encoding: "utf8",
+        timeout: 5000,
+      },
+    );
+    return probe.status === 0 && probe.stdout === "ok";
+  } catch {
+    return false;
+  }
 }
 
 const hasReliableSubprocess = isSubprocessReliable();
@@ -126,9 +130,31 @@ describe("package exports", () => {
       assert.ok(!Object.hasOwn(cliExport.types, "require"));
     }
   });
+
+  it("should publish the generator subpath", async () => {
+    const packageJson = JSON.parse(
+      await readFile(join(__dirname, "..", "package.json"), "utf-8"),
+    ) as PackageJson;
+    const denoJson = JSON.parse(
+      await readFile(join(__dirname, "..", "deno.json"), "utf-8"),
+    ) as DenoJson;
+    const generatorExport = packageJson.exports?.["./generator"];
+
+    assert.ok(isRecord(generatorExport));
+    assert.equal(generatorExport.import, "./dist/generator.js");
+    assert.equal(generatorExport.require, "./dist/generator.cjs");
+    assert.ok(isRecord(generatorExport.types));
+    assert.equal(generatorExport.types.import, "./dist/generator.d.ts");
+    assert.equal(generatorExport.types.require, "./dist/generator.d.cts");
+    assert.equal(denoJson.exports?.["./generator"], "./src/generator.ts");
+  });
 });
 
 interface PackageJson {
+  readonly exports?: Record<string, unknown>;
+}
+
+interface DenoJson {
   readonly exports?: Record<string, unknown>;
 }
 

--- a/packages/discover/src/cli.test.ts
+++ b/packages/discover/src/cli.test.ts
@@ -116,7 +116,9 @@ describe("optique-discover CLI", { skip: !hasReliableSubprocess }, () => {
     }
   });
 
-  it("should report a missing output option", async () => {
+  it("should report a missing output option", {
+    skip: !hasReliableSubprocess,
+  }, async () => {
     if (!hasReliableSubprocess) return;
 
     const dir = await makeTempDir();

--- a/packages/discover/src/cli.test.ts
+++ b/packages/discover/src/cli.test.ts
@@ -1,0 +1,144 @@
+import assert from "node:assert/strict";
+import { type ChildProcess, spawn, spawnSync } from "node:child_process";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it } from "node:test";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cliPathTs = join(__dirname, "cli.ts");
+const cliPathJs = join(__dirname, "..", "dist", "cli.js");
+
+interface RunResult {
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly exitCode: number;
+}
+
+function isSubprocessReliable(): boolean {
+  const probe = spawnSync(
+    process.execPath,
+    ["-e", "process.stdout.write('ok')"],
+    {
+      encoding: "utf8",
+      timeout: 5000,
+    },
+  );
+  return probe.status === 0 && probe.stdout === "ok";
+}
+
+const hasReliableSubprocess = isSubprocessReliable();
+
+function runCli(args: readonly string[]): Promise<RunResult> {
+  return new Promise((resolve) => {
+    let child: ChildProcess;
+
+    if ("Deno" in globalThis) {
+      child = spawn("deno", [
+        "run",
+        "--allow-read",
+        "--allow-write",
+        "--allow-env",
+        cliPathTs,
+        ...args,
+      ], { cwd: __dirname });
+    } else if ("Bun" in globalThis) {
+      child = spawn("bun", [cliPathJs, ...args], { cwd: __dirname });
+    } else {
+      child = spawn("node", ["--no-warnings", cliPathJs, ...args], {
+        cwd: __dirname,
+      });
+    }
+
+    let stdout = "";
+    let stderr = "";
+    child.stdout?.on("data", (data) => {
+      stdout += data.toString();
+    });
+    child.stderr?.on("data", (data) => {
+      stderr += data.toString();
+    });
+    child.on("close", (code) => {
+      resolve({ stdout, stderr, exitCode: code ?? 0 });
+    });
+  });
+}
+
+describe("optique-discover CLI", { skip: !hasReliableSubprocess }, () => {
+  it("should show help", async () => {
+    if (!hasReliableSubprocess) return;
+
+    const result = await runCli(["--help"]);
+
+    assert.equal(result.exitCode, 0);
+    assert.ok(result.stdout.includes("optique-discover"));
+    assert.ok(result.stdout.includes("--output"));
+  });
+
+  it("should generate a commands module", async () => {
+    if (!hasReliableSubprocess) return;
+
+    const dir = await makeTempDir();
+    try {
+      const commandsDir = join(dir, "src", "commands");
+      const outputFile = join(dir, "src", "commands.generated.ts");
+      await writeText(join(commandsDir, "build.ts"), "");
+      await writeText(join(commandsDir, "user", "add.ts"), "");
+
+      const result = await runCli([
+        commandsDir,
+        "--output",
+        outputFile,
+        "--extension",
+        ".ts",
+      ]);
+
+      assert.equal(result.exitCode, 0, result.stderr);
+      assert.equal(result.stderr, "");
+      assert.match(result.stdout, /Generated 2 command modules\./);
+      const generated = await readFile(outputFile, "utf-8");
+      assert.match(
+        generated,
+        /import \* as cmd0 from "\.\/commands\/build\.ts"/,
+      );
+      assert.match(generated, /"\.\/commands\/user\/add\.ts": cmd1/);
+      assert.match(generated, /base: "\.\/commands"/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("package exports", () => {
+  it("should not publish a CommonJS CLI subpath", async () => {
+    const packageJson = JSON.parse(
+      await readFile(join(__dirname, "..", "package.json"), "utf-8"),
+    ) as PackageJson;
+    const cliExport = packageJson.exports?.["./cli"];
+
+    assert.ok(isRecord(cliExport));
+    assert.ok(!Object.hasOwn(cliExport, "require"));
+    if (isRecord(cliExport.types)) {
+      assert.ok(!Object.hasOwn(cliExport.types, "require"));
+    }
+  });
+});
+
+interface PackageJson {
+  readonly exports?: Record<string, unknown>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === "object";
+}
+
+async function makeTempDir(): Promise<string> {
+  const { mkdtemp } = await import("node:fs/promises");
+  return await mkdtemp(join(tmpdir(), "optique-discover-cli-"));
+}
+
+async function writeText(path: string, text: string): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, text, "utf-8");
+}

--- a/packages/discover/src/cli.test.ts
+++ b/packages/discover/src/cli.test.ts
@@ -62,6 +62,9 @@ function runCli(args: readonly string[]): Promise<RunResult> {
     child.on("close", (code) => {
       resolve({ stdout, stderr, exitCode: code ?? 0 });
     });
+    child.on("error", (error) => {
+      resolve({ stdout, stderr: String(error), exitCode: 1 });
+    });
   });
 }
 

--- a/packages/discover/src/cli.ts
+++ b/packages/discover/src/cli.ts
@@ -12,6 +12,7 @@ import { printError, runSync } from "@optique/run";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 import { watchCommandsModule, writeCommandsModule } from "./generator.ts";
+import { isMainModule } from "./main-check.ts";
 // @ts-ignore: JSON import
 import denoJson from "../deno.json" with { type: "json" };
 
@@ -130,9 +131,11 @@ function writeGeneratedMessage(count: number): void {
   console.log(`Generated ${count} ${noun}.`);
 }
 
-const isMain: boolean = "main" in import.meta
-  ? import.meta.main
-  : process.argv[1] === fileURLToPath(import.meta.url);
+const isMain = isMainModule({
+  importMetaMain: "main" in import.meta ? import.meta.main : undefined,
+  modulePath: fileURLToPath(import.meta.url),
+  argvEntry: process.argv[1],
+});
 if (isMain) {
   void main().catch((error) => {
     printGenerationError(error, EXIT_GENERATION_FAILED);

--- a/packages/discover/src/cli.ts
+++ b/packages/discover/src/cli.ts
@@ -1,0 +1,118 @@
+/**
+ * CLI entry point for optique-discover.
+ * @module
+ */
+import { object } from "@optique/core/constructs";
+import { message } from "@optique/core/message";
+import { multiple, optional, withDefault } from "@optique/core/modifiers";
+import { argument, option } from "@optique/core/primitives";
+import { defineProgram } from "@optique/core/program";
+import { string } from "@optique/core/valueparser";
+import { printError, runSync } from "@optique/run";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+import { watchCommandsModule, writeCommandsModule } from "./generator.ts";
+// @ts-ignore: JSON import
+import denoJson from "../deno.json" with { type: "json" };
+
+const EXIT_GENERATION_FAILED = 1;
+const EXIT_INVALID_OPTIONS = 2;
+
+const cliProgram = defineProgram({
+  parser: object({
+    dir: argument(string({ metavar: "DIR" }), {
+      description: message`Directory containing command modules.`,
+    }),
+    outputFile: option("-o", "--output", string({ metavar: "FILE" }), {
+      description: message`Generated TypeScript module path.`,
+    }),
+    base: optional(
+      option("--base", string({ metavar: "PATH" }), {
+        description:
+          message`Module map base path passed to commandsFromModules().
+Defaults to the command directory relative to the generated module.`,
+      }),
+    ),
+    extensions: withDefault(
+      multiple(option("--extension", string({ metavar: "EXT" }))),
+      [],
+    ),
+    entryFileName: optional(
+      option("--entry-file-name", string({ metavar: "NAME" }), {
+        description: message`File name that maps to the containing command path.
+Defaults to commandsFromModules() behavior.`,
+      }),
+    ),
+    noEntryFileName: option("--no-entry-file-name", {
+      description: message`Treat entry files as ordinary command names.`,
+    }),
+    watch: option("--watch", {
+      description: message`Regenerate when command files are added, removed,
+or renamed.`,
+    }),
+  }),
+  metadata: {
+    name: "optique-discover",
+    version: denoJson.version,
+    brief: message`Generate static command modules for @optique/discover`,
+  },
+});
+
+export async function main(): Promise<void> {
+  const args = runSync(cliProgram, {
+    help: "option",
+    version: {
+      value: denoJson.version,
+      option: true,
+    },
+  });
+  if (args.noEntryFileName && args.entryFileName != null) {
+    printError(
+      message`Use either --entry-file-name or --no-entry-file-name, not both.`,
+      { exitCode: EXIT_INVALID_OPTIONS },
+    );
+  }
+
+  const options = {
+    dir: args.dir,
+    outputFile: args.outputFile,
+    ...(args.base != null ? { base: args.base } : {}),
+    ...(args.extensions.length > 0 ? { extensions: args.extensions } : {}),
+    ...(args.noEntryFileName
+      ? { entryFileName: false as const }
+      : args.entryFileName != null
+      ? { entryFileName: args.entryFileName }
+      : {}),
+  };
+
+  try {
+    if (args.watch) {
+      await watchCommandsModule({
+        ...options,
+        onGenerate(result) {
+          writeGeneratedMessage(result.files.length);
+        },
+      });
+    } else {
+      const result = await writeCommandsModule(options);
+      writeGeneratedMessage(result.files.length);
+    }
+  } catch (error) {
+    const messageText = error instanceof Error ? error.message : String(error);
+    printError(
+      message`Failed to generate command module: ${messageText}`,
+      { exitCode: EXIT_GENERATION_FAILED },
+    );
+  }
+}
+
+function writeGeneratedMessage(count: number): void {
+  const noun = count === 1 ? "command module" : "command modules";
+  // deno-lint-ignore no-console
+  console.log(`Generated ${count} ${noun}.`);
+}
+
+const isMain: boolean = "main" in import.meta
+  ? import.meta.main
+  : process.argv[1] === fileURLToPath(import.meta.url);
+if (isMain) main();

--- a/packages/discover/src/cli.ts
+++ b/packages/discover/src/cli.ts
@@ -10,9 +10,8 @@ import { defineProgram } from "@optique/core/program";
 import { string } from "@optique/core/valueparser";
 import { printError, runSync } from "@optique/run";
 import process from "node:process";
-import { fileURLToPath } from "node:url";
 import { watchCommandsModule, writeCommandsModule } from "./generator.ts";
-import { isMainModule } from "./main-check.ts";
+import { isMainModuleUrl } from "./main-check.ts";
 // @ts-ignore: JSON import
 import denoJson from "../deno.json" with { type: "json" };
 
@@ -131,9 +130,9 @@ function writeGeneratedMessage(count: number): void {
   console.log(`Generated ${count} ${noun}.`);
 }
 
-const isMain = isMainModule({
+const isMain = isMainModuleUrl({
   importMetaMain: "main" in import.meta ? import.meta.main : undefined,
-  modulePath: fileURLToPath(import.meta.url),
+  moduleUrl: import.meta.url,
   argvEntry: process.argv[1],
 });
 if (isMain) {

--- a/packages/discover/src/cli.ts
+++ b/packages/discover/src/cli.ts
@@ -58,6 +58,12 @@ or renamed.`,
   },
 });
 
+/**
+ * Runs the optique-discover command-line interface.
+ *
+ * @returns A promise that resolves after generation or watch mode finishes.
+ * @since 1.2.0
+ */
 export async function main(): Promise<void> {
   const args = runSync(cliProgram, {
     help: "option",
@@ -71,6 +77,7 @@ export async function main(): Promise<void> {
       message`Use either --entry-file-name or --no-entry-file-name, not both.`,
       { exitCode: EXIT_INVALID_OPTIONS },
     );
+    return;
   }
 
   const options = {
@@ -92,16 +99,27 @@ export async function main(): Promise<void> {
         onGenerate(result) {
           writeGeneratedMessage(result.files.length);
         },
+        onError(error) {
+          printGenerationError(error);
+        },
       });
     } else {
       const result = await writeCommandsModule(options);
       writeGeneratedMessage(result.files.length);
     }
   } catch (error) {
-    const messageText = error instanceof Error ? error.message : String(error);
+    printGenerationError(error, EXIT_GENERATION_FAILED);
+  }
+}
+
+function printGenerationError(error: unknown, exitCode?: number): void {
+  const messageText = error instanceof Error ? error.message : String(error);
+  if (exitCode == null) {
+    printError(message`Failed to generate command module: ${messageText}`);
+  } else {
     printError(
       message`Failed to generate command module: ${messageText}`,
-      { exitCode: EXIT_GENERATION_FAILED },
+      { exitCode },
     );
   }
 }
@@ -115,4 +133,8 @@ function writeGeneratedMessage(count: number): void {
 const isMain: boolean = "main" in import.meta
   ? import.meta.main
   : process.argv[1] === fileURLToPath(import.meta.url);
-if (isMain) main();
+if (isMain) {
+  void main().catch((error) => {
+    printGenerationError(error, EXIT_GENERATION_FAILED);
+  });
+}

--- a/packages/discover/src/generator.test.ts
+++ b/packages/discover/src/generator.test.ts
@@ -268,12 +268,19 @@ describe("watchCommandsModule()", () => {
 
       await rm(join(commandsDir, "build.ts"));
       await rm(join(commandsDir, "deploy.ts"));
-      await delay(80);
-      assert.deepEqual(generatedCounts, [1, 2]);
+      await waitFor(() => generatedCounts.length === 3);
+      assert.deepEqual(generatedCounts, [1, 2, 0]);
+      assert.equal(
+        await readFile(outputFile, "utf-8"),
+        `import type { ModuleCommand } from "@optique/discover";
+
+export default [] satisfies readonly ModuleCommand[];
+`,
+      );
 
       await writeText(join(commandsDir, "status.ts"), "");
-      await waitFor(() => generatedCounts.length === 3);
-      assert.deepEqual(generatedCounts, [1, 2, 1]);
+      await waitFor(() => generatedCounts.length === 4);
+      assert.deepEqual(generatedCounts, [1, 2, 0, 1]);
 
       controller.abort();
       await watching;

--- a/packages/discover/src/generator.test.ts
+++ b/packages/discover/src/generator.test.ts
@@ -3,7 +3,6 @@ import { mkdir, readFile, rm, unlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { describe, it } from "node:test";
-import { pathToFileURL } from "node:url";
 import {
   generateCommandsModule,
   watchCommandsModule,
@@ -121,7 +120,7 @@ export default commandsFromModules(
     }
   });
 
-  it("should statically import URL-significant paths through file URLs", async () => {
+  it("should statically import URL-significant paths with encoded specifiers", async () => {
     const dir = await makeTempDir();
     try {
       const commandsDir = join(dir, "src", "commands");
@@ -144,11 +143,11 @@ export default commandsFromModules(
         })),
         [
           {
-            importSpecifier: pathToFileURL(queryPath).href,
+            importSpecifier: "./commands/build%3Ffast.ts",
             modulePath: "./commands/build?fast.ts",
           },
           {
-            importSpecifier: pathToFileURL(fragmentPath).href,
+            importSpecifier: "./commands/user%23name/build%25fast.ts",
             modulePath: "./commands/user#name/build%fast.ts",
           },
         ],
@@ -156,22 +155,22 @@ export default commandsFromModules(
       assert.match(
         result.code,
         new RegExp(
-          `// @ts-ignore: File URL import preserves URL-significant ` +
-            `command paths\\.\\nimport \\* as cmd0 from ${
-              escapeRegExp(JSON.stringify(pathToFileURL(queryPath).href))
-            };`,
+          `// @ts-ignore: Percent-encoded import preserves ` +
+            `URL-significant command paths\\.\\nimport \\* as cmd0 ` +
+            `from "${escapeRegExp("./commands/build%3Ffast.ts")}";`,
         ),
       );
       assert.match(
         result.code,
         new RegExp(
-          `// @ts-ignore: File URL import preserves URL-significant ` +
-            `command paths\\.\\nimport \\* as cmd1 from ${
-              escapeRegExp(JSON.stringify(pathToFileURL(fragmentPath).href))
-            };`,
+          `// @ts-ignore: Percent-encoded import preserves ` +
+            `URL-significant command paths\\.\\nimport \\* as cmd1 ` +
+            `from "${escapeRegExp("./commands/user%23name/build%25fast.ts")}";`,
         ),
       );
       assert.doesNotMatch(result.code, /await import/);
+      assert.doesNotMatch(result.code, /file:/);
+      assert.doesNotMatch(result.code, new RegExp(escapeRegExp(dir)));
       assert.match(
         result.code,
         /"\.\/commands\/build\?fast\.ts": cmd0/,

--- a/packages/discover/src/generator.test.ts
+++ b/packages/discover/src/generator.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rm, unlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { describe, it } from "node:test";
@@ -180,6 +180,34 @@ export default commandsFromModules(
       await rm(dir, { recursive: true, force: true });
     }
   });
+
+  it("should reject duplicate generated command paths", async () => {
+    const dir = await makeTempDir();
+    try {
+      const commandsDir = join(dir, "commands");
+      const outputFile = join(dir, "generated.ts");
+      await writeText(join(commandsDir, "user.ts"), "");
+      await writeText(join(commandsDir, "user", "index.ts"), "");
+
+      await assert.rejects(
+        () =>
+          generateCommandsModule({
+            dir: commandsDir,
+            outputFile,
+            extensions: [".ts"],
+          }),
+        (error) => {
+          assert.ok(error instanceof TypeError);
+          assert.match(error.message, /Duplicate command path "user"/);
+          assert.match(error.message, /\.\/commands\/user\.ts/);
+          assert.match(error.message, /\.\/commands\/user\/index\.ts/);
+          return true;
+        },
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("writeCommandsModule()", () => {
@@ -237,6 +265,54 @@ describe("watchCommandsModule()", () => {
       await writeText(join(commandsDir, "deploy.ts"), "");
       await waitFor(() => generatedCounts.length === 2);
       assert.deepEqual(generatedCounts, [1, 2]);
+
+      await rm(join(commandsDir, "build.ts"));
+      await rm(join(commandsDir, "deploy.ts"));
+      await delay(80);
+      assert.deepEqual(generatedCounts, [1, 2]);
+
+      await writeText(join(commandsDir, "status.ts"), "");
+      await waitFor(() => generatedCounts.length === 3);
+      assert.deepEqual(generatedCounts, [1, 2, 1]);
+
+      controller.abort();
+      await watching;
+    } finally {
+      controller.abort();
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("should report watch errors without stopping", async () => {
+    const dir = await makeTempDir();
+    const controller = new AbortController();
+    try {
+      const commandsDir = join(dir, "commands");
+      const blockedPath = join(dir, "blocked");
+      const outputFile = join(blockedPath, "generated.ts");
+      await writeText(join(commandsDir, "build.ts"), "");
+      await writeText(blockedPath, "not a directory");
+
+      const errors: unknown[] = [];
+      const generatedCounts: number[] = [];
+      const watching = watchCommandsModule({
+        dir: commandsDir,
+        outputFile,
+        extensions: [".ts"],
+        intervalMs: 20,
+        signal: controller.signal,
+        onGenerate(result) {
+          generatedCounts.push(result.files.length);
+        },
+        onError(error) {
+          errors.push(error);
+        },
+      });
+
+      await waitFor(() => errors.length > 0);
+      await unlink(blockedPath);
+      await waitFor(() => generatedCounts.length === 1);
+      assert.deepEqual(generatedCounts, [1]);
 
       controller.abort();
       await watching;

--- a/packages/discover/src/generator.test.ts
+++ b/packages/discover/src/generator.test.ts
@@ -3,6 +3,7 @@ import { mkdir, readFile, rm, unlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { describe, it } from "node:test";
+import { pathToFileURL } from "node:url";
 import {
   generateCommandsModule,
   watchCommandsModule,
@@ -120,12 +121,15 @@ export default commandsFromModules(
     }
   });
 
-  it("should dynamically load escaped import specifiers", async () => {
+  it("should statically import URL-significant paths through file URLs", async () => {
     const dir = await makeTempDir();
     try {
       const commandsDir = join(dir, "src", "commands");
       const outputFile = join(dir, "src", "generated.ts");
-      await writeText(join(commandsDir, "user#name", "build%fast.ts"), "");
+      const queryPath = join(commandsDir, "build?fast.ts");
+      const fragmentPath = join(commandsDir, "user#name", "build%fast.ts");
+      await writeText(queryPath, "");
+      await writeText(fragmentPath, "");
 
       const result = await generateCommandsModule({
         dir: commandsDir,
@@ -140,22 +144,41 @@ export default commandsFromModules(
         })),
         [
           {
-            importSpecifier: "./commands/user%23name/build%25fast.ts",
+            importSpecifier: pathToFileURL(queryPath).href,
+            modulePath: "./commands/build?fast.ts",
+          },
+          {
+            importSpecifier: pathToFileURL(fragmentPath).href,
             modulePath: "./commands/user#name/build%fast.ts",
           },
         ],
       );
       assert.match(
         result.code,
-        /const cmd0 = await import\(new URL\("\.\/commands\/user%23name\/build%25fast\.ts", import\.meta\.url\)\.href\);/,
-      );
-      assert.doesNotMatch(
-        result.code,
-        /import \* as cmd0 from "\.\/commands\/user%23name\/build%25fast\.ts";/,
+        new RegExp(
+          `// @ts-ignore: File URL import preserves URL-significant ` +
+            `command paths\\.\\nimport \\* as cmd0 from ${
+              escapeRegExp(JSON.stringify(pathToFileURL(queryPath).href))
+            };`,
+        ),
       );
       assert.match(
         result.code,
-        /"\.\/commands\/user#name\/build%fast\.ts": cmd0/,
+        new RegExp(
+          `// @ts-ignore: File URL import preserves URL-significant ` +
+            `command paths\\.\\nimport \\* as cmd1 from ${
+              escapeRegExp(JSON.stringify(pathToFileURL(fragmentPath).href))
+            };`,
+        ),
+      );
+      assert.doesNotMatch(result.code, /await import/);
+      assert.match(
+        result.code,
+        /"\.\/commands\/build\?fast\.ts": cmd0/,
+      );
+      assert.match(
+        result.code,
+        /"\.\/commands\/user#name\/build%fast\.ts": cmd1/,
       );
     } finally {
       await rm(dir, { recursive: true, force: true });
@@ -402,6 +425,10 @@ function trackAbortListeners(signal: AbortSignal): () => number {
   });
 
   return () => activeCount;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[\\^$.*+?()[\]{}|]/g, "\\$&");
 }
 
 async function waitFor(predicate: () => boolean): Promise<void> {

--- a/packages/discover/src/generator.test.ts
+++ b/packages/discover/src/generator.test.ts
@@ -120,7 +120,7 @@ export default commandsFromModules(
     }
   });
 
-  it("should encode import specifiers without changing module map keys", async () => {
+  it("should dynamically load escaped import specifiers", async () => {
     const dir = await makeTempDir();
     try {
       const commandsDir = join(dir, "src", "commands");
@@ -146,6 +146,10 @@ export default commandsFromModules(
         ],
       );
       assert.match(
+        result.code,
+        /const cmd0 = await import\(new URL\("\.\/commands\/user%23name\/build%25fast\.ts", import\.meta\.url\)\.href\);/,
+      );
+      assert.doesNotMatch(
         result.code,
         /import \* as cmd0 from "\.\/commands\/user%23name\/build%25fast\.ts";/,
       );

--- a/packages/discover/src/generator.test.ts
+++ b/packages/discover/src/generator.test.ts
@@ -1,0 +1,328 @@
+import assert from "node:assert/strict";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { describe, it } from "node:test";
+import {
+  generateCommandsModule,
+  watchCommandsModule,
+  writeCommandsModule,
+} from "#src/generator.ts";
+
+describe("generateCommandsModule()", () => {
+  it("should generate a default export from command files", async () => {
+    const dir = await makeTempDir();
+    try {
+      const commandsDir = join(dir, "src", "commands");
+      const outputFile = join(dir, "src", "generated.ts");
+      await writeText(join(commandsDir, "build.ts"), "");
+      await writeText(join(commandsDir, "user", "add.ts"), "");
+
+      const result = await generateCommandsModule({
+        dir: commandsDir,
+        outputFile,
+        extensions: [".ts"],
+      });
+
+      assert.deepEqual(result.files.map((file) => file.modulePath), [
+        "./commands/build.ts",
+        "./commands/user/add.ts",
+      ]);
+      assert.equal(
+        result.code,
+        `import { commandsFromModules } from "@optique/discover";
+import * as cmd0 from "./commands/build.ts";
+import * as cmd1 from "./commands/user/add.ts";
+
+export default commandsFromModules(
+  {
+    "./commands/build.ts": cmd0,
+    "./commands/user/add.ts": cmd1,
+  },
+  {
+    base: "./commands",
+    extensions: [".ts"],
+  },
+);
+`,
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("should ignore declaration files and non-matching extensions", async () => {
+    const dir = await makeTempDir();
+    try {
+      const commandsDir = join(dir, "commands");
+      const outputFile = join(dir, "generated.ts");
+      await writeText(join(commandsDir, "add.ts"), "");
+      await writeText(join(commandsDir, "add.d.ts"), "");
+      await writeText(join(commandsDir, "notes.txt"), "");
+
+      const result = await generateCommandsModule({
+        dir: commandsDir,
+        outputFile,
+        extensions: [".ts"],
+      });
+
+      assert.deepEqual(result.files.map((file) => file.modulePath), [
+        "./commands/add.ts",
+      ]);
+      assert.doesNotMatch(result.code, /add\.d\.ts/);
+      assert.doesNotMatch(result.code, /notes\.txt/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("should include custom entry file options", async () => {
+    const dir = await makeTempDir();
+    try {
+      const commandsDir = join(dir, "commands");
+      const outputFile = join(dir, "generated.ts");
+      await writeText(join(commandsDir, "index.ts"), "");
+
+      const result = await generateCommandsModule({
+        dir: commandsDir,
+        outputFile,
+        extensions: [".ts"],
+        entryFileName: false,
+      });
+
+      assert.match(result.code, /entryFileName: false/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("should use an explicit base for module map keys", async () => {
+    const dir = await makeTempDir();
+    try {
+      const commandsDir = join(dir, "src", "commands");
+      const outputFile = join(dir, "src", "generated.ts");
+      await writeText(join(commandsDir, "build.ts"), "");
+
+      const result = await generateCommandsModule({
+        dir: commandsDir,
+        outputFile,
+        base: "@commands",
+        extensions: [".ts"],
+      });
+
+      assert.deepEqual(result.files.map((file) => file.modulePath), [
+        "@commands/build.ts",
+      ]);
+      assert.match(result.code, /"@commands\/build\.ts": cmd0/);
+      assert.match(result.code, /base: "@commands"/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("should encode import specifiers without changing module map keys", async () => {
+    const dir = await makeTempDir();
+    try {
+      const commandsDir = join(dir, "src", "commands");
+      const outputFile = join(dir, "src", "generated.ts");
+      await writeText(join(commandsDir, "user#name", "build%fast.ts"), "");
+
+      const result = await generateCommandsModule({
+        dir: commandsDir,
+        outputFile,
+        extensions: [".ts"],
+      });
+
+      assert.deepEqual(
+        result.files.map((file) => ({
+          importSpecifier: file.importSpecifier,
+          modulePath: file.modulePath,
+        })),
+        [
+          {
+            importSpecifier: "./commands/user%23name/build%25fast.ts",
+            modulePath: "./commands/user#name/build%fast.ts",
+          },
+        ],
+      );
+      assert.match(
+        result.code,
+        /import \* as cmd0 from "\.\/commands\/user%23name\/build%25fast\.ts";/,
+      );
+      assert.match(
+        result.code,
+        /"\.\/commands\/user#name\/build%fast\.ts": cmd0/,
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("should exclude the generated output file from the module map", async () => {
+    const dir = await makeTempDir();
+    try {
+      const commandsDir = join(dir, "commands");
+      const outputFile = join(commandsDir, "commands.generated.ts");
+      await writeText(join(commandsDir, "build.ts"), "");
+      await writeText(outputFile, "old generated module");
+
+      const result = await generateCommandsModule({
+        dir: commandsDir,
+        outputFile,
+        extensions: [".ts"],
+      });
+
+      assert.deepEqual(result.files.map((file) => file.modulePath), [
+        "./build.ts",
+      ]);
+      assert.doesNotMatch(result.code, /commands\.generated\.ts/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("writeCommandsModule()", () => {
+  it("should write the generated module to disk", async () => {
+    const dir = await makeTempDir();
+    try {
+      const commandsDir = join(dir, "commands");
+      const outputFile = join(dir, "generated", "commands.ts");
+      await writeText(join(commandsDir, "build.ts"), "");
+
+      const result = await writeCommandsModule({
+        dir: commandsDir,
+        outputFile,
+        extensions: [".ts"],
+      });
+
+      assert.equal(await readFile(outputFile, "utf-8"), result.code);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("watchCommandsModule()", () => {
+  it("should regenerate for file set changes but not content changes", async () => {
+    const dir = await makeTempDir();
+    const controller = new AbortController();
+    const activeAbortListeners = trackAbortListeners(controller.signal);
+    try {
+      const commandsDir = join(dir, "commands");
+      const outputFile = join(dir, "generated.ts");
+      await writeText(join(commandsDir, "build.ts"), "initial");
+
+      const generatedCounts: number[] = [];
+      const watching = watchCommandsModule({
+        dir: commandsDir,
+        outputFile,
+        extensions: [".ts"],
+        intervalMs: 20,
+        signal: controller.signal,
+        onGenerate(result) {
+          generatedCounts.push(result.files.length);
+        },
+      });
+
+      await waitFor(() => generatedCounts.length === 1);
+      await writeText(join(commandsDir, "build.ts"), "changed");
+      await delay(80);
+      assert.deepEqual(generatedCounts, [1]);
+      assert.ok(
+        activeAbortListeners() <= 1,
+        `Expected at most one active abort listener, got ${activeAbortListeners()}.`,
+      );
+
+      await writeText(join(commandsDir, "deploy.ts"), "");
+      await waitFor(() => generatedCounts.length === 2);
+      assert.deepEqual(generatedCounts, [1, 2]);
+
+      controller.abort();
+      await watching;
+    } finally {
+      controller.abort();
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+async function makeTempDir(): Promise<string> {
+  const { mkdtemp } = await import("node:fs/promises");
+  return await mkdtemp(join(tmpdir(), "optique-discover-generator-"));
+}
+
+async function writeText(path: string, text: string): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, text, "utf-8");
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function trackAbortListeners(signal: AbortSignal): () => number {
+  const originalAdd = signal.addEventListener.bind(signal);
+  const originalRemove = signal.removeEventListener.bind(signal);
+  const listeners = new Map<
+    EventListenerOrEventListenerObject,
+    EventListener
+  >();
+  let activeCount = 0;
+
+  function addEventListener(
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    options?: boolean | AddEventListenerOptions,
+  ): void {
+    if (type === "abort") {
+      const wrapped: EventListener = (event) => {
+        if (listeners.delete(listener)) activeCount--;
+        if (typeof listener === "function") {
+          listener.call(signal, event);
+        } else {
+          listener.handleEvent(event);
+        }
+      };
+      listeners.set(listener, wrapped);
+      activeCount++;
+      originalAdd(type, wrapped, options);
+      return;
+    }
+    originalAdd(type, listener, options);
+  }
+
+  function removeEventListener(
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    options?: boolean | EventListenerOptions,
+  ): void {
+    if (type === "abort") {
+      const wrapped = listeners.get(listener);
+      if (wrapped != null) {
+        listeners.delete(listener);
+        activeCount--;
+        originalRemove(type, wrapped, options);
+        return;
+      }
+    }
+    originalRemove(type, listener, options);
+  }
+
+  Object.defineProperties(signal, {
+    addEventListener: { value: addEventListener },
+    removeEventListener: { value: removeEventListener },
+  });
+
+  return () => activeCount;
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  const started = Date.now();
+  while (!predicate()) {
+    if (Date.now() - started > 2000) {
+      throw new Error("Timed out waiting for condition.");
+    }
+    await delay(10);
+  }
+}

--- a/packages/discover/src/generator.ts
+++ b/packages/discover/src/generator.ts
@@ -1,6 +1,6 @@
 import { mkdir, readdir, realpath, stat, writeFile } from "node:fs/promises";
 import { dirname, posix, relative, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { getDefaultExtensions } from "./index.ts";
 
 /**
@@ -15,7 +15,10 @@ export interface GeneratedCommandModuleFile {
   readonly filePath: string;
 
   /**
-   * Module specifier used by the generated module loader.
+   * Module specifier used by the generated import declaration.
+   *
+   * Paths containing URL-significant characters use absolute file URLs so
+   * runtime loaders and bundlers resolve the same command file.
    */
   readonly importSpecifier: string;
 
@@ -286,16 +289,17 @@ function generateCommandsModuleFromFiles(
 
 function formatCommandModuleImport(file: GeneratedCommandModuleFile): string {
   const importSpecifier = JSON.stringify(file.importSpecifier);
-  if (requiresDynamicImport(file.importSpecifier)) {
-    return `const ${file.identifier} = await import(` +
-      `new URL(${importSpecifier}, import.meta.url).href` +
-      `);`;
+  const importDeclaration =
+    `import * as ${file.identifier} from ${importSpecifier};`;
+  if (requiresTypeScriptResolutionIgnore(file.importSpecifier)) {
+    return `// @ts-ignore: File URL import preserves URL-significant ` +
+      `command paths.\n${importDeclaration}`;
   }
-  return `import * as ${file.identifier} from ${importSpecifier};`;
+  return importDeclaration;
 }
 
-function requiresDynamicImport(specifier: string): boolean {
-  return specifier.includes("%");
+function requiresTypeScriptResolutionIgnore(specifier: string): boolean {
+  return specifier.startsWith("file:");
 }
 
 function normalizeGenerateOptions(
@@ -526,12 +530,14 @@ function relativeModuleSpecifier(fromDir: string, target: string): string {
 }
 
 function relativeImportSpecifier(fromDir: string, target: string): string {
-  return encodeImportSpecifier(relativeModuleSpecifier(fromDir, target));
+  const specifier = relativeModuleSpecifier(fromDir, target);
+  if (requiresFileUrlImport(specifier)) return pathToFileURL(target).href;
+  return specifier;
 }
 
-function encodeImportSpecifier(specifier: string): string {
-  return specifier.split("/").map((segment) => encodeURIComponent(segment))
-    .join("/");
+function requiresFileUrlImport(specifier: string): boolean {
+  return specifier.includes("#") || specifier.includes("?") ||
+    specifier.includes("%");
 }
 
 function normalizeRelativePath(path: string): string {

--- a/packages/discover/src/generator.ts
+++ b/packages/discover/src/generator.ts
@@ -15,7 +15,7 @@ export interface GeneratedCommandModuleFile {
   readonly filePath: string;
 
   /**
-   * Module specifier used by the generated import declaration.
+   * Module specifier used by the generated module loader.
    */
   readonly importSpecifier: string;
 
@@ -260,13 +260,7 @@ function generateCommandsModuleFromFiles(
     };
   }
 
-  const imports = files
-    .map((file) =>
-      `import * as ${file.identifier} from ${
-        JSON.stringify(file.importSpecifier)
-      };`
-    )
-    .join("\n");
+  const imports = files.map(formatCommandModuleImport).join("\n");
   const entries = files
     .map((file) =>
       `    ${JSON.stringify(file.modulePath)}: ${file.identifier},`
@@ -288,6 +282,20 @@ function generateCommandsModuleFromFiles(
       `);\n`,
     files,
   };
+}
+
+function formatCommandModuleImport(file: GeneratedCommandModuleFile): string {
+  const importSpecifier = JSON.stringify(file.importSpecifier);
+  if (requiresDynamicImport(file.importSpecifier)) {
+    return `const ${file.identifier} = await import(` +
+      `new URL(${importSpecifier}, import.meta.url).href` +
+      `);`;
+  }
+  return `import * as ${file.identifier} from ${importSpecifier};`;
+}
+
+function requiresDynamicImport(specifier: string): boolean {
+  return specifier.includes("%");
 }
 
 function normalizeGenerateOptions(

--- a/packages/discover/src/generator.ts
+++ b/packages/discover/src/generator.ts
@@ -1,5 +1,5 @@
 import { mkdir, readdir, realpath, stat, writeFile } from "node:fs/promises";
-import { dirname, relative, resolve } from "node:path";
+import { dirname, posix, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { getDefaultExtensions } from "./index.ts";
 
@@ -108,6 +108,13 @@ export interface WatchCommandsModuleOptions
    * Callback invoked after each regeneration.
    */
   readonly onGenerate?: (result: GeneratedCommandsModule) => void;
+
+  /**
+   * Callback invoked when generation fails during watching.
+   *
+   * @since 1.2.0
+   */
+  readonly onError?: (error: unknown) => void;
 }
 
 interface NormalizedGenerateOptions {
@@ -163,8 +170,7 @@ export async function writeCommandsModule(
  *
  * @param options Watch options.
  * @returns A promise that resolves when the watch signal is aborted.
- * @throws {TypeError} If options are invalid or no command modules are found.
- * @throws {Error} If the generated module cannot be written.
+ * @throws {TypeError} If options are invalid.
  * @since 1.2.0
  */
 export async function watchCommandsModule(
@@ -180,21 +186,34 @@ export async function watchCommandsModule(
 
   let previousSignature: string | undefined;
   while (options.signal?.aborted !== true) {
-    const files = await collectGeneratedCommandFiles(normalized);
-    const signature = files.map((file) => file.filePath).join("\0");
-    if (signature !== previousSignature) {
-      const result = generateCommandsModuleFromFiles(normalized, files);
-      await mkdir(dirname(normalized.outputFile), { recursive: true });
-      await writeFile(normalized.outputFile, result.code, "utf-8");
-      options.onGenerate?.(result);
-      previousSignature = signature;
+    try {
+      const files = await collectGeneratedCommandFiles(normalized, {
+        allowEmpty: true,
+      });
+      const signature = files.map((file) => file.filePath).join("\0");
+      if (signature !== previousSignature) {
+        if (files.length > 0) {
+          const result = generateCommandsModuleFromFiles(normalized, files);
+          await mkdir(dirname(normalized.outputFile), { recursive: true });
+          await writeFile(normalized.outputFile, result.code, "utf-8");
+          options.onGenerate?.(result);
+        }
+        previousSignature = signature;
+      }
+    } catch (error) {
+      options.onError?.(error);
     }
     await delay(intervalMs, options.signal);
   }
 }
 
+interface CollectGeneratedCommandFilesOptions {
+  readonly allowEmpty?: boolean;
+}
+
 async function collectGeneratedCommandFiles(
   options: NormalizedGenerateOptions,
+  collectOptions: CollectGeneratedCommandFilesOptions = {},
 ): Promise<readonly GeneratedCommandModuleFile[]> {
   const filePaths = await collectCommandFiles(
     options.dir,
@@ -202,9 +221,10 @@ async function collectGeneratedCommandFiles(
     options.outputFile,
   );
   if (filePaths.length < 1) {
+    if (collectOptions.allowEmpty === true) return [];
     throw new TypeError(`No command modules found in ${options.dir}.`);
   }
-  return filePaths.map((filePath, index) => {
+  const files = filePaths.map((filePath, index) => {
     const importSpecifier = relativeImportSpecifier(
       options.outputDir,
       filePath,
@@ -226,6 +246,8 @@ async function collectGeneratedCommandFiles(
       identifier: `cmd${index}`,
     };
   });
+  rejectDuplicateCommandPaths(files, options);
+  return files;
 }
 
 function generateCommandsModuleFromFiles(
@@ -396,6 +418,94 @@ function isDeclarationFile(fileName: string): boolean {
   return /\.d\.[cm]?ts$/.test(fileName);
 }
 
+function rejectDuplicateCommandPaths(
+  files: readonly GeneratedCommandModuleFile[],
+  options: NormalizedGenerateOptions,
+): void {
+  const entryFileName = options.entryFileName ?? "index";
+  const seen = new Map<string, string>();
+  for (const file of files) {
+    const commandPath = commandPathFromModulePath(
+      options.base,
+      file.modulePath,
+      options.extensions,
+      entryFileName,
+    );
+    const key = commandPath.join("\0");
+    const previous = seen.get(key);
+    if (previous != null) {
+      throw new TypeError(
+        `Duplicate command path "${
+          displayCommandPath(commandPath)
+        }" from ${previous} and ${file.modulePath}.`,
+      );
+    }
+    seen.set(key, file.modulePath);
+  }
+}
+
+function commandPathFromModulePath(
+  base: string,
+  modulePath: string,
+  extensions: readonly string[],
+  entryFileName: string | false,
+): readonly string[] {
+  const withoutExtension = stripCommandExtension(modulePath, extensions);
+  const relativePath = relativeModulePath(base, withoutExtension, modulePath);
+  const path = relativePath.split("/").filter((segment) => segment.length > 0);
+  return commandPathFromSegments(path, modulePath, entryFileName);
+}
+
+function stripCommandExtension(
+  path: string,
+  extensions: readonly string[],
+): string {
+  const matchedExtension = extensions.find((ext) => path.endsWith(ext));
+  if (matchedExtension == null) {
+    throw new TypeError(`No configured extension matches ${path}.`);
+  }
+  return path.slice(0, -matchedExtension.length);
+}
+
+function relativeModulePath(
+  base: string,
+  modulePath: string,
+  originalModulePath: string,
+): string {
+  const normalizedBase = normalizeDerivedModulePath(base);
+  const normalizedPath = normalizeDerivedModulePath(modulePath);
+  const relativePath = posix.relative(normalizedBase, normalizedPath);
+  if (
+    relativePath.length < 1 ||
+    relativePath === ".." ||
+    relativePath.startsWith("../") ||
+    posix.isAbsolute(relativePath)
+  ) {
+    throw new TypeError(
+      `Module path ${originalModulePath} is not under base path ${base}.`,
+    );
+  }
+  return relativePath;
+}
+
+function commandPathFromSegments(
+  path: readonly string[],
+  source: string,
+  entryFileName: string | false,
+): readonly string[] {
+  if (path.length < 1) {
+    throw new TypeError(`Command module ${source} does not define a path.`);
+  }
+  if (entryFileName !== false && path[path.length - 1] === entryFileName) {
+    return path.slice(0, -1);
+  }
+  return path;
+}
+
+function displayCommandPath(path: readonly string[]): string {
+  return path.length < 1 ? "<root>" : path.join(" ");
+}
+
 function relativeModuleSpecifier(fromDir: string, target: string): string {
   const relativePath = normalizeRelativePath(relative(fromDir, target));
   return relativePath.startsWith(".") ? relativePath : `./${relativePath}`;
@@ -416,6 +526,10 @@ function normalizeRelativePath(path: string): string {
 
 function normalizeModulePath(path: string): string {
   return path.replaceAll("\\", "/");
+}
+
+function normalizeDerivedModulePath(path: string): string {
+  return posix.normalize(normalizeModulePath(path));
 }
 
 function joinModulePath(base: string, relativePath: string): string {

--- a/packages/discover/src/generator.ts
+++ b/packages/discover/src/generator.ts
@@ -1,0 +1,445 @@
+import { mkdir, readdir, realpath, stat, writeFile } from "node:fs/promises";
+import { dirname, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { getDefaultExtensions } from "./index.ts";
+
+/**
+ * A command module file included in generated discovery output.
+ *
+ * @since 1.2.0
+ */
+export interface GeneratedCommandModuleFile {
+  /**
+   * Absolute path to the command module file.
+   */
+  readonly filePath: string;
+
+  /**
+   * Module specifier used by the generated import declaration.
+   */
+  readonly importSpecifier: string;
+
+  /**
+   * Module map key passed to `commandsFromModules()`.
+   */
+  readonly modulePath: string;
+
+  /**
+   * Namespace import identifier used in the generated module.
+   */
+  readonly identifier: string;
+}
+
+/**
+ * Options for generating a static command module.
+ *
+ * @since 1.2.0
+ */
+export interface GenerateCommandsModuleOptions {
+  /**
+   * Directory containing command modules.
+   */
+  readonly dir: string | URL;
+
+  /**
+   * Path to the module that will be generated.
+   */
+  readonly outputFile: string | URL;
+
+  /**
+   * Module map base path passed to `commandsFromModules()`.
+   *
+   * By default, this is the command directory path relative to the generated
+   * module's containing directory.
+   */
+  readonly base?: string;
+
+  /**
+   * Module suffixes to include.
+   *
+   * @default Runtime-aware extension defaults from {@link getDefaultExtensions}
+   */
+  readonly extensions?: readonly string[];
+
+  /**
+   * Entry file name passed to `commandsFromModules()`.  Pass `false` to
+   * disable entry-file mapping.
+   */
+  readonly entryFileName?: string | false;
+}
+
+/**
+ * Result of generating a static command module.
+ *
+ * @since 1.2.0
+ */
+export interface GeneratedCommandsModule {
+  /**
+   * Generated TypeScript source code.
+   */
+  readonly code: string;
+
+  /**
+   * Command module files included in the generated module.
+   */
+  readonly files: readonly GeneratedCommandModuleFile[];
+}
+
+/**
+ * Options for watching and regenerating a static command module.
+ *
+ * @since 1.2.0
+ */
+export interface WatchCommandsModuleOptions
+  extends GenerateCommandsModuleOptions {
+  /**
+   * Polling interval in milliseconds.
+   *
+   * @default `250`
+   */
+  readonly intervalMs?: number;
+
+  /**
+   * Abort signal used to stop watching.
+   */
+  readonly signal?: AbortSignal;
+
+  /**
+   * Callback invoked after each regeneration.
+   */
+  readonly onGenerate?: (result: GeneratedCommandsModule) => void;
+}
+
+interface NormalizedGenerateOptions {
+  readonly dir: string;
+  readonly outputFile: string;
+  readonly outputDir: string;
+  readonly base: string;
+  readonly baseWasProvided: boolean;
+  readonly extensions: readonly string[];
+  readonly entryFileName: string | false | undefined;
+}
+
+/**
+ * Generates a TypeScript module that exports command entries.
+ *
+ * @param options Generation options.
+ * @returns The generated source code and command module metadata.
+ * @throws {TypeError} If options are invalid or no command modules are found.
+ * @since 1.2.0
+ */
+export async function generateCommandsModule(
+  options: GenerateCommandsModuleOptions,
+): Promise<GeneratedCommandsModule> {
+  const normalized = normalizeGenerateOptions(options);
+  const files = await collectGeneratedCommandFiles(normalized);
+  return generateCommandsModuleFromFiles(normalized, files);
+}
+
+/**
+ * Writes a generated command module to disk.
+ *
+ * @param options Generation options.
+ * @returns The generated source code and command module metadata.
+ * @throws {TypeError} If options are invalid or no command modules are found.
+ * @throws {Error} If the generated module cannot be written.
+ * @since 1.2.0
+ */
+export async function writeCommandsModule(
+  options: GenerateCommandsModuleOptions,
+): Promise<GeneratedCommandsModule> {
+  const result = await generateCommandsModule(options);
+  await mkdir(dirname(pathFromFile(options.outputFile)), { recursive: true });
+  await writeFile(pathFromFile(options.outputFile), result.code, "utf-8");
+  return result;
+}
+
+/**
+ * Watches the command file set and rewrites the generated module when it
+ * changes.
+ *
+ * Content-only edits do not trigger regeneration because they do not change
+ * the static module map.
+ *
+ * @param options Watch options.
+ * @returns A promise that resolves when the watch signal is aborted.
+ * @throws {TypeError} If options are invalid or no command modules are found.
+ * @throws {Error} If the generated module cannot be written.
+ * @since 1.2.0
+ */
+export async function watchCommandsModule(
+  options: WatchCommandsModuleOptions,
+): Promise<void> {
+  const normalized = normalizeGenerateOptions(options);
+  const intervalMs = options.intervalMs ?? 250;
+  if (!Number.isInteger(intervalMs) || intervalMs < 1) {
+    throw new TypeError(
+      `Watch interval must be a positive integer: ${intervalMs}`,
+    );
+  }
+
+  let previousSignature: string | undefined;
+  while (options.signal?.aborted !== true) {
+    const files = await collectGeneratedCommandFiles(normalized);
+    const signature = files.map((file) => file.filePath).join("\0");
+    if (signature !== previousSignature) {
+      const result = generateCommandsModuleFromFiles(normalized, files);
+      await mkdir(dirname(normalized.outputFile), { recursive: true });
+      await writeFile(normalized.outputFile, result.code, "utf-8");
+      options.onGenerate?.(result);
+      previousSignature = signature;
+    }
+    await delay(intervalMs, options.signal);
+  }
+}
+
+async function collectGeneratedCommandFiles(
+  options: NormalizedGenerateOptions,
+): Promise<readonly GeneratedCommandModuleFile[]> {
+  const filePaths = await collectCommandFiles(
+    options.dir,
+    options.extensions,
+    options.outputFile,
+  );
+  if (filePaths.length < 1) {
+    throw new TypeError(`No command modules found in ${options.dir}.`);
+  }
+  return filePaths.map((filePath, index) => {
+    const importSpecifier = relativeImportSpecifier(
+      options.outputDir,
+      filePath,
+    );
+    const defaultModulePath = relativeModuleSpecifier(
+      options.outputDir,
+      filePath,
+    );
+    const modulePath = options.baseWasProvided
+      ? joinModulePath(
+        options.base,
+        normalizeRelativePath(relative(options.dir, filePath)),
+      )
+      : defaultModulePath;
+    return {
+      filePath,
+      importSpecifier,
+      modulePath,
+      identifier: `cmd${index}`,
+    };
+  });
+}
+
+function generateCommandsModuleFromFiles(
+  options: NormalizedGenerateOptions,
+  files: readonly GeneratedCommandModuleFile[],
+): GeneratedCommandsModule {
+  const imports = files
+    .map((file) =>
+      `import * as ${file.identifier} from ${
+        JSON.stringify(file.importSpecifier)
+      };`
+    )
+    .join("\n");
+  const entries = files
+    .map((file) =>
+      `    ${JSON.stringify(file.modulePath)}: ${file.identifier},`
+    )
+    .join("\n");
+  const optionEntries = [
+    `    base: ${JSON.stringify(options.base)},`,
+    `    extensions: ${formatStringArray(options.extensions)},`,
+    ...(options.entryFileName === undefined ? [] : [
+      `    entryFileName: ${JSON.stringify(options.entryFileName)},`,
+    ]),
+  ].join("\n");
+  return {
+    code:
+      `import { commandsFromModules } from "@optique/discover";\n${imports}\n\n` +
+      `export default commandsFromModules(\n` +
+      `  {\n${entries}\n  },\n` +
+      `  {\n${optionEntries}\n  },\n` +
+      `);\n`,
+    files,
+  };
+}
+
+function normalizeGenerateOptions(
+  options: GenerateCommandsModuleOptions,
+): NormalizedGenerateOptions {
+  const dir = resolve(pathFromFile(options.dir));
+  const outputFile = resolve(pathFromFile(options.outputFile));
+  const outputDir = dirname(outputFile);
+  const baseWasProvided = options.base !== undefined;
+  const base = normalizeBase(
+    options.base ?? relativeModuleSpecifier(outputDir, dir),
+  );
+  return {
+    dir,
+    outputFile,
+    outputDir,
+    base,
+    baseWasProvided,
+    extensions: normalizeExtensions(
+      options.extensions ?? getDefaultExtensions(),
+    ),
+    entryFileName: normalizeEntryFileName(options.entryFileName),
+  };
+}
+
+function pathFromFile(path: string | URL): string {
+  return typeof path === "string" ? path : fileURLToPath(path);
+}
+
+function normalizeBase(base: string): string {
+  if (typeof base !== "string" || base.length < 1) {
+    throw new TypeError(`Module base path must be a non-empty string: ${base}`);
+  }
+  return normalizeModulePath(base);
+}
+
+function normalizeExtensions(extensions: readonly string[]): readonly string[] {
+  if (extensions.length < 1) {
+    throw new TypeError("At least one command file extension is required.");
+  }
+  const normalized: string[] = [];
+  for (const extension of extensions) {
+    if (!extension.startsWith(".") || extension.length < 2) {
+      throw new TypeError(
+        `Command file extension must start with a dot: ${extension}`,
+      );
+    }
+    if (!normalized.includes(extension)) normalized.push(extension);
+  }
+  return normalized.toSorted((a, b) =>
+    b.length - a.length || a.localeCompare(b)
+  );
+}
+
+function normalizeEntryFileName(
+  entryFileName: string | false | undefined,
+): string | false | undefined {
+  if (entryFileName === undefined) return undefined;
+  if (entryFileName === false) return false;
+  if (
+    typeof entryFileName !== "string" ||
+    entryFileName.length < 1 ||
+    entryFileName.includes("/") ||
+    entryFileName.includes("\\")
+  ) {
+    throw new TypeError(
+      `Command entry file name must be a non-empty file name: ${entryFileName}`,
+    );
+  }
+  return entryFileName;
+}
+
+async function collectCommandFiles(
+  dir: string,
+  extensions: readonly string[],
+  excludedFile: string,
+  activeDirs = new Set<string>(),
+): Promise<readonly string[]> {
+  const canonicalDir = await realpath(dir);
+  if (activeDirs.has(canonicalDir)) return [];
+  const nextActiveDirs = new Set(activeDirs);
+  nextActiveDirs.add(canonicalDir);
+
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files: string[] = [];
+  for (
+    const entry of entries.toSorted((a, b) => a.name.localeCompare(b.name))
+  ) {
+    const path = resolve(dir, entry.name);
+    const entryType = await getCommandFileEntryType(path, entry);
+    if (entryType === "directory") {
+      files.push(
+        ...await collectCommandFiles(
+          path,
+          extensions,
+          excludedFile,
+          nextActiveDirs,
+        ),
+      );
+    } else if (
+      entryType === "file" &&
+      path !== excludedFile &&
+      !isDeclarationFile(entry.name) &&
+      extensions.some((ext) => entry.name.endsWith(ext))
+    ) {
+      files.push(path);
+    }
+  }
+  return files;
+}
+
+async function getCommandFileEntryType(
+  path: string,
+  entry: {
+    isDirectory(): boolean;
+    isFile(): boolean;
+    isSymbolicLink(): boolean;
+  },
+): Promise<"directory" | "file" | undefined> {
+  if (entry.isDirectory()) return "directory";
+  if (entry.isFile()) return "file";
+  if (!entry.isSymbolicLink()) return undefined;
+  try {
+    const target = await stat(path);
+    if (target.isDirectory()) return "directory";
+    if (target.isFile()) return "file";
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function isDeclarationFile(fileName: string): boolean {
+  return /\.d\.[cm]?ts$/.test(fileName);
+}
+
+function relativeModuleSpecifier(fromDir: string, target: string): string {
+  const relativePath = normalizeRelativePath(relative(fromDir, target));
+  return relativePath.startsWith(".") ? relativePath : `./${relativePath}`;
+}
+
+function relativeImportSpecifier(fromDir: string, target: string): string {
+  return encodeImportSpecifier(relativeModuleSpecifier(fromDir, target));
+}
+
+function encodeImportSpecifier(specifier: string): string {
+  return specifier.split("/").map((segment) => encodeURIComponent(segment))
+    .join("/");
+}
+
+function normalizeRelativePath(path: string): string {
+  return path.replaceAll("\\", "/");
+}
+
+function normalizeModulePath(path: string): string {
+  return path.replaceAll("\\", "/");
+}
+
+function joinModulePath(base: string, relativePath: string): string {
+  if (base === "." || base === "./") return `./${relativePath}`;
+  const prefix = base.endsWith("/") ? base.slice(0, -1) : base;
+  return `${prefix}/${relativePath}`;
+}
+
+function formatStringArray(values: readonly string[]): string {
+  return `[${values.map((value) => JSON.stringify(value)).join(", ")}]`;
+}
+
+function delay(ms: number, signal: AbortSignal | undefined): Promise<void> {
+  if (signal?.aborted === true) return Promise.resolve();
+  return new Promise((resolve) => {
+    const onTimeout = () => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    };
+    const onAbort = () => {
+      clearTimeout(timeout);
+      resolve();
+    };
+    const timeout = setTimeout(onTimeout, ms);
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}

--- a/packages/discover/src/generator.ts
+++ b/packages/discover/src/generator.ts
@@ -192,12 +192,10 @@ export async function watchCommandsModule(
       });
       const signature = files.map((file) => file.filePath).join("\0");
       if (signature !== previousSignature) {
-        if (files.length > 0) {
-          const result = generateCommandsModuleFromFiles(normalized, files);
-          await mkdir(dirname(normalized.outputFile), { recursive: true });
-          await writeFile(normalized.outputFile, result.code, "utf-8");
-          options.onGenerate?.(result);
-        }
+        const result = generateCommandsModuleFromFiles(normalized, files);
+        await mkdir(dirname(normalized.outputFile), { recursive: true });
+        await writeFile(normalized.outputFile, result.code, "utf-8");
+        options.onGenerate?.(result);
         previousSignature = signature;
       }
     } catch (error) {
@@ -254,6 +252,14 @@ function generateCommandsModuleFromFiles(
   options: NormalizedGenerateOptions,
   files: readonly GeneratedCommandModuleFile[],
 ): GeneratedCommandsModule {
+  if (files.length < 1) {
+    return {
+      code: `import type { ModuleCommand } from "@optique/discover";\n\n` +
+        `export default [] satisfies readonly ModuleCommand[];\n`,
+      files,
+    };
+  }
+
   const imports = files
     .map((file) =>
       `import * as ${file.identifier} from ${

--- a/packages/discover/src/generator.ts
+++ b/packages/discover/src/generator.ts
@@ -1,6 +1,6 @@
 import { mkdir, readdir, realpath, stat, writeFile } from "node:fs/promises";
 import { dirname, posix, relative, resolve } from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
 import { getDefaultExtensions } from "./index.ts";
 
 /**
@@ -17,8 +17,8 @@ export interface GeneratedCommandModuleFile {
   /**
    * Module specifier used by the generated import declaration.
    *
-   * Paths containing URL-significant characters use absolute file URLs so
-   * runtime loaders and bundlers resolve the same command file.
+   * Paths containing URL-significant characters use percent-encoded
+   * relative specifiers so generated modules stay relocatable.
    */
   readonly importSpecifier: string;
 
@@ -292,14 +292,14 @@ function formatCommandModuleImport(file: GeneratedCommandModuleFile): string {
   const importDeclaration =
     `import * as ${file.identifier} from ${importSpecifier};`;
   if (requiresTypeScriptResolutionIgnore(file.importSpecifier)) {
-    return `// @ts-ignore: File URL import preserves URL-significant ` +
+    return `// @ts-ignore: Percent-encoded import preserves URL-significant ` +
       `command paths.\n${importDeclaration}`;
   }
   return importDeclaration;
 }
 
 function requiresTypeScriptResolutionIgnore(specifier: string): boolean {
-  return specifier.startsWith("file:");
+  return specifier.includes("%");
 }
 
 function normalizeGenerateOptions(
@@ -531,13 +531,20 @@ function relativeModuleSpecifier(fromDir: string, target: string): string {
 
 function relativeImportSpecifier(fromDir: string, target: string): string {
   const specifier = relativeModuleSpecifier(fromDir, target);
-  if (requiresFileUrlImport(specifier)) return pathToFileURL(target).href;
+  if (requiresEncodedImportSpecifier(specifier)) {
+    return encodeImportSpecifier(specifier);
+  }
   return specifier;
 }
 
-function requiresFileUrlImport(specifier: string): boolean {
+function requiresEncodedImportSpecifier(specifier: string): boolean {
   return specifier.includes("#") || specifier.includes("?") ||
     specifier.includes("%");
+}
+
+function encodeImportSpecifier(specifier: string): string {
+  return specifier.split("/").map((segment) => encodeURIComponent(segment))
+    .join("/");
 }
 
 function normalizeRelativePath(path: string): string {

--- a/packages/discover/src/main-check.test.ts
+++ b/packages/discover/src/main-check.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { isMainModule } from "#src/main-check.ts";
+import { isMainModule, isMainModuleUrl } from "#src/main-check.ts";
 
 describe("isMainModule()", () => {
   it("should use import.meta.main when the runtime provides it", () => {
@@ -44,6 +44,32 @@ describe("isMainModule()", () => {
     assert.ok(
       !isMainModule({
         modulePath: "/real/cli.js",
+      }),
+    );
+  });
+
+  it("should use import.meta.main before converting remote module URLs", () => {
+    assert.ok(
+      isMainModuleUrl({
+        importMetaMain: true,
+        moduleUrl: "https://jsr.io/@optique/discover/1.2.0/src/cli.ts",
+        argvEntry: "/real/cli.js",
+      }),
+    );
+    assert.ok(
+      !isMainModuleUrl({
+        importMetaMain: false,
+        moduleUrl: "file:///real/cli.js",
+        argvEntry: "/real/cli.js",
+      }),
+    );
+  });
+
+  it("should return false for non-file module URLs without import.meta.main", () => {
+    assert.ok(
+      !isMainModuleUrl({
+        moduleUrl: "https://jsr.io/@optique/discover/1.2.0/src/cli.ts",
+        argvEntry: "/real/cli.js",
       }),
     );
   });

--- a/packages/discover/src/main-check.test.ts
+++ b/packages/discover/src/main-check.test.ts
@@ -4,21 +4,19 @@ import { isMainModule } from "#src/main-check.ts";
 
 describe("isMainModule()", () => {
   it("should use import.meta.main when the runtime provides it", () => {
-    assert.equal(
+    assert.ok(
       isMainModule({
         importMetaMain: true,
         modulePath: "/real/cli.js",
         argvEntry: "/other/cli.js",
       }),
-      true,
     );
-    assert.equal(
-      isMainModule({
+    assert.ok(
+      !isMainModule({
         importMetaMain: false,
         modulePath: "/real/cli.js",
         argvEntry: "/real/cli.js",
       }),
-      false,
     );
   });
 
@@ -31,7 +29,7 @@ describe("isMainModule()", () => {
       ],
     ]);
 
-    assert.equal(
+    assert.ok(
       isMainModule({
         modulePath: "/project/node_modules/@optique/discover/dist/cli.js",
         argvEntry: "/project/node_modules/.bin/optique-discover",
@@ -39,16 +37,14 @@ describe("isMainModule()", () => {
           return realpaths.get(path) ?? path;
         },
       }),
-      true,
     );
   });
 
   it("should return false when no entry-point path exists", () => {
-    assert.equal(
-      isMainModule({
+    assert.ok(
+      !isMainModule({
         modulePath: "/real/cli.js",
       }),
-      false,
     );
   });
 });

--- a/packages/discover/src/main-check.test.ts
+++ b/packages/discover/src/main-check.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { isMainModule } from "#src/main-check.ts";
+
+describe("isMainModule()", () => {
+  it("should use import.meta.main when the runtime provides it", () => {
+    assert.equal(
+      isMainModule({
+        importMetaMain: true,
+        modulePath: "/real/cli.js",
+        argvEntry: "/other/cli.js",
+      }),
+      true,
+    );
+    assert.equal(
+      isMainModule({
+        importMetaMain: false,
+        modulePath: "/real/cli.js",
+        argvEntry: "/real/cli.js",
+      }),
+      false,
+    );
+  });
+
+  it("should compare real paths for Node versions without import.meta.main", () => {
+    const realpaths = new Map([
+      ["/project/node_modules/.bin/optique-discover", "/project/dist/cli.js"],
+      [
+        "/project/node_modules/@optique/discover/dist/cli.js",
+        "/project/dist/cli.js",
+      ],
+    ]);
+
+    assert.equal(
+      isMainModule({
+        modulePath: "/project/node_modules/@optique/discover/dist/cli.js",
+        argvEntry: "/project/node_modules/.bin/optique-discover",
+        realpath(path) {
+          return realpaths.get(path) ?? path;
+        },
+      }),
+      true,
+    );
+  });
+
+  it("should return false when no entry-point path exists", () => {
+    assert.equal(
+      isMainModule({
+        modulePath: "/real/cli.js",
+      }),
+      false,
+    );
+  });
+});

--- a/packages/discover/src/main-check.ts
+++ b/packages/discover/src/main-check.ts
@@ -1,4 +1,5 @@
 import { realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 /**
  * Options for checking whether an ESM module is the process entry point.
@@ -29,6 +30,34 @@ export interface MainModuleOptions {
 }
 
 /**
+ * Options for checking whether an ESM module URL is the process entry point.
+ *
+ * @internal
+ * @since 1.2.0
+ */
+export interface MainModuleUrlOptions {
+  /**
+   * `import.meta.main` when the current runtime provides it.
+   */
+  readonly importMetaMain?: boolean;
+
+  /**
+   * URL of the current module.
+   */
+  readonly moduleUrl: string;
+
+  /**
+   * Process entry-point path.
+   */
+  readonly argvEntry?: string;
+
+  /**
+   * Function used to resolve symlinks.
+   */
+  readonly realpath?: (path: string) => string;
+}
+
+/**
  * Checks whether a module is the current process entry point.
  *
  * @param options Main-module check inputs.
@@ -42,6 +71,27 @@ export function isMainModule(options: MainModuleOptions): boolean {
   const realpath = options.realpath ?? realpathSync;
   return realpathOrOriginal(options.argvEntry, realpath) ===
     realpathOrOriginal(options.modulePath, realpath);
+}
+
+/**
+ * Checks whether a module URL is the current process entry point.
+ *
+ * Non-file module URLs rely on `import.meta.main` because process entry points
+ * are file-system paths.
+ *
+ * @param options Main-module URL check inputs.
+ * @returns Whether the module should run as the process entry point.
+ * @internal
+ * @since 1.2.0
+ */
+export function isMainModuleUrl(options: MainModuleUrlOptions): boolean {
+  if (options.importMetaMain != null) return options.importMetaMain;
+  if (!options.moduleUrl.startsWith("file:")) return false;
+  return isMainModule({
+    modulePath: fileURLToPath(options.moduleUrl),
+    argvEntry: options.argvEntry,
+    realpath: options.realpath,
+  });
 }
 
 function realpathOrOriginal(

--- a/packages/discover/src/main-check.ts
+++ b/packages/discover/src/main-check.ts
@@ -1,0 +1,56 @@
+import { realpathSync } from "node:fs";
+
+/**
+ * Options for checking whether an ESM module is the process entry point.
+ *
+ * @internal
+ * @since 1.2.0
+ */
+export interface MainModuleOptions {
+  /**
+   * `import.meta.main` when the current runtime provides it.
+   */
+  readonly importMetaMain?: boolean;
+
+  /**
+   * Path to the current module.
+   */
+  readonly modulePath: string;
+
+  /**
+   * Process entry-point path.
+   */
+  readonly argvEntry?: string;
+
+  /**
+   * Function used to resolve symlinks.
+   */
+  readonly realpath?: (path: string) => string;
+}
+
+/**
+ * Checks whether a module is the current process entry point.
+ *
+ * @param options Main-module check inputs.
+ * @returns Whether the module should run as the process entry point.
+ * @internal
+ * @since 1.2.0
+ */
+export function isMainModule(options: MainModuleOptions): boolean {
+  if (options.importMetaMain != null) return options.importMetaMain;
+  if (options.argvEntry == null) return false;
+  const realpath = options.realpath ?? realpathSync;
+  return realpathOrOriginal(options.argvEntry, realpath) ===
+    realpathOrOriginal(options.modulePath, realpath);
+}
+
+function realpathOrOriginal(
+  path: string,
+  realpath: (path: string) => string,
+): string {
+  try {
+    return realpath(path);
+  } catch {
+    return path;
+  }
+}

--- a/packages/discover/tsdown.config.ts
+++ b/packages/discover/tsdown.config.ts
@@ -1,11 +1,28 @@
 import { defineConfig } from "tsdown";
+import { chmodSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 
 export default defineConfig({
   entry: [
     "src/index.ts",
     "src/command.ts",
+    "src/generator.ts",
+    "src/cli.ts",
   ],
   dts: true,
   format: ["esm", "cjs"],
   platform: "node",
+  hooks: {
+    "build:done": () => {
+      const shebang = "#!/usr/bin/env node\n";
+      for (const file of ["cli.js", "cli.cjs"]) {
+        const filePath = join("dist", file);
+        const content = readFileSync(filePath, "utf-8");
+        if (!content.startsWith("#!")) {
+          writeFileSync(filePath, shebang + content);
+        }
+        chmodSync(filePath, 0o755);
+      }
+    },
+  },
 });

--- a/packages/discover/tsdown.config.ts
+++ b/packages/discover/tsdown.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     "src/index.ts",
     "src/command.ts",
     "src/generator.ts",
+    "src/main-check.ts",
     "src/cli.ts",
   ],
   dts: true,


### PR DESCRIPTION
Closes #835.

Summary
-------

This PR adds the `optique-discover` CLI for projects that want static command discovery without maintaining a module map by hand. The command scans a command directory, writes a TypeScript module that imports each command file, and default-exports `commandsFromModules(...)`.

The generated module gives bundlers and single-file packagers an import graph they can see at build time. Watch mode keeps that file in sync when command files are added, removed, or renamed, while leaving content-only edits alone.


Changes
-------

 -  Adds generator helpers in *packages/discover/src/generator.ts* for generating, writing, and watching static command modules.
 -  Adds the `optique-discover` entry point in *packages/discover/src/cli.ts*, with `--output`, `--base`, repeated `--extension`, entry-file options, and `--watch`.
 -  Adds the npm bin entry in *packages/discover/package.json*, the JSR CLI subpath in *packages/discover/deno.json*, and the build entry in *packages/discover/tsdown.config.ts*.
 -  Keeps the npm `./cli` subpath import-only, so CommonJS consumers do not resolve the generated CLI bundle through `require()`.
 -  Encodes generated import specifiers without changing raw module-map keys, so legal paths containing URL-significant characters still derive command paths correctly.
 -  Documents the generated-module workflow in *docs/concepts/discover.md* and *packages/discover/README.md*.
 -  Adds the planned PR #841 changelog entry to *CHANGES.md*.
