### PR TITLE
“Did you mean?” hints for `choice()` value typos

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,10 +29,21 @@ To be released.
     while still retrying after a rejection.  A matching `.deferredValue()`
     fluent method is also available.  [[#846], [#848]]
 
+ -  Added `suggest` option to `choice()` for “Did you mean?” hints on invalid
+    values.  Set `suggest: "nearest"` to append a Levenshtein-based hint to
+    the error message, `{ maxDistance?, maxSuggestions? }` to tune the
+    thresholds, or a custom `(input, choices) => string[] | undefined`
+    function for domain-specific logic.  The default remains `"never"` for
+    backward compatibility.  A new `appendValueHint()` helper is exported
+    from the new `@optique/core/suggestion` subpath so custom value parsers
+    can reuse the same hint logic without re-implementing distance
+    calculation.  [[#849]]
+
 [#842]: https://github.com/dahlia/optique/issues/842
 [#843]: https://github.com/dahlia/optique/pull/843
 [#846]: https://github.com/dahlia/optique/issues/846
 [#848]: https://github.com/dahlia/optique/pull/848
+[#849]: https://github.com/dahlia/optique/pull/849
 
 ### @optique/derived-defaults
 

--- a/docs/concepts/valueparsers.md
+++ b/docs/concepts/valueparsers.md
@@ -654,6 +654,53 @@ const depth = choice([8, 10, 12]);
 > The `caseInsensitive` option is only available for string choices.
 > TypeScript will report an error if you try to use it with number choices.
 
+### “Did you mean?” hints
+
+*This feature is available since Optique 1.2.0.*
+
+By default, an invalid choice produces a plain error:
+
+~~~~ bash
+$ myapp --mode devo
+Error: Expected one of dev and prod, but got devo.
+~~~~
+
+Add `suggest: "nearest"` to append a hint when the input is close to a valid
+choice:
+
+~~~~ typescript twoslash
+import { choice } from "@optique/core/valueparser";
+// ---cut-before---
+const mode = choice(["dev", "prod"], { suggest: "nearest" });
+~~~~
+
+With this option, the same error becomes:
+
+~~~~ bash
+$ myapp --mode devo
+Error: Expected one of dev and prod, but got devo.
+
+Did you mean `dev`?
+~~~~
+
+The `suggest` option accepts:
+
+`"nearest"`
+:   Use Levenshtein distance with default thresholds to find the closest
+    valid choice.
+
+`{ maxDistance?, maxSuggestions? }`
+:   Same as `"nearest"` with custom limits.  `maxDistance` caps how far
+    apart two strings can be (default 3); `maxSuggestions` caps the number
+    of hints shown (default 3).
+
+`"never"` *(default)*
+:   Disable suggestions; preserve the plain error message.
+
+`(input, choices) => readonly string[] | undefined`
+:   Custom suggestion logic.  Return `undefined` or an empty array to
+    suppress the hint, or a list of strings to show as suggestions.
+
 > [!TIP]
 > You can display valid choices in help text by enabling the `showChoices`
 > option in your runner configuration.  See the

--- a/docs/concepts/valueparsers.md
+++ b/docs/concepts/valueparsers.md
@@ -680,7 +680,7 @@ With this option, the same error becomes:
 $ myapp --mode devo
 Error: Expected one of dev and prod, but got devo.
 
-Did you mean `dev`?
+Did you mean "dev"?
 ~~~~
 
 The `suggest` option accepts:

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -1373,6 +1373,108 @@ The `passThrough()` parser supports three capture formats:
 > The `"greedy"` format can shadow explicit parsers. Place it carefully,
 > typically as the last field in a subcommand-specific `object()`.
 
+### “Did you mean?” for value typos
+
+*This feature is available since Optique 1.2.0.*
+
+When a user mistypes an option value — `--mode devo` instead of `dev` — the
+default error only lists valid choices.  The `suggest` option on `choice()`
+appends a “Did you mean?” hint using the existing Levenshtein distance
+machinery, without any extra dependencies.
+
+#### Basic usage with `suggest: "nearest"`
+
+~~~~ typescript twoslash
+import { choice } from "@optique/core/valueparser";
+// ---cut-before---
+const mode = choice(["dev", "staging", "prod"], { suggest: "nearest" });
+~~~~
+
+A typo now produces:
+
+~~~~ bash
+$ myapp --mode devo
+Error: Expected one of dev, staging, and prod, but got devo.
+
+Did you mean `dev`?
+~~~~
+
+#### Custom filtering with the function form
+
+The function form gives full control.  It receives the raw input and the full
+choices array, so you can apply domain-specific logic — for example, only
+suggest choices that share a prefix with the input:
+
+~~~~ typescript twoslash
+import { choice } from "@optique/core/valueparser";
+// ---cut-before---
+const env = choice(["development", "staging", "production"], {
+  suggest(input, choices) {
+    // Only suggest choices that start with the same first letter.
+    return choices.filter((c) => c[0] === input[0]);
+  },
+});
+~~~~
+
+Return `undefined` or an empty array to suppress the hint entirely.
+
+#### Custom value parsers using `appendValueHint`
+
+If you build a value parser with its own closed candidate set, you can add
+the same hint without re-implementing distance logic.  Import
+`appendValueHint` from `@optique/core/suggestion`:
+
+~~~~ typescript twoslash
+import type { ValueParser, ValueParserResult } from "@optique/core/valueparser";
+import { appendValueHint } from "@optique/core/suggestion";
+import { message } from "@optique/core/message";
+
+const PALETTE = ["crimson", "emerald", "sapphire", "amber"] as const;
+
+function paletteColor(): ValueParser<"sync", string> {
+  return {
+    mode: "sync",
+    metavar: "COLOR",
+    placeholder: "crimson",
+    parse(input: string): ValueParserResult<string> {
+      if ((PALETTE as readonly string[]).includes(input)) {
+        return { success: true, value: input };
+      }
+      const base = message`Unknown color: ${input}.`;
+      return {
+        success: false,
+        error: appendValueHint(base, input, PALETTE),
+      };
+    },
+    format(value: string): string {
+      return value;
+    },
+  };
+}
+~~~~
+
+`appendValueHint(base, input, candidates, options?)` returns `base` unchanged
+when no candidate is close enough, so there is no need for an extra
+conditional.
+
+#### When not to use suggestions
+
+Very large candidate sets can produce noisy suggestions.  If your enum has
+dozens or hundreds of entries, set tight thresholds to keep the output clean:
+
+~~~~ typescript twoslash
+import { choice } from "@optique/core/valueparser";
+// ---cut-before---
+// Only suggest when distance ≤ 1 and cap at 2 hints.
+const lang = choice(
+  ["en", "es", "fr", "de", "zh", "ja", "ko"],
+  { suggest: { maxDistance: 1, maxSuggestions: 2 } },
+);
+~~~~
+
+Or keep the default `suggest: "never"` and rely on the choices list in the
+error message instead.
+
 ### Shell completion patterns
 
 *This API is available since Optique 0.6.0.*

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -1377,7 +1377,7 @@ The `passThrough()` parser supports three capture formats:
 
 *This feature is available since Optique 1.2.0.*
 
-When a user mistypes an option value — `--mode devo` instead of `dev` — the
+When a user mistypes an option value—`--mode devo` instead of `dev`—the
 default error only lists valid choices.  The `suggest` option on `choice()`
 appends a “Did you mean?” hint using the existing Levenshtein distance
 machinery, without any extra dependencies.
@@ -1402,7 +1402,7 @@ Did you mean `dev`?
 #### Custom filtering with the function form
 
 The function form gives full control.  It receives the raw input and the full
-choices array, so you can apply domain-specific logic — for example, only
+choices array, so you can apply domain-specific logic—for example, only
 suggest choices that share a prefix with the input:
 
 ~~~~ typescript twoslash

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -1396,7 +1396,7 @@ A typo now produces:
 $ myapp --mode devo
 Error: Expected one of dev, staging, and prod, but got devo.
 
-Did you mean `dev`?
+Did you mean "dev"?
 ~~~~
 
 #### Custom filtering with the function form

--- a/packages/core/deno.json
+++ b/packages/core/deno.json
@@ -20,6 +20,7 @@
     "./parser": "./src/parser.ts",
     "./primitives": "./src/primitives.ts",
     "./program": "./src/program.ts",
+    "./suggestion": "./src/suggestion.ts",
     "./usage": "./src/usage.ts",
     "./valueparser": "./src/valueparser.ts"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -179,6 +179,14 @@
       "import": "./dist/program.js",
       "require": "./dist/program.cjs"
     },
+    "./suggestion": {
+      "types": {
+        "import": "./dist/suggestion.d.ts",
+        "require": "./dist/suggestion.d.cts"
+      },
+      "import": "./dist/suggestion.js",
+      "require": "./dist/suggestion.cjs"
+    },
     "./usage": {
       "types": {
         "import": "./dist/usage.d.ts",

--- a/packages/core/src/public-api.test.ts
+++ b/packages/core/src/public-api.test.ts
@@ -52,6 +52,7 @@ test("package manifests expose only supported public subpaths", () => {
     "./parser",
     "./primitives",
     "./program",
+    "./suggestion",
     "./usage",
     "./valueparser",
   ].sort();

--- a/packages/core/src/suggestion.test.ts
+++ b/packages/core/src/suggestion.test.ts
@@ -1051,11 +1051,11 @@ describe("appendValueHint()", () => {
   });
 
   it("should append Did you mean hint when input is close to a candidate", () => {
-    const base = message`Expected one of dev or prod, but got devo.`;
+    const base = message`Invalid environment.`;
     const result = appendValueHint(base, "devo", ["dev", "prod"]);
     const str = formatMessage(result);
     assert.ok(str.includes("Did you mean"), `Expected hint in: ${str}`);
-    assert.ok(str.includes("dev"), `Expected "dev" in: ${str}`);
+    assert.ok(str.includes("`dev`"), `Expected suggested value in: ${str}`);
   });
 
   it("should respect custom maxDistance option", () => {
@@ -1089,5 +1089,12 @@ describe("appendValueHint()", () => {
     const base = message`Error.`;
     const result = appendValueHint(base, "devo", []);
     assert.deepEqual(result, base);
+  });
+
+  it("should return only the hint when base is empty and input is close", () => {
+    const result = appendValueHint([], "devo", ["dev", "prod"]);
+    const str = formatMessage(result);
+    assert.ok(str.includes("Did you mean"), `Expected hint in: ${str}`);
+    assert.ok(!str.startsWith("\n"), `Should not start with newline: ${str}`);
   });
 });

--- a/packages/core/src/suggestion.test.ts
+++ b/packages/core/src/suggestion.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import {
+  appendValueHint,
   createErrorWithSuggestions,
   createSuggestionMessage,
   deduplicateSuggestions,
@@ -1039,5 +1040,54 @@ describe("property-based tests", () => {
       ),
       propertyParameters,
     );
+  });
+});
+
+describe("appendValueHint()", () => {
+  it("should return base message unchanged when no close candidate exists", () => {
+    const base = message`Expected one of dev or prod, but got xyz.`;
+    const result = appendValueHint(base, "xyz", ["dev", "prod"]);
+    assert.deepEqual(result, base);
+  });
+
+  it("should append Did you mean hint when input is close to a candidate", () => {
+    const base = message`Expected one of dev or prod, but got devo.`;
+    const result = appendValueHint(base, "devo", ["dev", "prod"]);
+    const str = formatMessage(result);
+    assert.ok(str.includes("Did you mean"), `Expected hint in: ${str}`);
+    assert.ok(str.includes("dev"), `Expected "dev" in: ${str}`);
+  });
+
+  it("should respect custom maxDistance option", () => {
+    const base = message`Error.`;
+    const result = appendValueHint(base, "devoxxx", ["dev", "prod"], {
+      maxDistance: 1,
+    });
+    assert.deepEqual(result, base);
+  });
+
+  it("should respect custom maxSuggestions option", () => {
+    const base = message`Error.`;
+    const candidates = ["dev", "dew", "den"];
+    const result = appendValueHint(base, "devo", candidates, {
+      maxSuggestions: 1,
+    });
+    const str = formatMessage(result);
+    assert.ok(str.includes("Did you mean"), `Expected hint in: ${str}`);
+    // Should only show one suggestion due to maxSuggestions: 1
+    const matches = str.match(/`[^`]+`/g) ?? [];
+    assert.equal(matches.length, 1);
+  });
+
+  it("should return base message for empty input", () => {
+    const base = message`Error.`;
+    const result = appendValueHint(base, "", ["dev", "prod"]);
+    assert.deepEqual(result, base);
+  });
+
+  it("should return base message for empty candidates", () => {
+    const base = message`Error.`;
+    const result = appendValueHint(base, "devo", []);
+    assert.deepEqual(result, base);
   });
 });

--- a/packages/core/src/suggestion.test.ts
+++ b/packages/core/src/suggestion.test.ts
@@ -1055,7 +1055,7 @@ describe("appendValueHint()", () => {
     const result = appendValueHint(base, "devo", ["dev", "prod"]);
     const str = formatMessage(result);
     assert.ok(str.includes("Did you mean"), `Expected hint in: ${str}`);
-    assert.ok(str.includes("`dev`"), `Expected suggested value in: ${str}`);
+    assert.ok(str.includes('"dev"'), `Expected suggested value in: ${str}`);
   });
 
   it("should respect custom maxDistance option", () => {
@@ -1075,7 +1075,7 @@ describe("appendValueHint()", () => {
     const str = formatMessage(result);
     assert.ok(str.includes("Did you mean"), `Expected hint in: ${str}`);
     // Should only show one suggestion due to maxSuggestions: 1
-    const matches = str.match(/`[^`]+`/g) ?? [];
+    const matches = str.match(/"[^"]+"/g) ?? [];
     assert.equal(matches.length, 1);
   });
 
@@ -1096,5 +1096,15 @@ describe("appendValueHint()", () => {
     const str = formatMessage(result);
     assert.ok(str.includes("Did you mean"), `Expected hint in: ${str}`);
     assert.ok(!str.startsWith("\n"), `Should not start with newline: ${str}`);
+  });
+
+  it("should safely format candidates that contain backticks", () => {
+    const result = appendValueHint([], "foo`bar", ["foo`bar"]);
+    const str = formatMessage(result);
+    assert.ok(str.includes("Did you mean"), `Expected hint in: ${str}`);
+    assert.ok(
+      !str.includes("``"),
+      `Should not produce broken backtick pair in: ${str}`,
+    );
   });
 });

--- a/packages/core/src/suggestion.test.ts
+++ b/packages/core/src/suggestion.test.ts
@@ -2,6 +2,7 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import {
   appendValueHint,
+  appendValueSuggestions,
   createErrorWithSuggestions,
   createSuggestionMessage,
   deduplicateSuggestions,
@@ -1106,5 +1107,41 @@ describe("appendValueHint()", () => {
       !str.includes("``"),
       `Should not produce broken backtick pair in: ${str}`,
     );
+  });
+});
+
+describe("appendValueSuggestions()", () => {
+  it("should return base unchanged when suggestions is empty", () => {
+    const base = message`Error.`;
+    assert.deepEqual(appendValueSuggestions(base, []), base);
+  });
+
+  it("should format a single suggestion as Did you mean X?", () => {
+    const base = message`Error.`;
+    const result = appendValueSuggestions(base, ["dev"]);
+    const str = formatMessage(result);
+    assert.ok(str.includes("Did you mean"), `Expected hint in: ${str}`);
+    assert.ok(str.includes('"dev"'), `Expected quoted value in: ${str}`);
+  });
+
+  it("should list multiple suggestions on separate lines", () => {
+    const base = message`Error.`;
+    const result = appendValueSuggestions(base, ["dev", "prod"]);
+    const str = formatMessage(result);
+    assert.ok(
+      str.includes("Did you mean one of these?"),
+      `Expected header in: ${str}`,
+    );
+    const lines = str.split("\n");
+    const devLine = lines.find((l) => l.includes('"dev"'));
+    const prodLine = lines.find((l) => l.includes('"prod"'));
+    assert.ok(devLine != null, `Expected "dev" on its own line in: ${str}`);
+    assert.ok(prodLine != null, `Expected "prod" on its own line in: ${str}`);
+  });
+
+  it("should not prepend newlines when base is empty", () => {
+    const result = appendValueSuggestions([], ["dev"]);
+    const str = formatMessage(result);
+    assert.ok(!str.startsWith("\n"), `Should not start with newline: ${str}`);
   });
 });

--- a/packages/core/src/suggestion.ts
+++ b/packages/core/src/suggestion.ts
@@ -1,5 +1,5 @@
 import type { Message, MessageTerm } from "./message.ts";
-import { lineBreak, message, optionName, text } from "./message.ts";
+import { lineBreak, message, optionName, text, value } from "./message.ts";
 import type { Suggestion } from "./parser.ts";
 import type { Usage } from "./usage.ts";
 import {
@@ -464,11 +464,26 @@ export function appendValueHint(
     input,
     candidates,
     options != null
-      ? { ...DEFAULT_FIND_SIMILAR_OPTIONS, ...options }
+      ? {
+        maxDistance: options.maxDistance ??
+          DEFAULT_FIND_SIMILAR_OPTIONS.maxDistance,
+        maxDistanceRatio: DEFAULT_FIND_SIMILAR_OPTIONS.maxDistanceRatio,
+        maxSuggestions: options.maxSuggestions ??
+          DEFAULT_FIND_SIMILAR_OPTIONS.maxSuggestions,
+      }
       : undefined,
   );
-  const suggestionMsg = createSuggestionMessage(suggestions);
-  if (suggestionMsg.length === 0) return base;
+  if (suggestions.length === 0) return base;
+  let suggestionMsg: Message;
+  if (suggestions.length === 1) {
+    suggestionMsg = message`Did you mean ${value(suggestions[0])}?`;
+  } else {
+    const parts: MessageTerm[] = [text("Did you mean one of these?")];
+    for (const suggestion of suggestions) {
+      parts.push(text("\n  "), value(suggestion));
+    }
+    suggestionMsg = parts;
+  }
   return base.length > 0
     ? [...base, lineBreak(), lineBreak(), ...suggestionMsg]
     : suggestionMsg;

--- a/packages/core/src/suggestion.ts
+++ b/packages/core/src/suggestion.ts
@@ -468,9 +468,10 @@ export function appendValueHint(
       : undefined,
   );
   const suggestionMsg = createSuggestionMessage(suggestions);
-  return suggestionMsg.length > 0
+  if (suggestionMsg.length === 0) return base;
+  return base.length > 0
     ? [...base, lineBreak(), lineBreak(), ...suggestionMsg]
-    : base;
+    : suggestionMsg;
 }
 
 /**

--- a/packages/core/src/suggestion.ts
+++ b/packages/core/src/suggestion.ts
@@ -426,14 +426,48 @@ export function createErrorWithSuggestions(
 }
 
 /**
+ * Appends a "Did you mean …?" hint to a base message from a pre-filtered list
+ * of suggestion strings.
+ *
+ * Unlike {@link appendValueHint}, this function accepts suggestions that have
+ * already been selected by the caller—it only handles formatting and
+ * appending.  Useful when the caller provides its own distance logic (e.g.,
+ * the custom-function form of `choice()`'s `suggest` option).
+ *
+ * @param base The base error message.
+ * @param suggestions The already-filtered suggestion strings to display.
+ * @returns `base` with a "Did you mean …?" line appended, or `base` unchanged
+ *   when `suggestions` is empty.
+ * @since 1.2.0
+ */
+export function appendValueSuggestions(
+  base: Message,
+  suggestions: readonly string[],
+): Message {
+  if (suggestions.length === 0) return base;
+  let suggestionMsg: Message;
+  if (suggestions.length === 1) {
+    suggestionMsg = message`Did you mean ${value(suggestions[0])}?`;
+  } else {
+    const parts: MessageTerm[] = [text("Did you mean one of these?")];
+    for (const suggestion of suggestions) {
+      parts.push(lineBreak(), text("  "), value(suggestion));
+    }
+    suggestionMsg = parts;
+  }
+  return base.length > 0
+    ? [...base, lineBreak(), lineBreak(), ...suggestionMsg]
+    : suggestionMsg;
+}
+
+/**
  * Appends a "Did you mean …?" hint to a base error message when the input
  * is close to one of the candidate values.
  *
  * This helper is meant for closed-set value parsers (e.g. `choice()`) that
  * want to surface near-match suggestions without re-implementing distance
- * logic themselves.  It wraps {@link findSimilar} and
- * {@link createSuggestionMessage} and returns the `base` message unchanged
- * when no candidates are close enough.
+ * logic themselves.  It wraps {@link findSimilar} and returns the `base`
+ * message unchanged when no candidates are close enough.
  *
  * @param base The base error message to display.
  * @param input The invalid input the user typed.
@@ -447,7 +481,7 @@ export function createErrorWithSuggestions(
  * ```typescript
  * const base = message`Invalid color: ${input}.`;
  * appendValueHint(base, input, ["red", "green", "blue"]);
- * // → "Invalid color: redd.\n\nDid you mean `red`?"
+ * // → "Invalid color: redd.\n\nDid you mean \"red\"?"
  * ```
  *
  * @since 1.2.0
@@ -473,20 +507,7 @@ export function appendValueHint(
       }
       : undefined,
   );
-  if (suggestions.length === 0) return base;
-  let suggestionMsg: Message;
-  if (suggestions.length === 1) {
-    suggestionMsg = message`Did you mean ${value(suggestions[0])}?`;
-  } else {
-    const parts: MessageTerm[] = [text("Did you mean one of these?")];
-    for (const suggestion of suggestions) {
-      parts.push(text("\n  "), value(suggestion));
-    }
-    suggestionMsg = parts;
-  }
-  return base.length > 0
-    ? [...base, lineBreak(), lineBreak(), ...suggestionMsg]
-    : suggestionMsg;
+  return appendValueSuggestions(base, suggestions);
 }
 
 /**

--- a/packages/core/src/suggestion.ts
+++ b/packages/core/src/suggestion.ts
@@ -1,5 +1,5 @@
 import type { Message, MessageTerm } from "./message.ts";
-import { message, optionName, text } from "./message.ts";
+import { lineBreak, message, optionName, text } from "./message.ts";
 import type { Suggestion } from "./parser.ts";
 import type { Usage } from "./usage.ts";
 import {
@@ -423,6 +423,54 @@ export function createErrorWithSuggestions(
   return suggestionMsg.length > 0
     ? [...baseError, text("\n\n"), ...suggestionMsg]
     : baseError;
+}
+
+/**
+ * Appends a "Did you mean …?" hint to a base error message when the input
+ * is close to one of the candidate values.
+ *
+ * This helper is meant for closed-set value parsers (e.g. `choice()`) that
+ * want to surface near-match suggestions without re-implementing distance
+ * logic themselves.  It wraps {@link findSimilar} and
+ * {@link createSuggestionMessage} and returns the `base` message unchanged
+ * when no candidates are close enough.
+ *
+ * @param base The base error message to display.
+ * @param input The invalid input the user typed.
+ * @param candidates The list of valid candidate strings to suggest from.
+ * @param options Optional thresholds; defaults to
+ *   {@link DEFAULT_FIND_SIMILAR_OPTIONS}.
+ * @returns `base` with a "Did you mean …?" line appended when a close
+ *   candidate is found, or `base` unchanged when none are found.
+ *
+ * @example
+ * ```typescript
+ * const base = message`Invalid color: ${input}.`;
+ * appendValueHint(base, input, ["red", "green", "blue"]);
+ * // → "Invalid color: redd.\n\nDid you mean `red`?"
+ * ```
+ *
+ * @since 1.2.0
+ */
+export function appendValueHint(
+  base: Message,
+  input: string,
+  candidates: readonly string[],
+  options?: Readonly<
+    Pick<FindSimilarOptions, "maxDistance" | "maxSuggestions">
+  >,
+): Message {
+  const suggestions = findSimilar(
+    input,
+    candidates,
+    options != null
+      ? { ...DEFAULT_FIND_SIMILAR_OPTIONS, ...options }
+      : undefined,
+  );
+  const suggestionMsg = createSuggestionMessage(suggestions);
+  return suggestionMsg.length > 0
+    ? [...base, lineBreak(), lineBreak(), ...suggestionMsg]
+    : base;
 }
 
 /**

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -1862,21 +1862,21 @@ describe("choice", () => {
     it("should throw TypeError for invalid suggest value like true", () => {
       assert.throws(
         () => choice(["dev", "prod"], { suggest: true as never }),
-        TypeError,
+        { name: "TypeError", message: /Expected suggest to be/i },
       );
     });
 
     it("should throw TypeError for suggest string typo like nearset", () => {
       assert.throws(
         () => choice(["dev", "prod"], { suggest: "nearset" as never }),
-        TypeError,
+        { name: "TypeError", message: /Expected suggest to be/i },
       );
     });
 
     it("should throw TypeError for suggest: 0", () => {
       assert.throws(
         () => choice(["dev", "prod"], { suggest: 0 as never }),
-        TypeError,
+        { name: "TypeError", message: /Expected suggest to be/i },
       );
     });
   });

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -1919,6 +1919,21 @@ describe("choice", () => {
         },
       );
     });
+
+    it("should snapshot suggest object so later mutations are ignored", () => {
+      const suggestObj = { maxDistance: 3 };
+      const parser = choice(["dev", "prod"], { suggest: suggestObj });
+      (suggestObj as Record<string, unknown>).maxDistance = 0;
+      const result = parser.parse("devo");
+      assert.ok(!result.success);
+      if (!result.success) {
+        const str = formatMessage(result.error);
+        assert.ok(
+          str.includes("Did you mean"),
+          `Hint should appear with original maxDistance: ${str}`,
+        );
+      }
+    });
   });
 
   describe("number choices", () => {

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -1858,6 +1858,27 @@ describe("choice", () => {
         );
       }
     });
+
+    it("should throw TypeError for invalid suggest value like true", () => {
+      assert.throws(
+        () => choice(["dev", "prod"], { suggest: true as never }),
+        TypeError,
+      );
+    });
+
+    it("should throw TypeError for suggest string typo like nearset", () => {
+      assert.throws(
+        () => choice(["dev", "prod"], { suggest: "nearset" as never }),
+        TypeError,
+      );
+    });
+
+    it("should throw TypeError for suggest: 0", () => {
+      assert.throws(
+        () => choice(["dev", "prod"], { suggest: 0 as never }),
+        TypeError,
+      );
+    });
   });
 
   describe("number choices", () => {

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -1727,6 +1727,139 @@ describe("choice", () => {
     });
   });
 
+  describe("suggest option", () => {
+    it("should parse valid choice successfully even with suggest: nearest", () => {
+      const parser = choice(["dev", "prod"], { suggest: "nearest" });
+      const result = parser.parse("dev");
+      assert.ok(result.success);
+      if (result.success) {
+        assert.equal(result.value, "dev");
+      }
+    });
+
+    it("should append Did you mean hint with suggest: nearest", () => {
+      const parser = choice(["dev", "prod"], { suggest: "nearest" });
+      const result = parser.parse("devo");
+      assert.ok(!result.success);
+      if (!result.success) {
+        const errorStr = result.error.map((t) => {
+          if (t.type === "text") return t.text;
+          if (t.type === "value") return t.value;
+          if (t.type === "optionName") return t.optionName;
+          if (t.type === "lineBreak") return "\n";
+          return "";
+        }).join("");
+        assert.ok(
+          errorStr.includes("Did you mean"),
+          `Expected "Did you mean" in error: ${errorStr}`,
+        );
+        assert.ok(
+          errorStr.includes("dev"),
+          `Expected "dev" suggestion in error: ${errorStr}`,
+        );
+      }
+    });
+
+    it("should not append hint with default (no suggest option)", () => {
+      const parser = choice(["dev", "prod"]);
+      const result = parser.parse("devo");
+      assert.ok(!result.success);
+      if (!result.success) {
+        const errorStr = result.error.map((t) => {
+          if (t.type === "text") return t.text;
+          if (t.type === "value") return t.value;
+          if (t.type === "optionName") return t.optionName;
+          if (t.type === "lineBreak") return "\n";
+          return "";
+        }).join("");
+        assert.ok(
+          !errorStr.includes("Did you mean"),
+          `Should not contain "Did you mean": ${errorStr}`,
+        );
+      }
+    });
+
+    it("should not append hint with suggest: never", () => {
+      const parser = choice(["dev", "prod"], { suggest: "never" });
+      const result = parser.parse("devo");
+      assert.ok(!result.success);
+      if (!result.success) {
+        const errorStr = result.error.map((t) => {
+          if (t.type === "text") return t.text;
+          if (t.type === "value") return t.value;
+          if (t.type === "optionName") return t.optionName;
+          if (t.type === "lineBreak") return "\n";
+          return "";
+        }).join("");
+        assert.ok(
+          !errorStr.includes("Did you mean"),
+          `Should not contain "Did you mean": ${errorStr}`,
+        );
+      }
+    });
+
+    it("should suppress hint with suggest object when distance is too large", () => {
+      const parser = choice(["dev", "prod"], { suggest: { maxDistance: 1 } });
+      const result = parser.parse("devoxxx");
+      assert.ok(!result.success);
+      if (!result.success) {
+        const errorStr = result.error.map((t) => {
+          if (t.type === "text") return t.text;
+          if (t.type === "value") return t.value;
+          if (t.type === "optionName") return t.optionName;
+          if (t.type === "lineBreak") return "\n";
+          return "";
+        }).join("");
+        assert.ok(
+          !errorStr.includes("Did you mean"),
+          `Should not contain "Did you mean" for distant input: ${errorStr}`,
+        );
+      }
+    });
+
+    it("should use custom hint list with function form", () => {
+      const parser = choice(["dev", "prod", "staging"], {
+        suggest: (_input, _choices) => ["customHint"],
+      });
+      const result = parser.parse("devo");
+      assert.ok(!result.success);
+      if (!result.success) {
+        const errorStr = result.error.map((t) => {
+          if (t.type === "text") return t.text;
+          if (t.type === "value") return t.value;
+          if (t.type === "optionName") return t.optionName;
+          if (t.type === "lineBreak") return "\n";
+          return "";
+        }).join("");
+        assert.ok(
+          errorStr.includes("customHint"),
+          `Expected "customHint" in error: ${errorStr}`,
+        );
+      }
+    });
+
+    it("should suppress hint when function form returns undefined", () => {
+      const parser = choice(["dev", "prod"], {
+        suggest: () => undefined,
+      });
+      const result = parser.parse("devo");
+      assert.ok(!result.success);
+      if (!result.success) {
+        const errorStr = result.error.map((t) => {
+          if (t.type === "text") return t.text;
+          if (t.type === "value") return t.value;
+          if (t.type === "optionName") return t.optionName;
+          if (t.type === "lineBreak") return "\n";
+          return "";
+        }).join("");
+        assert.ok(
+          !errorStr.includes("Did you mean"),
+          `Should not contain "Did you mean": ${errorStr}`,
+        );
+      }
+    });
+  });
+
   describe("number choices", () => {
     it("should parse valid number values from the choice list", () => {
       const parser = choice([8, 10, 12]);

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -1879,6 +1879,46 @@ describe("choice", () => {
         { name: "TypeError", message: /Expected suggest to be/i },
       );
     });
+
+    it("should throw TypeError for negative maxDistance", () => {
+      assert.throws(
+        () => choice(["dev", "prod"], { suggest: { maxDistance: -1 } }),
+        {
+          name: "TypeError",
+          message: /suggest\.maxDistance.*non-negative integer/i,
+        },
+      );
+    });
+
+    it("should throw TypeError for fractional maxDistance", () => {
+      assert.throws(
+        () => choice(["dev", "prod"], { suggest: { maxDistance: 1.5 } }),
+        {
+          name: "TypeError",
+          message: /suggest\.maxDistance.*non-negative integer/i,
+        },
+      );
+    });
+
+    it("should throw TypeError for zero maxSuggestions", () => {
+      assert.throws(
+        () => choice(["dev", "prod"], { suggest: { maxSuggestions: 0 } }),
+        {
+          name: "TypeError",
+          message: /suggest\.maxSuggestions.*positive integer/i,
+        },
+      );
+    });
+
+    it("should throw TypeError for fractional maxSuggestions", () => {
+      assert.throws(
+        () => choice(["dev", "prod"], { suggest: { maxSuggestions: 1.5 } }),
+        {
+          name: "TypeError",
+          message: /suggest\.maxSuggestions.*positive integer/i,
+        },
+      );
+    });
   });
 
   describe("number choices", () => {

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -680,16 +680,44 @@ export function choice<const T extends string | number>(
   if (stringSuggest !== undefined) {
     const isValidString = stringSuggest === "nearest" ||
       stringSuggest === "never";
+    const isArray = Array.isArray(stringSuggest);
     const isValidObject = typeof stringSuggest === "object" &&
-      stringSuggest !== null;
+      stringSuggest !== null && !isArray;
     const isValidFunction = typeof stringSuggest === "function";
     if (!isValidString && !isValidObject && !isValidFunction) {
+      const actualType = isArray
+        ? "array"
+        : stringSuggest === null
+        ? "null"
+        : typeof stringSuggest;
       throw new TypeError(
         `Expected suggest to be "nearest", "never", an object, or a ` +
-          `function, but got ${typeof stringSuggest}: ${
-            String(stringSuggest)
-          }.`,
+          `function, but got ${actualType}: ${String(stringSuggest)}.`,
       );
+    }
+    if (isValidObject) {
+      const obj = stringSuggest as Readonly<
+        Pick<FindSimilarOptions, "maxDistance" | "maxSuggestions">
+      >;
+      if (
+        obj.maxDistance !== undefined &&
+        (typeof obj.maxDistance !== "number" || !isFinite(obj.maxDistance))
+      ) {
+        throw new TypeError(
+          `Expected suggest.maxDistance to be a finite number, but got ` +
+            `${typeof obj.maxDistance}: ${String(obj.maxDistance)}.`,
+        );
+      }
+      if (
+        obj.maxSuggestions !== undefined &&
+        (typeof obj.maxSuggestions !== "number" ||
+          !isFinite(obj.maxSuggestions))
+      ) {
+        throw new TypeError(
+          `Expected suggest.maxSuggestions to be a finite number, but got ` +
+            `${typeof obj.maxSuggestions}: ${String(obj.maxSuggestions)}.`,
+        );
+      }
     }
   }
   return {
@@ -868,7 +896,7 @@ function formatStringChoiceError(
 
   if (typeof suggest === "function") {
     const hints = suggest(input, choices);
-    if (!hints || hints.length === 0) return base;
+    if (!Array.isArray(hints) || hints.length === 0) return base;
     const suggestionMsg = createSuggestionMessage(hints);
     return suggestionMsg.length > 0
       ? [...base, lineBreak(), lineBreak(), ...suggestionMsg]

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -6,6 +6,7 @@ import {
   type MessageTerm,
   metavar as metavarTerm,
   text,
+  value as valueTerm,
   valueSet,
 } from "./message.ts";
 import { isDerivedValueParser } from "./internal/dependency.ts";
@@ -13,7 +14,6 @@ import { ensureNonEmptyString, type NonEmptyString } from "./nonempty.ts";
 import type { Mode, ModeIterable, ModeValue, Suggestion } from "./parser.ts";
 import {
   appendValueHint,
-  createSuggestionMessage,
   deduplicateSuggestions,
   type FindSimilarOptions,
 } from "./suggestion.ts";
@@ -701,21 +701,24 @@ export function choice<const T extends string | number>(
       >;
       if (
         obj.maxDistance !== undefined &&
-        (typeof obj.maxDistance !== "number" || !isFinite(obj.maxDistance))
+        (typeof obj.maxDistance !== "number" ||
+          !Number.isInteger(obj.maxDistance) ||
+          obj.maxDistance < 0)
       ) {
         throw new TypeError(
-          `Expected suggest.maxDistance to be a finite number, but got ` +
-            `${typeof obj.maxDistance}: ${String(obj.maxDistance)}.`,
+          `Expected suggest.maxDistance to be a non-negative integer, but ` +
+            `got ${typeof obj.maxDistance}: ${String(obj.maxDistance)}.`,
         );
       }
       if (
         obj.maxSuggestions !== undefined &&
         (typeof obj.maxSuggestions !== "number" ||
-          !isFinite(obj.maxSuggestions))
+          !Number.isInteger(obj.maxSuggestions) ||
+          obj.maxSuggestions < 1)
       ) {
         throw new TypeError(
-          `Expected suggest.maxSuggestions to be a finite number, but got ` +
-            `${typeof obj.maxSuggestions}: ${String(obj.maxSuggestions)}.`,
+          `Expected suggest.maxSuggestions to be a positive integer, but ` +
+            `got ${typeof obj.maxSuggestions}: ${String(obj.maxSuggestions)}.`,
         );
       }
     }
@@ -897,10 +900,17 @@ function formatStringChoiceError(
   if (typeof suggest === "function") {
     const hints = suggest(input, choices);
     if (!Array.isArray(hints) || hints.length === 0) return base;
-    const suggestionMsg = createSuggestionMessage(hints);
-    return suggestionMsg.length > 0
-      ? [...base, lineBreak(), lineBreak(), ...suggestionMsg]
-      : base;
+    let suggestionMsg: Message;
+    if (hints.length === 1) {
+      suggestionMsg = message`Did you mean ${valueTerm(hints[0])}?`;
+    } else {
+      const parts: MessageTerm[] = [text("Did you mean one of these?")];
+      for (const hint of hints) {
+        parts.push(text("\n  "), valueTerm(hint));
+      }
+      suggestionMsg = parts;
+    }
+    return [...base, lineBreak(), lineBreak(), ...suggestionMsg];
   }
 
   // Object form: { maxDistance?, maxSuggestions? }

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -11,7 +11,12 @@ import {
 import { isDerivedValueParser } from "./internal/dependency.ts";
 import { ensureNonEmptyString, type NonEmptyString } from "./nonempty.ts";
 import type { Mode, ModeIterable, ModeValue, Suggestion } from "./parser.ts";
-import { deduplicateSuggestions } from "./suggestion.ts";
+import {
+  appendValueHint,
+  createSuggestionMessage,
+  deduplicateSuggestions,
+  type FindSimilarOptions,
+} from "./suggestion.ts";
 
 export {
   ensureNonEmptyString,
@@ -293,6 +298,33 @@ export interface ChoiceOptionsBase {
    * @default `"TYPE"`
    */
   readonly metavar?: NonEmptyString;
+
+  /**
+   * Controls whether the error message for an invalid value includes a
+   * "Did you mean …?" hint based on Levenshtein distance.
+   *
+   * - `"nearest"`: append a hint with the closest valid choice(s) using
+   *   default distance thresholds.  Recommended for small-to-medium
+   *   enumeration sets.
+   * - `{ maxDistance?, maxSuggestions? }`: same as `"nearest"` but with
+   *   custom thresholds.
+   * - `"never"`: disable hints; emit the plain "not one of" error message
+   *   unchanged.
+   * - A function `(input, choices) => readonly string[] | undefined`:
+   *   custom suggestion logic.  Return `undefined` to suppress the hint,
+   *   or a non-empty array of strings to display as suggestions.
+   *
+   * @default `"never"` (backward-compatible: no hint is appended)
+   * @since 1.2.0
+   */
+  readonly suggest?:
+    | "nearest"
+    | "never"
+    | Readonly<Pick<FindSimilarOptions, "maxDistance" | "maxSuggestions">>
+    | ((
+      input: string,
+      choices: readonly string[],
+    ) => readonly string[] | undefined);
 }
 
 /**
@@ -644,6 +676,7 @@ export function choice<const T extends string | number>(
     }
   }
   const stringInvalidChoice = stringOptions.errors?.invalidChoice;
+  const stringSuggest = stringOptions.suggest;
   return {
     mode: "sync",
     metavar,
@@ -659,6 +692,7 @@ export function choice<const T extends string | number>(
             input,
             stringChoices,
             stringInvalidChoice,
+            stringSuggest,
           ),
         };
       }
@@ -803,13 +837,31 @@ function formatStringChoiceError(
     | Message
     | ((input: string, choices: readonly string[]) => Message)
     | undefined,
+  suggest: ChoiceOptionsBase["suggest"],
 ): Message {
-  if (invalidChoice) {
-    return typeof invalidChoice === "function"
+  const base = invalidChoice
+    ? (typeof invalidChoice === "function"
       ? invalidChoice(input, choices)
-      : invalidChoice;
+      : invalidChoice)
+    : formatDefaultChoiceError(input, choices);
+
+  if (suggest == null || suggest === "never") return base;
+
+  if (suggest === "nearest") {
+    return appendValueHint(base, input, choices);
   }
-  return formatDefaultChoiceError(input, choices);
+
+  if (typeof suggest === "function") {
+    const hints = suggest(input, choices);
+    if (!hints || hints.length === 0) return base;
+    const suggestionMsg = createSuggestionMessage(hints);
+    return suggestionMsg.length > 0
+      ? [...base, lineBreak(), lineBreak(), ...suggestionMsg]
+      : base;
+  }
+
+  // Object form: { maxDistance?, maxSuggestions? }
+  return appendValueHint(base, input, choices, suggest);
 }
 
 /**

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -298,6 +298,21 @@ export interface ChoiceOptionsBase {
    * @default `"TYPE"`
    */
   readonly metavar?: NonEmptyString;
+}
+
+/**
+ * Options for creating a {@link choice} parser with string values.
+ * @since 0.9.0
+ */
+export interface ChoiceOptionsString extends ChoiceOptionsBase {
+  /**
+   * If `true`, the parser will perform case-insensitive matching
+   * against the enumerated values. This means that input like "value",
+   * "Value", or "VALUE" will all match the same enumerated value.
+   * If `false`, the matching will be case-sensitive.
+   * @default `false`
+   */
+  readonly caseInsensitive?: boolean;
 
   /**
    * Controls whether the error message for an invalid value includes a
@@ -325,21 +340,6 @@ export interface ChoiceOptionsBase {
       input: string,
       choices: readonly string[],
     ) => readonly string[] | undefined);
-}
-
-/**
- * Options for creating a {@link choice} parser with string values.
- * @since 0.9.0
- */
-export interface ChoiceOptionsString extends ChoiceOptionsBase {
-  /**
-   * If `true`, the parser will perform case-insensitive matching
-   * against the enumerated values. This means that input like "value",
-   * "Value", or "VALUE" will all match the same enumerated value.
-   * If `false`, the matching will be case-sensitive.
-   * @default `false`
-   */
-  readonly caseInsensitive?: boolean;
 
   /**
    * Custom error messages for choice parsing failures.
@@ -837,7 +837,7 @@ function formatStringChoiceError(
     | Message
     | ((input: string, choices: readonly string[]) => Message)
     | undefined,
-  suggest: ChoiceOptionsBase["suggest"],
+  suggest: ChoiceOptionsString["suggest"],
 ): Message {
   const base = invalidChoice
     ? (typeof invalidChoice === "function"

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -677,6 +677,21 @@ export function choice<const T extends string | number>(
   }
   const stringInvalidChoice = stringOptions.errors?.invalidChoice;
   const stringSuggest = stringOptions.suggest;
+  if (stringSuggest !== undefined) {
+    const isValidString = stringSuggest === "nearest" ||
+      stringSuggest === "never";
+    const isValidObject = typeof stringSuggest === "object" &&
+      stringSuggest !== null;
+    const isValidFunction = typeof stringSuggest === "function";
+    if (!isValidString && !isValidObject && !isValidFunction) {
+      throw new TypeError(
+        `Expected suggest to be "nearest", "never", an object, or a ` +
+          `function, but got ${typeof stringSuggest}: ${
+            String(stringSuggest)
+          }.`,
+      );
+    }
+  }
   return {
     mode: "sync",
     metavar,

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -723,6 +723,13 @@ export function choice<const T extends string | number>(
       }
     }
   }
+  const snapshotSuggest =
+    typeof stringSuggest === "object" && stringSuggest !== null
+      ? {
+        maxDistance: stringSuggest.maxDistance,
+        maxSuggestions: stringSuggest.maxSuggestions,
+      }
+      : stringSuggest;
   return {
     mode: "sync",
     metavar,
@@ -738,7 +745,7 @@ export function choice<const T extends string | number>(
             input,
             stringChoices,
             stringInvalidChoice,
-            stringSuggest,
+            snapshotSuggest,
           ),
         };
       }

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -6,7 +6,6 @@ import {
   type MessageTerm,
   metavar as metavarTerm,
   text,
-  value as valueTerm,
   valueSet,
 } from "./message.ts";
 import { isDerivedValueParser } from "./internal/dependency.ts";
@@ -14,6 +13,7 @@ import { ensureNonEmptyString, type NonEmptyString } from "./nonempty.ts";
 import type { Mode, ModeIterable, ModeValue, Suggestion } from "./parser.ts";
 import {
   appendValueHint,
+  appendValueSuggestions,
   deduplicateSuggestions,
   type FindSimilarOptions,
 } from "./suggestion.ts";
@@ -899,18 +899,8 @@ function formatStringChoiceError(
 
   if (typeof suggest === "function") {
     const hints = suggest(input, choices);
-    if (!Array.isArray(hints) || hints.length === 0) return base;
-    let suggestionMsg: Message;
-    if (hints.length === 1) {
-      suggestionMsg = message`Did you mean ${valueTerm(hints[0])}?`;
-    } else {
-      const parts: MessageTerm[] = [text("Did you mean one of these?")];
-      for (const hint of hints) {
-        parts.push(text("\n  "), valueTerm(hint));
-      }
-      suggestionMsg = parts;
-    }
-    return [...base, lineBreak(), lineBreak(), ...suggestionMsg];
+    if (!Array.isArray(hints)) return base;
+    return appendValueSuggestions(base, hints);
   }
 
   // Object form: { maxDistance?, maxSuggestions? }


### PR DESCRIPTION
Summary
-------

 -  `choice()` gains a `suggest` option that appends a “Did you mean?” hint when the input is close to a valid choice.
 -  A new `appendValueHint()` helper, exported from `@optique/core/suggestion`, lets custom value parsers add the same hint without reimplementing distance logic.
 -  The default is `"never"`, so existing error messages are unchanged.


Motivation
----------

When a user mistypes an option name, Optique already offers a “Did you mean?” hint. The same machinery was already public, but it was never wired into value-level errors. A `--mode devo` typo got the same dry “not one of: dev, prod” message it would have gotten without the library, even though `dev` is one edit away.

The `suggest` option closes that gap. It's opt-in for backward compatibility and supports four forms: the built-in nearest-match heuristic with default or custom thresholds, and a function for domain-specific logic.


Test plan
---------

 -  [ ] `mise test` passes (Deno, Node.js, Bun)
 -  [ ] `suggest: "nearest"` appends a hint for near-miss inputs
 -  [ ] Default (`suggest` omitted or `"never"`) produces the same error as before
 -  [ ] Invalid `suggest` values (e.g. `true`, `"nearset"`) throw `TypeError` at construction
 -  [ ] `appendValueHint()` returns the base message unchanged when no candidate is close enough
 -  [ ] Docs build passes (`pnpm build` in *docs/*)
