### PR TITLE
Deferred handler-time values

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,8 +18,21 @@ To be released.
     `@optique/core/fluent` subpath exports `fluent()` for custom parsers that
     want to opt into the same method-style modifier surface.  [[#842], [#843]]
 
+ -  Added `deferredValue()` and `isDeferredValue()` for deferred handler-time
+    values.  `deferredValue()` wraps a parser so its parsed field becomes a
+    `DeferredValue`, a value-producing function that returns the wrapped
+    parser's value when it produced one, or runs a fallback resolver otherwise.
+    The fallback runs when the command handler calls the value rather than
+    during parsing, so its errors are handler errors.  The readonly `source`
+    property reports whether the value was `"specified"` or came from the
+    `"fallback"`, and an optional `memoize` flag reuses the resolved fallback
+    while still retrying after a rejection.  A matching `.deferredValue()`
+    fluent method is also available.  [[#846], [#848]]
+
 [#842]: https://github.com/dahlia/optique/issues/842
 [#843]: https://github.com/dahlia/optique/pull/843
+[#846]: https://github.com/dahlia/optique/issues/846
+[#848]: https://github.com/dahlia/optique/pull/848
 
 ### @optique/derived-defaults
 

--- a/docs/.vitepress/theme/components/ParserCatalog.vue
+++ b/docs/.vitepress/theme/components/ParserCatalog.vue
@@ -118,6 +118,7 @@ const combinators = [
     items: [
       ["optional", "optional-parser"],
       ["withDefault", "withdefault-parser"],
+      ["deferredValue", "deferredvalue-parser"],
       ["multiple", "multiple-parser"],
       ["map", "map-parser"],
     ],

--- a/docs/concepts/modifiers.md
+++ b/docs/concepts/modifiers.md
@@ -556,6 +556,144 @@ if (result.success) {
 ~~~~
 
 
+`deferredValue()` parser
+------------------------
+
+*This API is available since Optique 1.2.0.*
+
+`withDefault()` resolves its fallback while parsing. Sometimes that is too
+early. A value might come from an interactive prompt, a network call, or a
+lookup that only one branch of the command ever reaches. `deferredValue()`
+keeps the value the wrapped parser produces, usually from the command line, but
+leaves the fallback unresolved until the handler asks for it.
+
+The wrapped field becomes a function instead of a scalar. Calling it returns the
+value the wrapped parser produced, or runs the fallback resolver when the
+wrapped parser produced none. Because the fallback runs at handler time, a
+failing prompt or a failed lookup is a handler error rather than a parse error.
+A value that is specified but invalid still fails during parsing, the same as
+any other option.
+
+~~~~ typescript twoslash
+declare function deploy(options: { readonly apiToken: string }): Promise<void>;
+declare function promptForApiToken(serviceName: string): Promise<string>;
+const argv: string[] = [];
+// ---cut-before---
+import { object } from "@optique/core/constructs";
+import { deferredValue } from "@optique/core/modifiers";
+import { parse } from "@optique/core/parser";
+import { flag, option } from "@optique/core/primitives";
+import { string } from "@optique/core/valueparser";
+
+const parser = object({
+  deploy: flag("--deploy"),
+  serviceName: option("--service-name", string()),
+  apiToken: deferredValue(
+    option("--api-token", string()),
+    ({ serviceName }: { readonly serviceName: string }) =>
+      promptForApiToken(serviceName),
+  ),
+});
+
+const result = parse(parser, argv);
+if (result.success && result.value.deploy) {
+  // The prompt only runs on the deployment branch.
+  const apiToken = await result.value.apiToken({
+    serviceName: result.value.serviceName,
+  });
+  await deploy({ apiToken });
+}
+~~~~
+
+The wrapped option keeps its place in usage and help, exactly like `optional()`.
+Only the result type changes: `apiToken` is a
+`DeferredValue<string, { serviceName: string }>` rather than a `string`.
+
+Optique infers the fallback's argument type and makes it the argument the
+handler must pass. The call stays type-checked, and the fallback can be
+synchronous or asynchronous regardless of whether the wrapped parser is. When
+the fallback takes no argument, the deferred value is callable with no argument
+too.
+
+### Knowing which branch was taken
+
+A `source` property records the branch without running the function. It is
+`"specified"` when the wrapped parser produced a value, including an explicit
+`undefined`, and `"fallback"` otherwise. This is useful in tests, logs, and
+diagnostics.
+
+~~~~ typescript twoslash
+import { object } from "@optique/core/constructs";
+import { deferredValue } from "@optique/core/modifiers";
+import { parse } from "@optique/core/parser";
+import { option } from "@optique/core/primitives";
+import { string } from "@optique/core/valueparser";
+
+const parser = object({
+  apiToken: deferredValue(
+    option("--api-token", string()),
+    () => "from-keychain",
+  ),
+});
+
+const provided = parse(parser, ["--api-token", "abc"]);
+if (provided.success) {
+  provided.value.apiToken.source; // "specified"
+  await provided.value.apiToken(); // "abc"
+}
+
+const omitted = parse(parser, []);
+if (omitted.success) {
+  omitted.value.apiToken.source; // "fallback"
+  await omitted.value.apiToken(); // runs the resolver
+}
+~~~~
+
+### Memoizing the fallback
+
+Every call runs the fallback again by default, which matches the fact that the
+result is a function. For a prompt or an expensive lookup, pass
+`{ memoize: true }` to reuse the first resolved value, or the in-flight promise
+when calls overlap. A rejected fallback is never cached, so the next call
+retries it. The `"specified"` branch is already a constant function, so
+memoization only affects the fallback branch.
+
+~~~~ typescript twoslash
+declare function promptForApiToken(): Promise<string>;
+// ---cut-before---
+import { object } from "@optique/core/constructs";
+import { deferredValue } from "@optique/core/modifiers";
+import { option } from "@optique/core/primitives";
+import { string } from "@optique/core/valueparser";
+
+const parser = object({
+  apiToken: deferredValue(
+    option("--api-token", string()),
+    () => promptForApiToken(),
+    { memoize: true },
+  ),
+});
+~~~~
+
+### Identifying deferred values
+
+In ordinary code the static type already tells you whether a field is a
+`DeferredValue`. When you only have an `unknown` value, such as inside a generic
+result walker or a test helper, `isDeferredValue()` recognizes the values
+`deferredValue()` produces.
+
+~~~~ typescript twoslash
+import { isDeferredValue } from "@optique/core/modifiers";
+
+function describe(value: unknown): string {
+  if (isDeferredValue(value)) {
+    return `deferred (${value.source})`;
+  }
+  return String(value);
+}
+~~~~
+
+
 `map()` parser
 --------------
 

--- a/docs/concepts/modifiers.md
+++ b/docs/concepts/modifiers.md
@@ -618,9 +618,11 @@ too.
 ### Knowing which branch was taken
 
 A `source` property records the branch without running the function. It is
-`"specified"` when the wrapped parser produced a value, including an explicit
-`undefined`, and `"fallback"` otherwise. This is useful in tests, logs, and
-diagnostics.
+`"specified"` when the wrapped parser produced a value, whether from the command
+line or a source such as `bindEnv()`/`bindConfig()`, and `"fallback"` otherwise.
+Because a missing value is reported as `undefined`, a wrapped parser that yields
+`undefined` is treated as having produced no value and selects the fallback.
+This is useful in tests, logs, and diagnostics.
 
 ~~~~ typescript twoslash
 import { object } from "@optique/core/constructs";

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -1812,6 +1812,66 @@ fallback value still comes from the resolver.
 For more details, see
 [derived defaults](./concepts/derived-defaults.md).
 
+### Deferred handler-time values
+
+*This API is available since Optique 1.2.0.*
+
+The fallbacks above run while parsing.  Some values should wait.  A token might
+come from an interactive prompt, or a lookup that only the deployment branch of
+a command ever reaches.
+[`deferredValue()`](./concepts/modifiers.md#deferredvalue-parser) keeps the
+value the wrapped parser produces, but leaves the fallback unresolved until the
+handler calls for it.
+
+The parsed field becomes a function.  Calling it returns the value the wrapped
+parser produced, or runs the fallback when it produced none.  Because the
+fallback runs at handler time, a failing prompt is a handler error rather than a
+parse error, and a branch that never asks for the value never pays for it.
+
+~~~~ typescript twoslash
+import { object } from "@optique/core/constructs";
+import { deferredValue, withDefault } from "@optique/core/modifiers";
+import { message } from "@optique/core/message";
+import { flag, option } from "@optique/core/primitives";
+import { string } from "@optique/core/valueparser";
+import { print, run } from "@optique/run";
+declare function promptForApiToken(serviceName: string): Promise<string>;
+declare function deploy(serviceName: string, apiToken: string): Promise<void>;
+// ---cut-before---
+const parser = object({
+  deploy: withDefault(flag("--deploy"), false),
+  serviceName: option("--service-name", string({ metavar: "NAME" })),
+  apiToken: deferredValue(
+    option("--api-token", string({ metavar: "TOKEN" })),
+    ({ serviceName }: { readonly serviceName: string }) =>
+      promptForApiToken(serviceName),
+    { memoize: true },
+  ),
+});
+
+const result = run(parser);
+
+// Parsing never runs the fallback; apiToken is a function, not a string.
+if (result.deploy) {
+  // Resolve the token only on this branch and pass it on; never log a secret.
+  const apiToken = await result.apiToken({ serviceName: result.serviceName });
+  await deploy(result.serviceName, apiToken);
+  print(message`Deployed ${result.serviceName}.`);
+}
+~~~~
+
+A readonly `source` property on the field reports whether the value was
+`"specified"` or came from the `"fallback"`, without running the function.
+Pass `{ memoize: true }` to reuse the first resolved fallback value across
+calls; a rejected fallback is retried rather than cached.
+
+This differs from the derived defaults above: a derived default is computed
+during a second parse pass and the field stays a plain value, while a deferred
+value is resolved by the handler and the field is a function.  The repository
+includes a runnable version of this pattern in
+`examples/patterns/deferred-values.ts`.  For more details, see the
+[`deferredValue()`](./concepts/modifiers.md#deferredvalue-parser) modifier.
+
 
 Application structure patterns
 ------------------------------

--- a/examples/patterns/deferred-values.ts
+++ b/examples/patterns/deferred-values.ts
@@ -1,0 +1,92 @@
+import { object } from "@optique/core/constructs";
+import { deferredValue, withDefault } from "@optique/core/modifiers";
+import { message } from "@optique/core/message";
+import { flag, option } from "@optique/core/primitives";
+import { string } from "@optique/core/valueparser";
+import { print, run } from "@optique/run";
+
+// This example demonstrates deferredValue(): a parsed field that becomes a
+// value-producing function resolved at handler time instead of during parsing.
+//
+// An API token is accepted from the command line when given, but is only
+// resolved (here, prompted for) when the handler actually reaches the
+// deployment branch.  Run without --deploy and the prompt never happens.
+//
+// Usage:
+//   deno run -A examples/patterns/deferred-values.ts --service-name api
+//   deno run -A examples/patterns/deferred-values.ts --deploy --service-name api
+//   deno run -A examples/patterns/deferred-values.ts \
+//     --deploy --service-name api --api-token sekret
+
+// A stand-in for an interactive prompt or a credential lookup.  It runs only
+// when the deferred value is called, never during parsing.
+function promptForApiToken(serviceName: string): Promise<string> {
+  print(message`Prompting for an API token for ${serviceName}…`);
+  return Promise.resolve(`prompted-token-for-${serviceName}`);
+}
+
+// A stand-in for the deployment call.  It uses the token to authenticate but
+// never logs it; secrets should not be written to stdout or logs.
+function deploy(serviceName: string, _apiToken: string): Promise<void> {
+  print(message`Authenticating and deploying ${serviceName}…`);
+  return Promise.resolve();
+}
+
+const parser = object({
+  deploy: withDefault(
+    flag("--deploy", {
+      description: message`Deploy after building.`,
+    }),
+    false,
+  ),
+  serviceName: option("--service-name", string({ metavar: "NAME" }), {
+    description: message`The service to operate on.`,
+  }),
+  apiToken: deferredValue(
+    option("--api-token", string({ metavar: "TOKEN" }), {
+      description: message`API token; prompted for when omitted.`,
+    }),
+    ({ serviceName }: { readonly serviceName: string }) =>
+      promptForApiToken(serviceName),
+    { memoize: true },
+  ),
+});
+
+// Parsing the sync option never runs the async fallback.  apiToken is a
+// function, not a string, and its source tells which branch it will take.
+const result = run(parser);
+
+print(message`Service: ${result.serviceName}.`);
+print(message`API token source: ${result.apiToken.source}.`);
+
+if (result.deploy) {
+  // The token (the specified value, or the prompt) is resolved only here.
+  // With memoize: true, a second call would reuse the first resolved token.
+  // Pass it to the deployment call; never print the token itself.
+  const apiToken = await result.apiToken({ serviceName: result.serviceName });
+  await deploy(result.serviceName, apiToken);
+  print(message`Deployed ${result.serviceName}.`);
+} else {
+  print(message`Skipping deployment; the API token was never resolved.`);
+}
+
+// Examples:
+//
+//   $ deno run -A examples/patterns/deferred-values.ts --service-name api
+//   Service: api.
+//   API token source: fallback.
+//   Skipping deployment; the API token was never resolved.
+//
+//   $ deno run -A examples/patterns/deferred-values.ts --deploy --service-name api
+//   Service: api.
+//   API token source: fallback.
+//   Prompting for an API token for api…
+//   Authenticating and deploying api…
+//   Deployed api.
+//
+//   $ deno run -A examples/patterns/deferred-values.ts \
+//       --deploy --service-name api --api-token sekret
+//   Service: api.
+//   API token source: specified.
+//   Authenticating and deploying api…
+//   Deployed api.

--- a/packages/core/src/modifiers.test.ts
+++ b/packages/core/src/modifiers.test.ts
@@ -12615,6 +12615,42 @@ describe("deferredValue", () => {
       }
     });
   });
+
+  describe("fluent method", () => {
+    it("is available as a fluent method", () => {
+      const parser = object({
+        token: option("--token", string()).deferredValue(() => "fb"),
+      });
+      const provided = parse(parser, ["--token", "abc"]);
+      assert.ok(provided.success);
+      if (provided.success) {
+        assert.ok(isDeferredValue(provided.value.token));
+        assert.equal(provided.value.token.source, "specified");
+        assert.equal(provided.value.token(), "abc");
+      }
+      const omitted = parse(parser, []);
+      assert.ok(omitted.success);
+      if (omitted.success) {
+        assert.equal(omitted.value.token.source, "fallback");
+        assert.equal(omitted.value.token(), "fb");
+      }
+    });
+
+    it("forwards the inferred context type and options", () => {
+      const parser = object({
+        token: option("--token", string()).deferredValue(
+          ({ id }: { readonly id: string }) => `token-${id}`,
+          { memoize: true },
+        ),
+      });
+      const omitted = parse(parser, []);
+      assert.ok(omitted.success);
+      if (omitted.success) {
+        assert.equal(omitted.value.token.source, "fallback");
+        assert.equal(omitted.value.token({ id: "x" }), "token-x");
+      }
+    });
+  });
 });
 
 describe("isDeferredValue", () => {

--- a/packages/core/src/modifiers.test.ts
+++ b/packages/core/src/modifiers.test.ts
@@ -12434,6 +12434,22 @@ describe("deferredValue", () => {
     }
   });
 
+  it("is callable without arguments when the context includes undefined", () => {
+    const parser = object({
+      token: deferredValue(
+        option("--token", string()),
+        (ctx: { readonly id: string } | undefined) => ctx?.id ?? "anon",
+      ),
+    });
+    const result = parse(parser, []);
+    assert.ok(result.success);
+    if (result.success) {
+      // C includes undefined, so the deferred value is callable with no args.
+      assert.equal(result.value.token(), "anon");
+      assert.equal(result.value.token({ id: "abc" }), "abc");
+    }
+  });
+
   it("ignores the context argument in the specified branch", () => {
     const parser = object({
       token: deferredValue(

--- a/packages/core/src/modifiers.test.ts
+++ b/packages/core/src/modifiers.test.ts
@@ -21,6 +21,9 @@ import {
   url,
 } from "@optique/core/message";
 import {
+  type DeferredValue,
+  deferredValue,
+  isDeferredValue,
   map,
   multiple,
   nonEmpty,
@@ -12325,5 +12328,325 @@ describe("validateValue forwarding through modifiers (#414)", () => {
       );
       assert.equal(parser.validateValue, undefined);
     });
+  });
+});
+
+describe("deferredValue", () => {
+  it("returns the CLI value with source 'specified' when provided", () => {
+    const parser = object({
+      token: deferredValue(option("--token", string()), () => "fallback-token"),
+    });
+    const result = parse(parser, ["--token", "cli-token"]);
+    assert.ok(result.success);
+    if (result.success) {
+      const token: DeferredValue<string> = result.value.token;
+      assert.ok(isDeferredValue(token));
+      assert.equal(token.source, "specified");
+      assert.equal(token(), "cli-token");
+    }
+  });
+
+  it("runs the fallback with source 'fallback' when omitted", () => {
+    let called = 0;
+    const parser = object({
+      token: deferredValue(option("--token", string()), () => {
+        called++;
+        return "fallback-token";
+      }),
+    });
+    const result = parse(parser, []);
+    assert.ok(result.success);
+    if (result.success) {
+      const token = result.value.token;
+      assert.equal(token.source, "fallback");
+      assert.equal(called, 0);
+      assert.equal(token(), "fallback-token");
+      assert.equal(called, 1);
+    }
+  });
+
+  it("does not run the fallback during parsing", () => {
+    let called = 0;
+    const parser = object({
+      token: deferredValue(option("--token", string()), () => {
+        called++;
+        return "x";
+      }),
+    });
+    parse(parser, []);
+    assert.equal(called, 0);
+  });
+
+  it("passes handler-time context to the fallback", () => {
+    const parser = object({
+      service: option("--service", string()),
+      token: deferredValue(
+        option("--token", string()),
+        ({ service }: { readonly service: string }) => `token-for-${service}`,
+      ),
+    });
+    const result = parse(parser, ["--service", "api"]);
+    assert.ok(result.success);
+    if (result.success) {
+      assert.equal(result.value.token.source, "fallback");
+      assert.equal(
+        result.value.token({ service: result.value.service }),
+        "token-for-api",
+      );
+    }
+  });
+
+  it("ignores the context argument in the specified branch", () => {
+    const parser = object({
+      token: deferredValue(
+        option("--token", string()),
+        ({ service }: { readonly service: string }) => `token-for-${service}`,
+      ),
+    });
+    const result = parse(parser, ["--token", "abc"]);
+    assert.ok(result.success);
+    if (result.success) {
+      assert.equal(result.value.token.source, "specified");
+      assert.equal(result.value.token({ service: "ignored" }), "abc");
+    }
+  });
+
+  it("treats an explicitly produced undefined value as 'specified'", () => {
+    const parser = object({
+      x: deferredValue(
+        map(
+          option("--value", string()),
+          (value): string | undefined => value === "none" ? undefined : value,
+        ),
+        () => "fallback",
+      ),
+    });
+    const explicitUndefined = parse(parser, ["--value", "none"]);
+    assert.ok(explicitUndefined.success);
+    if (explicitUndefined.success) {
+      assert.equal(explicitUndefined.value.x.source, "specified");
+      assert.equal(explicitUndefined.value.x(), undefined);
+    }
+    const omitted = parse(parser, []);
+    assert.ok(omitted.success);
+    if (omitted.success) {
+      assert.equal(omitted.value.x.source, "fallback");
+      assert.equal(omitted.value.x(), "fallback");
+    }
+  });
+
+  it("propagates a parse error when a specified value is invalid", () => {
+    const parser = object({
+      token: deferredValue(
+        option("--token", choice(["a", "b"] as const)),
+        () => "a" as const,
+      ),
+    });
+    const result = parse(parser, ["--token", "zzz"]);
+    assert.ok(!result.success);
+  });
+
+  it("exposes source as an enumerable, readonly, non-writable property", () => {
+    const parser = object({
+      token: deferredValue(option("--token", string()), () => "fb"),
+    });
+    const result = parse(parser, []);
+    assert.ok(result.success);
+    if (result.success) {
+      const token = result.value.token;
+      const descriptor = Object.getOwnPropertyDescriptor(token, "source");
+      assert.ok(descriptor);
+      assert.ok(descriptor.enumerable);
+      assert.ok(!descriptor.writable);
+      assert.ok(!descriptor.configurable);
+      assert.ok(Object.keys(token).includes("source"));
+    }
+  });
+
+  it("preserves the wrapped parser's usage like optional()", () => {
+    const wrapped = option("--token", string());
+    const deferred = deferredValue(wrapped, () => "fb");
+    assert.deepEqual(deferred.usage, optional(wrapped).usage);
+  });
+
+  it("preserves the wrapped parser's documentation like optional()", () => {
+    const wrapped = option("--token", string());
+    const deferred = deferredValue(wrapped, () => "fb");
+    assert.deepEqual(
+      deferred.getDocFragments({ kind: "available", state: undefined }),
+      optional(wrapped).getDocFragments({
+        kind: "available",
+        state: undefined,
+      }),
+    );
+  });
+
+  describe("memoize", () => {
+    it("re-runs the fallback on every call by default", () => {
+      let called = 0;
+      const parser = object({
+        token: deferredValue(option("--token", string()), () => {
+          called++;
+          return `t${called}`;
+        }),
+      });
+      const result = parse(parser, []);
+      assert.ok(result.success);
+      if (result.success) {
+        assert.equal(result.value.token(), "t1");
+        assert.equal(result.value.token(), "t2");
+        assert.equal(called, 2);
+      }
+    });
+
+    it("reuses the resolved value when memoize is true", () => {
+      let called = 0;
+      const parser = object({
+        token: deferredValue(
+          option("--token", string()),
+          () => {
+            called++;
+            return `t${called}`;
+          },
+          { memoize: true },
+        ),
+      });
+      const result = parse(parser, []);
+      assert.ok(result.success);
+      if (result.success) {
+        assert.equal(result.value.token(), "t1");
+        assert.equal(result.value.token(), "t1");
+        assert.equal(called, 1);
+      }
+    });
+
+    it("reuses the in-flight promise for concurrent async calls", async () => {
+      let called = 0;
+      const parser = object({
+        token: deferredValue(
+          option("--token", asyncChoice(["a", "b"] as const)),
+          () => {
+            called++;
+            return Promise.resolve("resolved");
+          },
+          { memoize: true },
+        ),
+      });
+      const result = await parseAsync(parser, []);
+      assert.ok(result.success);
+      if (result.success) {
+        const first = result.value.token();
+        const second = result.value.token();
+        assert.equal(await first, "resolved");
+        assert.equal(await second, "resolved");
+        assert.equal(called, 1);
+      }
+    });
+
+    it("retries after a rejected fallback (does not cache rejection)", async () => {
+      let called = 0;
+      const parser = object({
+        token: deferredValue(
+          option("--token", asyncChoice(["a", "b"] as const)),
+          () => {
+            called++;
+            return called === 1
+              ? Promise.reject(new Error("boom"))
+              : Promise.resolve("second");
+          },
+          { memoize: true },
+        ),
+      });
+      const result = await parseAsync(parser, []);
+      assert.ok(result.success);
+      if (result.success) {
+        await assert.rejects(Promise.resolve(result.value.token()));
+        assert.equal(await result.value.token(), "second");
+        assert.equal(called, 2);
+      }
+    });
+  });
+
+  describe("async", () => {
+    it("works with an async wrapped parser (specified branch)", async () => {
+      const parser = object({
+        token: deferredValue(
+          option("--token", asyncChoice(["a", "b"] as const)),
+          () => Promise.resolve("fb" as const),
+        ),
+      });
+      const result = await parseAsync(parser, ["--token", "a"]);
+      assert.ok(result.success);
+      if (result.success) {
+        assert.equal(result.value.token.source, "specified");
+        assert.equal(await result.value.token(), "a");
+      }
+    });
+
+    it("works with an async wrapped parser (fallback branch)", async () => {
+      const parser = object({
+        token: deferredValue(
+          option("--token", asyncChoice(["a", "b"] as const)),
+          () => Promise.resolve("fb"),
+        ),
+      });
+      const result = await parseAsync(parser, []);
+      assert.ok(result.success);
+      if (result.success) {
+        assert.equal(result.value.token.source, "fallback");
+        assert.equal(await result.value.token(), "fb");
+      }
+    });
+
+    it("allows an async fallback even when the wrapped parser is sync", async () => {
+      const parser = object({
+        token: deferredValue(
+          option("--token", string()),
+          () => Promise.resolve("async-fb"),
+        ),
+      });
+      const result = parse(parser, []);
+      assert.ok(result.success);
+      if (result.success) {
+        assert.equal(result.value.token.source, "fallback");
+        const value = result.value.token();
+        assert.ok(value instanceof Promise);
+        assert.equal(await value, "async-fb");
+      }
+    });
+  });
+});
+
+describe("isDeferredValue", () => {
+  it("returns true for a deferred value from the specified branch", () => {
+    const parser = object({
+      token: deferredValue(option("--token", string()), () => "fb"),
+    });
+    const result = parse(parser, ["--token", "x"]);
+    assert.ok(result.success);
+    if (result.success) assert.ok(isDeferredValue(result.value.token));
+  });
+
+  it("returns true for a deferred value from the fallback branch", () => {
+    const parser = object({
+      token: deferredValue(option("--token", string()), () => "fb"),
+    });
+    const result = parse(parser, []);
+    assert.ok(result.success);
+    if (result.success) assert.ok(isDeferredValue(result.value.token));
+  });
+
+  it("returns false for a plain function", () => {
+    assert.ok(!isDeferredValue(() => "x"));
+    const fnWithSource = Object.assign(() => "x", { source: "specified" });
+    assert.ok(!isDeferredValue(fnWithSource));
+  });
+
+  it("returns false for non-function values", () => {
+    assert.ok(!isDeferredValue("x"));
+    assert.ok(!isDeferredValue(undefined));
+    assert.ok(!isDeferredValue(null));
+    assert.ok(!isDeferredValue(42));
+    assert.ok(!isDeferredValue({ source: "specified" }));
   });
 });

--- a/packages/core/src/modifiers.test.ts
+++ b/packages/core/src/modifiers.test.ts
@@ -12450,6 +12450,24 @@ describe("deferredValue", () => {
     }
   });
 
+  it("supports a fallback with an optional context parameter", () => {
+    // A fallback whose parameter is optional must not collapse to the
+    // no-argument form: the deferred value stays callable with and without the
+    // context argument.
+    const parser = object({
+      token: deferredValue(
+        option("--token", string()),
+        (ctx?: { readonly id: string }) => ctx?.id ?? "anon",
+      ),
+    });
+    const result = parse(parser, []);
+    assert.ok(result.success);
+    if (result.success) {
+      assert.equal(result.value.token(), "anon");
+      assert.equal(result.value.token({ id: "abc" }), "abc");
+    }
+  });
+
   it("ignores the context argument in the specified branch", () => {
     const parser = object({
       token: deferredValue(

--- a/packages/core/src/modifiers.test.ts
+++ b/packages/core/src/modifiers.test.ts
@@ -12465,7 +12465,10 @@ describe("deferredValue", () => {
     }
   });
 
-  it("treats an explicitly produced undefined value as 'specified'", () => {
+  it("treats an explicitly produced undefined value as a fallback", () => {
+    // optional() reports a missing value as undefined, so a wrapped parser that
+    // yields undefined is indistinguishable from "no value" and selects the
+    // fallback resolver.
     const parser = object({
       x: deferredValue(
         map(
@@ -12478,8 +12481,14 @@ describe("deferredValue", () => {
     const explicitUndefined = parse(parser, ["--value", "none"]);
     assert.ok(explicitUndefined.success);
     if (explicitUndefined.success) {
-      assert.equal(explicitUndefined.value.x.source, "specified");
-      assert.equal(explicitUndefined.value.x(), undefined);
+      assert.equal(explicitUndefined.value.x.source, "fallback");
+      assert.equal(explicitUndefined.value.x(), "fallback");
+    }
+    const provided = parse(parser, ["--value", "real"]);
+    assert.ok(provided.success);
+    if (provided.success) {
+      assert.equal(provided.value.x.source, "specified");
+      assert.equal(provided.value.x(), "real");
     }
     const omitted = parse(parser, []);
     assert.ok(omitted.success);

--- a/packages/core/src/modifiers.test.ts
+++ b/packages/core/src/modifiers.test.ts
@@ -12535,6 +12535,18 @@ describe("deferredValue", () => {
     }
   });
 
+  it("marks a wrapped dependency source as transformed", () => {
+    // The produced value is a function, so deferredValue() must not register it
+    // as a dependency source value.  Its metadata is marked transformed (as
+    // map() does), so the dependency runtime uses the raw inner value instead
+    // of the produced DeferredValue.
+    const source = dependency(choice(["dev", "prod"] as const));
+    const deferred = deferredValue(option("--mode", source), () => "dev");
+    assert.ok(deferred.dependencyMetadata?.source != null);
+    assert.ok(!deferred.dependencyMetadata?.source?.preservesSourceValue);
+    assert.ok(deferred.dependencyMetadata?.transform?.transformsSourceValue);
+  });
+
   it("propagates a parse error when a specified value is invalid", () => {
     const parser = object({
       token: deferredValue(

--- a/packages/core/src/modifiers.test.ts
+++ b/packages/core/src/modifiers.test.ts
@@ -8245,6 +8245,44 @@ describe("shouldDeferCompletion forwarding", () => {
       assert.deepEqual(inner.receivedStates[0], otherState);
     });
   });
+
+  describe("deferredValue() shouldDeferCompletion", () => {
+    it("should unwrap outer state before delegating to inner hook", () => {
+      const inner = createDeferrableParser(true);
+      const outer = deferredValue(inner, () => "fallback");
+
+      assert.ok(typeof outer.shouldDeferCompletion === "function");
+      const innerState: ValueParserResult<string> = {
+        success: true,
+        value: "hello",
+      };
+      outer.shouldDeferCompletion!([innerState]);
+
+      assert.equal(inner.receivedStates.length, 1);
+      assert.deepEqual(inner.receivedStates[0], innerState);
+    });
+
+    it("should return false when outer state is undefined", () => {
+      const inner = createDeferrableParser(true);
+      const outer = deferredValue(inner, () => "fallback");
+
+      const result = outer.shouldDeferCompletion!(undefined);
+      assert.ok(!result);
+      assert.equal(inner.receivedStates.length, 0);
+    });
+
+    it("should propagate inner hook's return value", () => {
+      const inner = createDeferrableParser(false);
+      const outer = deferredValue(inner, () => "fallback");
+
+      const innerState: ValueParserResult<string> = {
+        success: true,
+        value: "test",
+      };
+      const result = outer.shouldDeferCompletion!([innerState]);
+      assert.ok(!result);
+    });
+  });
 });
 
 describe(
@@ -12432,6 +12470,25 @@ describe("deferredValue", () => {
     if (omitted.success) {
       assert.equal(omitted.value.x.source, "fallback");
       assert.equal(omitted.value.x(), "fallback");
+    }
+  });
+
+  it("treats a value produced during completion as 'specified'", () => {
+    // constant() yields its value during completion without consuming a CLI
+    // token, the same path bindEnv()/bindConfig() take when they resolve a
+    // value from a non-CLI source.  The map() widens the literal to string so
+    // the fallback can differ from the produced value.
+    const parser = object({
+      region: deferredValue(
+        map(constant("us-east-1"), (value): string => value),
+        () => "fallback-region",
+      ),
+    });
+    const result = parse(parser, []);
+    assert.ok(result.success);
+    if (result.success) {
+      assert.equal(result.value.region.source, "specified");
+      assert.equal(result.value.region(), "us-east-1");
     }
   });
 

--- a/packages/core/src/modifiers.ts
+++ b/packages/core/src/modifiers.ts
@@ -1900,11 +1900,14 @@ function makeFallbackDeferredValue<T, C>(
  *
  * The parsed field becomes a {@link DeferredValue}: a value-producing function.
  * When the wrapped parser produced a value, calling the function returns that
- * value and {@link DeferredValue.source} is `"specified"`.  When the wrapped
- * parser did not produce a value, calling the function runs `fallback` and
- * `source` is `"fallback"`.  The fallback runs at handler time, so its errors
- * are handler errors rather than parser errors.  A value that is specified but
- * invalid still fails during parsing.
+ * value and {@link DeferredValue.source} is `"specified"`.  A value resolved
+ * from a source such as `bindEnv()`/`bindConfig()` counts as produced.  When
+ * the wrapped parser did not produce a value, calling the function runs
+ * `fallback` and `source` is `"fallback"`.  Because a missing value is reported
+ * as `undefined`, a wrapped parser that yields `undefined` is treated as having
+ * produced no value and selects the fallback.  The fallback runs at handler
+ * time, so its errors are handler errors rather than parser errors.  A value
+ * that is specified but invalid still fails during parsing.
  *
  * Like {@link optional}, the wrapped parser keeps its place in usage and help;
  * only the result type changes.  The fallback context type `C` is inferred from
@@ -1953,17 +1956,63 @@ export function deferredValue<M extends Mode, T, S, C = void>(
   options?: DeferredValueOptions,
 ): FluentParser<M, DeferredValue<T, C>, [S] | undefined> {
   const memoize = options?.memoize ?? false;
-  // Tag the produced value before optional() collapses "not matched" and a
-  // legitimately produced `undefined` into the same `undefined`.  After
-  // tagging, optional() yields the wrapper object when the wrapped parser
-  // produced a value (even `undefined`), or `undefined` when it did not.
-  return map(
-    optional(map(parser, (value: T): { readonly value: T } => ({ value }))),
-    (matched: { readonly value: T } | undefined): DeferredValue<T, C> =>
-      matched === undefined
-        ? makeFallbackDeferredValue<T, C>(fallback, memoize)
-        : makeSpecifiedDeferredValue<T, C>(matched.value),
-  );
+  // Build on optional() rather than map(): map()'s object spread drops the
+  // non-enumerable annotation markers that route bindEnv()/bindConfig() values,
+  // which would make a source-bound value look absent and wrongly select the
+  // fallback.  optional() already resolves CLI, environment, and config values
+  // and reports a missing value as `undefined`.
+  const base = optional(parser);
+  const complete = (
+    state: [S] | undefined,
+    exec?: ExecutionContext,
+  ): ModeValue<M, ValueParserResult<DeferredValue<T, C>>> =>
+    mapModeValue(
+      base.mode,
+      base.complete(state, exec),
+      (result): ValueParserResult<DeferredValue<T, C>> => {
+        if (!result.success) return result;
+        // Any value the wrapped parser produced (from the CLI or a source such
+        // as bindEnv()/bindConfig()) selects "specified".  optional() collapses
+        // a genuinely produced `undefined` into the same absence as "no value",
+        // so such a value selects the fallback resolver.
+        const value = result.value === undefined
+          ? makeFallbackDeferredValue<T, C>(fallback, memoize)
+          : makeSpecifiedDeferredValue<T, C>(result.value);
+        return result.deferred
+          ? { success: true, value, deferred: true }
+          : { success: true, value };
+      },
+    );
+  // Clone optional()'s parser so every own property, including the
+  // non-enumerable annotation markers an object spread would lose, is
+  // preserved.  Only the completion and the value-type tag are overridden.  The
+  // inner value hooks operate on T, not on the produced function, so they are
+  // removed, and the fluent marker is removed so fluent() rebinds its methods
+  // to this object instead of the optional() base.
+  const descriptors = Object.getOwnPropertyDescriptors(base) as Record<
+    PropertyKey,
+    PropertyDescriptor
+  >;
+  descriptors.complete = {
+    value: complete,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  };
+  descriptors.$valueType = {
+    value: [] as readonly DeferredValue<T, C>[],
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  };
+  delete descriptors.normalizeValue;
+  delete descriptors.validateValue;
+  delete descriptors[fluentParserMarker];
+  const deferredParser = Object.create(
+    Object.getPrototypeOf(base),
+    descriptors,
+  ) as Parser<M, DeferredValue<T, C>, [S] | undefined>;
+  return fluent(deferredParser);
 }
 
 /**

--- a/packages/core/src/modifiers.ts
+++ b/packages/core/src/modifiers.ts
@@ -1934,22 +1934,16 @@ function makeFallbackDeferredValue<T, C>(
  * @template M The execution mode of the wrapped parser.
  * @template T The resolved value type.
  * @template S The state type of the wrapped parser.
+ * @template C The handler-time context type, inferred from `fallback`.  A
+ *             fallback without a parameter yields a no-argument
+ *             {@link DeferredValue}; one whose parameter is optional or includes
+ *             `undefined` stays callable with no argument.
  * @param parser The parser that reads the CLI value.
  * @param fallback A resolver run at handler time when no value was specified.
  * @param options Optional {@link DeferredValueOptions}.
  * @returns A parser whose value is a {@link DeferredValue}.
  * @since 1.2.0
  */
-export function deferredValue<M extends Mode, T, S>(
-  parser: Parser<M, T, S>,
-  fallback: () => T | Promise<T>,
-  options?: DeferredValueOptions,
-): FluentParser<M, DeferredValue<T>, [S] | undefined>;
-export function deferredValue<M extends Mode, T, S, C>(
-  parser: Parser<M, T, S>,
-  fallback: (ctx: C) => T | Promise<T>,
-  options?: DeferredValueOptions,
-): FluentParser<M, DeferredValue<T, C>, [S] | undefined>;
 export function deferredValue<M extends Mode, T, S, C = void>(
   parser: Parser<M, T, S>,
   fallback: (ctx: C) => T | Promise<T>,
@@ -3474,16 +3468,13 @@ export interface ParserModifiers<
   /**
    * Defers this parser's value so the command handler resolves it.
    *
+   * @template C The handler-time context type, inferred from `fallback`.
    * @param fallback A resolver run at handler time when no value was specified.
    * @param options Optional {@link DeferredValueOptions}.
    * @returns A parser whose value is a {@link DeferredValue}.
    * @since 1.2.0
    */
-  deferredValue(
-    fallback: () => TValue | Promise<TValue>,
-    options?: DeferredValueOptions,
-  ): FluentParser<M, DeferredValue<TValue>, [TState] | undefined>;
-  deferredValue<C>(
+  deferredValue<C = void>(
     fallback: (ctx: C) => TValue | Promise<TValue>,
     options?: DeferredValueOptions,
   ): FluentParser<M, DeferredValue<TValue, C>, [TState] | undefined>;

--- a/packages/core/src/modifiers.ts
+++ b/packages/core/src/modifiers.ts
@@ -1966,22 +1966,27 @@ export function deferredValue<M extends Mode, T, S, C = void>(
     state: [S] | undefined,
     exec?: ExecutionContext,
   ): ModeValue<M, ValueParserResult<DeferredValue<T, C>>> =>
-    mapModeValue(
+    // wrapForMode() guards the boundary so a synchronous caller never silently
+    // receives a Promise when the wrapped parser is asynchronous.
+    wrapForMode<M, ValueParserResult<DeferredValue<T, C>>>(
       base.mode,
-      base.complete(state, exec),
-      (result): ValueParserResult<DeferredValue<T, C>> => {
-        if (!result.success) return result;
-        // Any value the wrapped parser produced (from the CLI or a source such
-        // as bindEnv()/bindConfig()) selects "specified".  optional() collapses
-        // a genuinely produced `undefined` into the same absence as "no value",
-        // so such a value selects the fallback resolver.
-        const value = result.value === undefined
-          ? makeFallbackDeferredValue<T, C>(fallback, memoize)
-          : makeSpecifiedDeferredValue<T, C>(result.value);
-        return result.deferred
-          ? { success: true, value, deferred: true }
-          : { success: true, value };
-      },
+      mapModeValue(
+        base.mode,
+        base.complete(state, exec),
+        (result): ValueParserResult<DeferredValue<T, C>> => {
+          if (!result.success) return result;
+          // Any value the wrapped parser produced (from the CLI or a source
+          // such as bindEnv()/bindConfig()) selects "specified".  optional()
+          // collapses a genuinely produced `undefined` into the same absence as
+          // "no value", so such a value selects the fallback resolver.
+          const value = result.value === undefined
+            ? makeFallbackDeferredValue<T, C>(fallback, memoize)
+            : makeSpecifiedDeferredValue<T, C>(result.value);
+          return result.deferred
+            ? { success: true, value, deferred: true }
+            : { success: true, value };
+        },
+      ),
     );
   // Clone optional()'s parser so every own property, including the
   // non-enumerable annotation markers an object spread would lose, is

--- a/packages/core/src/modifiers.ts
+++ b/packages/core/src/modifiers.ts
@@ -1783,6 +1783,7 @@ export type DeferredValueSource = "specified" | "fallback";
  */
 export type DeferredValue<T, C = void> =
   & ([C] extends [void] ? (() => T | Promise<T>)
+    : [undefined] extends [C] ? ((ctx?: C) => T | Promise<T>)
     : ((ctx: C) => T | Promise<T>))
   & {
     /**

--- a/packages/core/src/modifiers.ts
+++ b/packages/core/src/modifiers.ts
@@ -1757,7 +1757,8 @@ export function map<M extends Mode, T, U, TState>(
 /**
  * Identifies which branch a {@link DeferredValue} resolved from.
  *
- *  -  `"specified"` means the wrapped parser produced a value from CLI input.
+ *  -  `"specified"` means the wrapped parser produced a value, whether from
+ *     CLI input or another source such as `bindEnv()`/`bindConfig()`.
  *  -  `"fallback"` means {@link deferredValue} selected the fallback resolver.
  *
  * @since 1.2.0

--- a/packages/core/src/modifiers.ts
+++ b/packages/core/src/modifiers.ts
@@ -1755,6 +1755,237 @@ export function map<M extends Mode, T, U, TState>(
 }
 
 /**
+ * Identifies which branch a {@link DeferredValue} resolved from.
+ *
+ *  -  `"specified"` means the wrapped parser produced a value from CLI input.
+ *  -  `"fallback"` means {@link deferredValue} selected the fallback resolver.
+ *
+ * @since 1.2.0
+ */
+export type DeferredValueSource = "specified" | "fallback";
+
+/**
+ * A handler-time value produced by {@link deferredValue}.
+ *
+ * It is a value-producing function rather than a scalar value.  When the
+ * wrapped parser produced a value, calling it returns that value.  Otherwise
+ * calling it runs the fallback resolver.  The {@link DeferredValue.source}
+ * property tells which branch was selected without invoking the function.
+ *
+ * The call signature returns `T | Promise<T>` regardless of the wrapped
+ * parser's mode, so a synchronous parser may still pair with an asynchronous
+ * fallback resolver.
+ *
+ * @template T The resolved value type.
+ * @template C The handler-time context type passed to the fallback resolver.
+ * @since 1.2.0
+ */
+export type DeferredValue<T, C = void> =
+  & ([C] extends [void] ? (() => T | Promise<T>)
+    : ((ctx: C) => T | Promise<T>))
+  & {
+    /**
+     * Which branch produced this value: `"specified"` when the wrapped parser
+     * produced a value, `"fallback"` when the fallback resolver was selected.
+     */
+    readonly source: DeferredValueSource;
+  };
+
+/**
+ * Options for {@link deferredValue}.
+ * @since 1.2.0
+ */
+export interface DeferredValueOptions {
+  /**
+   * When `true`, a fallback-backed {@link DeferredValue} caches its first
+   * resolved value (or in-flight promise) and reuses it on later calls.
+   * A rejected fallback is not cached, so the next call retries it.  Defaults
+   * to `false`, meaning every call re-runs the fallback resolver.
+   */
+  readonly memoize?: boolean;
+}
+
+const deferredValueBrand: unique symbol = Symbol.for(
+  "@optique/core/deferredValue",
+);
+
+/**
+ * Brands a value-producing function as a {@link DeferredValue}.
+ *
+ * The brand is a hidden, non-enumerable symbol so {@link isDeferredValue} can
+ * recognize the value while object inspection only sees `source`.  The `source`
+ * property is enumerable but readonly and non-configurable.
+ *
+ * @param call The value-producing function.
+ * @param source The branch that produced the value.
+ * @returns The same function decorated as a {@link DeferredValue}.
+ */
+function brandDeferredValue<T, C>(
+  call: (ctx: C) => T | Promise<T>,
+  source: DeferredValueSource,
+): DeferredValue<T, C> {
+  Object.defineProperties(call, {
+    [deferredValueBrand]: {
+      value: true,
+      enumerable: false,
+      writable: false,
+      configurable: false,
+    },
+    source: {
+      value: source,
+      enumerable: true,
+      writable: false,
+      configurable: false,
+    },
+  });
+  return call as DeferredValue<T, C>;
+}
+
+/**
+ * Builds the `"specified"` branch: a function that returns the parsed value
+ * and ignores any handler-time context.
+ */
+function makeSpecifiedDeferredValue<T, C>(value: T): DeferredValue<T, C> {
+  return brandDeferredValue<T, C>((_ctx: C) => value, "specified");
+}
+
+/**
+ * Builds the `"fallback"` branch: a function that runs the fallback resolver,
+ * optionally memoizing the resolved value or in-flight promise.
+ */
+function makeFallbackDeferredValue<T, C>(
+  fallback: (ctx: C) => T | Promise<T>,
+  memoize: boolean,
+): DeferredValue<T, C> {
+  if (!memoize) {
+    return brandDeferredValue<T, C>((ctx: C) => fallback(ctx), "fallback");
+  }
+  let settled = false;
+  let settledValue: T;
+  let inFlight: Promise<T> | undefined;
+  const call = (ctx: C): T | Promise<T> => {
+    if (settled) return settledValue;
+    if (inFlight != null) return inFlight;
+    const result = fallback(ctx);
+    if (!isPromiseLike<T>(result)) {
+      settled = true;
+      settledValue = result;
+      return result;
+    }
+    const promise = Promise.resolve(result).then(
+      (resolved) => {
+        settled = true;
+        settledValue = resolved;
+        inFlight = undefined;
+        return resolved;
+      },
+      (error) => {
+        // Do not cache rejections: clearing the in-flight slot lets the next
+        // call retry the fallback.
+        inFlight = undefined;
+        throw error;
+      },
+    );
+    inFlight = promise;
+    return promise;
+  };
+  return brandDeferredValue<T, C>(call, "fallback");
+}
+
+/**
+ * Wraps a parser so its value is resolved by the command handler instead of
+ * during parsing.
+ *
+ * The parsed field becomes a {@link DeferredValue}: a value-producing function.
+ * When the wrapped parser produced a value, calling the function returns that
+ * value and {@link DeferredValue.source} is `"specified"`.  When the wrapped
+ * parser did not produce a value, calling the function runs `fallback` and
+ * `source` is `"fallback"`.  The fallback runs at handler time, so its errors
+ * are handler errors rather than parser errors.  A value that is specified but
+ * invalid still fails during parsing.
+ *
+ * Like {@link optional}, the wrapped parser keeps its place in usage and help;
+ * only the result type changes.  The fallback context type `C` is inferred from
+ * the `fallback` parameter.
+ *
+ * @example
+ * ```typescript
+ * const parser = object({
+ *   serviceName: option("--service-name", string()),
+ *   apiToken: deferredValue(
+ *     option("--api-token", string()),
+ *     ({ serviceName }: { readonly serviceName: string }) =>
+ *       promptForApiToken(serviceName),
+ *   ),
+ * });
+ *
+ * const parsed = parse(parser, argv);
+ * // The prompt only runs if this branch is reached.
+ * const apiToken = await parsed.apiToken({
+ *   serviceName: parsed.serviceName,
+ * });
+ * ```
+ *
+ * @template M The execution mode of the wrapped parser.
+ * @template T The resolved value type.
+ * @template S The state type of the wrapped parser.
+ * @param parser The parser that reads the CLI value.
+ * @param fallback A resolver run at handler time when no value was specified.
+ * @param options Optional {@link DeferredValueOptions}.
+ * @returns A parser whose value is a {@link DeferredValue}.
+ * @since 1.2.0
+ */
+export function deferredValue<M extends Mode, T, S>(
+  parser: Parser<M, T, S>,
+  fallback: () => T | Promise<T>,
+  options?: DeferredValueOptions,
+): FluentParser<M, DeferredValue<T>, [S] | undefined>;
+export function deferredValue<M extends Mode, T, S, C>(
+  parser: Parser<M, T, S>,
+  fallback: (ctx: C) => T | Promise<T>,
+  options?: DeferredValueOptions,
+): FluentParser<M, DeferredValue<T, C>, [S] | undefined>;
+export function deferredValue<M extends Mode, T, S, C = void>(
+  parser: Parser<M, T, S>,
+  fallback: (ctx: C) => T | Promise<T>,
+  options?: DeferredValueOptions,
+): FluentParser<M, DeferredValue<T, C>, [S] | undefined> {
+  const memoize = options?.memoize ?? false;
+  // Tag the produced value before optional() collapses "not matched" and a
+  // legitimately produced `undefined` into the same `undefined`.  After
+  // tagging, optional() yields the wrapper object when the wrapped parser
+  // produced a value (even `undefined`), or `undefined` when it did not.
+  return map(
+    optional(map(parser, (value: T): { readonly value: T } => ({ value }))),
+    (matched: { readonly value: T } | undefined): DeferredValue<T, C> =>
+      matched === undefined
+        ? makeFallbackDeferredValue<T, C>(fallback, memoize)
+        : makeSpecifiedDeferredValue<T, C>(matched.value),
+  );
+}
+
+/**
+ * Checks whether a value is a {@link DeferredValue} produced by
+ * {@link deferredValue}.
+ *
+ * Useful for tests, generic result walkers, and debugging code that only has an
+ * `unknown` value.  In ordinary code the static type already indicates whether a
+ * field is a {@link DeferredValue}.
+ *
+ * @param value The value to check.
+ * @returns `true` if `value` is a {@link DeferredValue}.
+ * @since 1.2.0
+ */
+export function isDeferredValue(
+  value: unknown,
+): value is DeferredValue<unknown> {
+  return typeof value === "function" &&
+    (value as { readonly [deferredValueBrand]?: unknown })[
+        deferredValueBrand
+      ] === true;
+}
+
+/**
  * Options for the {@link multiple} parser.
  */
 export interface MultipleOptions {

--- a/packages/core/src/modifiers.ts
+++ b/packages/core/src/modifiers.ts
@@ -3416,6 +3416,22 @@ export interface ParserModifiers<
   ): FluentParser<M, TValue | TDefault, [TState] | undefined>;
 
   /**
+   * Defers this parser's value so the command handler resolves it.
+   *
+   * @param fallback A resolver run at handler time when no value was specified.
+   * @param options Optional {@link DeferredValueOptions}.
+   * @returns A parser whose value is a {@link DeferredValue}.
+   */
+  deferredValue(
+    fallback: () => TValue | Promise<TValue>,
+    options?: DeferredValueOptions,
+  ): FluentParser<M, DeferredValue<TValue>, [TState] | undefined>;
+  deferredValue<C>(
+    fallback: (ctx: C) => TValue | Promise<TValue>,
+    options?: DeferredValueOptions,
+  ): FluentParser<M, DeferredValue<TValue, C>, [TState] | undefined>;
+
+  /**
    * Allows this parser to match multiple times.
    *
    * @param options Optional occurrence constraints.
@@ -3506,6 +3522,16 @@ export function fluent<M extends Mode, TValue, TState>(
     nonEmpty: {
       value() {
         return nonEmpty(parser);
+      },
+      configurable: true,
+      enumerable: false,
+    },
+    deferredValue: {
+      value<C = void>(
+        fallback: (ctx: C) => TValue | Promise<TValue>,
+        options?: DeferredValueOptions,
+      ) {
+        return deferredValue(parser, fallback, options);
       },
       configurable: true,
       enumerable: false,

--- a/packages/core/src/modifiers.ts
+++ b/packages/core/src/modifiers.ts
@@ -2007,6 +2007,20 @@ export function deferredValue<M extends Mode, T, S, C = void>(
   delete descriptors.normalizeValue;
   delete descriptors.validateValue;
   delete descriptors[fluentParserMarker];
+  // The produced value is a function, so if the wrapped parser is a dependency
+  // source, mark its metadata as transformed (as map() does).  Otherwise the
+  // dependency runtime would register this wrapper's DeferredValue function as
+  // the source value, and derived parsers would validate against a function
+  // instead of the raw inner value.
+  if (descriptors.dependencyMetadata?.value != null) {
+    descriptors.dependencyMetadata = {
+      ...descriptors.dependencyMetadata,
+      value: composeDependencyMetadata(
+        descriptors.dependencyMetadata.value,
+        "map",
+      ),
+    };
+  }
   const deferredParser = Object.create(
     Object.getPrototypeOf(base),
     descriptors,

--- a/packages/core/src/modifiers.ts
+++ b/packages/core/src/modifiers.ts
@@ -3472,6 +3472,7 @@ export interface ParserModifiers<
    * @param fallback A resolver run at handler time when no value was specified.
    * @param options Optional {@link DeferredValueOptions}.
    * @returns A parser whose value is a {@link DeferredValue}.
+   * @since 1.2.0
    */
   deferredValue(
     fallback: () => TValue | Promise<TValue>,

--- a/packages/env/src/index.test.ts
+++ b/packages/env/src/index.test.ts
@@ -29,7 +29,14 @@ import {
   suggestAsync,
   suggestSync,
 } from "@optique/core/parser";
-import { map, multiple, optional, withDefault } from "@optique/core/modifiers";
+import {
+  deferredValue,
+  isDeferredValue,
+  map,
+  multiple,
+  optional,
+  withDefault,
+} from "@optique/core/modifiers";
 import {
   argument,
   command,
@@ -724,6 +731,73 @@ describe("bindEnv()", () => {
     const result = parse(parser, []);
     assert.ok(result.success);
     assert.equal(result.value, 3000);
+  });
+
+  it("preserves source-bound values through deferredValue()", () => {
+    const context = createEnvContext({
+      source: (key) => key === "APP_TOKEN" ? "env-token" : undefined,
+      prefix: "APP_",
+    });
+    const parser = object({
+      token: deferredValue(
+        bindEnv(option("--token", string()), {
+          context,
+          key: "TOKEN",
+          parser: string(),
+        }),
+        () => "fallback-token",
+      ),
+    });
+    const annotations = context.getAnnotations();
+    if (annotations instanceof Promise) {
+      throw new TypeError("Expected synchronous annotations.");
+    }
+
+    // Env value present, no CLI: the deferred value reports "specified" and
+    // resolves to the environment value, not the fallback.
+    const fromEnv = parse(parser, [], { annotations });
+    assert.ok(fromEnv.success);
+    if (fromEnv.success) {
+      assert.ok(isDeferredValue(fromEnv.value.token));
+      assert.equal(fromEnv.value.token.source, "specified");
+      assert.equal(fromEnv.value.token(), "env-token");
+    }
+
+    // CLI value wins over the environment value.
+    const fromCli = parse(parser, ["--token", "cli-token"], { annotations });
+    assert.ok(fromCli.success);
+    if (fromCli.success) {
+      assert.equal(fromCli.value.token.source, "specified");
+      assert.equal(fromCli.value.token(), "cli-token");
+    }
+  });
+
+  it("falls back through deferredValue() when no source has a value", () => {
+    const context = createEnvContext({
+      source: () => undefined,
+      prefix: "APP_",
+    });
+    const parser = object({
+      token: deferredValue(
+        bindEnv(option("--token", string()), {
+          context,
+          key: "TOKEN",
+          parser: string(),
+        }),
+        () => "fallback-token",
+      ),
+    });
+    const annotations = context.getAnnotations();
+    if (annotations instanceof Promise) {
+      throw new TypeError("Expected synchronous annotations.");
+    }
+
+    const result = parse(parser, [], { annotations });
+    assert.ok(result.success);
+    if (result.success) {
+      assert.equal(result.value.token.source, "fallback");
+      assert.equal(result.value.token(), "fallback-token");
+    }
   });
 
   it("lets seq skip env-bound positional defaults before commands", () => {


### PR DESCRIPTION
Resolves #846. Split from #836, and a sibling of the derived defaults work in #845.


Background
----------

The discussion in #836 surfaced two patterns that look alike but want different models, so it was split in two. #845 covered derived defaults: a fallback that is computed from the first parse pass and handed back as a plain value. This change covers the other half. Here the value should not be resolved during parsing at all. It belongs to handler-time execution, and often only to the one branch that actually needs it.


Why defer resolution to the handler
-----------------------------------

Some fallbacks are expensive or interactive: an API token typed at a prompt, a credential fetched over the network, a path discovered by walking the filesystem. Resolving those while parsing is too early for two reasons. It does work the command may never use, and it turns what is really a handler failure (a cancelled prompt, a network timeout) into a parser error, which is reported and recovered from differently.

`withDefault()` cannot express this because it resolves eagerly, and derived defaults cannot either because they still produce a value before the handler runs. So `deferredValue()` keeps whatever value the wrapped parser produced, but leaves the fallback unresolved until the handler calls for it. A branch that never asks never pays the cost, and the fallback's errors stay where they belong.


What the change adds, and the reasoning behind it
-------------------------------------------------

`deferredValue()` and `isDeferredValue()` live in *@optique/core* (*packages/core/src/modifiers.ts*) next to `optional()`, `withDefault()`, and `map()`. Unlike derived defaults, this needs none of the `SourceContext` machinery: it is a pure combinator, so core is its natural home rather than a separate package.

The parsed field is a function, not a scalar. That shape is deliberate. It lets the result type say what is happening (this field is a resolver, not a value), and the earlier thunk-based userland attempt in #836 showed that an explicit, inspectable representation is easier to test than “some function.” Each value carries a readonly `source` of `"specified"` or `"fallback"` so tests, logs, and diagnostics can see which branch was taken without invoking it, and a `Symbol.for()` brand backs `isDeferredValue()` for code that only holds an `unknown`.

A few smaller decisions follow the same intent:

 -  `source` is keyed on whether the wrapped parser produced a value, not on whether a CLI token was present. This is why it composes with `bindEnv()` and `bindConfig()`: a value resolved from the environment or a config file still reads as `"specified"`.
 -  The fallback runs again on every call by default, which matches the fact that the field is a function. `{ memoize: true }` reuses the first resolved value or in-flight promise, but a rejected fallback is retried rather than cached, because a failed prompt or lookup should be retryable.
 -  The call signature returns `T | Promise<T>` regardless of the wrapped parser's mode, so a synchronous parser can still pair with an asynchronous fallback such as a prompt.
 -  Usage and help are preserved exactly as `optional()` does; only the result type changes. Implementing it on top of `optional()` and `map()` is what gives that composition for free, including source bindings and deferred completion.

A `.deferredValue()` fluent method is included so the combinator matches the method-style modifier surface added in 1.2.0, rather than being the one modifier that only works as a standalone wrapper.


Documentation
-------------

The concept reference goes in *docs/concepts/modifiers.md* alongside the other modifiers, since `deferredValue()` is a core modifier rather than a package of its own. A cookbook recipe sits in *docs/cookbook.md* next to derived defaults so readers comparing the two fallback models find them together, and a runnable example lives in *examples/patterns/deferred-values.ts*. The example and the recipe both pass the resolved token to a deploy stand-in without printing it, so they do not teach logging a secret. The landing-page parser catalog gains a matching chip.


Verification
------------

Tests are co-located in *packages/core/src/modifiers.test.ts* and cover the specified and fallback branches, an explicitly produced `undefined`, values resolved during completion, error propagation for invalid specified values, the `source` property, branding, memoization with retry-on-rejection, sync and async modes, `shouldDeferCompletion` forwarding, and the fluent method. `mise check` and `mise test` pass across Deno, Node.js, and Bun, and `pnpm build` in *docs/* type-checks the new examples.
