### PR TITLE
Derived defaults

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,6 +137,10 @@ Architecture
     command modules with handler dispatch.
  -  *@optique/config* (*packages/config/*): Configuration file integration.
     Provides `createConfigContext()` and `bindConfig()` for config fallbacks.
+ -  *@optique/derived-defaults* (*packages/derived-defaults/*): Derived
+    default integration. Provides `createDerivedDefaults()` and
+    `bindDerivedDefault()` for computing fallback values from first-pass parse
+    results.
  -  *@optique/env* (*packages/env/*): Environment variable integration.
     Provides `createEnvContext()`, `bindEnv()`, and `bool()`.
  -  *@optique/prompt* (*packages/prompt/*): Generic prompt adapter foundation.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,20 @@ To be released.
 [#842]: https://github.com/dahlia/optique/issues/842
 [#843]: https://github.com/dahlia/optique/pull/843
 
+### @optique/derived-defaults
+
+ -  Added the new *@optique/derived-defaults* package for computing fallback
+    values from the first-pass parse result.  `createDerivedDefaults()` creates
+    a two-pass source context, and `bindDerivedDefault()` binds an option to
+    one of the derived values while preserving the priority order of CLI
+    argument, then derived default, then static default.  The wrapper
+    revalidates derived values through the wrapped parser and exposes
+    `defaultDescription` for help text when the actual value is computed at
+    runtime.  [[#845], [#847]]
+
+[#845]: https://github.com/dahlia/optique/issues/845
+[#847]: https://github.com/dahlia/optique/pull/847
+
 ### @optique/discover
 
  -  Added `commandsFromModules()` for bundler-friendly command discovery from

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ Features
     more
  -  *Environment variable support*: Bind options to environment variables
     with type-safe parsing and fallback behavior (via *@optique/env*)
+ -  *Derived defaults*: Compute default values from the first-pass parse result
+    without lowering CLI argument priority (via *@optique/derived-defaults*)
  -  *Interactive prompts*: Prompt users for missing values via Inquirer.js or
     Clack with parser-integrated fallback flows (via *@optique/inquirer* and
     *@optique/clack*)
@@ -183,22 +185,23 @@ Optique is a monorepo which contains multiple packages.  The main package is
 *@optique/core*, which provides the shared types and parser combinators.
 The following is a list of the available packages:
 
-| Package                                  | JSR                          | npm                          | Description                                 |
-| ---------------------------------------- | ---------------------------- | ---------------------------- | ------------------------------------------- |
-| [@optique/core](/packages/core/)         | [JSR][jsr:@optique/core]     | [npm][npm:@optique/core]     | Shared types and parser combinators         |
-| [@optique/run](/packages/run/)           | [JSR][jsr:@optique/run]      | [npm][npm:@optique/run]      | Runner for Node.js/Deno/Bun                 |
-| [@optique/discover](/packages/discover/) | [JSR][jsr:@optique/discover] | [npm][npm:@optique/discover] | Runtime-aware command discovery             |
-| [@optique/config](/packages/config/)     | [JSR][jsr:@optique/config]   | [npm][npm:@optique/config]   | Config file support with [Standard Schema]  |
-| [@optique/clack](/packages/clack/)       | [JSR][jsr:@optique/clack]    | [npm][npm:@optique/clack]    | [Clack] prompt support                      |
-| [@optique/env](/packages/env/)           | [JSR][jsr:@optique/env]      | [npm][npm:@optique/env]      | Environment variable integration            |
-| [@optique/git](/packages/git/)           | [JSR][jsr:@optique/git]      | [npm][npm:@optique/git]      | Git reference parsers (branches, tags, etc) |
-| [@optique/logtape](/packages/logtape/)   | [JSR][jsr:@optique/logtape]  | [npm][npm:@optique/logtape]  | [LogTape] logging integration               |
-| [@optique/man](/packages/man/)           | [JSR][jsr:@optique/man]      | [npm][npm:@optique/man]      | Man page generation from parsers            |
-| [@optique/temporal](/packages/temporal/) | [JSR][jsr:@optique/temporal] | [npm][npm:@optique/temporal] | [Temporal] value parsers (date and time)    |
-| [@optique/valibot](/packages/valibot/)   | [JSR][jsr:@optique/valibot]  | [npm][npm:@optique/valibot]  | [Valibot] schema integration for validation |
-| [@optique/zod](/packages/zod/)           | [JSR][jsr:@optique/zod]      | [npm][npm:@optique/zod]      | [Zod] schema integration for validation     |
-| [@optique/inquirer](/packages/inquirer/) | [JSR][jsr:@optique/inquirer] | [npm][npm:@optique/inquirer] | [Inquirer.js] prompt support                |
-| [@optique/prompt](/packages/prompt/)     | [JSR][jsr:@optique/prompt]   | [npm][npm:@optique/prompt]   | Generic prompt adapter foundation           |
+| Package                                                  | JSR                                  | npm                                  | Description                                 |
+| -------------------------------------------------------- | ------------------------------------ | ------------------------------------ | ------------------------------------------- |
+| [@optique/core](/packages/core/)                         | [JSR][jsr:@optique/core]             | [npm][npm:@optique/core]             | Shared types and parser combinators         |
+| [@optique/run](/packages/run/)                           | [JSR][jsr:@optique/run]              | [npm][npm:@optique/run]              | Runner for Node.js/Deno/Bun                 |
+| [@optique/discover](/packages/discover/)                 | [JSR][jsr:@optique/discover]         | [npm][npm:@optique/discover]         | Runtime-aware command discovery             |
+| [@optique/config](/packages/config/)                     | [JSR][jsr:@optique/config]           | [npm][npm:@optique/config]           | Config file support with [Standard Schema]  |
+| [@optique/clack](/packages/clack/)                       | [JSR][jsr:@optique/clack]            | [npm][npm:@optique/clack]            | [Clack] prompt support                      |
+| [@optique/derived-defaults](/packages/derived-defaults/) | [JSR][jsr:@optique/derived-defaults] | [npm][npm:@optique/derived-defaults] | Defaults derived from parsed values         |
+| [@optique/env](/packages/env/)                           | [JSR][jsr:@optique/env]              | [npm][npm:@optique/env]              | Environment variable integration            |
+| [@optique/git](/packages/git/)                           | [JSR][jsr:@optique/git]              | [npm][npm:@optique/git]              | Git reference parsers (branches, tags, etc) |
+| [@optique/logtape](/packages/logtape/)                   | [JSR][jsr:@optique/logtape]          | [npm][npm:@optique/logtape]          | [LogTape] logging integration               |
+| [@optique/man](/packages/man/)                           | [JSR][jsr:@optique/man]              | [npm][npm:@optique/man]              | Man page generation from parsers            |
+| [@optique/temporal](/packages/temporal/)                 | [JSR][jsr:@optique/temporal]         | [npm][npm:@optique/temporal]         | [Temporal] value parsers (date and time)    |
+| [@optique/valibot](/packages/valibot/)                   | [JSR][jsr:@optique/valibot]          | [npm][npm:@optique/valibot]          | [Valibot] schema integration for validation |
+| [@optique/zod](/packages/zod/)                           | [JSR][jsr:@optique/zod]              | [npm][npm:@optique/zod]              | [Zod] schema integration for validation     |
+| [@optique/inquirer](/packages/inquirer/)                 | [JSR][jsr:@optique/inquirer]         | [npm][npm:@optique/inquirer]         | [Inquirer.js] prompt support                |
+| [@optique/prompt](/packages/prompt/)                     | [JSR][jsr:@optique/prompt]           | [npm][npm:@optique/prompt]           | Generic prompt adapter foundation           |
 
 [jsr:@optique/core]: https://jsr.io/@optique/core
 [npm:@optique/core]: https://www.npmjs.com/package/@optique/core
@@ -212,6 +215,8 @@ The following is a list of the available packages:
 [jsr:@optique/clack]: https://jsr.io/@optique/clack
 [npm:@optique/clack]: https://www.npmjs.com/package/@optique/clack
 [Clack]: https://github.com/bombshell-dev/clack
+[jsr:@optique/derived-defaults]: https://jsr.io/@optique/derived-defaults
+[npm:@optique/derived-defaults]: https://www.npmjs.com/package/@optique/derived-defaults
 [jsr:@optique/env]: https://jsr.io/@optique/env
 [npm:@optique/env]: https://www.npmjs.com/package/@optique/env
 [jsr:@optique/git]: https://jsr.io/@optique/git

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -70,6 +70,7 @@ const INTEGRATIONS = {
   text: "Integrations",
   items: [
     { text: "Config files", link: "/integrations/config" },
+    { text: "Derived defaults", link: "/integrations/derived-defaults" },
     { text: "Environment variables", link: "/integrations/env" },
     { text: "Clack prompts", link: "/integrations/clack" },
     { text: "Inquirer.js prompts", link: "/integrations/inquirer" },
@@ -94,6 +95,10 @@ const REFERENCES = {
     { text: "@optique/man", link: "https://jsr.io/@optique/man/doc" },
     { text: "@optique/env", link: "https://jsr.io/@optique/env/doc" },
     { text: "@optique/config", link: "https://jsr.io/@optique/config/doc" },
+    {
+      text: "@optique/derived-defaults",
+      link: "https://jsr.io/@optique/derived-defaults/doc",
+    },
     { text: "@optique/clack", link: "https://jsr.io/@optique/clack/doc" },
     {
       text: "@optique/inquirer",

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -57,6 +57,7 @@ const CONCEPTS = {
     { text: "Modifying combinators", link: "/concepts/modifiers" },
     { text: "Construct combinators", link: "/concepts/constructs" },
     { text: "Inter-option dependencies", link: "/concepts/dependencies" },
+    { text: "Derived defaults", link: "/concepts/derived-defaults" },
     { text: "Shell completion", link: "/concepts/completion" },
     { text: "Man pages", link: "/concepts/man" },
     { text: "Command discovery", link: "/concepts/discover" },
@@ -70,7 +71,6 @@ const INTEGRATIONS = {
   text: "Integrations",
   items: [
     { text: "Config files", link: "/integrations/config" },
-    { text: "Derived defaults", link: "/integrations/derived-defaults" },
     { text: "Environment variables", link: "/integrations/env" },
     { text: "Clack prompts", link: "/integrations/clack" },
     { text: "Inquirer.js prompts", link: "/integrations/inquirer" },

--- a/docs/.vitepress/theme/components/PackageGrid.vue
+++ b/docs/.vitepress/theme/components/PackageGrid.vue
@@ -6,6 +6,7 @@ const packages = [
   { name: "@optique/run", desc: "Process runner for Node.js, Deno, and Bun.", link: "https://jsr.io/@optique/run/doc", core: true },
   { name: "@optique/discover", desc: "File-based command discovery and dispatch.", link: "/concepts/discover" },
   { name: "@optique/config", desc: "Config-file values via Standard Schema.", link: "/integrations/config" },
+  { name: "@optique/derived-defaults", desc: "Defaults derived from parsed values.", link: "/integrations/derived-defaults" },
   { name: "@optique/clack", desc: "Interactive prompt fallback via Clack.", link: "/integrations/clack" },
   { name: "@optique/env", desc: "Environment-variable fallbacks.", link: "/integrations/env" },
   { name: "@optique/inquirer", desc: "Inquirer.js prompt fallback.", link: "/integrations/inquirer" },

--- a/docs/.vitepress/theme/components/PackageGrid.vue
+++ b/docs/.vitepress/theme/components/PackageGrid.vue
@@ -6,7 +6,7 @@ const packages = [
   { name: "@optique/run", desc: "Process runner for Node.js, Deno, and Bun.", link: "https://jsr.io/@optique/run/doc", core: true },
   { name: "@optique/discover", desc: "File-based command discovery and dispatch.", link: "/concepts/discover" },
   { name: "@optique/config", desc: "Config-file values via Standard Schema.", link: "/integrations/config" },
-  { name: "@optique/derived-defaults", desc: "Defaults derived from parsed values.", link: "/integrations/derived-defaults" },
+  { name: "@optique/derived-defaults", desc: "Defaults derived from parsed values.", link: "/concepts/derived-defaults" },
   { name: "@optique/clack", desc: "Interactive prompt fallback via Clack.", link: "/integrations/clack" },
   { name: "@optique/env", desc: "Environment-variable fallbacks.", link: "/integrations/env" },
   { name: "@optique/inquirer", desc: "Inquirer.js prompt fallback.", link: "/integrations/inquirer" },

--- a/docs/concepts/derived-defaults.md
+++ b/docs/concepts/derived-defaults.md
@@ -309,8 +309,9 @@ Composing with other sources
 
 `bindDerivedDefault()` composes with other source wrappers.  The outermost
 wrapper decides the higher-priority source, but wrapper-specific missing-value
-semantics still apply.  For example, put `bindDerivedDefault()` outside
-`bindEnv()` when an environment variable should override the derived value:
+semantics still apply.  For example, put `bindEnv()` outside
+`bindDerivedDefault()` when an environment variable should override the derived
+value:
 
 ~~~~ typescript twoslash
 import { object } from "@optique/core/constructs";
@@ -334,16 +335,16 @@ const derived = createDerivedDefaults({
 
 const parser = object({
   profile: option("--profile", string()),
-  port: bindDerivedDefault(
-    bindEnv(option("--port", integer()), {
-      context: env,
-      key: "PORT",
-      parser: integer(),
-    }),
-    {
+  port: bindEnv(
+    bindDerivedDefault(option("--port", integer()), {
       context: derived.context,
       key: "port",
       default: 3000,
+    }),
+    {
+      context: env,
+      key: "PORT",
+      parser: integer(),
     },
   ),
 });

--- a/docs/concepts/derived-defaults.md
+++ b/docs/concepts/derived-defaults.md
@@ -4,8 +4,8 @@ description: >-
   arguments as the highest-priority source.
 ---
 
-Derived default support
-=======================
+Derived defaults
+================
 
 *This API is available since Optique 1.2.0.*
 

--- a/docs/concepts/derived-defaults.md
+++ b/docs/concepts/derived-defaults.md
@@ -308,15 +308,14 @@ Composing with other sources
 ----------------------------
 
 `bindDerivedDefault()` composes with other source wrappers.  The outermost
-wrapper decides the higher-priority source.  For example, this parser resolves
-values in this order: CLI, then environment variable, then config file, then
-derived default, then static default.
+wrapper decides the higher-priority source, but wrapper-specific missing-value
+semantics still apply.  For example, put `bindDerivedDefault()` outside
+`bindEnv()` when an environment variable should override the derived value:
 
 ~~~~ typescript twoslash
 import { object } from "@optique/core/constructs";
 import { option } from "@optique/core/primitives";
 import { integer, string } from "@optique/core/valueparser";
-import { bindConfig, createConfigContext } from "@optique/config";
 import { bindEnv, createEnvContext } from "@optique/env";
 import {
   bindDerivedDefault,
@@ -324,41 +323,34 @@ import {
 } from "@optique/derived-defaults";
 
 const env = createEnvContext({ prefix: "APP_" });
-const config = createConfigContext({
-  schema: {
-    "~standard": {
-      version: 1,
-      vendor: "example",
-      validate: (input) => ({
-        value: input as { readonly port?: number },
-      }),
-    },
-  },
-});
 const derived = createDerivedDefaults({
-  port: (parsed: { readonly profile: string }) =>
-    parsed.profile === "public" ? 443 : 8080,
+  port: (parsed: { readonly profile?: string }) =>
+    parsed.profile == null
+      ? undefined
+      : parsed.profile === "public"
+      ? 443
+      : 8080,
 });
 
 const parser = object({
   profile: option("--profile", string()),
-  port: bindEnv(
-    bindConfig(
-      bindDerivedDefault(option("--port", integer()), {
-        context: derived.context,
-        key: "port",
-        default: 3000,
-      }),
-      {
-        context: config,
-        key: "port",
-      },
-    ),
-    {
+  port: bindDerivedDefault(
+    bindEnv(option("--port", integer()), {
       context: env,
       key: "PORT",
       parser: integer(),
+    }),
+    {
+      context: derived.context,
+      key: "port",
+      default: 3000,
     },
   ),
 });
 ~~~~
+
+This parser resolves `port` as CLI > environment variable > derived default >
+static default.  If you also use `bindConfig()`, place the default on the
+config wrapper when the configuration layer owns the missing-value fallback,
+or keep the wrappers separate for options whose fallback source should remain
+independent.

--- a/docs/concepts/derived-defaults.md
+++ b/docs/concepts/derived-defaults.md
@@ -52,15 +52,22 @@ Basic usage
 ### 1. Create a derived-default context
 
 Call `createDerivedDefaults()` with resolver functions.  Each resolver receives
-the first-pass parse result and returns either a fallback value or `undefined`
+the first-pass parse seed and returns either a fallback value or `undefined`
 when it has no value to provide.
+
+The seed is best-effort: it is available only after Optique can produce a
+phase-two value, and some fields may still be missing while required options
+are unresolved.  Write resolvers to check the fields they depend on and return
+`undefined` when the dependency is absent.
 
 ~~~~ typescript twoslash
 import { createDerivedDefaults } from "@optique/derived-defaults";
 
 const derived = createDerivedDefaults({
-  workspaceRoot: (parsed: { readonly serviceRoot: string }) =>
-    `${parsed.serviceRoot}/workspace`,
+  workspaceRoot: (parsed: { readonly serviceRoot?: string }) =>
+    parsed.serviceRoot == null
+      ? undefined
+      : `${parsed.serviceRoot}/workspace`,
 });
 ~~~~
 
@@ -79,8 +86,10 @@ import {
 } from "@optique/derived-defaults";
 
 const derived = createDerivedDefaults({
-  workspaceRoot: (parsed: { readonly serviceRoot: string }) =>
-    `${parsed.serviceRoot}/workspace`,
+  workspaceRoot: (parsed: { readonly serviceRoot?: string }) =>
+    parsed.serviceRoot == null
+      ? undefined
+      : `${parsed.serviceRoot}/workspace`,
 });
 
 const parser = object({
@@ -115,8 +124,10 @@ import {
 } from "@optique/derived-defaults";
 
 const derived = createDerivedDefaults({
-  workspaceRoot: (parsed: { readonly serviceRoot: string }) =>
-    `${parsed.serviceRoot}/workspace`,
+  workspaceRoot: (parsed: { readonly serviceRoot?: string }) =>
+    parsed.serviceRoot == null
+      ? undefined
+      : `${parsed.serviceRoot}/workspace`,
 });
 
 const parser = object({
@@ -199,8 +210,12 @@ import {
 } from "@optique/derived-defaults";
 
 const derived = createDerivedDefaults({
-  port: (parsed: { readonly profile: string }) =>
-    parsed.profile === "public" ? 443 : 8080,
+  port: (parsed: { readonly profile?: string }) =>
+    parsed.profile == null
+      ? undefined
+      : parsed.profile === "public"
+      ? 443
+      : 8080,
 });
 
 const parser = object({
@@ -232,7 +247,8 @@ import {
 declare function loadToken(service: string): Promise<string>;
 
 const derived = createDerivedDefaults({
-  token: (parsed: { readonly service: string }) => loadToken(parsed.service),
+  token: (parsed: { readonly service?: string }) =>
+    parsed.service == null ? undefined : loadToken(parsed.service),
 });
 
 const parser = object({
@@ -269,8 +285,10 @@ import {
 } from "@optique/derived-defaults";
 
 const derived = createDerivedDefaults({
-  workspaceRoot: (parsed: { readonly serviceRoot: string }) =>
-    `${parsed.serviceRoot}/workspace`,
+  workspaceRoot: (parsed: { readonly serviceRoot?: string }) =>
+    parsed.serviceRoot == null
+      ? undefined
+      : `${parsed.serviceRoot}/workspace`,
 });
 
 const parser = object({

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -1742,6 +1742,76 @@ sensible fallbacks and [`optional()`](./concepts/modifiers.md#optional-parser)
 when absence is meaningful.
 
 
+Default value patterns
+----------------------
+
+These recipes cover fallback values that are computed from parsed input or
+runtime state.
+
+### Derived defaults from parsed options
+
+*This API is available since Optique 1.2.0.*
+
+Sometimes one option has a natural fallback based on another option.  For
+example, a build tool might require a project root, then default its cache
+directory to a path inside that root unless the user overrides it explicitly.
+
+Use `createDerivedDefaults()` to compute those fallback values from the
+first-pass parse result, then wrap the option that should receive the fallback
+with `bindDerivedDefault()`:
+
+~~~~ typescript twoslash
+import { object } from "@optique/core/constructs";
+import { message } from "@optique/core/message";
+import { optional } from "@optique/core/modifiers";
+import { option } from "@optique/core/primitives";
+import { string } from "@optique/core/valueparser";
+import {
+  bindDerivedDefault,
+  createDerivedDefaults,
+} from "@optique/derived-defaults";
+import { runAsync } from "@optique/run";
+
+const derived = createDerivedDefaults({
+  cacheDir: (parsed: {
+    readonly projectRoot: string;
+    readonly profile?: string;
+  }) => {
+    const profile = parsed.profile ?? "default";
+    return `${parsed.projectRoot}/.cache/${profile}`;
+  },
+});
+
+const parser = object({
+  projectRoot: option("--project-root", string({ metavar: "DIR" })),
+  profile: optional(option("--profile", string({ metavar: "NAME" }))),
+  cacheDir: bindDerivedDefault(
+    option("--cache-dir", string({ metavar: "DIR" })),
+    {
+      context: derived.context,
+      key: "cacheDir",
+      defaultDescription: message`derived from --project-root`,
+    },
+  ),
+});
+
+const result = await runAsync(parser, {
+  args: ["--project-root", "/work/api", "--profile", "ci"],
+  contexts: [derived.context],
+});
+
+console.log(result.cacheDir); // "/work/api/.cache/ci"
+~~~~
+
+The priority order is: CLI argument > derived default > static default >
+error.  In this example, `--cache-dir /tmp/cache` would win over the computed
+path.  The `defaultDescription` option only affects help text; the actual
+fallback value still comes from the resolver.
+
+For more details, see
+[derived defaults](./concepts/derived-defaults.md).
+
+
 Application structure patterns
 ------------------------------
 

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -1774,9 +1774,10 @@ import { runAsync } from "@optique/run";
 
 const derived = createDerivedDefaults({
   cacheDir: (parsed: {
-    readonly projectRoot: string;
+    readonly projectRoot?: string;
     readonly profile?: string;
   }) => {
+    if (parsed.projectRoot == null) return undefined;
     const profile = parsed.profile ?? "default";
     return `${parsed.projectRoot}/.cache/${profile}`;
   },

--- a/docs/integrations/derived-defaults.md
+++ b/docs/integrations/derived-defaults.md
@@ -1,0 +1,346 @@
+---
+description: >-
+  Compute default values from the first-pass parse result while keeping CLI
+  arguments as the highest-priority source.
+---
+
+Derived default support
+=======================
+
+*This API is available since Optique 1.2.0.*
+
+The *@optique/derived-defaults* package lets you compute fallback values from
+values that Optique has already parsed.  This is useful when one option has a
+natural default that depends on another option, but the user should still be
+able to override it explicitly.
+
+The fallback priority is:
+
+1.  CLI argument
+2.  Derived default
+3.  Static default
+4.  Error
+
+::: code-group
+
+~~~~ bash [Deno]
+deno add jsr:@optique/derived-defaults
+~~~~
+
+~~~~ bash [npm]
+npm add @optique/derived-defaults
+~~~~
+
+~~~~ bash [pnpm]
+pnpm add @optique/derived-defaults
+~~~~
+
+~~~~ bash [Yarn]
+yarn add @optique/derived-defaults
+~~~~
+
+~~~~ bash [Bun]
+bun add @optique/derived-defaults
+~~~~
+
+:::
+
+
+Basic usage
+-----------
+
+### 1. Create a derived-default context
+
+Call `createDerivedDefaults()` with resolver functions.  Each resolver receives
+the first-pass parse result and returns either a fallback value or `undefined`
+when it has no value to provide.
+
+~~~~ typescript twoslash
+import { createDerivedDefaults } from "@optique/derived-defaults";
+
+const derived = createDerivedDefaults({
+  workspaceRoot: (parsed: { readonly serviceRoot: string }) =>
+    `${parsed.serviceRoot}/workspace`,
+});
+~~~~
+
+### 2. Bind parsers to derived values
+
+Use `bindDerivedDefault()` around the parser that should receive the derived
+fallback:
+
+~~~~ typescript twoslash
+import { object } from "@optique/core/constructs";
+import { option } from "@optique/core/primitives";
+import { string } from "@optique/core/valueparser";
+import {
+  bindDerivedDefault,
+  createDerivedDefaults,
+} from "@optique/derived-defaults";
+
+const derived = createDerivedDefaults({
+  workspaceRoot: (parsed: { readonly serviceRoot: string }) =>
+    `${parsed.serviceRoot}/workspace`,
+});
+
+const parser = object({
+  serviceRoot: option("--service-root", string()),
+  workspaceRoot: bindDerivedDefault(option("--workspace-root", string()), {
+    context: derived.context,
+    key: "workspaceRoot",
+  }),
+});
+~~~~
+
+### 3. Run with contexts
+
+Pass the derived-default context through `contexts`.  Optique first parses the
+CLI input, then calls your resolvers with that parsed value and completes the
+bound parsers from the resulting annotations.
+
+> [!WARNING]
+> `bindDerivedDefault()` only reads derived values when its context is
+> registered with the runner.  Omitting `contexts: [derived.context]` from the
+> `run()` call causes the parser to fall back to a static default if one exists
+> or fail as a missing value.
+
+~~~~ typescript twoslash
+import { object } from "@optique/core/constructs";
+import { option } from "@optique/core/primitives";
+import { string } from "@optique/core/valueparser";
+import { runAsync } from "@optique/run";
+import {
+  bindDerivedDefault,
+  createDerivedDefaults,
+} from "@optique/derived-defaults";
+
+const derived = createDerivedDefaults({
+  workspaceRoot: (parsed: { readonly serviceRoot: string }) =>
+    `${parsed.serviceRoot}/workspace`,
+});
+
+const parser = object({
+  serviceRoot: option("--service-root", string()),
+  workspaceRoot: bindDerivedDefault(option("--workspace-root", string()), {
+    context: derived.context,
+    key: "workspaceRoot",
+  }),
+});
+
+const result = await runAsync(parser, {
+  args: ["--service-root", "/srv/api"],
+  contexts: [derived.context],
+});
+
+console.log(result.workspaceRoot); // "/srv/api/workspace"
+~~~~
+
+
+Priority order
+--------------
+
+CLI arguments always win over derived values.  If the resolver returns
+`undefined`, `bindDerivedDefault()` falls through to the static `default` value
+when one is provided:
+
+~~~~ typescript twoslash
+import { object } from "@optique/core/constructs";
+import { option } from "@optique/core/primitives";
+import { string } from "@optique/core/valueparser";
+import { runAsync } from "@optique/run";
+import {
+  bindDerivedDefault,
+  createDerivedDefaults,
+} from "@optique/derived-defaults";
+
+const derived = createDerivedDefaults({
+  token: (parsed: { readonly service?: string }) =>
+    parsed.service == null ? undefined : `${parsed.service}-token`,
+});
+
+const parser = object({
+  service: option("--service", string()),
+  token: bindDerivedDefault(option("--token", string()), {
+    context: derived.context,
+    key: "token",
+    default: "local-token",
+  }),
+});
+
+const cliValue = await runAsync(parser, {
+  args: ["--service", "api", "--token", "manual"],
+  contexts: [derived.context],
+});
+
+const derivedValue = await runAsync(parser, {
+  args: ["--service", "api"],
+  contexts: [derived.context],
+});
+
+console.log(cliValue.token); // "manual"
+console.log(derivedValue.token); // "api-token"
+~~~~
+
+
+Validation
+----------
+
+Derived and static fallback values are validated through the wrapped parser.
+For example, a derived port number must still satisfy the `integer()` parser's
+range constraints:
+
+~~~~ typescript twoslash
+import { object } from "@optique/core/constructs";
+import { option } from "@optique/core/primitives";
+import { integer, string } from "@optique/core/valueparser";
+import {
+  bindDerivedDefault,
+  createDerivedDefaults,
+} from "@optique/derived-defaults";
+
+const derived = createDerivedDefaults({
+  port: (parsed: { readonly profile: string }) =>
+    parsed.profile === "public" ? 443 : 8080,
+});
+
+const parser = object({
+  profile: option("--profile", string()),
+  port: bindDerivedDefault(option("--port", integer({ min: 1, max: 65535 })), {
+    context: derived.context,
+    key: "port",
+  }),
+});
+~~~~
+
+
+Async resolvers
+---------------
+
+Resolvers may return promises.  Use `runAsync()` or another async runner when a
+resolver is asynchronous:
+
+~~~~ typescript twoslash
+import { object } from "@optique/core/constructs";
+import { option } from "@optique/core/primitives";
+import { string } from "@optique/core/valueparser";
+import { runAsync } from "@optique/run";
+import {
+  bindDerivedDefault,
+  createDerivedDefaults,
+} from "@optique/derived-defaults";
+
+declare function loadToken(service: string): Promise<string>;
+
+const derived = createDerivedDefaults({
+  token: (parsed: { readonly service: string }) => loadToken(parsed.service),
+});
+
+const parser = object({
+  service: option("--service", string()),
+  token: bindDerivedDefault(option("--token", string()), {
+    context: derived.context,
+    key: "token",
+  }),
+});
+
+const result = await runAsync(parser, {
+  args: ["--service", "api"],
+  contexts: [derived.context],
+});
+~~~~
+
+
+Help defaults
+-------------
+
+Derived values are computed from runtime parse results, so help text cannot
+show the exact default value without parsing first.  Use `defaultDescription`
+to document how the value is derived.  It accepts any Optique `Message`, so you
+can reference option names or use styled message fragments:
+
+~~~~ typescript twoslash
+import { object } from "@optique/core/constructs";
+import { option } from "@optique/core/primitives";
+import { message, optionName } from "@optique/core/message";
+import { string } from "@optique/core/valueparser";
+import {
+  bindDerivedDefault,
+  createDerivedDefaults,
+} from "@optique/derived-defaults";
+
+const derived = createDerivedDefaults({
+  workspaceRoot: (parsed: { readonly serviceRoot: string }) =>
+    `${parsed.serviceRoot}/workspace`,
+});
+
+const parser = object({
+  serviceRoot: option("--service-root", string()),
+  workspaceRoot: bindDerivedDefault(option("--workspace-root", string()), {
+    context: derived.context,
+    key: "workspaceRoot",
+    defaultDescription: message`derived from ${
+      optionName("--service-root")
+    }`,
+  }),
+});
+~~~~
+
+
+Composing with other sources
+----------------------------
+
+`bindDerivedDefault()` composes with other source wrappers.  The outermost
+wrapper decides the higher-priority source.  For example, this parser resolves
+values in this order: CLI, then environment variable, then config file, then
+derived default, then static default.
+
+~~~~ typescript twoslash
+import { object } from "@optique/core/constructs";
+import { option } from "@optique/core/primitives";
+import { integer, string } from "@optique/core/valueparser";
+import { bindConfig, createConfigContext } from "@optique/config";
+import { bindEnv, createEnvContext } from "@optique/env";
+import {
+  bindDerivedDefault,
+  createDerivedDefaults,
+} from "@optique/derived-defaults";
+
+const env = createEnvContext({ prefix: "APP_" });
+const config = createConfigContext({
+  schema: {
+    "~standard": {
+      version: 1,
+      vendor: "example",
+      validate: (input) => ({
+        value: input as { readonly port?: number },
+      }),
+    },
+  },
+});
+const derived = createDerivedDefaults({
+  port: (parsed: { readonly profile: string }) =>
+    parsed.profile === "public" ? 443 : 8080,
+});
+
+const parser = object({
+  profile: option("--profile", string()),
+  port: bindEnv(
+    bindConfig(
+      bindDerivedDefault(option("--port", integer()), {
+        context: derived.context,
+        key: "port",
+        default: 3000,
+      }),
+      {
+        context: config,
+        key: "port",
+      },
+    ),
+    {
+      context: env,
+      key: "PORT",
+      parser: integer(),
+    },
+  ),
+});
+~~~~

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,6 +5,7 @@
     "@optique/config": "workspace:",
     "@optique/core": "workspace:",
     "@optique/clack": "workspace:",
+    "@optique/derived-defaults": "workspace:",
     "@optique/discover": "workspace:",
     "@optique/env": "workspace:",
     "@optique/git": "workspace:",

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -31,6 +31,7 @@ export {
   mapModeValue,
   wrapForMode,
 } from "./internal/mode-dispatch.ts";
+export { extractPhase2SeedKey } from "./phase2-seed.ts";
 
 /**
  * Stable trait flags for custom parser extensions.

--- a/packages/core/src/public-api.test.ts
+++ b/packages/core/src/public-api.test.ts
@@ -103,6 +103,7 @@ test("extension module exposes the supported extension helpers", () => {
     "defineTraits",
     "delegateSuggestNodes",
     "dispatchByMode",
+    "extractPhase2SeedKey",
     "getTraits",
     "inheritAnnotations",
     "injectAnnotations",

--- a/packages/derived-defaults/README.md
+++ b/packages/derived-defaults/README.md
@@ -50,6 +50,7 @@ const parser = object({
 });
 
 const result = await runAsync(parser, {
+  args: ["--service-root", "/srv/app"],
   contexts: [derived.context],
 });
 

--- a/packages/derived-defaults/README.md
+++ b/packages/derived-defaults/README.md
@@ -72,7 +72,7 @@ Documentation
 -------------
 
 For full documentation, visit
-<https://optique.dev/integrations/derived-defaults>.
+<https://optique.dev/concepts/derived-defaults>.
 
 
 License

--- a/packages/derived-defaults/README.md
+++ b/packages/derived-defaults/README.md
@@ -37,8 +37,10 @@ import {
 } from "@optique/derived-defaults";
 
 const derived = createDerivedDefaults({
-  workspaceRoot: (parsed: { readonly serviceRoot: string }) =>
-    `${parsed.serviceRoot}/workspace`,
+  workspaceRoot: (parsed: { readonly serviceRoot?: string }) =>
+    parsed.serviceRoot == null
+      ? undefined
+      : `${parsed.serviceRoot}/workspace`,
 });
 
 const parser = object({

--- a/packages/derived-defaults/README.md
+++ b/packages/derived-defaults/README.md
@@ -1,0 +1,80 @@
+@optique/derived-defaults
+=========================
+
+Derived default value support for [Optique].
+
+This package lets CLI applications compute default values from the first-pass
+parse result while keeping clear priority handling:
+
+CLI arguments > derived defaults > static defaults.
+
+[Optique]: https://optique.dev/
+
+
+Installation
+------------
+
+~~~~ bash
+deno add jsr:@optique/derived-defaults
+npm add @optique/derived-defaults
+pnpm add @optique/derived-defaults
+yarn add @optique/derived-defaults
+bun add @optique/derived-defaults
+~~~~
+
+
+Quick start
+-----------
+
+~~~~ typescript
+import { object } from "@optique/core/constructs";
+import { option } from "@optique/core/primitives";
+import { string } from "@optique/core/valueparser";
+import { runAsync } from "@optique/run";
+import {
+  bindDerivedDefault,
+  createDerivedDefaults,
+} from "@optique/derived-defaults";
+
+const derived = createDerivedDefaults({
+  workspaceRoot: (parsed: { readonly serviceRoot: string }) =>
+    `${parsed.serviceRoot}/workspace`,
+});
+
+const parser = object({
+  serviceRoot: option("--service-root", string()),
+  workspaceRoot: bindDerivedDefault(option("--workspace-root", string()), {
+    context: derived.context,
+    key: "workspaceRoot",
+  }),
+});
+
+const result = await runAsync(parser, {
+  contexts: [derived.context],
+});
+
+console.log(result);
+~~~~
+
+
+Features
+--------
+
+ -  *Two-pass defaults* derived from already parsed CLI values
+ -  *Async resolver support* with `runAsync()`/`runWith()`
+ -  *Fallback validation* through the wrapped Optique parser
+ -  *Custom help text* for values that are computed at runtime
+ -  *Composable contexts* with `run()`/`runAsync()`/`runWith()`
+
+
+Documentation
+-------------
+
+For full documentation, visit
+<https://optique.dev/integrations/derived-defaults>.
+
+
+License
+-------
+
+MIT License. See [LICENSE](../../LICENSE) for details.

--- a/packages/derived-defaults/deno.json
+++ b/packages/derived-defaults/deno.json
@@ -6,7 +6,11 @@
     ".": "./src/index.ts"
   },
   "imports": {
-    "#src/": "./src/"
+    "#src/": "./src/",
+    "@optique/config": "../config/src/index.ts",
+    "@optique/core": "../core/src/index.ts",
+    "@optique/env": "../env/src/index.ts",
+    "@optique/run": "../run/src/index.ts"
   },
   "exclude": [
     "dist/",

--- a/packages/derived-defaults/deno.json
+++ b/packages/derived-defaults/deno.json
@@ -1,0 +1,39 @@
+{
+  "name": "@optique/derived-defaults",
+  "version": "1.2.0",
+  "license": "MIT",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "imports": {
+    "#src/": "./src/"
+  },
+  "exclude": [
+    "dist/",
+    "node_modules",
+    "tsdown.config.ts"
+  ],
+  "tasks": {
+    "build": "pnpm build",
+    "test": "deno test",
+    "test:node": {
+      "dependencies": [
+        "build"
+      ],
+      "command": "node --test"
+    },
+    "test:bun": {
+      "dependencies": [
+        "build"
+      ],
+      "command": "bun test"
+    },
+    "test-all": {
+      "dependencies": [
+        "test",
+        "test:node",
+        "test:bun"
+      ]
+    }
+  }
+}

--- a/packages/derived-defaults/package.json
+++ b/packages/derived-defaults/package.json
@@ -1,0 +1,83 @@
+{
+  "name": "@optique/derived-defaults",
+  "version": "1.2.0",
+  "description": "Derived default value support for Optique",
+  "keywords": [
+    "CLI",
+    "command-line",
+    "commandline",
+    "parser",
+    "defaults",
+    "source-context"
+  ],
+  "license": "MIT",
+  "author": {
+    "name": "Hong Minhee",
+    "email": "hong@minhee.org",
+    "url": "https://hongminhee.org/"
+  },
+  "homepage": "https://optique.dev/",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dahlia/optique.git",
+    "directory": "packages/derived-defaults/"
+  },
+  "bugs": {
+    "url": "https://github.com/dahlia/optique/issues"
+  },
+  "funding": [
+    "https://github.com/sponsors/dahlia"
+  ],
+  "engines": {
+    "node": ">=20.0.0",
+    "bun": ">=1.2.0",
+    "deno": ">=2.3.0"
+  },
+  "files": [
+    "dist/",
+    "package.json",
+    "README.md"
+  ],
+  "type": "module",
+  "module": "./dist/index.js",
+  "main": "./dist/index.cjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": {
+        "import": "./dist/index.d.ts",
+        "require": "./dist/index.d.cts"
+      },
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "imports": {
+    "#src/*.ts": {
+      "node": "./dist/*.js",
+      "default": "./src/*.ts"
+    }
+  },
+  "sideEffects": false,
+  "dependencies": {
+    "@optique/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@optique/config": "workspace:*",
+    "@optique/env": "workspace:*",
+    "@optique/run": "workspace:*",
+    "@types/node": "catalog:",
+    "fast-check": "catalog:",
+    "tsdown": "catalog:",
+    "typescript": "catalog:"
+  },
+  "scripts": {
+    "build": "tsdown",
+    "prepack": "tsdown",
+    "prepublish": "tsdown",
+    "test": "node --test",
+    "test:bun": "bun test",
+    "test:deno": "deno test",
+    "test-all": "tsdown && node --test && bun test && deno test"
+  }
+}

--- a/packages/derived-defaults/src/index.test.ts
+++ b/packages/derived-defaults/src/index.test.ts
@@ -1,0 +1,342 @@
+import { strict as assert } from "node:assert";
+import { describe, it } from "node:test";
+import { formatDocPage } from "@optique/core/doc";
+import { message, optionName } from "@optique/core/message";
+import { object } from "@optique/core/constructs";
+import { option } from "@optique/core/primitives";
+import { getDocPage, parse } from "@optique/core/parser";
+import { integer, string } from "@optique/core/valueparser";
+import { bindEnv, bool, createEnvContext } from "@optique/env";
+import { bindConfig, createConfigContext } from "@optique/config";
+import { run, runAsync, runSync } from "@optique/run";
+import { bindDerivedDefault, createDerivedDefaults } from "./index.ts";
+
+async function captureRunFailure(
+  callback: (options: {
+    readonly stderr: (message: string) => void;
+    readonly onExit: (code: number) => never;
+  }) => Promise<unknown> | unknown,
+): Promise<{ readonly code: number; readonly stderr: string }> {
+  let stderr = "";
+  let exitCode: number | undefined;
+  await assert.rejects(
+    async () =>
+      await callback({
+        stderr: (message) => {
+          stderr += message;
+        },
+        onExit: (code) => {
+          exitCode = code;
+          throw new Error(`exit ${code}`);
+        },
+      }),
+    /exit /u,
+  );
+  assert.equal(exitCode, 1);
+  return { code: exitCode, stderr };
+}
+
+describe("createDerivedDefaults()", () => {
+  it("derives fallback values from the first-pass parse result", async () => {
+    const derived = createDerivedDefaults({
+      workspaceRoot: (parsed: { readonly serviceRoot: string }) =>
+        `${parsed.serviceRoot}/workspace`,
+    });
+    const parser = object({
+      serviceRoot: option("--service-root", string()),
+      workspaceRoot: bindDerivedDefault(option("--workspace-root", string()), {
+        context: derived.context,
+        key: "workspaceRoot",
+      }),
+    });
+
+    const result = await runAsync(parser, {
+      args: ["--service-root", "/srv/app"],
+      contexts: [derived.context],
+    });
+
+    assert.deepEqual(result, {
+      serviceRoot: "/srv/app",
+      workspaceRoot: "/srv/app/workspace",
+    });
+  });
+
+  it("does not call resolvers during phase 1", async () => {
+    const calls: string[] = [];
+    const derived = createDerivedDefaults({
+      token: (parsed: { readonly service: string }) => {
+        calls.push(parsed.service);
+        return `${parsed.service}-token`;
+      },
+    });
+    const parser = object({
+      service: option("--service", string()),
+      token: bindDerivedDefault(option("--token", string()), {
+        context: derived.context,
+        key: "token",
+      }),
+    });
+
+    await runAsync(parser, {
+      args: ["--service", "api"],
+      contexts: [derived.context],
+    });
+
+    assert.deepEqual(calls, ["api"]);
+  });
+});
+
+describe("bindDerivedDefault()", () => {
+  it("prefers CLI input over a derived fallback", async () => {
+    const derived = createDerivedDefaults({
+      workspaceRoot: () => "/derived",
+    });
+    const parser = object({
+      workspaceRoot: bindDerivedDefault(option("--workspace-root", string()), {
+        context: derived.context,
+        key: "workspaceRoot",
+      }),
+    });
+
+    const result = await runAsync(parser, {
+      args: ["--workspace-root", "/cli"],
+      contexts: [derived.context],
+    });
+
+    assert.equal(result.workspaceRoot, "/cli");
+  });
+
+  it("falls through from undefined to a static default", async () => {
+    const derived = createDerivedDefaults({
+      workspaceRoot: () => undefined,
+    });
+    const parser = object({
+      workspaceRoot: bindDerivedDefault(option("--workspace-root", string()), {
+        context: derived.context,
+        key: "workspaceRoot",
+        default: "/static",
+      }),
+    });
+
+    const result = await runAsync(parser, {
+      args: [],
+      contexts: [derived.context],
+    });
+
+    assert.equal(result.workspaceRoot, "/static");
+  });
+
+  it("fails when no CLI, derived, or static default value exists", async () => {
+    const derived = createDerivedDefaults({
+      workspaceRoot: () => undefined,
+    });
+    const parser = object({
+      workspaceRoot: bindDerivedDefault(option("--workspace-root", string()), {
+        context: derived.context,
+        key: "workspaceRoot",
+      }),
+    });
+
+    const failure = await captureRunFailure((options) =>
+      runAsync(parser, {
+        args: [],
+        contexts: [derived.context],
+        ...options,
+      })
+    );
+
+    assert.match(failure.stderr, /No matching option found\./u);
+  });
+
+  it("supports async resolvers with async runners", async () => {
+    const derived = createDerivedDefaults({
+      token: (parsed: { readonly service: string }) =>
+        Promise.resolve(`${parsed.service}-token`),
+    });
+    const parser = object({
+      service: option("--service", string()),
+      token: bindDerivedDefault(option("--token", string()), {
+        context: derived.context,
+        key: "token",
+      }),
+    });
+
+    const result = await runAsync(parser, {
+      args: ["--service", "api"],
+      contexts: [derived.context],
+    });
+
+    assert.equal(result.token, "api-token");
+  });
+
+  it("rejects async resolvers in sync runners", () => {
+    const derived = createDerivedDefaults({
+      token: (parsed: { readonly service: string }) =>
+        Promise.resolve(`${parsed.service}-token`),
+    });
+    const parser = object({
+      service: option("--service", string()),
+      token: bindDerivedDefault(option("--token", string()), {
+        context: derived.context,
+        key: "token",
+      }),
+    });
+
+    assert.throws(
+      () =>
+        runSync(parser, {
+          args: ["--service", "api"],
+          contexts: [derived.context],
+          stderr: () => {},
+        }),
+      /returned a Promise in sync mode/u,
+    );
+  });
+
+  it("reports when its context was not registered", async () => {
+    const derived = createDerivedDefaults({
+      token: () => "secret",
+    });
+    const other = createEnvContext({
+      source: () => undefined,
+    });
+    const parser = object({
+      token: bindDerivedDefault(option("--token", string()), {
+        context: derived.context,
+        key: "token",
+      }),
+    });
+
+    const failure = await captureRunFailure((options) =>
+      runAsync(parser, {
+        args: [],
+        contexts: [other],
+        ...options,
+      })
+    );
+
+    assert.match(failure.stderr, /No matching option found\./u);
+  });
+
+  it("revalidates derived values through the wrapped parser", async () => {
+    const derived = createDerivedDefaults({
+      port: (parsed: { readonly service: string }) =>
+        parsed.service === "api" ? 70_000 : 80,
+    });
+    const parser = object({
+      service: option("--service", string()),
+      port: bindDerivedDefault(option("--port", integer({ max: 65_535 })), {
+        context: derived.context,
+        key: "port",
+      }),
+    });
+
+    const failure = await captureRunFailure((options) =>
+      runAsync(parser, {
+        args: ["--service", "api"],
+        contexts: [derived.context],
+        ...options,
+      })
+    );
+
+    assert.match(failure.stderr, /Expected a value less than or equal to/u);
+  });
+
+  it("uses defaultDescription for help without resolving fallback", () => {
+    let called = false;
+    const derived = createDerivedDefaults({
+      workspaceRoot: () => {
+        called = true;
+        return "/derived";
+      },
+    });
+    const parser = object({
+      workspaceRoot: bindDerivedDefault(option("--workspace-root", string()), {
+        context: derived.context,
+        key: "workspaceRoot",
+        defaultDescription: message`derived from ${
+          optionName("--service-root")
+        }`,
+      }),
+    });
+
+    const page = getDocPage(parser);
+    assert.ok(page != null);
+    const help = formatDocPage("tool", page, {
+      showDefault: true,
+    });
+
+    assert.match(help, /derived from `--service-root`/u);
+    assert.ok(!called);
+  });
+
+  it("lets wrapper nesting define source priority", async () => {
+    const env = createEnvContext({
+      prefix: "APP_",
+      source: (key) => key === "APP_VERBOSE" ? "true" : undefined,
+    });
+    const config = createConfigContext({
+      schema: {
+        "~standard": {
+          version: 1,
+          vendor: "test",
+          validate: (input) => ({
+            value: input as { readonly verbose: boolean },
+          }),
+        },
+      },
+    });
+    const derived = createDerivedDefaults({
+      verbose: () => false,
+    });
+    const parser = object({
+      verbose: bindEnv(
+        bindConfig(
+          bindDerivedDefault(option("--verbose"), {
+            context: derived.context,
+            key: "verbose",
+            default: false,
+          }),
+          {
+            context: config,
+            key: "verbose",
+          },
+        ),
+        {
+          context: env,
+          key: "VERBOSE",
+          parser: bool(),
+        },
+      ),
+    });
+
+    const result = await run(parser, {
+      args: [],
+      contexts: [env, config, derived.context],
+      contextOptions: {
+        load: () => ({ config: { verbose: false }, meta: undefined }),
+      },
+    });
+
+    assert.equal(result.verbose, true);
+  });
+
+  it("works with low-level parse annotations", () => {
+    const derived = createDerivedDefaults({
+      token: () => "from-derived",
+    });
+    const annotations = derived.context.getAnnotations({
+      phase: "phase2",
+      parsed: {},
+    });
+    assert.ok(!(annotations instanceof Promise));
+    const parser = bindDerivedDefault(option("--token", string()), {
+      context: derived.context,
+      key: "token",
+    });
+
+    const result = parse(parser, [], { annotations });
+
+    assert.deepEqual(result, { success: true, value: "from-derived" });
+  });
+});

--- a/packages/derived-defaults/src/index.test.ts
+++ b/packages/derived-defaults/src/index.test.ts
@@ -1,7 +1,7 @@
 import { strict as assert } from "node:assert";
 import { describe, it } from "node:test";
 import { formatDocPage } from "@optique/core/doc";
-import { message, optionName } from "@optique/core/message";
+import { formatMessage, message, optionName } from "@optique/core/message";
 import { object } from "@optique/core/constructs";
 import { withDefault } from "@optique/core/modifiers";
 import { option } from "@optique/core/primitives";
@@ -265,6 +265,53 @@ describe("bindDerivedDefault()", () => {
     });
 
     assert.equal(result.workspaceRoot, "/inner");
+  });
+
+  it("preserves inner fallback errors after derived fallback misses", () => {
+    const env = createEnvContext({
+      prefix: "APP_",
+      source: (key) => key === "APP_PORT" ? "invalid" : undefined,
+    });
+    const derived = createDerivedDefaults({
+      port: () => undefined,
+      token: () => "secret",
+    });
+    const parser = bindDerivedDefault(
+      bindEnv(option("--port", integer()), {
+        context: env,
+        key: "PORT",
+        parser: integer(),
+      }),
+      {
+        context: derived.context,
+        key: "port",
+      },
+    );
+
+    const envAnnotations = env.getAnnotations();
+    if (envAnnotations instanceof Promise) {
+      throw new TypeError("Expected synchronous env annotations.");
+    }
+    const derivedAnnotations = derived.context.getAnnotations({
+      phase: "phase2",
+      parsed: {},
+    });
+    if (derivedAnnotations instanceof Promise) {
+      throw new TypeError("Expected synchronous derived annotations.");
+    }
+    const annotations = {
+      ...envAnnotations,
+      ...derivedAnnotations,
+    };
+    const result = parse(parser, [], { annotations });
+
+    assert.ok(!result.success);
+    const error = formatMessage(result.error);
+    assert.match(error, /Expected a valid integer/u);
+    assert.doesNotMatch(
+      error,
+      /Missing required derived default value/u,
+    );
   });
 
   it("fails when no CLI, derived, or static default value exists", async () => {

--- a/packages/derived-defaults/src/index.test.ts
+++ b/packages/derived-defaults/src/index.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 import { formatDocPage } from "@optique/core/doc";
 import { message, optionName } from "@optique/core/message";
 import { object } from "@optique/core/constructs";
+import { withDefault } from "@optique/core/modifiers";
 import { option } from "@optique/core/primitives";
 import { getDocPage, parse } from "@optique/core/parser";
 import { integer, string } from "@optique/core/valueparser";
@@ -124,6 +125,28 @@ describe("bindDerivedDefault()", () => {
     });
 
     assert.equal(result.workspaceRoot, "/static");
+  });
+
+  it("falls through from undefined to an inner parser fallback", async () => {
+    const derived = createDerivedDefaults({
+      workspaceRoot: () => undefined,
+    });
+    const parser = object({
+      workspaceRoot: bindDerivedDefault(
+        withDefault(option("--workspace-root", string()), "/inner"),
+        {
+          context: derived.context,
+          key: "workspaceRoot",
+        },
+      ),
+    });
+
+    const result = await runAsync(parser, {
+      args: [],
+      contexts: [derived.context],
+    });
+
+    assert.equal(result.workspaceRoot, "/inner");
   });
 
   it("fails when no CLI, derived, or static default value exists", async () => {

--- a/packages/derived-defaults/src/index.test.ts
+++ b/packages/derived-defaults/src/index.test.ts
@@ -131,6 +131,24 @@ describe("createDerivedDefaults()", () => {
     assert.ok(!called);
     assert.match(failure.stderr, /No matching option found\./u);
   });
+
+  it("does not call resolvers with a null phase-two seed", () => {
+    let called = false;
+    const derived = createDerivedDefaults({
+      workspaceRoot: (parsed: { readonly serviceRoot: string }) => {
+        called = true;
+        return `${parsed.serviceRoot}/workspace`;
+      },
+    });
+
+    const annotations = derived.context.getAnnotations({
+      phase: "phase2",
+      parsed: null,
+    });
+
+    assert.ok(!called);
+    assert.deepEqual(annotations, {});
+  });
 });
 
 describe("bindDerivedDefault()", () => {

--- a/packages/derived-defaults/src/index.test.ts
+++ b/packages/derived-defaults/src/index.test.ts
@@ -519,6 +519,29 @@ describe("bindDerivedDefault()", () => {
     assert.deepEqual(extractor(parser.initialState), { value: "inner" });
   });
 
+  it("rejects async inner phase-two seeds in sync mode", () => {
+    const derived = createDerivedDefaults({
+      token: () => "fallback",
+    });
+    const innerParser = { ...option("--token", string()) };
+    Object.defineProperty(innerParser, extractPhase2SeedKey, {
+      value: () => Promise.resolve({ value: "inner" }),
+      configurable: true,
+    });
+    const parser = bindDerivedDefault(innerParser, {
+      context: derived.context,
+      key: "token",
+    });
+    const extractor = (parser as typeof parser & {
+      readonly [extractPhase2SeedKey]: (state: unknown) => unknown;
+    })[extractPhase2SeedKey];
+
+    assert.throws(
+      () => extractor(parser.initialState),
+      /Synchronous mode cannot wrap Promise value/u,
+    );
+  });
+
   it("wraps phase-two seed fallbacks in async mode", async () => {
     const derived = createDerivedDefaults({
       token: () => "fallback",

--- a/packages/derived-defaults/src/index.test.ts
+++ b/packages/derived-defaults/src/index.test.ts
@@ -318,6 +318,31 @@ describe("bindDerivedDefault()", () => {
     assert.match(failure.stderr, /Expected a value less than or equal to/u);
   });
 
+  it("rejects async fallback validation in sync mode", () => {
+    const derived = createDerivedDefaults({
+      token: () => "secret",
+    });
+    const annotations = derived.context.getAnnotations({
+      phase: "phase2",
+      parsed: {},
+    });
+    assert.ok(!(annotations instanceof Promise));
+    const innerParser = { ...option("--token", string()) };
+    Object.defineProperty(innerParser, "validateValue", {
+      value: () => Promise.resolve({ success: true, value: "secret" }),
+      configurable: true,
+    });
+    const parser = bindDerivedDefault(innerParser, {
+      context: derived.context,
+      key: "token",
+    });
+
+    assert.throws(
+      () => parse(parser, [], { annotations }),
+      /Synchronous mode cannot wrap Promise value/u,
+    );
+  });
+
   it("uses defaultDescription for help without resolving fallback", () => {
     let called = false;
     const derived = createDerivedDefaults({

--- a/packages/derived-defaults/src/index.test.ts
+++ b/packages/derived-defaults/src/index.test.ts
@@ -103,6 +103,34 @@ describe("createDerivedDefaults()", () => {
 
     assert.deepEqual(calls, ["api"]);
   });
+
+  it("does not call resolvers without a phase-two seed", async () => {
+    let called = false;
+    const derived = createDerivedDefaults({
+      workspaceRoot: (parsed: { readonly serviceRoot: string }) => {
+        called = true;
+        return `${parsed.serviceRoot}/workspace`;
+      },
+    });
+    const parser = object({
+      serviceRoot: option("--service-root", string()),
+      workspaceRoot: bindDerivedDefault(option("--workspace-root", string()), {
+        context: derived.context,
+        key: "workspaceRoot",
+      }),
+    });
+
+    const failure = await captureRunFailure((options) =>
+      runAsync(parser, {
+        args: [],
+        contexts: [derived.context],
+        ...options,
+      })
+    );
+
+    assert.ok(!called);
+    assert.match(failure.stderr, /No matching option found\./u);
+  });
 });
 
 describe("bindDerivedDefault()", () => {

--- a/packages/derived-defaults/src/index.test.ts
+++ b/packages/derived-defaults/src/index.test.ts
@@ -6,12 +6,29 @@ import { object } from "@optique/core/constructs";
 import { withDefault } from "@optique/core/modifiers";
 import { option } from "@optique/core/primitives";
 import { getDocPage, parse } from "@optique/core/parser";
-import { integer, string } from "@optique/core/valueparser";
+import { integer, string, type ValueParser } from "@optique/core/valueparser";
 import { bindEnv, bool, createEnvContext } from "@optique/env";
 import { bindConfig, createConfigContext } from "@optique/config";
-import { extractPhase2SeedKey } from "@optique/core/extension";
+import {
+  extractPhase2SeedKey,
+  injectAnnotations,
+} from "@optique/core/extension";
 import { run, runAsync, runSync } from "@optique/run";
 import { bindDerivedDefault, createDerivedDefaults } from "./index.ts";
+
+function asyncString(): ValueParser<"async", string> {
+  return {
+    mode: "async",
+    metavar: "STRING",
+    placeholder: "",
+    parse(input) {
+      return Promise.resolve({ success: true, value: input });
+    },
+    format(value) {
+      return value;
+    },
+  };
+}
 
 async function captureRunFailure(
   callback: (options: {
@@ -387,6 +404,35 @@ describe("bindDerivedDefault()", () => {
     })[extractPhase2SeedKey];
 
     assert.deepEqual(extractor(parser.initialState), { value: "inner" });
+  });
+
+  it("wraps phase-two seed fallbacks in async mode", async () => {
+    const derived = createDerivedDefaults({
+      token: () => "fallback",
+    });
+    const parser = bindDerivedDefault(option("--token", asyncString()), {
+      context: derived.context,
+      key: "token",
+    });
+    const extractor = (parser as typeof parser & {
+      readonly [extractPhase2SeedKey]: (state: unknown) => unknown;
+    })[extractPhase2SeedKey];
+
+    const emptySeed = extractor(parser.initialState);
+    assert.ok(emptySeed instanceof Promise);
+    assert.equal(await emptySeed, null);
+
+    const phase1Annotations = derived.context.getInternalAnnotations?.(
+      { phase: "phase1" },
+      {},
+    );
+    assert.ok(phase1Annotations != null);
+    const deferredSeed = extractor(injectAnnotations({}, phase1Annotations));
+    assert.ok(deferredSeed instanceof Promise);
+    assert.deepEqual(await deferredSeed, {
+      value: undefined,
+      deferred: true,
+    });
   });
 
   it("uses defaultDescription for help without resolving fallback", () => {

--- a/packages/derived-defaults/src/index.test.ts
+++ b/packages/derived-defaults/src/index.test.ts
@@ -9,6 +9,7 @@ import { getDocPage, parse } from "@optique/core/parser";
 import { integer, string } from "@optique/core/valueparser";
 import { bindEnv, bool, createEnvContext } from "@optique/env";
 import { bindConfig, createConfigContext } from "@optique/config";
+import { extractPhase2SeedKey } from "@optique/core/extension";
 import { run, runAsync, runSync } from "@optique/run";
 import { bindDerivedDefault, createDerivedDefaults } from "./index.ts";
 
@@ -341,6 +342,51 @@ describe("bindDerivedDefault()", () => {
       () => parse(parser, [], { annotations }),
       /Synchronous mode cannot wrap Promise value/u,
     );
+  });
+
+  it("rejects async CLI completion in sync mode", () => {
+    const derived = createDerivedDefaults({
+      token: () => "fallback",
+    });
+    const innerParser = { ...option("--token", string()) };
+    Object.defineProperty(innerParser, "complete", {
+      value: () => Promise.resolve({ success: true, value: "cli" }),
+      configurable: true,
+    });
+    const parser = bindDerivedDefault(innerParser, {
+      context: derived.context,
+      key: "token",
+    });
+    const annotations = derived.context.getAnnotations({
+      phase: "phase2",
+      parsed: {},
+    });
+    assert.ok(!(annotations instanceof Promise));
+
+    assert.throws(
+      () => parse(parser, ["--token", "cli"], { annotations }),
+      /Synchronous mode cannot wrap Promise value/u,
+    );
+  });
+
+  it("delegates phase-two seeds to wrapped parsers", () => {
+    const derived = createDerivedDefaults({
+      token: () => "fallback",
+    });
+    const innerParser = { ...option("--token", string()) };
+    Object.defineProperty(innerParser, extractPhase2SeedKey, {
+      value: () => ({ value: "inner" }),
+      configurable: true,
+    });
+    const parser = bindDerivedDefault(innerParser, {
+      context: derived.context,
+      key: "token",
+    });
+    const extractor = (parser as typeof parser & {
+      readonly [extractPhase2SeedKey]: (state: unknown) => unknown;
+    })[extractPhase2SeedKey];
+
+    assert.deepEqual(extractor(parser.initialState), { value: "inner" });
   });
 
   it("uses defaultDescription for help without resolving fallback", () => {

--- a/packages/derived-defaults/src/index.test.ts
+++ b/packages/derived-defaults/src/index.test.ts
@@ -353,7 +353,7 @@ describe("bindDerivedDefault()", () => {
       },
     });
 
-    assert.equal(result.verbose, true);
+    assert.ok(result.verbose);
   });
 
   it("works with low-level parse annotations", () => {

--- a/packages/derived-defaults/src/index.test.ts
+++ b/packages/derived-defaults/src/index.test.ts
@@ -5,8 +5,13 @@ import { formatMessage, message, optionName } from "@optique/core/message";
 import { object } from "@optique/core/constructs";
 import { withDefault } from "@optique/core/modifiers";
 import { option } from "@optique/core/primitives";
-import { getDocPage, parse } from "@optique/core/parser";
-import { integer, string, type ValueParser } from "@optique/core/valueparser";
+import { getDocPage, parse, type Parser } from "@optique/core/parser";
+import {
+  integer,
+  string,
+  type ValueParser,
+  type ValueParserResult,
+} from "@optique/core/valueparser";
 import { bindEnv, bool, createEnvContext } from "@optique/env";
 import { bindConfig, createConfigContext } from "@optique/config";
 import {
@@ -28,6 +33,59 @@ function asyncString(): ValueParser<"async", string> {
       return value;
     },
   };
+}
+
+function dependencySourceParser(options: {
+  readonly validateValue?: () =>
+    | ValueParserResult<string>
+    | Promise<ValueParserResult<string>>;
+  readonly extractSourceValue?: (
+    state: unknown,
+  ) => ValueParserResult<unknown> | Promise<ValueParserResult<unknown>>;
+} = {}): Parser<"sync", string, unknown> {
+  const sourceId = Symbol("@optique/derived-defaults/test-source");
+  const parser: Parser<"sync", string, unknown> = {
+    mode: "sync",
+    $valueType: [] as readonly string[],
+    $stateType: [] as readonly unknown[],
+    priority: 0,
+    usage: [],
+    leadingNames: new Set<string>(),
+    acceptingAnyToken: false,
+    initialState: undefined,
+    parse(context) {
+      return {
+        success: true as const,
+        next: context,
+        consumed: [],
+      };
+    },
+    complete() {
+      return { success: false as const, error: message`Missing value.` };
+    },
+    suggest() {
+      return [];
+    },
+    getDocFragments() {
+      return { fragments: [] };
+    },
+    dependencyMetadata: {
+      source: {
+        kind: "source",
+        sourceId,
+        preservesSourceValue: true,
+        extractSourceValue: options.extractSourceValue ??
+          (() => ({ success: true as const, value: "source" })),
+      },
+    },
+  };
+  if (options.validateValue != null) {
+    Object.defineProperty(parser, "validateValue", {
+      value: options.validateValue,
+      configurable: true,
+    });
+  }
+  return parser;
 }
 
 async function captureRunFailure(
@@ -495,6 +553,89 @@ describe("bindDerivedDefault()", () => {
 
     assert.throws(
       () => parse(parser, ["--token", "cli"], { annotations }),
+      /Synchronous mode cannot wrap Promise value/u,
+    );
+  });
+
+  it("rejects async missing source defaults in sync mode", () => {
+    const derived = createDerivedDefaults({
+      token: () => undefined,
+    });
+    const parser = bindDerivedDefault(
+      dependencySourceParser({
+        validateValue: () =>
+          Promise.resolve({ success: true as const, value: "default" }),
+      }),
+      {
+        context: derived.context,
+        key: "token",
+        default: "default",
+      },
+    );
+    const getMissingSourceValue = parser.dependencyMetadata?.source
+      ?.getMissingSourceValue;
+    assert.ok(getMissingSourceValue != null);
+
+    assert.throws(
+      () => getMissingSourceValue(),
+      /Synchronous mode cannot wrap Promise value/u,
+    );
+  });
+
+  it("rejects async derived source validation in sync mode", () => {
+    const derived = createDerivedDefaults({
+      token: () => "derived",
+    });
+    const annotations = derived.context.getAnnotations({
+      phase: "phase2",
+      parsed: {},
+    });
+    assert.ok(!(annotations instanceof Promise));
+    const parser = bindDerivedDefault(
+      dependencySourceParser({
+        validateValue: () =>
+          Promise.resolve({ success: true as const, value: "derived" }),
+      }),
+      {
+        context: derived.context,
+        key: "token",
+      },
+    );
+    const extractSourceValue = parser.dependencyMetadata?.source
+      ?.extractSourceValue;
+    assert.ok(extractSourceValue != null);
+
+    assert.throws(
+      () => extractSourceValue(injectAnnotations({}, annotations)),
+      /Synchronous mode cannot wrap Promise value/u,
+    );
+  });
+
+  it("rejects async delegated source extraction in sync mode", () => {
+    const derived = createDerivedDefaults({
+      token: () => undefined,
+    });
+    const annotations = derived.context.getAnnotations({
+      phase: "phase2",
+      parsed: {},
+    });
+    assert.ok(!(annotations instanceof Promise));
+    const parser = bindDerivedDefault(
+      dependencySourceParser({
+        extractSourceValue: () =>
+          Promise.resolve({ success: true as const, value: "source" }),
+      }),
+      {
+        context: derived.context,
+        key: "token",
+      },
+    );
+    const extractSourceValue = parser.dependencyMetadata?.source
+      ?.extractSourceValue;
+    assert.ok(extractSourceValue != null);
+
+    assert.throws(
+      () => extractSourceValue(injectAnnotations({}, annotations)),
       /Synchronous mode cannot wrap Promise value/u,
     );
   });

--- a/packages/derived-defaults/src/index.test.ts
+++ b/packages/derived-defaults/src/index.test.ts
@@ -88,6 +88,18 @@ describe("createDerivedDefaults()", () => {
 });
 
 describe("bindDerivedDefault()", () => {
+  it("rejects derived values that do not match the parser value type", () => {
+    const derived = createDerivedDefaults({
+      port: () => "5432",
+    });
+
+    void bindDerivedDefault(option("--port", integer()), {
+      context: derived.context,
+      // @ts-expect-error: derived strings cannot default an integer parser.
+      key: "port",
+    });
+  });
+
   it("prefers CLI input over a derived fallback", async () => {
     const derived = createDerivedDefaults({
       workspaceRoot: () => "/derived",

--- a/packages/derived-defaults/src/index.test.ts
+++ b/packages/derived-defaults/src/index.test.ts
@@ -119,6 +119,28 @@ describe("bindDerivedDefault()", () => {
     assert.equal(result.workspaceRoot, "/cli");
   });
 
+  it("preserves invalid explicit CLI input over derived fallback", async () => {
+    const derived = createDerivedDefaults({
+      port: () => 5432,
+    });
+    const parser = object({
+      port: bindDerivedDefault(option("--port", integer()), {
+        context: derived.context,
+        key: "port",
+      }),
+    });
+
+    const failure = await captureRunFailure((options) =>
+      runAsync(parser, {
+        args: ["--port", "invalid"],
+        contexts: [derived.context],
+        ...options,
+      })
+    );
+
+    assert.match(failure.stderr, /Expected a valid integer/u);
+  });
+
   it("falls through from undefined to a static default", async () => {
     const derived = createDerivedDefaults({
       workspaceRoot: () => undefined,
@@ -181,6 +203,25 @@ describe("bindDerivedDefault()", () => {
     );
 
     assert.match(failure.stderr, /No matching option found\./u);
+  });
+
+  it("derives all fields when no CLI input seeds phase two", async () => {
+    const derived = createDerivedDefaults({
+      token: () => "secret",
+    });
+    const parser = object({
+      token: bindDerivedDefault(option("--token", string()), {
+        context: derived.context,
+        key: "token",
+      }),
+    });
+
+    const result = await runAsync(parser, {
+      args: [],
+      contexts: [derived.context],
+    });
+
+    assert.deepEqual(result, { token: "secret" });
   });
 
   it("supports async resolvers with async runners", async () => {

--- a/packages/derived-defaults/src/index.test.ts
+++ b/packages/derived-defaults/src/index.test.ts
@@ -149,6 +149,26 @@ describe("createDerivedDefaults()", () => {
     assert.ok(!called);
     assert.deepEqual(annotations, {});
   });
+
+  it("passes undefined to default-parameter resolvers for null seeds", () => {
+    let called = false;
+    const derived = createDerivedDefaults({
+      workspaceRoot: (
+        { serviceRoot }: { readonly serviceRoot?: string } = {},
+      ) => {
+        called = true;
+        return serviceRoot == null ? undefined : `${serviceRoot}/workspace`;
+      },
+    });
+
+    const annotations = derived.context.getAnnotations({
+      phase: "phase2",
+      parsed: null,
+    });
+
+    assert.ok(called);
+    assert.deepEqual(annotations, {});
+  });
 });
 
 describe("bindDerivedDefault()", () => {

--- a/packages/derived-defaults/src/index.ts
+++ b/packages/derived-defaults/src/index.ts
@@ -232,7 +232,7 @@ export function createDerivedDefaults<const TResolvers extends object>(
           ];
         // Resolvers that declare a parsed-value parameter depend on a seed.
         // Zero-argument resolvers can still provide global defaults.
-        if (request.parsed === undefined && resolver.length > 0) {
+        if (request.parsed == null && resolver.length > 0) {
           continue;
         }
         const resolved = resolver(request.parsed);

--- a/packages/derived-defaults/src/index.ts
+++ b/packages/derived-defaults/src/index.ts
@@ -393,10 +393,7 @@ export function bindDerivedDefault<
                 message`Derived default value could not be read: the derived default context was not passed to run()'s contexts option.`,
             };
           }
-          return {
-            success: false as const,
-            error: message`Missing required derived default value.`,
-          };
+          return result;
         },
       );
     }

--- a/packages/derived-defaults/src/index.ts
+++ b/packages/derived-defaults/src/index.ts
@@ -175,7 +175,7 @@ function validateFallbackValue<M extends Mode, TValue>(
       value,
     });
   }
-  return innerParser.validateValue(value) as ModeValue<M, Result<TValue>>;
+  return wrapForMode(mode, innerParser.validateValue(value));
 }
 
 /**

--- a/packages/derived-defaults/src/index.ts
+++ b/packages/derived-defaults/src/index.ts
@@ -383,7 +383,10 @@ export function bindDerivedDefault<
     if (innerParser?.canSkip?.(getInnerState(state as TState), exec) === true) {
       return mapModeValue(
         mode,
-        innerParser.complete(getInnerState(state as TState), exec),
+        wrapForMode(
+          mode,
+          innerParser.complete(getInnerState(state as TState), exec),
+        ),
         (result) => {
           if (result.success) return result;
           if (contextAbsent) {
@@ -413,6 +416,7 @@ export function bindDerivedDefault<
   function getDerivedSourceValue(
     state: unknown,
     innerState: unknown,
+    mode: M,
     extractInnerSourceValue: (
       state: unknown,
     ) =>
@@ -436,20 +440,29 @@ export function bindDerivedDefault<
       ) {
         return parsed;
       }
-      return innerParser.validateValue(parsed.value) as
-        | ValueParserResult<unknown>
-        | Promise<ValueParserResult<unknown>>;
+      return wrapForMode(
+        mode,
+        innerParser.validateValue(parsed.value) as
+          | ValueParserResult<unknown>
+          | Promise<ValueParserResult<unknown>>,
+      );
     };
     if (derivedValue !== undefined) {
-      return validateFallback({ success: true as const, value: derivedValue });
+      return wrapForMode(
+        mode,
+        validateFallback({ success: true as const, value: derivedValue }),
+      );
     }
     if (options.default !== undefined) {
-      return validateFallback({
-        success: true as const,
-        value: options.default,
-      });
+      return wrapForMode(
+        mode,
+        validateFallback({
+          success: true as const,
+          value: options.default,
+        }),
+      );
     }
-    return extractInnerSourceValue(innerState);
+    return wrapForMode(mode, extractInnerSourceValue(innerState));
   }
 
   const boundParser: Parser<M, TValue, TState> = {
@@ -524,7 +537,7 @@ export function bindDerivedDefault<
       };
       return mapModeValue(
         parser.mode,
-        parser.parse(innerContext),
+        wrapForMode(parser.mode, parser.parse(innerContext)),
         processResult,
       );
     },
@@ -624,11 +637,17 @@ export function bindDerivedDefault<
           options.default !== undefined
         ? () => {
           if (typeof parser.validateValue === "function") {
-            return parser.validateValue(options.default!) as
-              | ValueParserResult<unknown>
-              | Promise<ValueParserResult<unknown>>;
+            return wrapForMode(
+              parser.mode,
+              parser.validateValue(options.default!) as
+                | ValueParserResult<unknown>
+                | Promise<ValueParserResult<unknown>>,
+            );
           }
-          return { success: true as const, value: options.default };
+          return wrapForMode(parser.mode, {
+            success: true as const,
+            value: options.default,
+          });
         }
         : undefined,
       extractSourceValue: (state: unknown) => {
@@ -637,22 +656,33 @@ export function bindDerivedDefault<
             return getDerivedSourceValue(
               state,
               state,
+              parser.mode,
               sourceMetadata.extractSourceValue,
               parser,
             );
           }
-          return sourceMetadata.extractSourceValue(state);
+          return wrapForMode(
+            parser.mode,
+            sourceMetadata.extractSourceValue(state),
+          );
         }
         if (state.hasCliValue) {
-          return sourceMetadata.extractSourceValue(state.cliState);
+          return wrapForMode(
+            parser.mode,
+            sourceMetadata.extractSourceValue(state.cliState),
+          );
         }
         const fallbackState = state.cliState ?? state;
         if (!sourceMetadata.preservesSourceValue) {
-          return sourceMetadata.extractSourceValue(fallbackState);
+          return wrapForMode(
+            parser.mode,
+            sourceMetadata.extractSourceValue(fallbackState),
+          );
         }
         return getDerivedSourceValue(
           state,
           fallbackState,
+          parser.mode,
           sourceMetadata.extractSourceValue,
           parser,
         );

--- a/packages/derived-defaults/src/index.ts
+++ b/packages/derived-defaults/src/index.ts
@@ -528,7 +528,10 @@ export function bindDerivedDefault<
     },
     complete(state, exec) {
       if (isBindState(state) && state.hasCliValue) {
-        return parser.complete(state.cliState!, exec);
+        return wrapForMode(
+          parser.mode,
+          parser.complete(state.cliState!, exec),
+        );
       }
       return getDerivedOrDefault(state, parser.mode, exec, parser);
     },
@@ -558,13 +561,19 @@ export function bindDerivedDefault<
     },
   };
   Object.defineProperty(boundParser, extractPhase2SeedKey, {
-    value(state: TState) {
+    value(state: TState, exec?: ExecutionContext) {
       const annotations = getAnnotations(state);
       if (
         annotations?.[options.context.id] !==
           phase1DerivedDefaultAnnotationMarker
       ) {
-        return null;
+        const extractInnerPhase2Seed = (parser as typeof parser & {
+          readonly [extractPhase2SeedKey]?: (
+            state: TState,
+            exec?: ExecutionContext,
+          ) => ModeValue<M, unknown>;
+        })[extractPhase2SeedKey];
+        return extractInnerPhase2Seed?.(getInnerState(state), exec) ?? null;
       }
       return { value: undefined as TValue, deferred: true as const };
     },

--- a/packages/derived-defaults/src/index.ts
+++ b/packages/derived-defaults/src/index.ts
@@ -351,6 +351,7 @@ export function bindDerivedDefault<
   function getDerivedOrDefault(
     state: unknown,
     mode: M,
+    exec: ExecutionContext | undefined,
     innerParser?: Parser<M, TValue, unknown>,
   ): ModeValue<M, Result<TValue>> {
     const annotations = getAnnotations(state);
@@ -362,6 +363,26 @@ export function bindDerivedDefault<
     }
     if (options.default !== undefined) {
       return validateFallbackValue(mode, innerParser, options.default);
+    }
+    if (innerParser?.canSkip?.(getInnerState(state as TState), exec) === true) {
+      return mapModeValue(
+        mode,
+        innerParser.complete(getInnerState(state as TState), exec),
+        (result) => {
+          if (result.success) return result;
+          if (contextAbsent) {
+            return {
+              success: false as const,
+              error:
+                message`Derived default value could not be read: the derived default context was not passed to run()'s contexts option.`,
+            };
+          }
+          return {
+            success: false as const,
+            error: message`Missing required derived default value.`,
+          };
+        },
+      );
     }
     if (contextAbsent) {
       return wrapForMode(mode, {
@@ -498,7 +519,7 @@ export function bindDerivedDefault<
       if (isBindState(state) && state.hasCliValue) {
         return parser.complete(state.cliState!, exec);
       }
-      return getDerivedOrDefault(state, parser.mode, parser);
+      return getDerivedOrDefault(state, parser.mode, exec, parser);
     },
     suggest(context, prefix) {
       const innerState = getInnerState(context.state);

--- a/packages/derived-defaults/src/index.ts
+++ b/packages/derived-defaults/src/index.ts
@@ -182,6 +182,8 @@ function validateFallbackValue<M extends Mode, TValue>(
  *
  * @param resolvers Resolver map keyed by derived value name.
  * @returns A derived-default context bundle.
+ * @throws {TypeError} If `resolvers` is not an object or contains a
+ * non-function resolver.
  * @since 1.2.0
  */
 export function createDerivedDefaults<const TResolvers extends object>(
@@ -212,9 +214,7 @@ export function createDerivedDefaults<const TResolvers extends object>(
       if (request.phase === "phase1") {
         return { [contextId]: phase1DerivedDefaultAnnotationMarker };
       }
-      return Object.getOwnPropertySymbols(annotations).includes(contextId)
-        ? undefined
-        : { [contextId]: undefined };
+      return contextId in annotations ? undefined : { [contextId]: undefined };
     },
     getAnnotations(
       request?: SourceContextRequest,
@@ -265,6 +265,7 @@ export function createDerivedDefaults<const TResolvers extends object>(
  * @param parser Parser that reads the CLI value.
  * @param options Derived default binding options.
  * @returns A parser with derived fallback behavior.
+ * @throws {TypeError} If `options.key` is not a property key.
  * @since 1.2.0
  */
 export function bindDerivedDefault<

--- a/packages/derived-defaults/src/index.ts
+++ b/packages/derived-defaults/src/index.ts
@@ -235,7 +235,7 @@ export function createDerivedDefaults<const TResolvers extends object>(
         if (request.parsed == null && resolver.length > 0) {
           continue;
         }
-        const resolved = resolver(request.parsed);
+        const resolved = resolver(request.parsed ?? undefined);
         if (isPromiseLike(resolved)) {
           pending.push(
             Promise.resolve(resolved).then((value) => {

--- a/packages/derived-defaults/src/index.ts
+++ b/packages/derived-defaults/src/index.ts
@@ -1,0 +1,606 @@
+/**
+ * Derived default support for Optique.
+ *
+ * @module
+ * @since 1.2.0
+ */
+
+import type { Message } from "@optique/core/message";
+import { message } from "@optique/core/message";
+import type { DocFragment } from "@optique/core/doc";
+import {
+  defineTraits,
+  delegateSuggestNodes,
+  inheritAnnotations,
+  injectAnnotations,
+  mapModeValue,
+  mapSourceMetadata,
+  type ParserSourceMetadata,
+  withAnnotationView,
+  wrapForMode,
+} from "@optique/core/extension";
+import { fluent, type FluentParser } from "@optique/core/fluent";
+import type {
+  ExecutionContext,
+  Mode,
+  ModeValue,
+  Parser,
+  ParserResult,
+  Result,
+} from "@optique/core/parser";
+import { getAnnotations } from "@optique/core/annotations";
+import type {
+  Annotations,
+  SourceContext,
+  SourceContextRequest,
+} from "@optique/core/context";
+import type { ValueParserResult } from "@optique/core/valueparser";
+
+/**
+ * Resolver function for a derived default value.
+ *
+ * @since 1.2.0
+ */
+export type DerivedDefaultResolver<TParsed, TValue> = (
+  parsed: TParsed,
+) => TValue | undefined | Promise<TValue | undefined>;
+
+/**
+ * Values produced by a derived-default resolver map.
+ *
+ * @since 1.2.0
+ */
+export type DerivedDefaultValues<TResolvers> = {
+  readonly [K in keyof TResolvers]: TResolvers[K] extends
+    (parsed: infer _TParsed) => infer TValue
+    ? Exclude<Awaited<TValue>, undefined>
+    : never;
+};
+
+/**
+ * Source context for derived defaults.
+ *
+ * @since 1.2.0
+ */
+export interface DerivedDefaultsContext<TValues extends object>
+  extends SourceContext {
+  readonly phase: "two-pass";
+  readonly $values?: TValues;
+}
+
+/**
+ * Derived-default context bundle.
+ *
+ * @since 1.2.0
+ */
+export interface DerivedDefaults<TValues extends object> {
+  readonly context: DerivedDefaultsContext<TValues>;
+}
+
+/**
+ * Options for binding a parser to a derived default value.
+ *
+ * @since 1.2.0
+ */
+export interface BindDerivedDefaultOptions<
+  TValues extends object,
+  TKey extends keyof TValues,
+  TValue,
+> {
+  readonly context: DerivedDefaultsContext<TValues>;
+  readonly key: TKey;
+  readonly default?: TValue;
+  readonly defaultDescription?: Message;
+}
+
+interface DerivedDefaultAnnotationData<TValues extends object> {
+  readonly values: TValues;
+}
+
+const phase1DerivedDefaultAnnotationMarker = Symbol(
+  "@optique/derived-defaults/phase1Annotation",
+);
+
+function getTypeName(value: unknown): string {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "array";
+  return typeof value;
+}
+
+function isPromiseLike<T>(value: unknown): value is PromiseLike<T> {
+  return value != null &&
+    (typeof value === "object" || typeof value === "function") &&
+    "then" in value &&
+    typeof (value as Record<string, unknown>).then === "function";
+}
+
+function validateSourceContextRequest(request: unknown): asserts request is
+  | undefined
+  | SourceContextRequest {
+  if (request === undefined) return;
+  if (
+    request === null ||
+    typeof request !== "object" ||
+    !("phase" in request) ||
+    (request.phase !== "phase1" && request.phase !== "phase2") ||
+    (request.phase === "phase2" && !("parsed" in request))
+  ) {
+    throw new TypeError(
+      "Expected getAnnotations() to receive no request or a " +
+        'SourceContextRequest ({ phase: "phase1" } or ' +
+        `{ phase: "phase2", parsed }), but got: ${getTypeName(request)}.`,
+    );
+  }
+}
+
+function replaceDefaultDescription(
+  fragments: readonly DocFragment[],
+  description: Message | undefined,
+): readonly DocFragment[] {
+  if (description == null) return fragments;
+  return fragments.map((fragment): DocFragment => {
+    if (fragment.type === "entry") {
+      return { ...fragment, default: description };
+    }
+    return {
+      ...fragment,
+      entries: fragment.entries.map((entry) => ({
+        ...entry,
+        default: description,
+      })),
+    };
+  });
+}
+
+function validateFallbackValue<M extends Mode, TValue>(
+  mode: M,
+  innerParser: Parser<M, TValue, unknown> | undefined,
+  value: TValue,
+): ModeValue<M, Result<TValue>> {
+  if (
+    innerParser == null || typeof innerParser.validateValue !== "function"
+  ) {
+    return wrapForMode(mode, {
+      success: true as const,
+      value,
+    });
+  }
+  return innerParser.validateValue(value) as ModeValue<M, Result<TValue>>;
+}
+
+/**
+ * Creates a derived-default context.
+ *
+ * @param resolvers Resolver map keyed by derived value name.
+ * @returns A derived-default context bundle.
+ * @since 1.2.0
+ */
+export function createDerivedDefaults<const TResolvers extends object>(
+  resolvers: TResolvers,
+): DerivedDefaults<DerivedDefaultValues<TResolvers>> {
+  if (resolvers == null || typeof resolvers !== "object") {
+    throw new TypeError(
+      `Expected resolvers to be an object, but got: ${getTypeName(resolvers)}.`,
+    );
+  }
+  for (const key of Reflect.ownKeys(resolvers)) {
+    const resolver = (resolvers as Record<PropertyKey, unknown>)[key];
+    if (typeof resolver !== "function") {
+      throw new TypeError(
+        `Expected resolver ${String(key)} to be a function, but got: ${
+          getTypeName(resolver)
+        }.`,
+      );
+    }
+  }
+
+  type Values = DerivedDefaultValues<TResolvers>;
+  const contextId = Symbol(`@optique/derived-defaults:${Math.random()}`);
+  const context: DerivedDefaultsContext<Values> = {
+    id: contextId,
+    phase: "two-pass",
+    getInternalAnnotations(request, annotations) {
+      if (request.phase === "phase1") {
+        return { [contextId]: phase1DerivedDefaultAnnotationMarker };
+      }
+      return Object.getOwnPropertySymbols(annotations).includes(contextId)
+        ? undefined
+        : { [contextId]: undefined };
+    },
+    getAnnotations(
+      request?: SourceContextRequest,
+    ): Annotations | Promise<Annotations> {
+      validateSourceContextRequest(request);
+      if (request?.phase !== "phase2") return {};
+
+      const values: Record<PropertyKey, unknown> = {};
+      const pending: Promise<void>[] = [];
+      for (const key of Reflect.ownKeys(resolvers)) {
+        const resolver =
+          (resolvers as Record<PropertyKey, (parsed: unknown) => unknown>)[
+            key
+          ];
+        const resolved = resolver(request.parsed);
+        if (isPromiseLike(resolved)) {
+          pending.push(
+            Promise.resolve(resolved).then((value) => {
+              if (value !== undefined) values[key] = value;
+            }),
+          );
+        } else if (resolved !== undefined) {
+          values[key] = resolved;
+        }
+      }
+
+      const buildAnnotations = (): Annotations =>
+        Reflect.ownKeys(values).length === 0 ? {} : {
+          [contextId]: {
+            values: values as Values,
+          } satisfies DerivedDefaultAnnotationData<Values>,
+        };
+      return pending.length === 0
+        ? buildAnnotations()
+        : Promise.all(pending).then(buildAnnotations);
+    },
+    [Symbol.dispose]() {
+      // No-op. Derived-default annotations are detached parse-time snapshots.
+    },
+  };
+
+  return { context };
+}
+
+/**
+ * Binds a parser to a derived default value.
+ *
+ * @param parser Parser that reads the CLI value.
+ * @param options Derived default binding options.
+ * @returns A parser with derived fallback behavior.
+ * @since 1.2.0
+ */
+export function bindDerivedDefault<
+  M extends Mode,
+  TValue,
+  TState,
+  TValues extends object,
+  TKey extends keyof TValues,
+>(
+  parser: Parser<M, TValue, TState>,
+  options: BindDerivedDefaultOptions<TValues, TKey, TValue>,
+): FluentParser<M, TValue, TState> {
+  const keyType = typeof options.key;
+  if (
+    keyType !== "string" && keyType !== "number" && keyType !== "symbol"
+  ) {
+    throw new TypeError(
+      `Expected key to be a property key, but got: ${
+        getTypeName(options.key)
+      }.`,
+    );
+  }
+
+  const bindStateKey: unique symbol = Symbol(
+    "@optique/derived-defaults/bindState",
+  );
+  type BindState =
+    & { readonly [K in typeof bindStateKey]: true }
+    & { readonly hasCliValue: boolean; readonly cliState?: TState };
+
+  function isBindState(value: unknown): value is BindState {
+    return value != null &&
+      typeof value === "object" &&
+      bindStateKey in value;
+  }
+
+  function shouldDeferCompletion(
+    state: unknown,
+    exec?: ExecutionContext,
+  ): boolean {
+    const annotations = getAnnotations(state);
+    if (
+      annotations?.[options.context.id] === phase1DerivedDefaultAnnotationMarker
+    ) {
+      return true;
+    }
+    return parser.shouldDeferCompletion?.(
+      getInnerState(state as TState),
+      exec,
+    ) === true;
+  }
+
+  function getInnerState(state: TState): TState {
+    if (!isBindState(state)) return state;
+    if (state.cliState !== undefined) return state.cliState as TState;
+    const initialState = parser.initialState;
+    if (initialState != null && typeof initialState !== "object") {
+      return initialState;
+    }
+    const annotated = inheritAnnotations(state, initialState);
+    if (
+      annotated === initialState &&
+      initialState != null &&
+      typeof initialState === "object"
+    ) {
+      const annotations = getAnnotations(state);
+      return annotations == null
+        ? initialState
+        : withAnnotationView(initialState, annotations);
+    }
+    return annotated;
+  }
+
+  function getDerivedValue(state: unknown): TValue | undefined {
+    const annotations = getAnnotations(state);
+    const annotationValue = annotations?.[options.context.id];
+    if (
+      annotationValue == null ||
+      typeof annotationValue !== "object" ||
+      !("values" in annotationValue)
+    ) {
+      return undefined;
+    }
+    return (annotationValue as DerivedDefaultAnnotationData<TValues>)
+      .values[options.key] as TValue | undefined;
+  }
+
+  function hasDerivedFallback(state: TState): boolean {
+    if (getDerivedValue(state) !== undefined) return true;
+    return options.default !== undefined;
+  }
+
+  function getDerivedOrDefault(
+    state: unknown,
+    mode: M,
+    innerParser?: Parser<M, TValue, unknown>,
+  ): ModeValue<M, Result<TValue>> {
+    const annotations = getAnnotations(state);
+    const contextId = options.context.id;
+    const contextAbsent = annotations != null && !(contextId in annotations);
+    const derivedValue = getDerivedValue(state);
+    if (derivedValue !== undefined) {
+      return validateFallbackValue(mode, innerParser, derivedValue);
+    }
+    if (options.default !== undefined) {
+      return validateFallbackValue(mode, innerParser, options.default);
+    }
+    if (contextAbsent) {
+      return wrapForMode(mode, {
+        success: false as const,
+        error:
+          message`Derived default value could not be read: the derived default context was not passed to run()'s contexts option.`,
+      });
+    }
+    return wrapForMode(mode, {
+      success: false as const,
+      error: message`Missing required derived default value.`,
+    });
+  }
+
+  function getDerivedSourceValue(
+    state: unknown,
+    innerState: unknown,
+    extractInnerSourceValue: (
+      state: unknown,
+    ) =>
+      | ValueParserResult<unknown>
+      | Promise<ValueParserResult<unknown> | undefined>
+      | undefined,
+    innerParser?: Parser<M, TValue, unknown>,
+  ):
+    | ValueParserResult<unknown>
+    | Promise<ValueParserResult<unknown> | undefined>
+    | undefined {
+    const derivedValue = getDerivedValue(state);
+    const validateFallback = (
+      parsed: ValueParserResult<TValue>,
+    ):
+      | ValueParserResult<unknown>
+      | Promise<ValueParserResult<unknown>> => {
+      if (!parsed.success) return parsed;
+      if (
+        innerParser == null || typeof innerParser.validateValue !== "function"
+      ) {
+        return parsed;
+      }
+      return innerParser.validateValue(parsed.value) as
+        | ValueParserResult<unknown>
+        | Promise<ValueParserResult<unknown>>;
+    };
+    if (derivedValue !== undefined) {
+      return validateFallback({ success: true as const, value: derivedValue });
+    }
+    if (options.default !== undefined) {
+      return validateFallback({
+        success: true as const,
+        value: options.default,
+      });
+    }
+    return extractInnerSourceValue(innerState);
+  }
+
+  const boundParser: Parser<M, TValue, TState> = {
+    mode: parser.mode,
+    $valueType: parser.$valueType,
+    $stateType: parser.$stateType,
+    priority: parser.priority,
+    usage: options.default !== undefined
+      ? [{ type: "optional", terms: parser.usage }]
+      : parser.usage,
+    leadingNames: parser.leadingNames,
+    acceptingAnyToken: parser.acceptingAnyToken,
+    initialState: parser.initialState,
+    canSkip(state, exec) {
+      if (isBindState(state)) {
+        if (state.hasCliValue) {
+          return parser.canSkip?.(state.cliState!, exec) === true;
+        }
+        if (hasDerivedFallback(state)) return true;
+        return parser.canSkip?.(getInnerState(state), exec) === true;
+      }
+      if (hasDerivedFallback(state)) return true;
+      return parser.canSkip?.(state, exec) === true;
+    },
+    getSuggestRuntimeNodes(state, path) {
+      const innerState = getInnerState(state);
+      return delegateSuggestNodes(
+        parser,
+        boundParser,
+        state,
+        path,
+        innerState,
+      );
+    },
+    parse(context) {
+      const annotations = getAnnotations(context.state);
+      const innerState = isBindState(context.state)
+        ? (context.state.hasCliValue
+          ? context.state.cliState as TState
+          : parser.initialState)
+        : context.state;
+      const innerContext = innerState !== context.state
+        ? { ...context, state: innerState }
+        : context;
+      const processResult = (
+        result: ParserResult<TState>,
+      ): ParserResult<TState> => {
+        if (result.success) {
+          const cliConsumed = result.consumed.length > 0;
+          const nextState = injectAnnotations({
+            [bindStateKey]: true as const,
+            hasCliValue: cliConsumed,
+            cliState: result.next.state,
+          }, annotations);
+          return {
+            success: true,
+            ...(result.provisional ? { provisional: true as const } : {}),
+            next: { ...result.next, state: nextState as TState },
+            consumed: result.consumed,
+          };
+        }
+        if (result.consumed > 0) return result;
+        const nextState = injectAnnotations({
+          [bindStateKey]: true as const,
+          hasCliValue: false,
+        }, annotations);
+        return {
+          success: true,
+          next: { ...innerContext, state: nextState as TState },
+          consumed: [],
+        };
+      };
+      return mapModeValue(
+        parser.mode,
+        parser.parse(innerContext),
+        processResult,
+      );
+    },
+    complete(state, exec) {
+      if (isBindState(state) && state.hasCliValue) {
+        return parser.complete(state.cliState!, exec);
+      }
+      return getDerivedOrDefault(state, parser.mode, parser);
+    },
+    suggest(context, prefix) {
+      const innerState = getInnerState(context.state);
+      const innerContext = innerState !== context.state
+        ? { ...context, state: innerState }
+        : context;
+      return parser.suggest(innerContext, prefix);
+    },
+    shouldDeferCompletion,
+    getDocFragments(state, upperDefaultValue) {
+      const defaultValue = upperDefaultValue ?? options.default;
+      const fragments = parser.getDocFragments(state, defaultValue);
+      if (
+        upperDefaultValue !== undefined || options.defaultDescription == null
+      ) {
+        return fragments;
+      }
+      return {
+        ...fragments,
+        fragments: replaceDefaultDescription(
+          fragments.fragments,
+          options.defaultDescription,
+        ),
+      };
+    },
+  };
+  defineTraits(boundParser, {
+    inheritsAnnotations: true,
+    completesFromSource: true,
+  });
+  if ("placeholder" in parser) {
+    Object.defineProperty(boundParser, "placeholder", {
+      get() {
+        return parser.placeholder;
+      },
+      configurable: true,
+      enumerable: false,
+    });
+  }
+  if (typeof parser.normalizeValue === "function") {
+    Object.defineProperty(boundParser, "normalizeValue", {
+      value: parser.normalizeValue.bind(parser),
+      configurable: true,
+      enumerable: false,
+    });
+  }
+  if (typeof parser.validateValue === "function") {
+    Object.defineProperty(boundParser, "validateValue", {
+      value: parser.validateValue.bind(parser),
+      configurable: true,
+      enumerable: false,
+    });
+  }
+  const dependencyMetadata = mapSourceMetadata(
+    parser,
+    (sourceMetadata: ParserSourceMetadata<M, TValue, TState>) => ({
+      ...sourceMetadata,
+      getMissingSourceValue: sourceMetadata.preservesSourceValue !== false &&
+          options.default !== undefined
+        ? () => {
+          if (typeof parser.validateValue === "function") {
+            return parser.validateValue(options.default!) as
+              | ValueParserResult<unknown>
+              | Promise<ValueParserResult<unknown>>;
+          }
+          return { success: true as const, value: options.default };
+        }
+        : undefined,
+      extractSourceValue: (state: unknown) => {
+        if (!isBindState(state)) {
+          if (sourceMetadata.preservesSourceValue) {
+            return getDerivedSourceValue(
+              state,
+              state,
+              sourceMetadata.extractSourceValue,
+              parser,
+            );
+          }
+          return sourceMetadata.extractSourceValue(state);
+        }
+        if (state.hasCliValue) {
+          return sourceMetadata.extractSourceValue(state.cliState);
+        }
+        const fallbackState = state.cliState ?? state;
+        if (!sourceMetadata.preservesSourceValue) {
+          return sourceMetadata.extractSourceValue(fallbackState);
+        }
+        return getDerivedSourceValue(
+          state,
+          fallbackState,
+          sourceMetadata.extractSourceValue,
+          parser,
+        );
+      },
+    }),
+  );
+  if (dependencyMetadata != null) {
+    Object.defineProperty(boundParser, "dependencyMetadata", {
+      value: dependencyMetadata,
+      configurable: true,
+      enumerable: false,
+    });
+  }
+  return fluent(boundParser);
+}

--- a/packages/derived-defaults/src/index.ts
+++ b/packages/derived-defaults/src/index.ts
@@ -230,6 +230,11 @@ export function createDerivedDefaults<const TResolvers extends object>(
           (resolvers as Record<PropertyKey, (parsed: unknown) => unknown>)[
             key
           ];
+        // Resolvers that declare a parsed-value parameter depend on a seed.
+        // Zero-argument resolvers can still provide global defaults.
+        if (request.parsed === undefined && resolver.length > 0) {
+          continue;
+        }
         const resolved = resolver(request.parsed);
         if (isPromiseLike(resolved)) {
           pending.push(

--- a/packages/derived-defaults/src/index.ts
+++ b/packages/derived-defaults/src/index.ts
@@ -577,7 +577,10 @@ export function bindDerivedDefault<
         })[extractPhase2SeedKey];
         return extractInnerPhase2Seed == null
           ? wrapForMode(parser.mode, null)
-          : extractInnerPhase2Seed(getInnerState(state), exec);
+          : wrapForMode(
+            parser.mode,
+            extractInnerPhase2Seed(getInnerState(state), exec),
+          );
       }
       return wrapForMode(parser.mode, {
         value: undefined as TValue,

--- a/packages/derived-defaults/src/index.ts
+++ b/packages/derived-defaults/src/index.ts
@@ -58,6 +58,15 @@ export type DerivedDefaultValues<TResolvers> = {
 };
 
 /**
+ * Keys whose derived default values are assignable to a parser value type.
+ *
+ * @since 1.2.0
+ */
+export type DerivedDefaultKey<TValues extends object, TValue> = {
+  readonly [K in keyof TValues]: TValues[K] extends TValue ? K : never;
+}[keyof TValues];
+
+/**
  * Source context for derived defaults.
  *
  * @since 1.2.0
@@ -84,8 +93,8 @@ export interface DerivedDefaults<TValues extends object> {
  */
 export interface BindDerivedDefaultOptions<
   TValues extends object,
-  TKey extends keyof TValues,
   TValue,
+  TKey extends DerivedDefaultKey<TValues, TValue>,
 > {
   readonly context: DerivedDefaultsContext<TValues>;
   readonly key: TKey;
@@ -263,10 +272,10 @@ export function bindDerivedDefault<
   TValue,
   TState,
   TValues extends object,
-  TKey extends keyof TValues,
+  TKey extends DerivedDefaultKey<TValues, TValue>,
 >(
   parser: Parser<M, TValue, TState>,
-  options: BindDerivedDefaultOptions<TValues, TKey, TValue>,
+  options: BindDerivedDefaultOptions<TValues, TValue, TKey>,
 ): FluentParser<M, TValue, TState> {
   const keyType = typeof options.key;
   if (

--- a/packages/derived-defaults/src/index.ts
+++ b/packages/derived-defaults/src/index.ts
@@ -573,9 +573,14 @@ export function bindDerivedDefault<
             exec?: ExecutionContext,
           ) => ModeValue<M, unknown>;
         })[extractPhase2SeedKey];
-        return extractInnerPhase2Seed?.(getInnerState(state), exec) ?? null;
+        return extractInnerPhase2Seed == null
+          ? wrapForMode(parser.mode, null)
+          : extractInnerPhase2Seed(getInnerState(state), exec);
       }
-      return { value: undefined as TValue, deferred: true as const };
+      return wrapForMode(parser.mode, {
+        value: undefined as TValue,
+        deferred: true as const,
+      });
     },
     configurable: true,
   });

--- a/packages/derived-defaults/src/index.ts
+++ b/packages/derived-defaults/src/index.ts
@@ -11,6 +11,7 @@ import type { DocFragment } from "@optique/core/doc";
 import {
   defineTraits,
   delegateSuggestNodes,
+  extractPhase2SeedKey,
   inheritAnnotations,
   injectAnnotations,
   mapModeValue,
@@ -556,6 +557,19 @@ export function bindDerivedDefault<
       };
     },
   };
+  Object.defineProperty(boundParser, extractPhase2SeedKey, {
+    value(state: TState) {
+      const annotations = getAnnotations(state);
+      if (
+        annotations?.[options.context.id] !==
+          phase1DerivedDefaultAnnotationMarker
+      ) {
+        return null;
+      }
+      return { value: undefined as TValue, deferred: true as const };
+    },
+    configurable: true,
+  });
   defineTraits(boundParser, {
     inheritsAnnotations: true,
     completesFromSource: true,

--- a/packages/derived-defaults/tsdown.config.ts
+++ b/packages/derived-defaults/tsdown.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+  entry: [
+    "src/index.ts",
+  ],
+  dts: true,
+  format: ["esm", "cjs"],
+  platform: "node",
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       '@optique/core':
         specifier: 'workspace:'
         version: link:../packages/core
+      '@optique/derived-defaults':
+        specifier: 'workspace:'
+        version: link:../packages/derived-defaults
       '@optique/discover':
         specifier: 'workspace:'
         version: link:../packages/discover

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -241,6 +241,34 @@ importers:
         specifier: 'catalog:'
         version: 5.8.3
 
+  packages/derived-defaults:
+    dependencies:
+      '@optique/core':
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      '@optique/config':
+        specifier: workspace:*
+        version: link:../config
+      '@optique/env':
+        specifier: workspace:*
+        version: link:../env
+      '@optique/run':
+        specifier: workspace:*
+        version: link:../run
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.12.4
+      fast-check:
+        specifier: 'catalog:'
+        version: 4.7.0
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.13.0(typescript@5.8.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.8.3
+
   packages/discover:
     dependencies:
       '@optique/core':


### PR DESCRIPTION
Closes #845.


Summary
-------

This adds *@optique/derived-defaults*, a small integration package for defaults that are computed from the result of an earlier parse pass. It is meant for options such as workspace paths, service endpoints, or related values that can be inferred from other CLI input, while still keeping explicit CLI arguments at the highest priority.

The package exposes `createDerivedDefaults()` for the two-pass source context and `bindDerivedDefault()` for attaching a derived fallback to an existing parser. Resolvers can be sync or async. Fallback values are validated through the wrapped parser, and `defaultDescription` lets help output describe a runtime default without resolving it during documentation generation.

This also documents the new package in *docs/integrations/derived-defaults.md*, adds it to the package listings, and records the change in *CHANGES.md*.


Details
-------

 -  Added *@optique/derived-defaults* under *packages/derived-defaults/*.
 -  Added a two-pass `SourceContext` for deriving defaults from parsed values.
 -  Added type constraints so derived values must match the wrapped parser value type.
 -  Preserved lower-priority wrapped fallbacks such as `withDefault()`.
 -  Added Deno/Node/Bun-compatible tests for sync, async, validation, help text, source priority, low-level annotations, and invalid type bindings.
 -  Added VitePress documentation and a runnable package README quick start.


Validation
----------

 -  `deno test -A packages/derived-defaults/src/index.test.ts`
 -  `mise check && mise test`
 -  `cd docs && pnpm i && pnpm build`

