### PR TITLE
Keep nested help scoped with completion enabled

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,16 @@ Version 1.1.1
 
 To be released.
 
+### @optique/core
+
+ -  Fixed nested subcommand `--help` output when the completion option is
+    enabled.  Help for commands such as `demo group sub --help` now stays
+    scoped to the selected subcommand instead of also showing sibling commands
+    and top-level meta command or option usage.  [[#855], [#859]]
+
+[#855]: https://github.com/dahlia/optique/issues/855
+[#859]: https://github.com/dahlia/optique/pull/859
+
 
 Version 1.1.0
 -------------

--- a/packages/core/src/facade.test.ts
+++ b/packages/core/src/facade.test.ts
@@ -3696,6 +3696,64 @@ describe("Subcommand help edge cases (Issue #26 comprehensive coverage)", () => 
     );
   });
 
+  it("should scope nested subcommand help with completion option enabled", () => {
+    const parser = or(
+      command(
+        "group",
+        or(
+          command("sub", object({ action: constant("sub") })),
+          command("other", object({ action: constant("other") })),
+        ),
+      ),
+    );
+
+    for (
+      const completion of [
+        { option: true },
+        { command: true, option: true },
+      ] as const
+    ) {
+      let helpOutput = "";
+      const result = runParser(parser, "demo", ["group", "sub", "--help"], {
+        help: {
+          command: true,
+          option: true,
+          onShow: () => "help-shown",
+        },
+        completion: {
+          ...completion,
+          onShow: () => "completion-shown",
+        },
+        stdout: (text) => {
+          helpOutput = text;
+        },
+      });
+
+      assert.equal(result, "help-shown");
+      assert.ok(helpOutput.includes("Usage: demo group sub"));
+      assert.ok(
+        !helpOutput.includes("demo group other"),
+        `Help output should not contain sibling usage but got:\n${helpOutput}`,
+      );
+      assert.ok(
+        !helpOutput.includes("demo help"),
+        `Help output should not contain help command usage but got:\n${helpOutput}`,
+      );
+      assert.ok(
+        !helpOutput.includes("demo completion"),
+        `Help output should not contain completion command usage but got:\n${helpOutput}`,
+      );
+      assert.ok(
+        !helpOutput.includes("demo --completion"),
+        `Help output should not contain completion option usage but got:\n${helpOutput}`,
+      );
+      assert.ok(
+        !helpOutput.includes("--completion SHELL"),
+        `Help output should not contain completion option docs but got:\n${helpOutput}`,
+      );
+    }
+  });
+
   describe("completion functionality", () => {
     it("should generate bash completion script when completion command is used", () => {
       const parser = object({

--- a/packages/core/src/facade.ts
+++ b/packages/core/src/facade.ts
@@ -2566,6 +2566,7 @@ export function runParser<
         // generation.  Include completion command in help even though it's
         // handled via early return.
         let helpGeneratorParser: Parser<Mode, unknown, unknown>;
+        let docGeneratorParser: Parser<Mode, unknown, unknown>;
         const helpAsCommand = helpCommandConfig != null;
         const versionAsCommand = versionCommandConfig != null;
         const completionAsCommand = completionCommandConfig != null;
@@ -2584,6 +2585,7 @@ export function runParser<
         ) {
           // User wants help for completion command specifically
           helpGeneratorParser = completionParsers.completionCommand;
+          docGeneratorParser = helpGeneratorParser;
         } else if (
           requestedCommand != null &&
           !classified.preferUserCommandDocs &&
@@ -2593,6 +2595,7 @@ export function runParser<
         ) {
           // User wants help for help command specifically
           helpGeneratorParser = helpParsers.helpCommand;
+          docGeneratorParser = helpGeneratorParser;
         } else if (
           requestedCommand != null &&
           !classified.preferUserCommandDocs &&
@@ -2602,6 +2605,7 @@ export function runParser<
         ) {
           // User wants help for version command specifically
           helpGeneratorParser = versionParsers.versionCommand;
+          docGeneratorParser = helpGeneratorParser;
         } else {
           // General help or help for user-defined commands
           // Collect all command parsers to include in help generation
@@ -2724,6 +2728,9 @@ export function runParser<
               ...commandParsers,
             );
           }
+          docGeneratorParser = classified.commands.length > 0
+            ? parser
+            : helpGeneratorParser;
         }
 
         // Helper function to report invalid commands before --help
@@ -2865,7 +2872,7 @@ export function runParser<
                 }
                 // Commands are valid; proceed with help display
                 const docOrPromise = getDocPage(
-                  helpGeneratorParser,
+                  docGeneratorParser,
                   classified.commands,
                 );
                 return docOrPromise instanceof Promise
@@ -2883,7 +2890,7 @@ export function runParser<
 
         // Get doc page - may return Promise for async parsers
         const docOrPromise = getDocPage(
-          helpGeneratorParser,
+          docGeneratorParser,
           classified.commands,
         );
         if (docOrPromise instanceof Promise) {


### PR DESCRIPTION
This fixes a case where nested subcommand help was rendered through the parser that had been expanded with completion and other meta commands. That parser is still the right one for checking whether a requested help path is valid, and it is still needed for top-level help because top-level help should mention the available meta commands and options.

The scoped documentation path now uses the original user parser once the requested command has been validated. That keeps `demo group sub --help` focused on `demo group sub`, without leaking sibling command usage or completion entries into the page.

The regression test in *packages/core/src/facade.test.ts* covers both completion modes that can expose this bug: option-only completion and combined command/option completion. The implementation change stays in *packages/core/src/facade.ts*, and *CHANGES.md* records the fix for the 1.1.1 release notes.

Fixes #855.