### PR TITLE
Lifecycle hooks for `runProgram()`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -61,6 +61,19 @@ To be released.
 
 ### @optique/discover
 
+ -  Added lifecycle hooks to `runProgram()` for cross-cutting around-handler
+    behavior such as log scopes, tracing spans, lazy resource setup, and
+    failure reporting.  The new `hooks` option takes `beforeEach`, `afterEach`,
+    and `onError` callbacks; `beforeEach` returns a `ProgramHookContext` whose
+    `resource` is threaded forward to the handler's new second argument and to
+    `afterEach`/`onError`.  Hooks may be synchronous or asynchronous, and
+    `onError` observes failures without swallowing them, so `runProgram()`
+    re-throws the original error and process exit codes are unchanged.
+    `defineCommand()` gains a matching per-command `hooks` field that nests
+    inside the program-level hooks (`program.beforeEach` →
+    `command.beforeEach` → handler, unwinding in reverse).  The new
+    `ProgramHooks` and `ProgramHookContext` types are exported.  [[#851]]
+
  -  Added `commandsFromModules()` for bundler-friendly command discovery from
     static module maps such as eager `import.meta.glob()` results.  The helper
     derives command paths with the same extension, entry-file, duplicate-path,
@@ -86,6 +99,7 @@ To be released.
 [#839]: https://github.com/dahlia/optique/pull/839
 [#840]: https://github.com/dahlia/optique/pull/840
 [#841]: https://github.com/dahlia/optique/pull/841
+[#851]: https://github.com/dahlia/optique/pull/851
 
 ### @optique/prompt
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -9,6 +9,7 @@ import {
   groupIconVitePlugin,
 } from "vitepress-plugin-group-icons";
 import llmstxt from "vitepress-plugin-llms";
+import { withMermaid } from "vitepress-plugin-mermaid";
 
 let extraNav: { text: string; link: string }[] = [];
 if (process.env.EXTRA_NAV_TEXT && process.env.EXTRA_NAV_LINK) {
@@ -120,7 +121,7 @@ const TOP_NAV = [
 ];
 
 // https://vitepress.dev/reference/site-config
-export default defineConfig({
+export default withMermaid(defineConfig({
   title: "Optique",
   description: "Type-safe combinatorial CLI parser for TypeScript",
   themeConfig: {
@@ -266,4 +267,4 @@ export default defineConfig({
       ],
     ];
   },
-});
+}));

--- a/docs/concepts/discover.md
+++ b/docs/concepts/discover.md
@@ -296,6 +296,74 @@ Prefer `commandsFromModules()` when you want to keep deriving paths from a
 command directory layout.
 
 
+Lifecycle hooks
+---------------
+
+*This API is available since Optique 1.2.0.*
+
+`runProgram()` normally dispatches straight to the matched command's handler.
+A `hooks` option wraps every handler with `beforeEach`, `afterEach`, and
+`onError`, so cross-cutting concerns such as log scopes, tracing spans, lazy
+resource setup, and failure reporting can live in one place instead of inside
+every command.  Hooks are opt-in: a `runProgram()` call without them behaves
+exactly as before.
+
+~~~~ typescript twoslash
+import { runProgram } from "@optique/discover";
+
+await runProgram({
+  dir: new URL("./commands/", import.meta.url),
+  metadata: { name: "admin", version: "1.0.0" },
+  hooks: {
+    beforeEach({ path }) {
+      const label = path.length > 0 ? path.join(" ") : "admin";
+      return { resource: { label, startedAt: Date.now() } };
+    },
+    afterEach(context) {
+      const { label, startedAt } = context.resource as {
+        label: string;
+        startedAt: number;
+      };
+      console.log(`${label} finished in ${Date.now() - startedAt}ms.`);
+    },
+    onError(_context, error) {
+      console.error("Handler failed:", error);
+    },
+  },
+});
+~~~~
+
+`beforeEach` receives the invocation: the matched command, its resolved command
+`path` (always populated, even when a discovered command omits an explicit
+`path`), the parsed value, and the handler.  It returns a context object whose
+`resource` is threaded forward to the handler's second parameter and to
+`afterEach`/`onError`, so handlers and later hooks reach the resource without
+global state.  Each hook may be synchronous or return a promise; `runProgram()`
+awaits it.
+
+Hooks can also be attached to a single command through
+`defineCommand({ hooks })` for a per-command preflight.  Command-level hooks
+nest inside the program-level ones, and teardown unwinds in reverse:
+
+~~~~ mermaid
+flowchart TB
+  pb["program.beforeEach"] --> cb["command.beforeEach"] --> h["handler"]
+  h -- success --> ca["command.afterEach"] --> pa["program.afterEach"]
+  h -- failure --> ce["command.onError"] --> pe["program.onError"]
+~~~~
+
+A *parse error*, such as a missing option or an invalid value, is handled by
+*@optique/run*'s error display before any handler or hook runs; `beforeEach`
+does not fire for it.  A *handler error*, anything the handler, `beforeEach`, or
+`afterEach` throws or rejects, is passed to `onError`.  `onError` observes and
+cleans up but does not swallow the error: `runProgram()` re-throws it afterward,
+so process exit codes are unchanged.
+
+For a worked example with LogTape scopes and tracing spans, plus a per-command
+preflight, see the [program-level lifecycle hooks
+recipe](../cookbook.md#program-level-lifecycle-hooks) in the cookbook.
+
+
 File names and extensions
 -------------------------
 

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -2263,6 +2263,161 @@ The repository also includes a runnable version of this pattern in
 `examples/patterns/command-discovery.ts`.  For the full API details, see
 [command discovery](./concepts/discover.md).
 
+### Program-level lifecycle hooks
+
+*This API is available since Optique 1.2.0.*
+
+`runProgram()` dispatches straight to the matched command's handler.  When a
+whole family of commands needs the same *around-handler* behavior — opening a
+log scope, starting a tracing span, lazily booting a resource, printing a
+“finished in *X*ms” line, reporting failures — that logic should not be copied
+into every handler or smuggled into a parser.  Pass a `hooks` object to
+`runProgram()` instead.  Hooks are opt-in: a `runProgram()` call without them
+behaves exactly as before.
+
+The `beforeEach` hook runs before each handler and returns a
+`ProgramHookContext`.  It receives the invocation, including the resolved
+command `path` (populated even when a discovered command omits an explicit
+`path`).  Whatever it stores in `resource` is threaded forward to `afterEach`,
+to `onError`, and to the handler's second parameter, so the resource never has
+to live in a module-level variable:
+
+~~~~ typescript twoslash
+import { getLogger } from "@logtape/logtape";
+import { runProgram } from "@optique/discover";
+
+// A minimal tracing span, standing in for an OpenTelemetry or Sentry span.
+interface Span {
+  end(): void;
+  recordException(error: unknown): void;
+}
+declare function startSpan(name: string): Span;
+
+interface Telemetry {
+  readonly logger: ReturnType<typeof getLogger>;
+  readonly span: Span;
+}
+// ---cut-before---
+await runProgram({
+  dir: new URL("./commands/", import.meta.url),
+  metadata: { name: "tasks", version: "1.0.0" },
+  hooks: {
+    beforeEach({ path }) {
+      const name = path.length > 0 ? path.join(" ") : "tasks";
+      const logger = getLogger(["tasks", name]);
+      logger.info("Command started.");
+      const resource: Telemetry = { logger, span: startSpan(name) };
+      return { resource };
+    },
+    afterEach(context) {
+      const { logger, span } = context.resource as Telemetry;
+      logger.info("Command finished.");
+      span.end();
+    },
+    onError(context, error) {
+      const { logger, span } = context.resource as Telemetry;
+      logger.error("Command failed.", { error });
+      span.recordException(error);
+      span.end();
+    },
+  },
+});
+~~~~
+
+A handler reads the resource through its second parameter.  Existing
+single-argument handlers keep working unchanged; only the ones that need the
+resource declare it:
+
+~~~~ typescript twoslash
+import { getLogger } from "@logtape/logtape";
+import { object } from "@optique/core/constructs";
+import { message } from "@optique/core/message";
+import { withDefault } from "@optique/core/modifiers";
+import { option } from "@optique/core/primitives";
+import { string } from "@optique/core/valueparser";
+import { defineCommand } from "@optique/discover/command";
+
+interface Telemetry {
+  readonly logger: ReturnType<typeof getLogger>;
+}
+// ---cut-before---
+export default defineCommand({
+  parser: object({
+    target: withDefault(option("--target", string()), "app"),
+  }),
+  metadata: { brief: message`Build the project.` },
+  handler(value, context) {
+    const { logger } = context?.resource as Telemetry;
+    logger.info("Building {target}.", { target: value.target });
+  },
+});
+~~~~
+
+#### Per-command preflight
+
+When only one command needs its own setup — for example, a `deploy` command that
+always refreshes an auth token — put the hooks on the command definition instead
+of the program.  Command-level hooks nest inside the program-level ones, so the
+program hook still wraps every command:
+
+~~~~ typescript twoslash
+import { object } from "@optique/core/constructs";
+import { message } from "@optique/core/message";
+import { option } from "@optique/core/primitives";
+import { choice } from "@optique/core/valueparser";
+import { defineCommand } from "@optique/discover/command";
+
+interface TokenRefresher {
+  release(): void;
+}
+declare function refreshAuthToken(): TokenRefresher;
+// ---cut-before---
+export default defineCommand({
+  parser: object({
+    environment: option("--env", choice(["staging", "production"])),
+  }),
+  metadata: { brief: message`Deploy the project.` },
+  hooks: {
+    beforeEach() {
+      return { resource: refreshAuthToken() };
+    },
+    afterEach(context) {
+      (context.resource as TokenRefresher).release();
+    },
+  },
+  handler(value) {
+    console.log(`Deploying to ${value.environment}.`);
+  },
+});
+~~~~
+
+Because this command defines its own `beforeEach`, its handler receives the
+command-level resource; a command without command-level hooks receives the
+program-level one.  The execution order when both levels are present is:
+
+~~~~ mermaid
+flowchart TB
+  pb["program.beforeEach"] --> cb["command.beforeEach"] --> h["handler"]
+  h -- success --> ca["command.afterEach"] --> pa["program.afterEach"]
+  h -- failure --> ce["command.onError"] --> pe["program.onError"]
+~~~~
+
+#### Parser errors versus handler errors
+
+Hooks wrap the *handler*, not the parser.  A *parser error* — a missing option
+or a bad value — is detected before any handler runs and is printed by
+*@optique/run*'s error display; `beforeEach` never fires for it.  A *handler
+error* — anything the handler, `beforeEach`, or `afterEach` throws or rejects —
+is passed to `onError`.  `onError` is for observation and cleanup only:
+`runProgram()` re-throws the original error after it resolves, so the process
+still exits with the same non-zero code it would without hooks.  Command-level
+hooks run before program-level hooks on the way out, so the most specific
+cleanup happens first.
+
+The repository includes a runnable version of this pattern in
+`examples/patterns/program-hooks.ts`.  For the hook contract and ordering, see
+[lifecycle hooks](./concepts/discover.md#lifecycle-hooks).
+
 
 Integration patterns
 --------------------

--- a/docs/package.json
+++ b/docs/package.json
@@ -22,11 +22,13 @@
     "arktype": "^2.1.29",
     "markdown-it-deflist": "^3.0.0",
     "markdown-it-footnote": "^4.0.0",
+    "mermaid": "^11.16.0",
     "typescript": "catalog:",
     "valibot": "catalog:",
     "vitepress": "^2.0.0-alpha.17",
     "vitepress-plugin-group-icons": "^1.6.3",
     "vitepress-plugin-llms": "^1.7.3",
+    "vitepress-plugin-mermaid": "^2.0.17",
     "zod": "catalog:"
   },
   "scripts": {

--- a/examples/patterns/program-hooks.ts
+++ b/examples/patterns/program-hooks.ts
@@ -1,0 +1,117 @@
+import { object } from "@optique/core/constructs";
+import { message, text } from "@optique/core/message";
+import { withDefault } from "@optique/core/modifiers";
+import { option } from "@optique/core/primitives";
+import { choice, string } from "@optique/core/valueparser";
+import { defineCommand, runProgram } from "@optique/discover";
+import { print } from "@optique/run";
+import process from "node:process";
+
+// This example shows how runProgram()'s lifecycle hooks let cross-cutting
+// concerns — timing, structured logging, resource setup, error reporting —
+// live in one place instead of being copied into every command handler.
+//
+// Usage:
+//   deno run -A examples/patterns/program-hooks.ts build --target web
+//   deno run -A examples/patterns/program-hooks.ts deploy --env staging
+//   deno run -A examples/patterns/program-hooks.ts deploy --env production
+
+// A tiny stand-in for a real log scope, tracing span, or pooled resource.
+// A beforeEach hook opens one and returns it as the hook context's resource;
+// the matching afterEach and onError hooks receive the same object, and the
+// command handler reads it through its second parameter.
+interface Scope {
+  readonly label: string;
+  readonly startedAt: number;
+  log(line: string): void;
+}
+
+function openScope(label: string): Scope {
+  print(message`▶ ${text(label)} started.`);
+  return {
+    label,
+    startedAt: Date.now(),
+    log(line: string) {
+      print(message`  ${text(label)}: ${text(line)}`);
+    },
+  };
+}
+
+const build = defineCommand({
+  path: ["build"],
+  parser: object({
+    target: withDefault(
+      option("--target", string({ metavar: "TARGET" })),
+      "app",
+    ),
+  }),
+  metadata: { brief: message`Build the project.` },
+  // build has no command-level hooks, so its handler receives the program-level
+  // scope opened by the program beforeEach below.
+  handler(value, context) {
+    const scope = context?.resource as Scope;
+    scope.log(`compiling ${value.target}`);
+  },
+});
+
+const deploy = defineCommand({
+  path: ["deploy"],
+  parser: object({
+    environment: option("--env", choice(["staging", "production"] as const)),
+    dryRun: option("--dry-run"),
+  }),
+  metadata: { brief: message`Deploy the project.` },
+  // A per-command preflight that lives with the command, not in the program
+  // hook: deploy always refreshes its auth token before running.  Because this
+  // command defines its own beforeEach, the handler receives this command-level
+  // scope instead of the program-level one.
+  hooks: {
+    beforeEach({ value }) {
+      const { environment } = value as { environment: string };
+      const scope = openScope(`deploy:${environment}`);
+      scope.log("refreshed auth token");
+      return { resource: scope };
+    },
+    afterEach(context) {
+      const scope = context.resource as Scope;
+      scope.log("released auth token");
+    },
+  },
+  handler(value, context) {
+    const scope = context?.resource as Scope;
+    const action = value.dryRun ? "planning" : "deploying";
+    scope.log(`${action} ${value.environment}`);
+  },
+});
+
+await runProgram({
+  commands: [build, deploy],
+  metadata: {
+    name: "tasks",
+    version: "1.0.0",
+    brief: message`Project task runner with lifecycle hooks.`,
+  },
+  args: process.argv.slice(2),
+  // Program-level hooks wrap every command.  beforeEach opens a scope keyed by
+  // the command path and threads it forward; afterEach reports the elapsed time
+  // on success; onError reports failures without swallowing them (runProgram
+  // re-throws so the process still exits non-zero).
+  hooks: {
+    beforeEach({ path }) {
+      const label = path.length > 0 ? path.join(" ") : "tasks";
+      return { resource: openScope(label) };
+    },
+    afterEach(context) {
+      const scope = context.resource as Scope;
+      print(
+        message`✔ ${text(scope.label)} finished in ${
+          text(`${Date.now() - scope.startedAt}ms`)
+        }.`,
+      );
+    },
+    onError(context, error) {
+      const scope = context.resource as Scope;
+      print(message`✘ ${text(scope.label)} failed: ${text(String(error))}`);
+    },
+  },
+});

--- a/examples/patterns/program-hooks.ts
+++ b/examples/patterns/program-hooks.ts
@@ -72,9 +72,16 @@ const deploy = defineCommand({
       scope.log("refreshed auth token");
       return { resource: scope };
     },
+    // Release the token on both the success and failure paths, the same way a
+    // try/finally would: afterEach runs after a successful handler, onError
+    // after a failing one.
     afterEach(context) {
       const scope = context.resource as Scope;
       scope.log("released auth token");
+    },
+    onError(context) {
+      const scope = context.resource as Scope | undefined;
+      scope?.log("released auth token");
     },
   },
   handler(value, context) {
@@ -110,8 +117,11 @@ await runProgram({
       );
     },
     onError(context, error) {
-      const scope = context.resource as Scope;
-      print(message`✘ ${text(scope.label)} failed: ${text(String(error))}`);
+      // beforeEach may have failed before opening a scope, so the resource can
+      // be absent here.
+      const scope = context.resource as Scope | undefined;
+      const label = scope?.label ?? "tasks";
+      print(message`✘ ${text(label)} failed: ${text(String(error))}`);
     },
   },
 });

--- a/packages/discover/src/command.ts
+++ b/packages/discover/src/command.ts
@@ -24,6 +24,139 @@ export type CommandMetadata = CommandOptions;
 export type CommandPath = readonly string[];
 
 /**
+ * Resource bundle threaded through {@link ProgramHooks} for a single command
+ * run.
+ *
+ * A {@link ProgramHooks.beforeEach} hook returns this object; the dispatcher
+ * forwards it to the command handler's second parameter and to the matching
+ * {@link ProgramHooks.afterEach} and {@link ProgramHooks.onError} hooks.  This
+ * threads handler-time resources without global state.
+ *
+ * @since 1.2.0
+ */
+export interface ProgramHookContext {
+  /**
+   * Caller-defined resource.  Common shapes include a database pool, a logger
+   * scope, or a tracing span.
+   */
+  readonly resource?: unknown;
+}
+
+/**
+ * The parsed command selected by a discovered command parser.
+ *
+ * Most applications receive this only indirectly through `runProgram()`, which
+ * calls the handler automatically.
+ *
+ * @since 1.1.0
+ */
+export interface ProgramInvocation {
+  /**
+   * The command definition that matched the input.
+   */
+  readonly command: AnyCommand;
+
+  /**
+   * The resolved command path that matched the input.
+   *
+   * Unlike {@link CommandDefinition.path}, this is always populated: for
+   * file-based discovery it is the path derived from the module's location even
+   * when the command definition omits an explicit `path`.  The root command
+   * uses an empty array.  Lifecycle hooks can use this to identify which
+   * command is running.
+   */
+  readonly path: CommandPath;
+
+  /**
+   * Parsed value produced by the command parser.
+   */
+  readonly value: unknown;
+
+  /**
+   * Handler to call with {@link ProgramInvocation.value} and, when a
+   * {@link ProgramHooks} `beforeEach` produced one, a {@link ProgramHookContext}.
+   *
+   * The context is optional: `runProgram()` supplies it only when a program-level
+   * or command-level `beforeEach` ran, and callers that dispatch invocations
+   * directly can keep passing only the value.
+   */
+  readonly handler: (
+    value: unknown,
+    context?: ProgramHookContext,
+  ) => void | Promise<void>;
+}
+
+/**
+ * Lifecycle hooks invoked around a command handler.
+ *
+ * Hooks let cross-cutting concerns — log scopes, tracing spans, lazy resource
+ * setup, structured timing, error reporting — live in a single place instead
+ * of being duplicated inside every command handler.  Pass them to
+ * `runProgram({ hooks })` to wrap every command, or to
+ * {@link CommandDefinition.hooks} to wrap a single command.
+ *
+ * When both program-level and command-level hooks are present, they nest:
+ *
+ * ```
+ * program.beforeEach → command.beforeEach → handler
+ *                                             ↓
+ * program.afterEach  ← command.afterEach  ←─┘
+ * program.onError    ← command.onError    ← on failure
+ * ```
+ *
+ * @since 1.2.0
+ */
+export interface ProgramHooks {
+  /**
+   * Called before the command handler runs, receiving the matched command, its
+   * resolved {@link ProgramInvocation.path}, the parsed value, and the handler
+   * via {@link ProgramInvocation}.
+   *
+   * The returned {@link ProgramHookContext} is threaded forward as the second
+   * argument to the command handler (when this is the most specific hook scope)
+   * and to {@link afterEach} and {@link onError}.
+   *
+   * Returning a promise is supported; the dispatcher awaits it.  A rejected
+   * promise (or a thrown error) aborts the command before the handler runs and
+   * invokes {@link onError}.
+   */
+  readonly beforeEach?: (
+    invocation: ProgramInvocation,
+  ) => ProgramHookContext | Promise<ProgramHookContext>;
+
+  /**
+   * Called after the handler returns successfully, receiving the context from
+   * {@link beforeEach} (or an empty object when no `beforeEach` ran) and the
+   * handler's return value.
+   *
+   * Returning a promise is supported; the dispatcher awaits it.  If this hook
+   * throws or rejects, the dispatcher treats it as a handler failure and
+   * invokes {@link onError} with the thrown error.
+   */
+  readonly afterEach?: (
+    context: ProgramHookContext,
+    result: unknown,
+  ) => void | Promise<void>;
+
+  /**
+   * Called when the handler (or {@link beforeEach}/{@link afterEach}) throws or
+   * rejects, receiving the context from {@link beforeEach} (or an empty object)
+   * and the thrown error.
+   *
+   * The dispatcher re-throws the original error after this hook resolves, so
+   * process exit-code behavior is unchanged; the hook is for observation and
+   * cleanup, not for swallowing the error.  An error thrown by this hook itself
+   * is suppressed so it cannot mask the original failure.
+   *
+   * Returning a promise is supported; the dispatcher awaits it.
+   */
+  readonly onError?: (
+    context: ProgramHookContext,
+    error: unknown,
+  ) => void | Promise<void>;
+}
+
+/**
  * Input accepted by {@link defineCommand}.
  *
  * @template M The mode of the command parser.
@@ -51,13 +184,34 @@ export interface CommandDefinition<M extends Mode, T> {
   readonly metadata?: CommandMetadata;
 
   /**
+   * Lifecycle hooks scoped to this command.
+   *
+   * These run inside any program-level hooks passed to `runProgram({ hooks })`:
+   * the program-level `beforeEach` runs first, then this command's
+   * `beforeEach`, then the handler; teardown unwinds in reverse.  Use this when
+   * a single command needs its own preflight, such as a `deploy` command that
+   * always refreshes an auth token, instead of program-wide logic.
+   *
+   * @since 1.2.0
+   */
+  readonly hooks?: ProgramHooks;
+
+  /**
    * Handles the parsed command value.
    *
    * @param value Parsed command value.
+   * @param context Resource bundle from the most specific {@link ProgramHooks}
+   *                `beforeEach` that ran.  It is omitted when no program-level
+   *                or command-level `beforeEach` ran, so a plain command
+   *                without hooks receives only the value, exactly as before.
+   *                Existing single-argument handlers can ignore it.
    * @returns Nothing, or a promise that resolves when command handling
    *          completes.
    */
-  readonly handler: (value: T) => void | Promise<void>;
+  readonly handler: (
+    value: T,
+    context?: ProgramHookContext,
+  ) => void | Promise<void>;
 }
 
 /**
@@ -105,7 +259,10 @@ export type AnyCommand = Omit<Command<Mode, unknown>, "handler"> & {
   /**
    * Erased command handler.
    */
-  readonly handler: (value: never) => void | Promise<void>;
+  readonly handler: (
+    value: never,
+    context?: ProgramHookContext,
+  ) => void | Promise<void>;
 };
 
 /**
@@ -117,7 +274,10 @@ export type AnyStaticCommand = Omit<StaticCommand<Mode, unknown>, "handler"> & {
   /**
    * Erased command handler.
    */
-  readonly handler: (value: never) => void | Promise<void>;
+  readonly handler: (
+    value: never,
+    context?: ProgramHookContext,
+  ) => void | Promise<void>;
 };
 
 /**
@@ -130,7 +290,8 @@ export type AnyStaticCommand = Omit<StaticCommand<Mode, unknown>, "handler"> & {
  * @template T The parsed value passed to the command handler.
  * @param command The command definition.
  * @returns The same command definition with inferred types.
- * @throws {TypeError} If the parser, path, or handler is missing or malformed.
+ * @throws {TypeError} If the parser, path, handler, or hooks are missing or
+ *         malformed.
  * @since 1.1.0
  */
 export function defineCommand<M extends Mode, T>(
@@ -149,6 +310,7 @@ export function defineCommand<M extends Mode, T>(
   if (typeof command.handler !== "function") {
     throw new TypeError("Command handler must be a function.");
   }
+  if (command.hooks != null) validateHooks(command.hooks, "Command");
   return {
     ...command,
     [commandBrand]: true,
@@ -174,6 +336,32 @@ export function isCommand(value: unknown): value is AnyCommand {
     isParser((value as { readonly parser?: unknown }).parser) &&
     typeof (value as { readonly handler?: unknown }).handler === "function"
   );
+}
+
+/**
+ * Validates a {@link ProgramHooks} value, throwing a descriptive error when it
+ * is malformed.
+ *
+ * @param hooks The value to validate.
+ * @param scope Label used in error messages: `"Command"` for command-level
+ *              hooks and `"Program"` for program-level hooks.
+ * @throws {TypeError} If `hooks` is not an object, or a hook is neither
+ *         nullish nor a function.
+ * @internal
+ */
+export function validateHooks(
+  hooks: unknown,
+  scope: "Command" | "Program",
+): asserts hooks is ProgramHooks {
+  if (typeof hooks !== "object" || hooks == null) {
+    throw new TypeError(`${scope} hooks must be an object.`);
+  }
+  for (const name of ["beforeEach", "afterEach", "onError"] as const) {
+    const hook = (hooks as Record<string, unknown>)[name];
+    if (hook != null && typeof hook !== "function") {
+      throw new TypeError(`${scope} hook "${name}" must be a function.`);
+    }
+  }
 }
 
 function validateCommandPath(path: unknown): asserts path is CommandPath {

--- a/packages/discover/src/command.ts
+++ b/packages/discover/src/command.ts
@@ -353,6 +353,9 @@ export function validateHooks(
   hooks: unknown,
   scope: "Command" | "Program",
 ): asserts hooks is ProgramHooks {
+  if (Array.isArray(hooks)) {
+    throw new TypeError(`${scope} hooks must be an object, not an array.`);
+  }
   if (typeof hooks !== "object" || hooks == null) {
     throw new TypeError(`${scope} hooks must be an object.`);
   }

--- a/packages/discover/src/command.ts
+++ b/packages/discover/src/command.ts
@@ -114,7 +114,9 @@ export interface ProgramHooks {
    *
    * The returned {@link ProgramHookContext} is threaded forward as the second
    * argument to the command handler (when this is the most specific hook scope)
-   * and to {@link afterEach} and {@link onError}.
+   * and to {@link afterEach} and {@link onError}.  Returning a context is
+   * optional: omit the return or return `null`, and an empty context is
+   * threaded forward instead.
    *
    * Returning a promise is supported; the dispatcher awaits it.  A rejected
    * promise (or a thrown error) aborts the command before the handler runs and
@@ -122,7 +124,11 @@ export interface ProgramHooks {
    */
   readonly beforeEach?: (
     invocation: ProgramInvocation,
-  ) => ProgramHookContext | Promise<ProgramHookContext>;
+  ) =>
+    | ProgramHookContext
+    | null
+    | void
+    | Promise<ProgramHookContext | null | void>;
 
   /**
    * Called after the handler returns successfully, receiving the context from

--- a/packages/discover/src/index.test.ts
+++ b/packages/discover/src/index.test.ts
@@ -2498,9 +2498,9 @@ describe("runProgram() lifecycle hooks", () => {
     });
 
     await runHooked([greet], ["greet"], {
-      // Simulate a loosely typed caller whose beforeEach returns nothing; the
-      // dispatcher must substitute an empty context.
-      beforeEach: (() => undefined) as never,
+      // beforeEach may omit a return; the dispatcher substitutes an empty
+      // context for the nullish result.
+      beforeEach() {},
       afterEach(context) {
         afterContext = context;
       },

--- a/packages/discover/src/index.test.ts
+++ b/packages/discover/src/index.test.ts
@@ -142,6 +142,18 @@ describe("defineCommand()", () => {
       () =>
         defineCommand({
           parser: object({}),
+          hooks: [] as never,
+          handler() {},
+        }),
+      {
+        name: "TypeError",
+        message: "Command hooks must be an object, not an array.",
+      },
+    );
+    assert.throws(
+      () =>
+        defineCommand({
+          parser: object({}),
           hooks: { beforeEach: "nope" as never },
           handler() {},
         }),
@@ -2459,12 +2471,43 @@ describe("runProgram() lifecycle hooks", () => {
       { name: "TypeError", message: "Program hooks must be an object." },
     );
     await assert.rejects(
+      () => runHooked([greet], ["greet"], [] as never),
+      {
+        name: "TypeError",
+        message: "Program hooks must be an object, not an array.",
+      },
+    );
+    await assert.rejects(
       () => runHooked([greet], ["greet"], { afterEach: "nope" as never }),
       {
         name: "TypeError",
         message: 'Program hook "afterEach" must be a function.',
       },
     );
+  });
+
+  it("defaults a nullish beforeEach result to an empty context", async () => {
+    let afterContext: unknown = "unset";
+    let handlerContext: unknown = "unset";
+    const greet = defineCommand({
+      path: ["greet"],
+      parser: object({}),
+      handler(_value, context) {
+        handlerContext = context;
+      },
+    });
+
+    await runHooked([greet], ["greet"], {
+      // Simulate a loosely typed caller whose beforeEach returns nothing; the
+      // dispatcher must substitute an empty context.
+      beforeEach: (() => undefined) as never,
+      afterEach(context) {
+        afterContext = context;
+      },
+    });
+
+    assert.deepEqual(afterContext, {});
+    assert.deepEqual(handlerContext, {});
   });
 
   it("exposes the resolved command path to hooks", async () => {

--- a/packages/discover/src/index.test.ts
+++ b/packages/discover/src/index.test.ts
@@ -32,11 +32,13 @@ import { dirname, join } from "node:path";
 import { describe, it } from "node:test";
 import { defineCommand } from "#src/command.ts";
 import {
+  type AnyStaticCommand,
   type CommandPath,
   commandsFromModules,
   createProgramParser,
   discoverCommands,
   getDefaultExtensions,
+  type ProgramHooks,
   runProgram,
 } from "#src/index.ts";
 
@@ -127,6 +129,43 @@ describe("defineCommand()", () => {
         message: "Command path must be an array of non-empty strings.",
       },
     );
+    assert.throws(
+      () =>
+        defineCommand({
+          parser: object({}),
+          hooks: "nope" as never,
+          handler() {},
+        }),
+      { name: "TypeError", message: "Command hooks must be an object." },
+    );
+    assert.throws(
+      () =>
+        defineCommand({
+          parser: object({}),
+          hooks: { beforeEach: "nope" as never },
+          handler() {},
+        }),
+      {
+        name: "TypeError",
+        message: 'Command hook "beforeEach" must be a function.',
+      },
+    );
+  });
+
+  it("accepts a command with lifecycle hooks", () => {
+    const order: string[] = [];
+    const cmd = defineCommand({
+      parser: object({}),
+      hooks: {
+        beforeEach() {
+          order.push("before");
+          return { resource: order };
+        },
+      },
+      handler() {},
+    });
+    assert.equal(typeof cmd.hooks?.beforeEach, "function");
+    assert.deepEqual(order, []);
   });
 });
 
@@ -2008,6 +2047,463 @@ describe("runProgram()", () => {
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
+  });
+});
+
+describe("runProgram() lifecycle hooks", () => {
+  function runHooked(
+    commands: readonly AnyStaticCommand[],
+    args: readonly string[],
+    hooks?: ProgramHooks,
+  ): Promise<void> {
+    return runProgram({
+      commands,
+      metadata: { name: "tool", version: "1.0.0" },
+      args,
+      hooks,
+      stdout() {},
+      stderr() {},
+      onExit(exitCode): never {
+        throw new ExitSignal(exitCode);
+      },
+    });
+  }
+
+  it("produces identical handler output with and without hooks", async () => {
+    const calls: unknown[] = [];
+    const greet = defineCommand({
+      path: ["greet"],
+      parser: object({ name: option("--name", string()) }),
+      handler(value) {
+        calls.push(value);
+      },
+    });
+
+    await runHooked([greet], ["greet", "--name", "world"]);
+    await runHooked([greet], ["greet", "--name", "world"], {});
+
+    assert.deepEqual(calls, [{ name: "world" }, { name: "world" }]);
+  });
+
+  it("calls the handler with one argument unless a beforeEach runs", async () => {
+    const argCounts: number[] = [];
+    const greet = defineCommand({
+      path: ["greet"],
+      parser: object({}),
+      handler(...args: unknown[]) {
+        argCounts.push(args.length);
+      },
+    });
+
+    await runHooked([greet], ["greet"]);
+    await runHooked([greet], ["greet"], {});
+    await runHooked([greet], ["greet"], { afterEach() {} });
+    await runHooked([greet], ["greet"], {
+      beforeEach: () => ({ resource: 1 }),
+    });
+
+    assert.deepEqual(argCounts, [1, 1, 1, 2]);
+  });
+
+  it("forwards the beforeEach resource to the handler", async () => {
+    const scope = { id: "log-scope" };
+    let received: unknown;
+    const greet = defineCommand({
+      path: ["greet"],
+      parser: object({}),
+      handler(_value, context) {
+        received = context?.resource;
+      },
+    });
+
+    await runHooked([greet], ["greet"], {
+      beforeEach: () => ({ resource: scope }),
+    });
+
+    assert.equal(received, scope);
+  });
+
+  it("runs afterEach after a successful handler with the same context", async () => {
+    const order: string[] = [];
+    const scope = { id: "scope" };
+    let afterContext: unknown;
+    const greet = defineCommand({
+      path: ["greet"],
+      parser: object({}),
+      handler() {
+        order.push("handler");
+      },
+    });
+
+    await runHooked([greet], ["greet"], {
+      beforeEach() {
+        order.push("before");
+        return { resource: scope };
+      },
+      afterEach(context) {
+        order.push("after");
+        afterContext = context.resource;
+      },
+    });
+
+    assert.deepEqual(order, ["before", "handler", "after"]);
+    assert.equal(afterContext, scope);
+  });
+
+  it("invokes onError and re-throws the original handler error", async () => {
+    const error = new Error("boom");
+    let observed: unknown;
+    let afterEachRan = false;
+    const fail = defineCommand({
+      path: ["fail"],
+      parser: object({}),
+      handler() {
+        throw error;
+      },
+    });
+
+    await assert.rejects(
+      () =>
+        runHooked([fail], ["fail"], {
+          afterEach() {
+            afterEachRan = true;
+          },
+          onError(_context, caught) {
+            observed = caught;
+          },
+        }),
+      (caught) => caught === error,
+    );
+
+    assert.equal(observed, error);
+    assert.ok(!afterEachRan);
+  });
+
+  it("re-throws the same handler error with and without onError", async () => {
+    const error = new Error("boom");
+    const fail = defineCommand({
+      path: ["fail"],
+      parser: object({}),
+      handler() {
+        throw error;
+      },
+    });
+
+    // Without hooks: the error propagates out of runProgram untouched, and the
+    // error-exit path (onExit) is never reached.  Asserting the rejection is the
+    // original error proves onExit was not triggered, so exit-code behavior is
+    // identical with hooks installed.
+    await assert.rejects(
+      () => runHooked([fail], ["fail"]),
+      (caught) => caught === error,
+    );
+    await assert.rejects(
+      () => runHooked([fail], ["fail"], { onError() {} }),
+      (caught) => caught === error,
+    );
+  });
+
+  it("rejects with an async handler rejection and runs onError", async () => {
+    const error = new Error("async boom");
+    let observed: unknown;
+    const fail = defineCommand({
+      path: ["fail"],
+      parser: object({}),
+      async handler() {
+        await Promise.resolve();
+        throw error;
+      },
+    });
+
+    await assert.rejects(
+      () =>
+        runHooked([fail], ["fail"], {
+          onError(_context, caught) {
+            observed = caught;
+          },
+        }),
+      (caught) => caught === error,
+    );
+
+    assert.equal(observed, error);
+  });
+
+  it("skips the handler and invokes onError when beforeEach rejects", async () => {
+    const error = new Error("preflight failed");
+    let handlerRan = false;
+    let observed: unknown;
+    const greet = defineCommand({
+      path: ["greet"],
+      parser: object({}),
+      handler() {
+        handlerRan = true;
+      },
+    });
+
+    await assert.rejects(
+      () =>
+        runHooked([greet], ["greet"], {
+          beforeEach() {
+            throw error;
+          },
+          onError(_context, caught) {
+            observed = caught;
+          },
+        }),
+      (caught) => caught === error,
+    );
+
+    assert.ok(!handlerRan);
+    assert.equal(observed, error);
+  });
+
+  it("treats an afterEach rejection as a handler error", async () => {
+    const error = new Error("teardown failed");
+    let observed: unknown;
+    const greet = defineCommand({
+      path: ["greet"],
+      parser: object({}),
+      handler() {},
+    });
+
+    await assert.rejects(
+      () =>
+        runHooked([greet], ["greet"], {
+          afterEach() {
+            throw error;
+          },
+          onError(_context, caught) {
+            observed = caught;
+          },
+        }),
+      (caught) => caught === error,
+    );
+
+    assert.equal(observed, error);
+  });
+
+  it("awaits asynchronous hooks around the handler", async () => {
+    const order: string[] = [];
+    const greet = defineCommand({
+      path: ["greet"],
+      parser: object({}),
+      async handler() {
+        await Promise.resolve();
+        order.push("handler");
+      },
+    });
+
+    await runHooked([greet], ["greet"], {
+      async beforeEach() {
+        await Promise.resolve();
+        order.push("before");
+        return {};
+      },
+      async afterEach() {
+        await Promise.resolve();
+        order.push("after");
+      },
+    });
+
+    assert.deepEqual(order, ["before", "handler", "after"]);
+  });
+
+  it("composes program-level and command-level hooks in order", async () => {
+    const order: string[] = [];
+    const deploy = defineCommand({
+      path: ["deploy"],
+      parser: object({}),
+      hooks: {
+        beforeEach() {
+          order.push("command.before");
+          return { resource: "command" };
+        },
+        afterEach() {
+          order.push("command.after");
+        },
+      },
+      handler(_value, context) {
+        order.push(`handler:${String(context?.resource)}`);
+      },
+    });
+
+    await runHooked([deploy], ["deploy"], {
+      beforeEach() {
+        order.push("program.before");
+        return { resource: "program" };
+      },
+      afterEach() {
+        order.push("program.after");
+      },
+    });
+
+    assert.deepEqual(order, [
+      "program.before",
+      "command.before",
+      "handler:command",
+      "command.after",
+      "program.after",
+    ]);
+  });
+
+  it("threads the program context to the handler without command beforeEach", async () => {
+    let received: unknown;
+    const deploy = defineCommand({
+      path: ["deploy"],
+      parser: object({}),
+      hooks: {
+        afterEach() {},
+      },
+      handler(_value, context) {
+        received = context?.resource;
+      },
+    });
+
+    await runHooked([deploy], ["deploy"], {
+      beforeEach: () => ({ resource: "program" }),
+    });
+
+    assert.equal(received, "program");
+  });
+
+  it("runs command onError before program onError on failure", async () => {
+    const order: string[] = [];
+    const error = new Error("boom");
+    const fail = defineCommand({
+      path: ["fail"],
+      parser: object({}),
+      hooks: {
+        onError() {
+          order.push("command.error");
+        },
+      },
+      handler() {
+        throw error;
+      },
+    });
+
+    await assert.rejects(
+      () =>
+        runHooked([fail], ["fail"], {
+          onError() {
+            order.push("program.error");
+          },
+        }),
+      (caught) => caught === error,
+    );
+
+    assert.deepEqual(order, ["command.error", "program.error"]);
+  });
+
+  it("does not let a throwing onError mask the original error", async () => {
+    const original = new Error("handler boom");
+    const fail = defineCommand({
+      path: ["fail"],
+      parser: object({}),
+      handler() {
+        throw original;
+      },
+    });
+
+    await assert.rejects(
+      () =>
+        runHooked([fail], ["fail"], {
+          onError() {
+            throw new Error("onError boom");
+          },
+        }),
+      (caught) => caught === original,
+    );
+  });
+
+  it("keeps the original error when a command onError throws", async () => {
+    const original = new Error("handler boom");
+    let programObserved: unknown;
+    const fail = defineCommand({
+      path: ["fail"],
+      parser: object({}),
+      hooks: {
+        onError() {
+          throw new Error("command onError boom");
+        },
+      },
+      handler() {
+        throw original;
+      },
+    });
+
+    await assert.rejects(
+      () =>
+        runHooked([fail], ["fail"], {
+          onError(_context, caught) {
+            programObserved = caught;
+          },
+        }),
+      (caught) => caught === original,
+    );
+
+    // The program-level onError still observes the original handler error,
+    // not the command-level onError's own failure.
+    assert.equal(programObserved, original);
+  });
+
+  it("rejects malformed program-level hooks", async () => {
+    const greet = defineCommand({
+      path: ["greet"],
+      parser: object({}),
+      handler() {},
+    });
+
+    await assert.rejects(
+      () => runHooked([greet], ["greet"], "nope" as never),
+      { name: "TypeError", message: "Program hooks must be an object." },
+    );
+    await assert.rejects(
+      () => runHooked([greet], ["greet"], { afterEach: "nope" as never }),
+      {
+        name: "TypeError",
+        message: 'Program hook "afterEach" must be a function.',
+      },
+    );
+  });
+
+  it("exposes the resolved command path to hooks", async () => {
+    const invocationPaths: (readonly string[])[] = [];
+    const commandPaths: unknown[] = [];
+    // commandsFromModules derives the path from the module key while the
+    // command definition omits an explicit path, mirroring file-based
+    // discovery.
+    const commands = commandsFromModules({
+      "./commands/user/add.ts": {
+        default: defineCommand({
+          parser: object({}),
+          handler() {},
+        }),
+      },
+    }, { base: "./commands", extensions: [".ts"] });
+
+    await runProgram({
+      commands,
+      metadata: { name: "tool", version: "1.0.0" },
+      args: ["user", "add"],
+      hooks: {
+        beforeEach(invocation) {
+          invocationPaths.push(invocation.path);
+          commandPaths.push(invocation.command.path);
+          return {};
+        },
+      },
+      stdout() {},
+      stderr() {},
+      onExit(exitCode): never {
+        throw new ExitSignal(exitCode);
+      },
+    });
+
+    // The resolved path identifies the command even though the definition
+    // itself declared no path.
+    assert.deepEqual(invocationPaths, [["user", "add"]]);
+    assert.deepEqual(commandPaths, [undefined]);
   });
 });
 

--- a/packages/discover/src/index.ts
+++ b/packages/discover/src/index.ts
@@ -37,6 +37,10 @@ import {
   type CommandMetadata,
   type CommandPath,
   isCommand,
+  type ProgramHookContext,
+  type ProgramHooks,
+  type ProgramInvocation,
+  validateHooks,
 } from "./command.ts";
 
 export { defineCommand, isCommand } from "./command.ts";
@@ -47,33 +51,11 @@ export type {
   CommandDefinition,
   CommandMetadata,
   CommandPath,
+  ProgramHookContext,
+  ProgramHooks,
+  ProgramInvocation,
   StaticCommand,
 } from "./command.ts";
-
-/**
- * The parsed command selected by a discovered command parser.
- *
- * Most applications receive this only indirectly through {@link runProgram},
- * which calls the handler automatically.
- *
- * @since 1.1.0
- */
-export interface ProgramInvocation {
-  /**
-   * The command definition that matched the input.
-   */
-  readonly command: AnyCommand;
-
-  /**
-   * Parsed value produced by the command parser.
-   */
-  readonly value: unknown;
-
-  /**
-   * Handler to call with {@link ProgramInvocation.value}.
-   */
-  readonly handler: (value: unknown) => void | Promise<void>;
-}
 
 /**
  * A command paired with its command path.
@@ -269,6 +251,19 @@ interface RunProgramBaseOptions extends
    * @default `"both"`
    */
   readonly completion?: RunOptions["completion"] | false;
+
+  /**
+   * Lifecycle hooks invoked around each command handler.
+   *
+   * Use these for cross-cutting concerns such as opening a log scope, starting
+   * a tracing span, or reporting handler failures, without duplicating the
+   * logic in every command.  Hooks are opt-in: omitting this field keeps the
+   * exact behavior of a plain `runProgram()` call.  Command-level hooks defined
+   * on {@link CommandDefinition.hooks} nest inside these.
+   *
+   * @since 1.2.0
+   */
+  readonly hooks?: ProgramHooks;
 }
 
 /**
@@ -533,10 +528,12 @@ export function createProgramParser(
  * @param options Program options.
  * @returns A promise that resolves after the selected command handler
  *          completes.
- * @throws {TypeError} If discovery or command loading fails.
+ * @throws {TypeError} If discovery or command loading fails, or `hooks` is
+ *         malformed.
  * @since 1.1.0
  */
 export async function runProgram(options: RunProgramOptions): Promise<void> {
+  if (options.hooks != null) validateHooks(options.hooks, "Program");
   let commands: readonly Pick<DiscoveredCommand, "path" | "command">[];
   if (isStaticRunProgramOptions(options)) {
     commands = staticCommandsToEntries(options.commands);
@@ -549,7 +546,83 @@ export async function runProgram(options: RunProgramOptions): Promise<void> {
   }
   const parser = createProgramParser(commands, options.metadata);
   const invocation = await runAsync(parser, buildRunOptions(options));
-  await invocation.handler(invocation.value);
+  await dispatchInvocation(invocation, options.hooks);
+}
+
+/**
+ * Runs a command handler wrapped in the program-level and command-level
+ * lifecycle hooks.
+ *
+ * The hooks nest: the program-level `beforeEach` runs first, then the command's
+ * `beforeEach`, then the handler; `afterEach` and `onError` unwind in reverse,
+ * with the command-level hook running before the program-level one.
+ *
+ * @param invocation The selected command invocation.
+ * @param programHooks Program-level hooks, if any.
+ * @returns A promise that resolves after the handler and matching hooks
+ *          complete.
+ * @throws The original error thrown by `beforeEach`, the handler, or
+ *         `afterEach`, re-thrown after the `onError` hooks run.
+ */
+async function dispatchInvocation(
+  invocation: ProgramInvocation,
+  programHooks: ProgramHooks | undefined,
+): Promise<void> {
+  const commandHooks = invocation.command.hooks;
+  await runHookScope(
+    programHooks,
+    invocation,
+    (programContext) =>
+      runHookScope(commandHooks, invocation, (commandContext) => {
+        // Pass the hook context only when a beforeEach actually produced one,
+        // using the most specific scope.  When no beforeEach ran, call the
+        // handler with just the value so handlers see the exact single-argument
+        // call shape of a plain runProgram() without hooks.
+        if (commandHooks?.beforeEach != null) {
+          return invocation.handler(invocation.value, commandContext);
+        }
+        if (programHooks?.beforeEach != null) {
+          return invocation.handler(invocation.value, programContext);
+        }
+        return invocation.handler(invocation.value);
+      }),
+  );
+}
+
+/**
+ * Runs an inner step wrapped in a single set of lifecycle hooks.
+ *
+ * @param hooks The hooks for this scope, if any.
+ * @param invocation The selected command invocation passed to `beforeEach`.
+ * @param inner The step to wrap; receives the context from `beforeEach`.
+ * @returns The value returned by `inner`.
+ * @throws The original error thrown by `beforeEach`, `inner`, or `afterEach`,
+ *         re-thrown after `onError` runs.  An error thrown by `onError` itself
+ *         is suppressed so it cannot mask the original failure.
+ */
+async function runHookScope(
+  hooks: ProgramHooks | undefined,
+  invocation: ProgramInvocation,
+  inner: (context: ProgramHookContext) => unknown | Promise<unknown>,
+): Promise<unknown> {
+  let context: ProgramHookContext = {};
+  try {
+    if (hooks?.beforeEach != null) context = await hooks.beforeEach(invocation);
+    const result = await inner(context);
+    if (hooks?.afterEach != null) await hooks.afterEach(context, result);
+    return result;
+  } catch (error) {
+    if (hooks?.onError != null) {
+      try {
+        await hooks.onError(context, error);
+      } catch {
+        // An onError hook that itself throws must not replace the original
+        // failure: runProgram() always re-throws the original error so the
+        // process exit code stays tied to the real cause.
+      }
+    }
+    throw error;
+  }
 }
 
 /**
@@ -577,6 +650,7 @@ export interface ProgramHelpMetadata {
 interface CommandTreeNode {
   readonly children: Map<string, CommandTreeNode>;
   command?: AnyCommand;
+  path?: CommandPath;
 }
 
 type MutableSourceContext = {
@@ -929,6 +1003,7 @@ function buildCommandTree(
       current = child;
     }
     current.command = entry.command;
+    current.path = entry.path;
   }
   return root;
 }
@@ -939,10 +1014,16 @@ function buildNodeParser(
 ): Parser<Mode, ProgramInvocation, unknown> {
   const childParser = buildChildrenParser(node, inheritedHidden);
   if (childParser != null && node.command != null) {
-    return createExecutableNodeParser(childParser, node.command);
+    return createExecutableNodeParser(
+      childParser,
+      node.command,
+      node.path ?? [],
+    );
   }
   if (childParser != null) return childParser;
-  if (node.command != null) return createLeafParser(node.command);
+  if (node.command != null) {
+    return createLeafParser(node.command, node.path ?? []);
+  }
   throw new TypeError("Command tree node must contain a command.");
 }
 
@@ -957,8 +1038,9 @@ type ExecutableNodeParserState = ExecutableNodeState | undefined;
 function createExecutableNodeParser(
   childParser: Parser<Mode, ProgramInvocation, unknown>,
   commandDefinition: AnyCommand,
+  path: CommandPath,
 ): Parser<Mode, ProgramInvocation, ExecutableNodeParserState> {
-  const leafParser = createLeafParser(commandDefinition, true);
+  const leafParser = createLeafParser(commandDefinition, path, true);
   const branchParsers = [childParser, leafParser] as const;
   const parser = longestMatch(
     childParser,
@@ -1566,13 +1648,16 @@ function commandMetadataWithInheritedHidden(
 
 function createLeafParser(
   commandDefinition: AnyCommand,
+  path: CommandPath,
   includeMetadata = false,
 ): Parser<Mode, ProgramInvocation, unknown> {
   const parser = map(commandDefinition.parser, (value): ProgramInvocation => ({
     command: commandDefinition,
+    path,
     value,
     handler: commandDefinition.handler as (
       value: unknown,
+      context?: ProgramHookContext,
     ) => void | Promise<void>,
   })) as Parser<Mode, ProgramInvocation, unknown>;
   if (!includeMetadata) return parser;
@@ -1662,6 +1747,7 @@ function buildRunOptions(options: RunProgramOptions): RunOptions {
     extensions: _extensions,
     entryFileName: _entryFileName,
     metadata: _metadata,
+    hooks: _hooks,
     help,
     version,
     completion,

--- a/packages/discover/src/index.ts
+++ b/packages/discover/src/index.ts
@@ -607,7 +607,11 @@ async function runHookScope(
 ): Promise<unknown> {
   let context: ProgramHookContext = {};
   try {
-    if (hooks?.beforeEach != null) context = await hooks.beforeEach(invocation);
+    // Default a nullish beforeEach result to an empty context so afterEach,
+    // onError, and the handler never receive null/undefined.
+    if (hooks?.beforeEach != null) {
+      context = (await hooks.beforeEach(invocation)) ?? {};
+    }
     const result = await inner(context);
     if (hooks?.afterEach != null) await hooks.afterEach(context, result);
     return result;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,9 @@ importers:
       markdown-it-footnote:
         specifier: ^4.0.0
         version: 4.0.0
+      mermaid:
+        specifier: ^11.16.0
+        version: 11.16.0
       typescript:
         specifier: 'catalog:'
         version: 5.8.3
@@ -141,6 +144,9 @@ importers:
       vitepress-plugin-llms:
         specifier: ^1.7.3
         version: 1.7.3
+      vitepress-plugin-mermaid:
+        specifier: ^2.0.17
+        version: 2.0.17(mermaid@11.16.0)(vitepress@2.0.0-alpha.17(@types/node@20.19.41)(jiti@2.5.1)(postcss@8.5.15)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.2))
       zod:
         specifier: 'catalog:'
         version: 4.1.12
@@ -558,6 +564,15 @@ packages:
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
+  '@braintree/sanitize-url@6.0.4':
+    resolution: {integrity: sha512-s3jaWicZd0pkP0jf5ysyHUI/RE7MHos6qlToFcGWXVp+ykHOy77OUMrfbgJ9it2C5bow7OIQwYYaHjk9XlBQ2A==}
+
+  '@braintree/sanitize-url@7.1.2':
+    resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
+
+  '@chevrotain/types@11.1.2':
+    resolution: {integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==}
+
   '@clack/core@1.4.2':
     resolution: {integrity: sha512-0Ty/1Gfm+Kb07sXcuESjyKfwEhSy4Ns1AgeEisHb/bDY5fWme0tTeTkU14T1Gmcs17YIjB/teiDe4uaCghbYqQ==}
     engines: {node: '>= 20.12.0'}
@@ -813,6 +828,9 @@ packages:
 
   '@iconify/utils@3.0.1':
     resolution: {integrity: sha512-A78CUEnFGX8I/WlILxJCuIJXloL0j/OJ9PSchPAfCargEIKmUBWvvEMmKWB5oONwiUqlNt+5eRufdkLxeHIWYw==}
+
+  '@iconify/utils@3.1.3':
+    resolution: {integrity: sha512-LPKOXPn/zV+zis1oOfGWogaXVpqUybF3ZS6SCZIsz8vg0ivVp9+fVqyYB7xq0aiST/VhUQYGO1qo6uoYSiEJqw==}
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -1137,6 +1155,12 @@ packages:
   '@logtape/logtape@2.0.4':
     resolution: {integrity: sha512-Z4COeAMdedcBFuFkXaPFvDPOVuHoEom1hwNnPCIkSyojyikuNguplwPoSG+kZthWrS7GiOJo1USQyjWwIFfTKA==}
 
+  '@mermaid-js/mermaid-mindmap@9.3.0':
+    resolution: {integrity: sha512-IhtYSVBBRYviH1Ehu8gk69pMDF8DSRqXBRDMWrEfHoaMruHeaP2DXA3PBnuwsMaCdPQhlUUcy/7DBLAEIXvCAw==}
+
+  '@mermaid-js/parser@1.2.0':
+    resolution: {integrity: sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==}
+
   '@napi-rs/wasm-runtime@1.0.1':
     resolution: {integrity: sha512-KVlQ/jgywZpixGCKMNwxStmmbYEMyokZpCf2YuIChhfJA2uqfAKNEM8INz7zzTo55iEXfBhIIs3VqYyqzDLj8g==}
 
@@ -1414,11 +1438,107 @@ packages:
   '@tybys/wasm-util@0.10.0':
     resolution: {integrity: sha512-VyyPYFlOMNylG45GoAe0xDoLwWuowvf92F9kySqzYh8vmYm7D2u4iUJKa1tOUpS70Ku13ASrOkS4ScXFsTaCNQ==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-axis@3.0.6':
+    resolution: {integrity: sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==}
+
+  '@types/d3-brush@3.0.6':
+    resolution: {integrity: sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==}
+
+  '@types/d3-chord@3.0.6':
+    resolution: {integrity: sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-contour@3.0.6':
+    resolution: {integrity: sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==}
+
+  '@types/d3-delaunay@6.0.4':
+    resolution: {integrity: sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==}
+
+  '@types/d3-dispatch@3.0.7':
+    resolution: {integrity: sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==}
+
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
+  '@types/d3-dsv@3.0.7':
+    resolution: {integrity: sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-fetch@3.0.7':
+    resolution: {integrity: sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==}
+
+  '@types/d3-force@3.0.10':
+    resolution: {integrity: sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==}
+
+  '@types/d3-format@3.0.4':
+    resolution: {integrity: sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==}
+
+  '@types/d3-geo@3.1.0':
+    resolution: {integrity: sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==}
+
+  '@types/d3-hierarchy@3.1.7':
+    resolution: {integrity: sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-polygon@3.0.2':
+    resolution: {integrity: sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==}
+
+  '@types/d3-quadtree@3.0.6':
+    resolution: {integrity: sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==}
+
+  '@types/d3-random@3.0.3':
+    resolution: {integrity: sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==}
+
+  '@types/d3-scale-chromatic@3.1.0':
+    resolution: {integrity: sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time-format@4.0.3':
+    resolution: {integrity: sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
+  '@types/d3@7.4.3':
+    resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
+
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
@@ -1444,6 +1564,9 @@ packages:
   '@types/node@24.12.4':
     resolution: {integrity: sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
@@ -1458,6 +1581,9 @@ packages:
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
     deprecated: Potential CWE-502 - Update to 1.3.1 or higher
+
+  '@upsetjs/venn.js@2.0.0':
+    resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
 
   '@vitejs/plugin-vue@6.0.7':
     resolution: {integrity: sha512-km+p+XdSz9Sxm5rqUbqcSfZYaAniKxWBj1KURl+Jr7UaPvvX7BmaWMdP69I5rrFDeQGyxAG7NXdc57vz+snhWg==}
@@ -1703,6 +1829,14 @@ packages:
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
+  commander@7.2.0:
+    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
+    engines: {node: '>= 10'}
+
+  commander@8.3.0:
+    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
+    engines: {node: '>= 12'}
+
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
 
@@ -1717,6 +1851,12 @@ packages:
     resolution: {integrity: sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==}
     engines: {node: '>=12.13'}
 
+  cose-base@1.0.3:
+    resolution: {integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==}
+
+  cose-base@2.2.0:
+    resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
+
   crc-32@1.2.2:
     resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
     engines: {node: '>=0.8'}
@@ -1724,6 +1864,165 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  cytoscape-cose-bilkent@4.1.0:
+    resolution: {integrity: sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape-fcose@2.2.0:
+    resolution: {integrity: sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape@3.34.0:
+    resolution: {integrity: sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==}
+    engines: {node: '>=0.10'}
+
+  d3-array@2.12.1:
+    resolution: {integrity: sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==}
+
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-axis@3.0.0:
+    resolution: {integrity: sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==}
+    engines: {node: '>=12'}
+
+  d3-brush@3.0.0:
+    resolution: {integrity: sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==}
+    engines: {node: '>=12'}
+
+  d3-chord@3.0.1:
+    resolution: {integrity: sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-contour@4.0.2:
+    resolution: {integrity: sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==}
+    engines: {node: '>=12'}
+
+  d3-delaunay@6.0.4:
+    resolution: {integrity: sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-dsv@3.0.1:
+    resolution: {integrity: sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-fetch@3.0.1:
+    resolution: {integrity: sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==}
+    engines: {node: '>=12'}
+
+  d3-force@3.0.0:
+    resolution: {integrity: sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-geo@3.1.1:
+    resolution: {integrity: sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==}
+    engines: {node: '>=12'}
+
+  d3-hierarchy@3.1.2:
+    resolution: {integrity: sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@1.0.9:
+    resolution: {integrity: sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-polygon@3.0.1:
+    resolution: {integrity: sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==}
+    engines: {node: '>=12'}
+
+  d3-quadtree@3.0.1:
+    resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
+    engines: {node: '>=12'}
+
+  d3-random@3.0.1:
+    resolution: {integrity: sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==}
+    engines: {node: '>=12'}
+
+  d3-sankey@0.12.3:
+    resolution: {integrity: sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==}
+
+  d3-scale-chromatic@3.1.0:
+    resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@1.3.7:
+    resolution: {integrity: sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
+
+  d3@7.9.0:
+    resolution: {integrity: sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==}
+    engines: {node: '>=12'}
+
+  dagre-d3-es@7.0.14:
+    resolution: {integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==}
+
+  dayjs@1.11.21:
+    resolution: {integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==}
 
   de-indent@1.0.2:
     resolution: {integrity: sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==}
@@ -1751,6 +2050,9 @@ packages:
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
 
+  delaunator@5.1.0:
+    resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
+
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -1768,6 +2070,9 @@ packages:
   diff@8.0.2:
     resolution: {integrity: sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg==}
     engines: {node: '>=0.3.1'}
+
+  dompurify@3.4.11:
+    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
 
   dts-resolver@2.1.1:
     resolution: {integrity: sha512-3BiGFhB6mj5Kv+W2vdJseQUYW+SKVzAFJL6YNP6ursbrwy1fXHRotfHi3xLNxe4wZl/K8qbAFeCDjZLjzqxxRw==}
@@ -1879,6 +2184,9 @@ packages:
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
+
+  es-toolkit@1.49.0:
+    resolution: {integrity: sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==}
 
   esbuild@0.27.3:
     resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
@@ -1999,6 +2307,9 @@ packages:
     resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
     engines: {node: '>=6.0'}
 
+  hachure-fill@0.5.2:
+    resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
+
   has-property-descriptors@1.0.2:
     resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
 
@@ -2030,6 +2341,10 @@ packages:
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
@@ -2041,8 +2356,18 @@ packages:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
 
+  import-meta-resolve@4.2.0:
+    resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
+
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  internmap@1.0.1:
+    resolution: {integrity: sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   is-callable@1.2.7:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
@@ -2092,6 +2417,13 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  katex@0.16.47:
+    resolution: {integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==}
+    hasBin: true
+
+  khroma@2.1.0:
+    resolution: {integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==}
+
   kind-of@6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
     engines: {node: '>=0.10.0'}
@@ -2103,12 +2435,21 @@ packages:
   kolorist@1.8.0:
     resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
 
+  layout-base@1.0.2:
+    resolution: {integrity: sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==}
+
+  layout-base@2.0.1:
+    resolution: {integrity: sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==}
+
   linkify-it@5.0.0:
     resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
 
   local-pkg@1.1.2:
     resolution: {integrity: sha512-arhlxbFRmoQHl33a0Zkle/YWlmNwoyt6QNZEIJcqNbdrsix5Lvc4HyyI3EnwxTYlZYc32EbYrQ8SzEZ7dqgg9A==}
     engines: {node: '>=14'}
+
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
@@ -2139,6 +2480,11 @@ packages:
   markdown-title@1.0.2:
     resolution: {integrity: sha512-MqIQVVkz+uGEHi3TsHx/czcxxCbRIL7sv5K5DnYw/tI+apY54IbPefV/cmgxp6LoJSEx/TqcHdLs/298afG5QQ==}
     engines: {node: '>=6'}
+
+  marked@16.4.2:
+    resolution: {integrity: sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==}
+    engines: {node: '>= 20'}
+    hasBin: true
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -2185,6 +2531,9 @@ packages:
 
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
+
+  mermaid@11.16.0:
+    resolution: {integrity: sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==}
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
@@ -2299,6 +2648,9 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  non-layered-tidy-tree-layout@2.0.2:
+    resolution: {integrity: sha512-gkXMxRzUH+PB0ax9dUN0yYF0S25BqeAYqhgMaLUFmpXLEk7Fcu8f4emJuOAY0V8kjDICxROIKsTAKsV/v355xw==}
+
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
 
@@ -2319,6 +2671,9 @@ packages:
 
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+
+  path-data-parser@0.1.0:
+    resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
 
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
@@ -2349,6 +2704,12 @@ packages:
 
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
+
+  points-on-curve@0.2.0:
+    resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
+
+  points-on-path@0.2.1:
+    resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -2414,6 +2775,9 @@ packages:
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
+  robust-predicates@3.0.3:
+    resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
+
   rolldown-plugin-dts@0.14.1:
     resolution: {integrity: sha512-M++jFiiI0dwd9jNnta5vfxc058wwoibgeBzNMZw0QRm8jPJYxy4P3nQYlBtwQagKUDQVR0LXHSrRgXTezELEhw==}
     engines: {node: '>=20.18.0'}
@@ -2438,6 +2802,12 @@ packages:
     resolution: {integrity: sha512-RZn2XTjXb8t5g13f5YclGoilU/kwT696DIkY3sywjdZidNSi3+vseaQov7D7BZXVJCPv3pDWUN69C78GGbXsKw==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  roughjs@4.6.6:
+    resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
+
+  rw@1.3.3:
+    resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
@@ -2518,6 +2888,9 @@ packages:
     resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
     engines: {node: '>=0.10.0'}
 
+  stylis@4.4.0:
+    resolution: {integrity: sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==}
+
   superjson@2.2.2:
     resolution: {integrity: sha512-5JRxVqC8I8NuOUjzBbvVJAKNM8qoVuH0O77h4WInc/qC2q5IreqKxYwgkga3PfA22OayK2ikceb/B26dztPl+Q==}
     engines: {node: '>=16'}
@@ -2548,6 +2921,10 @@ packages:
 
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
+  ts-dedent@2.3.0:
+    resolution: {integrity: sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==}
+    engines: {node: '>=6.10'}
 
   tsdown@0.13.0:
     resolution: {integrity: sha512-+1ZqbLIYDAiNxtAvq9RsTg55PRvaMxGmtvRFBW2J+i4GfDKiyHAkxez1eB3EPvHG1Z917nsf2madsSeblJS3GA==}
@@ -2644,6 +3021,10 @@ packages:
   unist-util-visit@5.0.0:
     resolution: {integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==}
 
+  uuid@14.0.1:
+    resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
+    hasBin: true
+
   valibot@1.2.0:
     resolution: {integrity: sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==}
     peerDependencies:
@@ -2706,6 +3087,12 @@ packages:
 
   vitepress-plugin-llms@1.7.3:
     resolution: {integrity: sha512-XhTVbUrKwrzrwlRKd/zT2owvjwi5cdB21HgDRcHqp9PYK4Fy+mBYJUoTcLaJ5IKD1DDrJZMo0DuJeyC5RSDI9Q==}
+
+  vitepress-plugin-mermaid@2.0.17:
+    resolution: {integrity: sha512-IUzYpwf61GC6k0XzfmAmNrLvMi9TRrVRMsUyCA8KNXhg/mQ1VqWnO0/tBVPiX5UoKF1mDUwqn5QV4qAJl6JnUg==}
+    peerDependencies:
+      mermaid: 10 || 11
+      vitepress: ^1.0.0 || ^1.0.0-alpha
 
   vitepress@2.0.0-alpha.17:
     resolution: {integrity: sha512-Z3VPUpwk/bHYqt1uMVOOK1/4xFiWQov1GNc2FvMdz6kvje4JRXEOngVI9C+bi5jeedMSHiA4dwKkff1NCvbZ9Q==}
@@ -2837,6 +3224,13 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
+
+  '@braintree/sanitize-url@6.0.4':
+    optional: true
+
+  '@braintree/sanitize-url@7.1.2': {}
+
+  '@chevrotain/types@11.1.2': {}
 
   '@clack/core@1.4.2':
     dependencies:
@@ -3015,6 +3409,12 @@ snapshots:
       mlly: 1.7.4
     transitivePeerDependencies:
       - supports-color
+
+  '@iconify/utils@3.1.3':
+    dependencies:
+      '@antfu/install-pkg': 1.1.0
+      '@iconify/types': 2.0.0
+      import-meta-resolve: 4.2.0
 
   '@img/colour@1.1.0': {}
 
@@ -3266,6 +3666,21 @@ snapshots:
 
   '@logtape/logtape@2.0.4': {}
 
+  '@mermaid-js/mermaid-mindmap@9.3.0':
+    dependencies:
+      '@braintree/sanitize-url': 6.0.4
+      cytoscape: 3.34.0
+      cytoscape-cose-bilkent: 4.1.0(cytoscape@3.34.0)
+      cytoscape-fcose: 2.2.0(cytoscape@3.34.0)
+      d3: 7.9.0
+      khroma: 2.1.0
+      non-layered-tidy-tree-layout: 2.0.2
+    optional: true
+
+  '@mermaid-js/parser@1.2.0':
+    dependencies:
+      '@chevrotain/types': 11.1.2
+
   '@napi-rs/wasm-runtime@1.0.1':
     dependencies:
       '@emnapi/core': 1.4.5
@@ -3510,11 +3925,130 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-axis@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-brush@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-chord@3.0.6': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-contour@3.0.6':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-delaunay@6.0.4': {}
+
+  '@types/d3-dispatch@3.0.7': {}
+
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-dsv@3.0.7': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-fetch@3.0.7':
+    dependencies:
+      '@types/d3-dsv': 3.0.7
+
+  '@types/d3-force@3.0.10': {}
+
+  '@types/d3-format@3.0.4': {}
+
+  '@types/d3-geo@3.1.0':
+    dependencies:
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-hierarchy@3.1.7': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-polygon@3.0.2': {}
+
+  '@types/d3-quadtree@3.0.6': {}
+
+  '@types/d3-random@3.0.3': {}
+
+  '@types/d3-scale-chromatic@3.1.0': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-selection@3.0.11': {}
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time-format@4.0.3': {}
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3@7.4.3':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-axis': 3.0.6
+      '@types/d3-brush': 3.0.6
+      '@types/d3-chord': 3.0.6
+      '@types/d3-color': 3.1.3
+      '@types/d3-contour': 3.0.6
+      '@types/d3-delaunay': 6.0.4
+      '@types/d3-dispatch': 3.0.7
+      '@types/d3-drag': 3.0.7
+      '@types/d3-dsv': 3.0.7
+      '@types/d3-ease': 3.0.2
+      '@types/d3-fetch': 3.0.7
+      '@types/d3-force': 3.0.10
+      '@types/d3-format': 3.0.4
+      '@types/d3-geo': 3.1.0
+      '@types/d3-hierarchy': 3.1.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-path': 3.1.1
+      '@types/d3-polygon': 3.0.2
+      '@types/d3-quadtree': 3.0.6
+      '@types/d3-random': 3.0.3
+      '@types/d3-scale': 4.0.9
+      '@types/d3-scale-chromatic': 3.1.0
+      '@types/d3-selection': 3.0.11
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-time-format': 4.0.3
+      '@types/d3-timer': 3.0.2
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 2.1.0
 
   '@types/estree@1.0.8': {}
+
+  '@types/geojson@7946.0.16': {}
 
   '@types/hast@3.0.4':
     dependencies:
@@ -3543,6 +4077,9 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/unist@3.0.3': {}
 
   '@types/web-bluetooth@0.0.21': {}
@@ -3555,6 +4092,11 @@ snapshots:
       - supports-color
 
   '@ungap/structured-clone@1.3.0': {}
+
+  '@upsetjs/venn.js@2.0.0':
+    optionalDependencies:
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   '@vitejs/plugin-vue@6.0.7(vite@7.3.5(patch_hash=c93908c36d57e15b6a2d0014f356e0ddcb021ece7c4436f9145cc52acb6dcb49)(@types/node@20.19.41)(jiti@2.5.1)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.38(typescript@5.8.3))':
     dependencies:
@@ -3788,6 +4330,10 @@ snapshots:
 
   comma-separated-tokens@2.0.3: {}
 
+  commander@7.2.0: {}
+
+  commander@8.3.0: {}
+
   confbox@0.1.8: {}
 
   confbox@0.2.2: {}
@@ -3798,9 +4344,203 @@ snapshots:
     dependencies:
       is-what: 4.1.16
 
+  cose-base@1.0.3:
+    dependencies:
+      layout-base: 1.0.2
+
+  cose-base@2.2.0:
+    dependencies:
+      layout-base: 2.0.1
+
   crc-32@1.2.2: {}
 
   csstype@3.2.3: {}
+
+  cytoscape-cose-bilkent@4.1.0(cytoscape@3.34.0):
+    dependencies:
+      cose-base: 1.0.3
+      cytoscape: 3.34.0
+
+  cytoscape-fcose@2.2.0(cytoscape@3.34.0):
+    dependencies:
+      cose-base: 2.2.0
+      cytoscape: 3.34.0
+
+  cytoscape@3.34.0: {}
+
+  d3-array@2.12.1:
+    dependencies:
+      internmap: 1.0.1
+
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-axis@3.0.0: {}
+
+  d3-brush@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3-chord@3.0.1:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-color@3.1.0: {}
+
+  d3-contour@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-delaunay@6.0.4:
+    dependencies:
+      delaunator: 5.1.0
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-dsv@3.0.1:
+    dependencies:
+      commander: 7.2.0
+      iconv-lite: 0.6.3
+      rw: 1.3.3
+
+  d3-ease@3.0.1: {}
+
+  d3-fetch@3.0.1:
+    dependencies:
+      d3-dsv: 3.0.1
+
+  d3-force@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-timer: 3.0.1
+
+  d3-format@3.1.2: {}
+
+  d3-geo@3.1.1:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-hierarchy@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@1.0.9: {}
+
+  d3-path@3.1.0: {}
+
+  d3-polygon@3.0.1: {}
+
+  d3-quadtree@3.0.1: {}
+
+  d3-random@3.0.1: {}
+
+  d3-sankey@0.12.3:
+    dependencies:
+      d3-array: 2.12.1
+      d3-shape: 1.3.7
+
+  d3-scale-chromatic@3.1.0:
+    dependencies:
+      d3-color: 3.1.0
+      d3-interpolate: 3.0.1
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-shape@1.3.7:
+    dependencies:
+      d3-path: 1.0.9
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3@7.9.0:
+    dependencies:
+      d3-array: 3.2.4
+      d3-axis: 3.0.0
+      d3-brush: 3.0.0
+      d3-chord: 3.0.1
+      d3-color: 3.1.0
+      d3-contour: 4.0.2
+      d3-delaunay: 6.0.4
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-dsv: 3.0.1
+      d3-ease: 3.0.1
+      d3-fetch: 3.0.1
+      d3-force: 3.0.0
+      d3-format: 3.1.2
+      d3-geo: 3.1.1
+      d3-hierarchy: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-path: 3.1.0
+      d3-polygon: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-random: 3.0.1
+      d3-scale: 4.0.2
+      d3-scale-chromatic: 3.1.0
+      d3-selection: 3.0.0
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+      d3-timer: 3.0.1
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+      d3-zoom: 3.0.0
+
+  dagre-d3-es@7.0.14:
+    dependencies:
+      d3: 7.9.0
+      lodash-es: 4.18.1
+
+  dayjs@1.11.21: {}
 
   de-indent@1.0.2: {}
 
@@ -3824,6 +4564,10 @@ snapshots:
 
   defu@6.1.4: {}
 
+  delaunator@5.1.0:
+    dependencies:
+      robust-predicates: 3.0.3
+
   dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
@@ -3835,6 +4579,10 @@ snapshots:
   diff3@0.0.3: {}
 
   diff@8.0.2: {}
+
+  dompurify@3.4.11:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   dts-resolver@2.1.1: {}
 
@@ -3904,6 +4652,8 @@ snapshots:
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
+
+  es-toolkit@1.49.0: {}
 
   esbuild@0.27.3:
     optionalDependencies:
@@ -4032,6 +4782,8 @@ snapshots:
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
 
+  hachure-fill@0.5.2: {}
+
   has-property-descriptors@1.0.2:
     dependencies:
       es-define-property: 1.0.1
@@ -4070,6 +4822,10 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
   iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
@@ -4078,7 +4834,13 @@ snapshots:
 
   ignore@5.3.2: {}
 
+  import-meta-resolve@4.2.0: {}
+
   inherits@2.0.4: {}
+
+  internmap@1.0.1: {}
+
+  internmap@2.0.3: {}
 
   is-callable@1.2.7: {}
 
@@ -4121,11 +4883,21 @@ snapshots:
 
   jsesc@3.1.0: {}
 
+  katex@0.16.47:
+    dependencies:
+      commander: 8.3.0
+
+  khroma@2.1.0: {}
+
   kind-of@6.0.3: {}
 
   kleur@4.1.5: {}
 
   kolorist@1.8.0: {}
+
+  layout-base@1.0.2: {}
+
+  layout-base@2.0.1: {}
 
   linkify-it@5.0.0:
     dependencies:
@@ -4136,6 +4908,8 @@ snapshots:
       mlly: 1.7.4
       pkg-types: 2.3.0
       quansync: 0.2.11
+
+  lodash-es@4.18.1: {}
 
   longest-streak@3.1.0: {}
 
@@ -4163,6 +4937,8 @@ snapshots:
   markdown-table@3.0.4: {}
 
   markdown-title@1.0.2: {}
+
+  marked@16.4.2: {}
 
   math-intrinsics@1.1.0: {}
 
@@ -4292,6 +5068,30 @@ snapshots:
       '@types/mdast': 4.0.4
 
   mdurl@2.0.0: {}
+
+  mermaid@11.16.0:
+    dependencies:
+      '@braintree/sanitize-url': 7.1.2
+      '@iconify/utils': 3.1.3
+      '@mermaid-js/parser': 1.2.0
+      '@types/d3': 7.4.3
+      '@upsetjs/venn.js': 2.0.0
+      cytoscape: 3.34.0
+      cytoscape-cose-bilkent: 4.1.0(cytoscape@3.34.0)
+      cytoscape-fcose: 2.2.0(cytoscape@3.34.0)
+      d3: 7.9.0
+      d3-sankey: 0.12.3
+      dagre-d3-es: 7.0.14
+      dayjs: 1.11.21
+      dompurify: 3.4.11
+      es-toolkit: 1.49.0
+      katex: 0.16.47
+      khroma: 2.1.0
+      marked: 16.4.2
+      roughjs: 4.6.6
+      stylis: 4.4.0
+      ts-dedent: 2.3.0
+      uuid: 14.0.1
 
   micromark-core-commonmark@2.0.3:
     dependencies:
@@ -4480,6 +5280,9 @@ snapshots:
 
   nanoid@3.3.14: {}
 
+  non-layered-tidy-tree-layout@2.0.2:
+    optional: true
+
   ohash@2.0.11: {}
 
   once@1.4.0:
@@ -4499,6 +5302,8 @@ snapshots:
   pako@1.0.11: {}
 
   path-browserify@1.0.1: {}
+
+  path-data-parser@0.1.0: {}
 
   path-to-regexp@6.3.0: {}
 
@@ -4525,6 +5330,13 @@ snapshots:
       confbox: 0.2.2
       exsolve: 1.0.7
       pathe: 2.0.3
+
+  points-on-curve@0.2.0: {}
+
+  points-on-path@0.2.1:
+    dependencies:
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
 
   possible-typed-array-names@1.1.0: {}
 
@@ -4603,6 +5415,8 @@ snapshots:
 
   rfdc@1.4.1: {}
 
+  robust-predicates@3.0.3: {}
+
   rolldown-plugin-dts@0.14.1(rolldown@1.0.0-beta.29)(typescript@5.8.3):
     dependencies:
       '@babel/generator': 7.28.0
@@ -4667,6 +5481,15 @@ snapshots:
       '@rollup/rollup-win32-ia32-msvc': 4.46.3
       '@rollup/rollup-win32-x64-msvc': 4.46.3
       fsevents: 2.3.3
+
+  roughjs@4.6.6:
+    dependencies:
+      hachure-fill: 0.5.2
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
+      points-on-path: 0.2.1
+
+  rw@1.3.3: {}
 
   safe-buffer@5.2.1: {}
 
@@ -4788,6 +5611,8 @@ snapshots:
 
   strip-bom-string@1.0.0: {}
 
+  stylis@4.4.0: {}
+
   superjson@2.2.2:
     dependencies:
       copy-anything: 3.0.5
@@ -4814,6 +5639,8 @@ snapshots:
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
+
+  ts-dedent@2.3.0: {}
 
   tsdown@0.13.0(typescript@5.8.3):
     dependencies:
@@ -4935,6 +5762,8 @@ snapshots:
       unist-util-is: 6.0.0
       unist-util-visit-parents: 6.0.1
 
+  uuid@14.0.1: {}
+
   valibot@1.2.0(typescript@5.8.3):
     optionalDependencies:
       typescript: 5.8.3
@@ -4992,6 +5821,13 @@ snapshots:
     transitivePeerDependencies:
       - '@75lb/nature'
       - supports-color
+
+  vitepress-plugin-mermaid@2.0.17(mermaid@11.16.0)(vitepress@2.0.0-alpha.17(@types/node@20.19.41)(jiti@2.5.1)(postcss@8.5.15)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.2)):
+    dependencies:
+      mermaid: 11.16.0
+      vitepress: 2.0.0-alpha.17(@types/node@20.19.41)(jiti@2.5.1)(postcss@8.5.15)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.2)
+    optionalDependencies:
+      '@mermaid-js/mermaid-mindmap': 9.3.0
 
   vitepress@2.0.0-alpha.17(@types/node@20.19.41)(jiti@2.5.1)(postcss@8.5.15)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.2):
     dependencies:


### PR DESCRIPTION
Why
---

*@optique/discover* is, in practice, a small application runtime: it preloads config, runs two-pass source contexts, dispatches the matched command, and resolves dependencies. The one thing it never owned was the *around-handler* lifecycle, and that gap is what this change is really about. Without a seam between “parsing succeeded” and “the handler is done,” every cross-cutting concern (opening a LogTape scope, starting a Sentry or OTel span, booting a database pool lazily, printing a “finished in Xms” line, reporting a crash to telemetry while still exiting non-zero) had to be bolted on in one of two wrong places.

The first wrong place is the parser. People reach for `bindConfig` factories or `deferredValue()` resolvers and start opening databases or loggers inside them. But those are *value* systems; making them carry *command* lifecycle couples resource ownership to whichever option happened to trigger a fallback, and the cleanup half has nowhere natural to live. The second wrong place is the handler itself, where the same `try { const ctx = open(); await body(ctx); } finally { await ctx.close(); }` gets copy-pasted into every command file and silently diverges the moment one developer forgets it. The motivation here is to give that logic a single home so it stops leaking into layers that were never meant to hold it.

The hooks deliberately live only on `runProgram()` and `defineCommand()`, not on *@optique/run*'s `run()` and not in *@optique/core*. `run()` simply calls one parser and exits, so the caller already controls everything around it; lifecycle hooks only earn their keep once you dispatch *many* commands that share pre/post logic, which is precisely the *@optique/discover* layer. Keeping them out of *@optique/core* is a hard constraint, not an accident: the combinator contract stays untouched, so no parser, value parser, or modifier gains a new responsibility just because programs grew a lifecycle.

Finally, the hooks are framed to *observe*, not to *gatekeep*. They cannot rewrite parser input, cannot cancel a command, and cannot swallow a failure. That restraint is intentional, because the alternative (yargs-style middleware that mutates arguments, or a hook that can quietly turn a crash into a success) trades a small ergonomic win for a large loss of predictability, and it would make the exit-code behavior of a CLI depend on hook ordering. Keeping the model to a fixed three-point lifecycle (the same shape cobra, oclif, and clipanion converged on) keeps it easy to reason about.


How
---

 -  *Nesting over composition.* Program-level hooks wrap command-level hooks, which wrap the handler, and teardown unwinds in reverse (`program.beforeEach` then `command.beforeEach` then handler; on the way out `command.afterEach` then `program.afterEach`). This mirrors stack unwinding, so the most specific setup is the first to be torn down, and it lets a single command (say, a `deploy` that always refreshes a token) own its preflight without the program-level hook having to know about it.

 -  *Threading resources through return values, not globals.* `beforeEach` returns a `ProgramHookContext`, and whatever it stores in `resource` is handed forward to `afterEach`, to `onError`, and to the handler's second argument. The reason is to avoid module-level mutable state entirely: the thing a `beforeEach` opens is exactly the thing its `afterEach` closes, with no shared variable in between. The handler signature grows by one optional positional parameter, which is backward compatible because a handler that ignores it keeps type-checking and running unchanged.

 -  *`onError` re-throws the original error, always.* The hook runs for observation and cleanup, then the dispatcher re-throws the very error that caused the failure, so process exit codes are identical to a hookless run. This holds even when `onError` itself throws: its error is suppressed rather than allowed to mask the real cause, because a bug in telemetry reporting should never rewrite which failure the operator sees. A rejection from `afterEach` is treated as a handler failure too, which is the natural extension and keeps the dispatcher to one code path.

 -  *No context argument when no `beforeEach` ran.* If neither scope defines a `beforeEach`, the handler is called with just the value, reproducing the exact call shape (down to argument arity) of `runProgram()` before this change. This is why the context parameter is typed as optional rather than required: the type now tells the truth about when a context is actually supplied, instead of promising an object that the runtime would not always pass.

 -  *Exposing the resolved path on the invocation, not faking it on the command.* File-based discovery derives a command's path from its module location, so a discovered command usually omits an explicit `path` and `command.path` is `undefined`. The dispatcher already knows the derived path, so `ProgramInvocation` now carries a resolved `path` that is always populated. It lives on the invocation rather than being written back onto the command definition, because the path is a property of *this* match, not of the user-authored command, and a hook that labels work by command path needs it to be reliable.

 -  *Validating hooks the way other callbacks are validated.* Both program- and command-level hooks are checked at the boundary, so passing a non-function `beforeEach` fails fast with a clear `TypeError` instead of surfacing later as a generic “not a function” deep inside dispatch. This matches how the project already guards its other runtime callback options.


What
----

The surface added is small and entirely within *@optique/discover*: an opt-in `hooks` option on `runProgram()` (the `ProgramHooks` shape of `beforeEach`/`afterEach`/`onError`), a matching per-command `hooks` field on `defineCommand()`, a resolved `path` on `ProgramInvocation`, and the exported `ProgramHooks` and `ProgramHookContext` types. The change is documented with a “Lifecycle hooks” section in *docs/concepts/discover.md* and a worked recipe in *docs/cookbook.md*, both using a Mermaid flowchart for the ordering (the docs gained *vitepress-plugin-mermaid* for this), plus a runnable *examples/patterns/program-hooks.ts*.


Test plan
---------

 -  [ ] `mise test` passes (Deno, Node.js, Bun)
 -  [ ] Absent or empty hooks produce identical behavior, including handler argument arity
 -  [ ] A `beforeEach` resource reaches `handler(value, ctx)` as well as `afterEach` and `onError`
 -  [ ] `onError` runs on a throwing or rejecting handler and the original error is re-thrown, even when `onError` itself throws
 -  [ ] Program- and command-level hooks compose in the documented order
 -  [ ] `invocation.path` is populated for discovered commands that omit an explicit `path`
 -  [ ] Docs build passes (`pnpm build` in *docs/*)
