### PR TITLE
Add official Optique agent skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,6 +200,26 @@ Reference anchors come from the concept-page heading slug: the `string()`
 parser heading becomes `#string-parser`, and `gitBranch()` becomes
 `#gitbranch`.  Verify anchors against the built docs.
 
+### Keeping agent guidance in sync
+
+The official Optique Agent Skill is maintained at
+*packages/core/skills/optique/SKILL.md*.  Update it alongside documentation
+when a change affects how agents should use the library:
+
+ -  *New feature or parser*: mention it when the skill's concise rules,
+    examples, reference links, or integration package table would otherwise
+    become incomplete.
+ -  *API contract change*: update affected examples and guidance so agents do
+    not keep producing stale imports, option shapes, return types, or usage
+    patterns.
+ -  *New common pitfall*: add a short warning to the skill only when it belongs
+    in the quick checklist; otherwise update *docs/pitfalls.md* and keep the
+    skill pointing to that maintained guide.
+
+When editing the skill, keep it concise and run the colocated
+*packages/core/skills/optique/SKILL.test.ts* checks so its TypeScript examples
+and package metadata stay valid.
+
 
 Development practices
 ---------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,11 +39,19 @@ To be released.
     can reuse the same hint logic without re-implementing distance
     calculation.  [[#849]]
 
+ -  Added an official Agent Skill under *skills/optique/* in *@optique/core*,
+    declared through the package's `agents.skills` metadata.  The skill gives
+    AI coding agents concise guidance for using Optique correctly, links to
+    maintained reference pages for API details, and keeps its inline TypeScript
+    examples covered by a snippet type-checking test.  [[#850], [#852]]
+
 [#842]: https://github.com/dahlia/optique/issues/842
 [#843]: https://github.com/dahlia/optique/pull/843
 [#846]: https://github.com/dahlia/optique/issues/846
 [#848]: https://github.com/dahlia/optique/pull/848
 [#849]: https://github.com/dahlia/optique/pull/849
+[#850]: https://github.com/dahlia/optique/issues/850
+[#852]: https://github.com/dahlia/optique/pull/852
 
 ### @optique/derived-defaults
 

--- a/packages/core/deno.json
+++ b/packages/core/deno.json
@@ -31,9 +31,14 @@
     "dist/",
     "tsdown.config.ts"
   ],
+  "publish": {
+    "exclude": [
+      "skills/optique/SKILL.test.ts"
+    ]
+  },
   "tasks": {
     "build": "pnpm build",
-    "test": "deno test",
+    "test": "deno test --allow-read --allow-env",
     "test:node": {
       "dependencies": [
         "build"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,8 +36,17 @@
   "files": [
     "dist/",
     "package.json",
-    "README.md"
+    "README.md",
+    "skills/optique/SKILL.md"
   ],
+  "agents": {
+    "skills": [
+      {
+        "name": "optique",
+        "path": "./skills/optique"
+      }
+    ]
+  },
   "type": "module",
   "module": "./dist/index.js",
   "main": "./dist/index.cjs",
@@ -224,7 +233,7 @@
     "prepublish": "tsdown",
     "test": "node --test",
     "test:bun": "bun test",
-    "test:deno": "deno test",
-    "test-all": "tsdown && node --test && bun test && deno test"
+    "test:deno": "deno test --allow-read --allow-env",
+    "test-all": "tsdown && node --test && bun test && deno test --allow-read --allow-env"
   }
 }

--- a/packages/core/skills/optique/SKILL.md
+++ b/packages/core/skills/optique/SKILL.md
@@ -1,0 +1,229 @@
+---
+name: optique
+description: >
+  Use this skill when writing any code that builds a command-line interface
+  with Optique in TypeScript or JavaScript. Covers the combinatorial parser
+  model, choosing @optique/core vs @optique/run, value parsers, structured
+  messages, optional()/withDefault()/multiple(), subcommands with command()
+  and or(), shell completion, async parsing, the integration packages, and
+  common mistakes to avoid. Trigger whenever the user is parsing command-line
+  arguments, building a CLI, or adding options or subcommands to a tool.
+license: MIT
+---
+
+Optique is a type-safe combinatorial CLI parser. Use it by describing the CLI
+grammar with parsers and combinators, not by manually walking `argv`.
+
+If web access is available, start from <https://optique.dev/llms.txt> for the
+maintained documentation index. Keep the rules below in mind even when offline;
+they cover the parts agents most often get wrong.
+
+
+Core rules
+----------
+
+ -  Use `run()` from `@optique/run` for real CLI applications. It reads
+    `process.argv`/`Deno.args`, handles help, version output, errors, exit
+    codes, colors, terminal width, and shell completion. Use `parse()` from
+    `@optique/core/parser` or `runParser()` from `@optique/core/facade` when
+    embedding Optique in tests, libraries, tools, or custom runtimes.
+ -  Compose parsers with `object()`, `tuple()`, `seq()`, `or()`, `merge()`, and
+    modifiers. Do not write imperative `if`/`else` argument scanners around
+    Optique parsers.
+ -  Let TypeScript infer the parsed value type from the parser. Do not
+    hand-maintain a separate interface for the result unless another API
+    boundary requires it.
+ -  Most parsers are required until you wrap them. `optional(p)` yields
+    `undefined`; `withDefault(p, value)` yields a fallback value. For Boolean
+    flags, use `withDefault(flag("--name"), false)` when absence should mean
+    `false`.
+ -  Use `message` from `@optique/core/message` for descriptions, help text, and
+    custom errors. Prefer semantic message helpers such as `optionName()` and
+    `metavar()` over string concatenation when naming CLI elements.
+ -  Use value parsers such as `integer()`, `choice()`, `url()`, and `uuid()`
+    instead of validating raw strings after parsing. Use `path()` from
+    `@optique/run/valueparser` for file-system paths. Write a custom
+    `{ mode, metavar, parse, format }` value parser only when the catalog does
+    not cover the domain.
+ -  Async value parsers make the containing parser async. If you use packages
+    such as `@optique/git`, remember to `await run(...)`, `await parse(...)`, or
+    `await runParser(...)` as appropriate.
+ -  Build subcommands with `command()` combined by `or()`. Put a literal field
+    such as `command: constant("serve")` in each branch when you want a
+    discriminated union.
+ -  Enable completion through `run(parser, { completion: "both" })` for CLI
+    apps. Do not hand-write completion scripts from parser metadata.
+
+
+Canonical app shape
+-------------------
+
+~~~~ typescript
+import { object } from "@optique/core/constructs";
+import { message } from "@optique/core/message";
+import { withDefault } from "@optique/core/modifiers";
+import { argument, flag, option } from "@optique/core/primitives";
+import { integer, string } from "@optique/core/valueparser";
+import { run } from "@optique/run";
+
+const parser = object({
+  input: argument(string({ metavar: "FILE" }), {
+    description: message`Input file to process.`,
+  }),
+  port: withDefault(
+    option("--port", integer({ min: 1, max: 65535 }), {
+      description: message`Port to listen on.`,
+    }),
+    3000,
+  ),
+  verbose: withDefault(
+    flag("-v", "--verbose", { description: message`Enable verbose logging.` }),
+    false,
+  ),
+});
+
+const config = run(parser, {
+  brief: message`Process a file.`,
+  completion: "both",
+  showDefault: true,
+});
+
+console.log(`Processing ${config.input} on port ${config.port}.`);
+~~~~
+
+
+Subcommands
+-----------
+
+Use `command()` for each branch and `or()` to require exactly one matching
+subcommand. Use `optional(or(...))` only when no subcommand is valid.
+
+~~~~ typescript
+import { object, or } from "@optique/core/constructs";
+import { withDefault } from "@optique/core/modifiers";
+import { parse } from "@optique/core/parser";
+import { command, constant, flag, option } from "@optique/core/primitives";
+import { integer } from "@optique/core/valueparser";
+
+const parser = or(
+  command("build", object({
+    command: constant("build"),
+    watch: withDefault(flag("--watch"), false),
+  })),
+  command("serve", object({
+    command: constant("serve"),
+    port: withDefault(option("--port", integer({ min: 1 })), 3000),
+  })),
+);
+
+const result = parse(parser, ["serve", "--port", "8080"]);
+
+if (result.success) {
+  switch (result.value.command) {
+    case "build":
+      result.value.watch;
+      break;
+    case "serve":
+      result.value.port;
+      break;
+  }
+}
+~~~~
+
+
+Custom value parsers
+--------------------
+
+Prefer the built-in catalog first. When a custom domain is needed, keep the
+validation in a value parser so help, errors, defaults, prompts, and completion
+all see the same typed value.
+
+~~~~ typescript
+import { message } from "@optique/core/message";
+import type { ValueParser, ValueParserResult } from "@optique/core/valueparser";
+
+const levels = ["debug", "info", "warn", "error"] as const;
+type Level = typeof levels[number];
+
+function isLevel(input: string): input is Level {
+  return (levels as readonly string[]).includes(input);
+}
+
+function logLevel(): ValueParser<"sync", Level> {
+  return {
+    mode: "sync",
+    metavar: "LEVEL",
+    placeholder: "info",
+    parse(input: string): ValueParserResult<Level> {
+      if (isLevel(input)) return { success: true, value: input };
+      return { success: false, error: message`Invalid log level: ${input}.` };
+    },
+    format(value: Level): string {
+      return value;
+    },
+  };
+}
+
+const parser = logLevel();
+~~~~
+
+
+Common mistakes checklist
+-------------------------
+
+ -  Do not parse `process.argv` manually before calling Optique. Pass the parser
+    to `run()` for applications, or pass explicit argument arrays to `parse()`
+    in tests and embedded use.
+ -  Do not treat `or(a, b)` as “zero or more alternatives.” It requires one
+    matching branch unless the whole `or()` is wrapped in `optional()` or
+    `withDefault()`.
+ -  Do not use `object()` for mutually exclusive subcommands. Use
+    `or(command(...), command(...))`.
+ -  Do not forget that `flag("--x")` is required. Wrap it in `optional()` or
+    `withDefault(..., false)` for ordinary optional flags.
+ -  Do not expect `multiple(p)` to fail when absent; it returns `[]`. Wrap with
+    `nonEmpty()` when at least one value is required.
+ -  Do not confuse free-order parsing with `seq()`. Most constructs let child
+    parsers compete by priority; use `seq()` only when the grammar is truly
+    ordered.
+ -  Do not concatenate plain strings for errors or descriptions. Use structured
+    `message` values.
+ -  Do not forget to register source contexts when using `bindEnv()`,
+    `bindConfig()`, or `bindDerivedDefault()`.
+
+For the detailed maintained guide, use <https://optique.dev/pitfalls.md>.
+
+
+Reference links
+---------------
+
+ -  Documentation index for agents: <https://optique.dev/llms.txt>
+ -  Runners and entry points: <https://optique.dev/concepts/runners.md>
+ -  Primitive parsers: <https://optique.dev/concepts/primitives.md>
+ -  Construct combinators: <https://optique.dev/concepts/constructs.md>
+ -  Modifiers: <https://optique.dev/concepts/modifiers.md>
+ -  Value parser catalog: <https://optique.dev/concepts/valueparsers.md>
+ -  Structured messages: <https://optique.dev/concepts/messages.md>
+ -  Shell completion: <https://optique.dev/concepts/completion.md>
+ -  Command discovery: <https://optique.dev/concepts/discover.md>
+ -  Man pages: <https://optique.dev/concepts/man.md>
+
+
+Integration packages
+--------------------
+
+| Package                     | Use for                                   | Docs                                               |
+| --------------------------- | ----------------------------------------- | -------------------------------------------------- |
+| `@optique/env`              | Environment variable fallbacks            | <https://optique.dev/integrations/env.md>          |
+| `@optique/config`           | Configuration file fallbacks              | <https://optique.dev/integrations/config.md>       |
+| `@optique/derived-defaults` | Defaults computed from first-pass results | <https://optique.dev/concepts/derived-defaults.md> |
+| `@optique/prompt`           | Generic prompt adapter foundation         | <https://optique.dev/integrations/prompt.md>       |
+| `@optique/clack`            | Clack interactive fallback prompts        | <https://optique.dev/integrations/clack.md>        |
+| `@optique/inquirer`         | Inquirer.js interactive fallback prompts  | <https://optique.dev/integrations/inquirer.md>     |
+| `@optique/zod`              | Zod-backed value parsing                  | <https://optique.dev/integrations/zod.md>          |
+| `@optique/valibot`          | Valibot-backed value parsing              | <https://optique.dev/integrations/valibot.md>      |
+| `@optique/temporal`         | Temporal date and time parsers            | <https://optique.dev/integrations/temporal.md>     |
+| `@optique/git`              | Async Git reference validation            | <https://optique.dev/integrations/git.md>          |
+| `@optique/logtape`          | LogTape verbosity and log-level options   | <https://optique.dev/integrations/logtape.md>      |
+| `@optique/man`              | Man page generation                       | <https://optique.dev/concepts/man.md>              |
+| `@optique/discover`         | File-based command discovery              | <https://optique.dev/concepts/discover.md>         |

--- a/packages/core/skills/optique/SKILL.test.ts
+++ b/packages/core/skills/optique/SKILL.test.ts
@@ -19,9 +19,13 @@ const compilerOptions: ts.CompilerOptions = {
   target: ts.ScriptTarget.ES2022,
 };
 
-type PackageManifest = {
+type DenoManifest = {
   readonly name?: string;
-  readonly exports?: Record<string, string>;
+  readonly exports?: string | Record<string, string>;
+};
+
+type PackageManifest = {
+  readonly exports?: string | Record<string, unknown>;
 };
 
 const nodeStubs = `
@@ -155,27 +159,53 @@ async function readWorkspaceExports(): Promise<ReadonlyMap<string, string>> {
     if (!entry.isDirectory()) continue;
 
     const packageDir = join(packagesDir, entry.name);
-    let manifest: PackageManifest;
+    let denoManifest: DenoManifest;
     try {
-      manifest = JSON.parse(
+      denoManifest = JSON.parse(
         await readFile(join(packageDir, "deno.json"), "utf-8"),
-      ) as PackageManifest;
+      ) as DenoManifest;
     } catch (error) {
       if (isFileNotFoundError(error)) continue;
       throw error;
     }
 
-    if (manifest.name == null || manifest.exports == null) continue;
+    if (denoManifest.name == null || denoManifest.exports == null) continue;
 
-    for (const [subpath, target] of Object.entries(manifest.exports)) {
+    const packageManifest = JSON.parse(
+      await readFile(join(packageDir, "package.json"), "utf-8"),
+    ) as PackageManifest;
+    const denoExports = normalizeDenoExports(denoManifest.exports);
+
+    for (const [subpath, target] of Object.entries(denoExports)) {
+      if (!hasPackageExport(packageManifest.exports, subpath)) {
+        throw new Error(
+          `${denoManifest.name} exports ${subpath} from deno.json but not package.json.`,
+        );
+      }
+
       const specifier = subpath === "."
-        ? manifest.name
-        : `${manifest.name}${subpath.slice(1)}`;
+        ? denoManifest.name
+        : `${denoManifest.name}${subpath.slice(1)}`;
       result.set(specifier, join(packageDir, target));
     }
   }
 
   return result;
+}
+
+function normalizeDenoExports(
+  exports: string | Record<string, string>,
+): Record<string, string> {
+  return typeof exports === "string" ? { ".": exports } : exports;
+}
+
+function hasPackageExport(
+  exports: string | Record<string, unknown> | undefined,
+  subpath: string,
+): boolean {
+  if (exports == null) return false;
+  if (typeof exports === "string") return subpath === ".";
+  return Object.hasOwn(exports, subpath);
 }
 
 function isFileNotFoundError(error: unknown): boolean {
@@ -297,7 +327,7 @@ describe("Optique agent skill", () => {
       lineCount <= 300,
       `Expected SKILL.md to be concise, got ${lineCount} lines.`,
     );
-    assert.match(skill, /^---\nname: optique\n/m);
+    assert.match(skill, /^---\nname: optique\n/);
     assert.match(skill, /https:\/\/optique\.dev\/llms\.txt/);
     assert.match(skill, /https:\/\/optique\.dev\/pitfalls\.md/);
     assert.match(skill, /https:\/\/optique\.dev\/concepts\/valueparsers\.md/);

--- a/packages/core/skills/optique/SKILL.test.ts
+++ b/packages/core/skills/optique/SKILL.test.ts
@@ -2,11 +2,12 @@ import assert from "node:assert/strict";
 import { readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
 import ts from "typescript";
 
-const root = new URL("../../../../", new URL(".", import.meta.url)).pathname;
+const root = fileURLToPath(new URL("../../../../", import.meta.url));
 const packageJsonPath = join(root, "packages/core/package.json");
-const skillPath = new URL("SKILL.md", import.meta.url).pathname;
+const skillPath = fileURLToPath(new URL("SKILL.md", import.meta.url));
 const compilerOptions: ts.CompilerOptions = {
   allowImportingTsExtensions: true,
   lib: ["lib.esnext.d.ts", "lib.dom.d.ts"],
@@ -188,10 +189,15 @@ function typeCheckSnippets(
   workspaceExports: ReadonlyMap<string, string>,
 ): readonly ts.Diagnostic[] {
   const snippets = new Map<string, string>();
-  snippets.set(join(root, "tmp/skill-snippets/node-stubs.d.ts"), nodeStubs);
+  snippets.set(
+    normalizePath(join(root, "tmp/skill-snippets/node-stubs.d.ts")),
+    nodeStubs,
+  );
   for (const [index, block] of blocks.entries()) {
     snippets.set(
-      join(root, "tmp/skill-snippets", `snippet-${index + 1}.ts`),
+      normalizePath(
+        join(root, "tmp/skill-snippets", `snippet-${index + 1}.ts`),
+      ),
       `${block}\n`,
     );
   }
@@ -201,9 +207,9 @@ function typeCheckSnippets(
   const defaultReadFile = host.readFile.bind(host);
 
   host.fileExists = (fileName) =>
-    snippets.has(fileName) || defaultFileExists(fileName);
+    snippets.has(normalizePath(fileName)) || defaultFileExists(fileName);
   host.readFile = (fileName) =>
-    snippets.get(fileName) ?? defaultReadFile(fileName);
+    snippets.get(normalizePath(fileName)) ?? defaultReadFile(fileName);
   host.resolveModuleNames = (moduleNames, containingFile) =>
     moduleNames.map((moduleName) => {
       const workspaceFile = workspaceExports.get(moduleName);
@@ -224,6 +230,10 @@ function typeCheckSnippets(
   return ts.getPreEmitDiagnostics(program);
 }
 
+function normalizePath(path: string): string {
+  return path.replace(/\\/g, "/");
+}
+
 function formatDiagnostic(diagnostic: ts.Diagnostic): string {
   const message = ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n");
   if (diagnostic.file == null || diagnostic.start == null) return message;
@@ -231,8 +241,10 @@ function formatDiagnostic(diagnostic: ts.Diagnostic): string {
   const { line, character } = diagnostic.file.getLineAndCharacterOfPosition(
     diagnostic.start,
   );
-  const relativePath = diagnostic.file.fileName.startsWith(root)
-    ? diagnostic.file.fileName.slice(root.length)
+  const normalizedFileName = normalizePath(diagnostic.file.fileName);
+  const normalizedRoot = normalizePath(root);
+  const relativePath = normalizedFileName.startsWith(normalizedRoot)
+    ? normalizedFileName.slice(normalizedRoot.length)
     : diagnostic.file.fileName;
   return `${relativePath}:${line + 1}:${character + 1}: ${message}`;
 }

--- a/packages/core/skills/optique/SKILL.test.ts
+++ b/packages/core/skills/optique/SKILL.test.ts
@@ -1,0 +1,310 @@
+import assert from "node:assert/strict";
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import ts from "typescript";
+
+const root = new URL("../../../../", new URL(".", import.meta.url)).pathname;
+const packageJsonPath = join(root, "packages/core/package.json");
+const skillPath = new URL("SKILL.md", import.meta.url).pathname;
+const compilerOptions: ts.CompilerOptions = {
+  allowImportingTsExtensions: true,
+  lib: ["lib.esnext.d.ts", "lib.dom.d.ts"],
+  module: ts.ModuleKind.NodeNext,
+  moduleResolution: ts.ModuleResolutionKind.NodeNext,
+  noEmit: true,
+  skipLibCheck: true,
+  strict: true,
+  target: ts.ScriptTarget.ES2022,
+};
+
+type PackageManifest = {
+  readonly name?: string;
+  readonly exports?: Record<string, string>;
+};
+
+const nodeStubs = `
+declare module "node:fs" {
+  export interface Stats {
+    isDirectory(): boolean;
+    isFile(): boolean;
+  }
+  export function existsSync(path: string): boolean;
+  export function statSync(path: string): Stats;
+}
+
+declare module "node:path" {
+  declare const path: {
+    basename(path: string, suffix?: string): string;
+    dirname(path: string): string;
+    extname(path: string): string;
+  };
+  export function basename(path: string, suffix?: string): string;
+  export function dirname(path: string): string;
+  export function extname(path: string): string;
+  export default path;
+}
+
+declare module "node:process" {
+  interface WritableStreamLike {
+    readonly columns?: number;
+    readonly isTTY?: boolean;
+    write(chunk: string): boolean;
+  }
+
+  declare const process: {
+    argv: string[];
+    stdout: WritableStreamLike;
+    stderr: WritableStreamLike;
+    exit(code?: number): never;
+  };
+  export default process;
+}
+`;
+
+function extractTypeScriptBlocks(markdown: string): string[] {
+  const blocks: string[] = [];
+  const lines = markdown.replaceAll("\r\n", "\n").replaceAll("\r", "\n")
+    .split("\n");
+
+  for (let index = 0; index < lines.length; index++) {
+    const opening = getFenceOpening(lines[index]);
+    if (opening == null) continue;
+
+    const body: string[] = [];
+    for (index++; index < lines.length; index++) {
+      if (isFenceClosing(lines[index], opening.marker, opening.length)) {
+        break;
+      }
+      body.push(lines[index]);
+    }
+
+    if (opening.language === "typescript" || opening.language === "ts") {
+      blocks.push(body.join("\n").trim());
+    }
+  }
+
+  return blocks;
+}
+
+function getFenceOpening(
+  line: string,
+): {
+  readonly marker: "`" | "~";
+  readonly length: number;
+  readonly language: string;
+} | undefined {
+  const indent = countLeadingSpaces(line);
+  if (indent > 3) return undefined;
+
+  const marker = line[indent];
+  if (marker !== "`" && marker !== "~") return undefined;
+
+  const length = countRepeated(line, indent, marker);
+  if (length < 3) return undefined;
+
+  const info = line.slice(indent + length).trim();
+  if (marker === "`" && info.includes("`")) return undefined;
+
+  return {
+    marker,
+    length,
+    language: getFirstWord(info).toLowerCase(),
+  };
+}
+
+function isFenceClosing(
+  line: string,
+  marker: "`" | "~",
+  openingLength: number,
+): boolean {
+  const indent = countLeadingSpaces(line);
+  if (indent > 3) return false;
+
+  const length = countRepeated(line, indent, marker);
+  return length >= openingLength && line.slice(indent + length).trim() === "";
+}
+
+function countLeadingSpaces(line: string): number {
+  let count = 0;
+  while (line[count] === " ") count++;
+  return count;
+}
+
+function countRepeated(line: string, start: number, char: string): number {
+  let count = 0;
+  while (line[start + count] === char) count++;
+  return count;
+}
+
+function getFirstWord(text: string): string {
+  for (let index = 0; index < text.length; index++) {
+    const char = text[index];
+    if (char === " " || char === "\t") return text.slice(0, index);
+  }
+  return text;
+}
+
+async function readWorkspaceExports(): Promise<ReadonlyMap<string, string>> {
+  const result = new Map<string, string>();
+  const packagesDir = join(root, "packages");
+  const packages = await readdir(packagesDir, { withFileTypes: true });
+
+  for (const entry of packages) {
+    if (!entry.isDirectory()) continue;
+
+    const packageDir = join(packagesDir, entry.name);
+    let manifest: PackageManifest;
+    try {
+      manifest = JSON.parse(
+        await readFile(join(packageDir, "deno.json"), "utf-8"),
+      ) as PackageManifest;
+    } catch (error) {
+      if (isFileNotFoundError(error)) continue;
+      throw error;
+    }
+
+    if (manifest.name == null || manifest.exports == null) continue;
+
+    for (const [subpath, target] of Object.entries(manifest.exports)) {
+      const specifier = subpath === "."
+        ? manifest.name
+        : `${manifest.name}${subpath.slice(1)}`;
+      result.set(specifier, join(packageDir, target));
+    }
+  }
+
+  return result;
+}
+
+function isFileNotFoundError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const { code } = error as { readonly code?: unknown };
+  return code === "ENOENT";
+}
+
+function typeCheckSnippets(
+  blocks: readonly string[],
+  workspaceExports: ReadonlyMap<string, string>,
+): readonly ts.Diagnostic[] {
+  const snippets = new Map<string, string>();
+  snippets.set(join(root, "tmp/skill-snippets/node-stubs.d.ts"), nodeStubs);
+  for (const [index, block] of blocks.entries()) {
+    snippets.set(
+      join(root, "tmp/skill-snippets", `snippet-${index + 1}.ts`),
+      `${block}\n`,
+    );
+  }
+
+  const host = ts.createCompilerHost(compilerOptions, true);
+  const defaultFileExists = host.fileExists.bind(host);
+  const defaultReadFile = host.readFile.bind(host);
+
+  host.fileExists = (fileName) =>
+    snippets.has(fileName) || defaultFileExists(fileName);
+  host.readFile = (fileName) =>
+    snippets.get(fileName) ?? defaultReadFile(fileName);
+  host.resolveModuleNames = (moduleNames, containingFile) =>
+    moduleNames.map((moduleName) => {
+      const workspaceFile = workspaceExports.get(moduleName);
+      if (workspaceFile != null) {
+        return { resolvedFileName: workspaceFile, extension: ts.Extension.Ts };
+      }
+
+      return ts.resolveModuleName(
+        moduleName,
+        containingFile,
+        compilerOptions,
+        host,
+      )
+        .resolvedModule;
+    });
+
+  const program = ts.createProgram([...snippets.keys()], compilerOptions, host);
+  return ts.getPreEmitDiagnostics(program);
+}
+
+function formatDiagnostic(diagnostic: ts.Diagnostic): string {
+  const message = ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n");
+  if (diagnostic.file == null || diagnostic.start == null) return message;
+
+  const { line, character } = diagnostic.file.getLineAndCharacterOfPosition(
+    diagnostic.start,
+  );
+  const relativePath = diagnostic.file.fileName.startsWith(root)
+    ? diagnostic.file.fileName.slice(root.length)
+    : diagnostic.file.fileName;
+  return `${relativePath}:${line + 1}:${character + 1}: ${message}`;
+}
+
+describe("Optique agent skill", () => {
+  it("should extract TypeScript examples from Markdown fences", () => {
+    const markdown = [
+      "~~~~ ts twoslash",
+      "const short = true;",
+      "~~~~",
+      "```` typescript",
+      "const nested = `not a fence`;",
+      "```",
+      "````",
+      "``` javascript",
+      "const ignored = true;",
+      "```",
+    ].join("\n");
+
+    assert.deepEqual(extractTypeScriptBlocks(markdown), [
+      "const short = true;",
+      "const nested = `not a fence`;\n```",
+    ]);
+  });
+
+  it("should be declared in the core package metadata", async () => {
+    const packageJson = JSON.parse(
+      await readFile(packageJsonPath, "utf-8"),
+    ) as {
+      readonly agents?: {
+        readonly skills?: readonly {
+          readonly name: string;
+          readonly path: string;
+        }[];
+      };
+      readonly files?: readonly string[];
+    };
+
+    assert.deepEqual(packageJson.agents?.skills, [
+      { name: "optique", path: "./skills/optique" },
+    ]);
+    assert.ok(packageJson.files?.includes("skills/optique/SKILL.md"));
+  });
+
+  it("should keep the skill concise and point agents to maintained references", async () => {
+    const skill = await readFile(skillPath, "utf-8");
+    const lineCount = skill.split("\n").length;
+
+    assert.ok(
+      lineCount <= 300,
+      `Expected SKILL.md to be concise, got ${lineCount} lines.`,
+    );
+    assert.match(skill, /^---\nname: optique\n/m);
+    assert.match(skill, /https:\/\/optique\.dev\/llms\.txt/);
+    assert.match(skill, /https:\/\/optique\.dev\/pitfalls\.md/);
+    assert.match(skill, /https:\/\/optique\.dev\/concepts\/valueparsers\.md/);
+  });
+
+  it("should type-check TypeScript examples in the skill", async () => {
+    const skill = await readFile(skillPath, "utf-8");
+    const blocks = extractTypeScriptBlocks(skill);
+
+    assert.ok(blocks.length > 0, "Expected at least one TypeScript example.");
+
+    const diagnostics = typeCheckSnippets(blocks, await readWorkspaceExports());
+
+    assert.equal(
+      diagnostics.length,
+      0,
+      `Skill TypeScript examples failed to type-check:\n${
+        diagnostics.map(formatDiagnostic).join("\n")
+      }`,
+    );
+  });
+});

--- a/packages/core/skills/optique/SKILL.test.ts
+++ b/packages/core/skills/optique/SKILL.test.ts
@@ -327,7 +327,7 @@ describe("Optique agent skill", () => {
       lineCount <= 300,
       `Expected SKILL.md to be concise, got ${lineCount} lines.`,
     );
-    assert.match(skill, /^---\nname: optique\n/);
+    assert.match(skill, /^---\r?\nname: optique\r?\n/);
     assert.match(skill, /https:\/\/optique\.dev\/llms\.txt/);
     assert.match(skill, /https:\/\/optique\.dev\/pitfalls\.md/);
     assert.match(skill, /https:\/\/optique\.dev\/concepts\/valueparsers\.md/);


### PR DESCRIPTION
Optique should give coding agents the same versioned, package-local guidance that human users get from the docs, because otherwise generated CLI code drifts toward stale imports, imperative argv parsing, and common combinator mistakes.

This PR ships that guidance from `@optique/core` through `agents.skills` metadata, keeps the skill concise enough to be useful in agent context, and protects its TypeScript examples with a colocated compiler-backed test. The test stays out of published skill assets so the package exposes the guidance without extra implementation baggage.

It also documents that future feature, parser, API contract, and pitfall changes should keep the skill in sync with the maintained docs.

Closes #850.