### PR TITLE
Hide usage lines in full help output

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -45,6 +45,11 @@ To be released.
     maintained reference pages for API details, and keeps its inline TypeScript
     examples covered by a snippet type-checking test.  [[#850], [#852]]
 
+ -  Added `showUsage` to `DocPageFormatOptions` and the core runner
+    `RunOptions`.  Passing `showUsage: false` omits the `Usage:` synopsis
+    from full help pages, including `aboveError: "help"` output, while leaving
+    explicit usage-only error preambles unchanged.  [[#856], [#860]]
+
 [#842]: https://github.com/dahlia/optique/issues/842
 [#843]: https://github.com/dahlia/optique/pull/843
 [#846]: https://github.com/dahlia/optique/issues/846
@@ -52,6 +57,8 @@ To be released.
 [#849]: https://github.com/dahlia/optique/pull/849
 [#850]: https://github.com/dahlia/optique/issues/850
 [#852]: https://github.com/dahlia/optique/pull/852
+[#856]: https://github.com/dahlia/optique/issues/856
+[#860]: https://github.com/dahlia/optique/pull/860
 
 ### @optique/derived-defaults
 
@@ -101,6 +108,11 @@ To be released.
     with nested commands such as `stash list`.  The `entryFileName` option
     customizes or disables the entry-file rule.  [[#838], [#839]]
 
+ -  `runProgram()` now accepts `showUsage: false` for compact command-list
+    help.  The option is forwarded to *@optique/run* so discovered command
+    programs can show the brief and command sections without the expanded
+    `Usage:` synopsis.  [[#856], [#860]]
+
 [#830]: https://github.com/dahlia/optique/issues/830
 [#835]: https://github.com/dahlia/optique/issues/835
 [#838]: https://github.com/dahlia/optique/issues/838
@@ -108,6 +120,13 @@ To be released.
 [#840]: https://github.com/dahlia/optique/pull/840
 [#841]: https://github.com/dahlia/optique/pull/841
 [#851]: https://github.com/dahlia/optique/pull/851
+
+### @optique/run
+
+ -  Added `showUsage` to `RunOptions`.  Passing `showUsage: false` omits the
+    `Usage:` synopsis from full help pages produced by `run()`, `runSync()`,
+    and `runAsync()`, while usage-only error output remains unchanged.
+    [[#856], [#860]]
 
 ### @optique/prompt
 

--- a/docs/concepts/discover.md
+++ b/docs/concepts/discover.md
@@ -130,10 +130,16 @@ await runProgram({
     brief: message`Administrative command-line tools.`,
   },
   help: { option: true },
+  showUsage: false,
   version: false,
   completion: false,
 });
 ~~~~
+
+`showUsage: false` is useful for larger command trees because root help can
+act as a compact command menu: the program brief and command list remain, but
+the expanded `Usage:` synopsis is omitted.  The same setting applies when
+`aboveError: "help"` renders a full help page above a parse error.
 
 
 Running with static module maps

--- a/docs/concepts/runners.md
+++ b/docs/concepts/runners.md
@@ -298,6 +298,7 @@ const prog = defineProgram({
 const result = runParser(prog, ["--name", "test"], {
   colors: true,           // Force colored output
   maxWidth: 80,          // Wrap text at 80 columns
+  showUsage: false,      // Hide Usage: in full help pages
   showDefault: true,     // Show default values in help text
   help: {                // Grouped help API
     option: true,        // Only --help option, no help command
@@ -322,6 +323,12 @@ const result = runParser(prog, ["--name", "test"], {
 Use this approach when you need automatic help and error handling but want
 control over process behavior, or when integrating with frameworks that
 manage process lifecycle.
+
+Pass `showUsage: false` when a command menu should show the brief,
+description, and generated sections without the `Usage:` synopsis.  The
+setting applies to full help pages, including help rendered above parse
+errors with `aboveError: "help"`.  It does not change the explicit
+usage-only preamble from `aboveError: "usage"`.
 
 ### Explicit sync/async variants
 

--- a/packages/core/skills/optique/SKILL.md
+++ b/packages/core/skills/optique/SKILL.md
@@ -53,6 +53,8 @@ Core rules
     discriminated union.
  -  Enable completion through `run(parser, { completion: "both" })` for CLI
     apps. Do not hand-write completion scripts from parser metadata.
+ -  Use `showUsage: false` in runner options when full help should show the
+    brief and command or option sections without the `Usage:` synopsis.
 
 
 Canonical app shape

--- a/packages/core/src/doc.test.ts
+++ b/packages/core/src/doc.test.ts
@@ -86,6 +86,56 @@ describe("formatDocPage", () => {
     assert.equal(result, expected);
   });
 
+  it("should omit usage when showUsage is false", () => {
+    const page: DocPage = {
+      brief: message`Project tools.`,
+      usage: [{ type: "command", name: "build" }],
+      description: message`Run project automation commands.`,
+      sections: [{
+        entries: [{
+          term: { type: "command", name: "build" },
+          description: message`Build the project.`,
+        }],
+      }],
+    };
+
+    const result = formatDocPage("myapp", page, { showUsage: false });
+
+    assert.ok(!result.includes("Usage:"));
+    assert.ok(result.includes("Project tools."));
+    assert.ok(result.includes("Run project automation commands."));
+    assert.ok(result.includes("build"));
+    assert.ok(result.includes("Build the project."));
+  });
+
+  it("should ignore suppressed usage when validating maxWidth", () => {
+    const page: DocPage = {
+      usage: [{
+        type: "command",
+        name: "very-long-command-name-that-would-not-fit",
+      }],
+      sections: [{
+        entries: [{
+          term: { type: "command", name: "run" },
+          description: message`Run.`,
+        }],
+      }],
+    };
+
+    assert.throws(
+      () => formatDocPage("myapp", page, { maxWidth: 10 }),
+      RangeError,
+    );
+
+    const result = formatDocPage("myapp", page, {
+      maxWidth: 10,
+      showUsage: false,
+    });
+
+    assert.ok(!result.includes("Usage:"));
+    assert.ok(result.includes("run"));
+  });
+
   it("should format a page with description", () => {
     const page: DocPage = {
       description: [{ type: "text", text: "This is a detailed description" }],

--- a/packages/core/src/doc.ts
+++ b/packages/core/src/doc.ts
@@ -400,6 +400,14 @@ export interface DocPageFormatOptions {
   maxWidth?: number;
 
   /**
+   * Whether to include the usage synopsis in the output.
+   *
+   * @default `true`
+   * @since 1.2.0
+   */
+  showUsage?: boolean;
+
+  /**
    * Whether and how to display default values for options and arguments.
    *
    * - `boolean`: When `true`, displays defaults using format `[value]`
@@ -558,6 +566,7 @@ export function formatDocPage(
   validateProgramName(programName);
   const termIndent = options.termIndent ?? 2;
   const termWidth = options.termWidth ?? 26;
+  const showUsage = options.showUsage ?? true;
   if (
     options.maxWidth != null &&
     (!Number.isFinite(options.maxWidth) || !Number.isInteger(options.maxWidth))
@@ -672,7 +681,7 @@ export function formatDocPage(
     // the 7 matches the continuation indent, so terms fitting within
     // the first line's total width are guaranteed not to overflow.
     const programNameWidth = getDisplayWidth(programName);
-    const usageMin = page.usage != null
+    const usageMin = page.usage != null && showUsage
       ? 7 + Math.max(
         programNameWidth,
         Math.min(
@@ -736,7 +745,7 @@ export function formatDocPage(
     });
     output += "\n";
   }
-  if (page.usage != null) {
+  if (page.usage != null && showUsage) {
     const usageLabel = options.colors ? "\x1b[1;2mUsage:\x1b[0m " : "Usage: ";
     output += usageLabel;
     output += indentLines(

--- a/packages/core/src/facade.test.ts
+++ b/packages/core/src/facade.test.ts
@@ -1937,6 +1937,48 @@ describe("runParser", () => {
       assert.ok(errorOutput.includes("Error:"));
     });
 
+    it("should omit usage from help above error when showUsage is false", () => {
+      const parser = object({
+        port: argument(integer({ metavar: "PORT" })),
+      });
+
+      let errorOutput = "";
+
+      runParser(parser, "test", ["not-a-number"], {
+        aboveError: "help",
+        showUsage: false,
+        onError: () => "handled",
+        stderr: (text) => {
+          errorOutput += text;
+        },
+      });
+
+      assert.ok(!errorOutput.includes("Usage:"));
+      assert.ok(errorOutput.includes("PORT"));
+      assert.ok(errorOutput.includes("Error:"));
+    });
+
+    it("should keep usage-only error output when showUsage is false", () => {
+      const parser = object({
+        port: argument(integer({ metavar: "PORT" })),
+      });
+
+      let errorOutput = "";
+
+      runParser(parser, "test", ["not-a-number"], {
+        aboveError: "usage",
+        showUsage: false,
+        onError: () => "handled",
+        stderr: (text) => {
+          errorOutput += text;
+        },
+      });
+
+      assert.ok(errorOutput.includes("Usage: test"));
+      assert.ok(errorOutput.includes("PORT"));
+      assert.ok(errorOutput.includes("Error:"));
+    });
+
     it("should show nothing above error when aboveError is 'none'", () => {
       const parser = object({
         port: argument(integer()),
@@ -10230,6 +10272,30 @@ describe("runWithAsync", () => {
   });
 
   describe("sectionOrder option", () => {
+    it("should omit usage from help output when showUsage is false", () => {
+      const parser = or(
+        command("build", object({ verbose: flag("--verbose") })),
+        command("deploy", object({ env: option("--env", string()) })),
+      );
+
+      let helpOutput = "";
+      const result = runParser(parser, "myapp", ["--help"], {
+        help: {
+          option: true,
+          onShow: () => "shown",
+        },
+        showUsage: false,
+        stdout: (text) => {
+          helpOutput = text;
+        },
+      });
+
+      assert.equal(result, "shown");
+      assert.ok(!helpOutput.includes("Usage:"));
+      assert.ok(helpOutput.includes("build"));
+      assert.ok(helpOutput.includes("deploy"));
+    });
+
     it("should use custom sectionOrder comparator to control section ordering in help output", () => {
       const parser = or(
         command("build", object({ verbose: flag("--verbose") })),

--- a/packages/core/src/facade.test.ts
+++ b/packages/core/src/facade.test.ts
@@ -1958,6 +1958,41 @@ describe("runParser", () => {
       assert.ok(errorOutput.includes("Error:"));
     });
 
+    it("should preserve sectionOrder in help above error", () => {
+      const parser = object({
+        beta: group(
+          "Beta",
+          option("--beta", string(), { description: message`Beta option.` }),
+        ),
+        alpha: group(
+          "Alpha",
+          option("--alpha", string(), { description: message`Alpha option.` }),
+        ),
+        port: argument(integer({ metavar: "PORT" })),
+      });
+
+      let errorOutput = "";
+
+      runParser(parser, "test", ["not-a-number"], {
+        aboveError: "help",
+        sectionOrder: (a: DocSection, b: DocSection): number => {
+          const aTitle = a.title ?? "";
+          const bTitle = b.title ?? "";
+          return aTitle.localeCompare(bTitle);
+        },
+        onError: () => "handled",
+        stderr: (text) => {
+          errorOutput += text;
+        },
+      });
+
+      const alphaIndex = errorOutput.indexOf("Alpha:");
+      const betaIndex = errorOutput.indexOf("Beta:");
+      assert.ok(alphaIndex >= 0, "Alpha section should be present.");
+      assert.ok(betaIndex >= 0, "Beta section should be present.");
+      assert.ok(alphaIndex < betaIndex, "Alpha should appear before Beta.");
+    });
+
     it("should keep usage-only error output when showUsage is false", () => {
       const parser = object({
         port: argument(integer({ metavar: "PORT" })),

--- a/packages/core/src/facade.ts
+++ b/packages/core/src/facade.ts
@@ -2945,6 +2945,7 @@ export function runParser<
                 maxWidth,
                 showDefault,
                 showChoices,
+                sectionOrder,
                 showUsage,
               }));
             }

--- a/packages/core/src/facade.ts
+++ b/packages/core/src/facade.ts
@@ -1339,6 +1339,18 @@ export interface RunOptions<THelp, TError> {
   readonly showChoices?: boolean | ShowChoicesOptions;
 
   /**
+   * Whether to include the usage synopsis in full help output.
+   *
+   * This affects help pages produced by `--help`, the help command, and
+   * `aboveError: "help"`.  It does not suppress usage-only error preambles
+   * from `aboveError: "usage"`.
+   *
+   * @default `true`
+   * @since 1.2.0
+   */
+  readonly showUsage?: boolean;
+
+  /**
    * A custom comparator function to control the order of sections in the
    * help output.  When provided, it is used instead of the default smart
    * sort (command-only sections first, then mixed, then option/argument-only
@@ -1527,6 +1539,7 @@ function handleCompletion<M extends Mode, THelp, TError>(
   completionOptionDisplayName?: string,
   isOptionMode?: boolean,
   sectionOrder?: (a: DocSection, b: DocSection) => number,
+  showUsage?: boolean,
   rootOptionSuggestions: readonly LiteralSuggestion[] = [],
 ): ModeValue<M, THelp | TError> {
   const shellName = completionArgs[0] || "";
@@ -1548,7 +1561,12 @@ function handleCompletion<M extends Mode, THelp, TError>(
       const doc = getDocPage(completionParser, [displayName]);
       if (doc) {
         stderr(
-          formatDocPage(programName, doc, { colors, maxWidth, sectionOrder }),
+          formatDocPage(programName, doc, {
+            colors,
+            maxWidth,
+            sectionOrder,
+            showUsage,
+          }),
         );
       }
     }
@@ -2346,6 +2364,7 @@ export function runParser<
     showDefault,
     showChoices,
     sectionOrder,
+    showUsage,
     aboveError = "usage",
     onError = () => {
       throw new RunParserError("Failed to parse command line arguments.");
@@ -2558,6 +2577,7 @@ export function runParser<
           completionOptionNames[0],
           classified.source === "option",
           sectionOrder,
+          showUsage,
           rootOptionSuggestions,
         ) as InferValue<TParser>;
 
@@ -2809,6 +2829,7 @@ export function runParser<
               showDefault,
               showChoices,
               sectionOrder,
+              showUsage,
             }));
           }
           return onHelp(0);
@@ -2924,6 +2945,7 @@ export function runParser<
                 maxWidth,
                 showDefault,
                 showChoices,
+                showUsage,
               }));
             }
           }

--- a/packages/discover/src/index.test.ts
+++ b/packages/discover/src/index.test.ts
@@ -1759,6 +1759,44 @@ describe("runProgram()", () => {
     assert.match(stdout, /user remove\s+Remove a user\./);
   });
 
+  it("omits usage from statically registered root help when showUsage is false", async () => {
+    const addCommand = defineCommand({
+      path: ["user", "add"],
+      parser: object({}),
+      metadata: { brief: message`Add a user.` },
+      handler() {},
+    });
+    const removeCommand = defineCommand({
+      path: ["user", "remove"],
+      parser: object({}),
+      metadata: { brief: message`Remove a user.` },
+      handler() {},
+    });
+    let stdout = "";
+
+    await assert.rejects(
+      () =>
+        runProgram({
+          commands: [addCommand, removeCommand],
+          metadata: { name: "tool", version: "1.0.0" },
+          args: ["--help"],
+          showUsage: false,
+          stdout(text) {
+            stdout += `${text}\n`;
+          },
+          stderr() {},
+          onExit(exitCode): never {
+            throw new ExitSignal(exitCode);
+          },
+        }),
+      ExitSignal,
+    );
+
+    assert.doesNotMatch(stdout, /Usage:/);
+    assert.match(stdout, /user add\s+Add a user\./);
+    assert.match(stdout, /user remove\s+Remove a user\./);
+  });
+
   it("passes static command values to phase-two source contexts", async () => {
     const phase2Values: unknown[] = [];
     const context: SourceContext = {

--- a/packages/run/src/run.test.ts
+++ b/packages/run/src/run.test.ts
@@ -1667,6 +1667,36 @@ describe("runAsync", () => {
       assert.ok(typeof helpOutput === "string");
     });
 
+    it("should omit usage from help output when showUsage is false", () => {
+      const parser = or(
+        command("build", object({})),
+        command("deploy", object({})),
+      );
+
+      let helpOutput = "";
+
+      try {
+        run(parser, {
+          args: ["--help"],
+          programName: "myapp",
+          help: "option",
+          showUsage: false,
+          stdout: (text) => {
+            helpOutput += `${text}\n`;
+          },
+          onExit: () => {
+            throw new Error("EXIT");
+          },
+        });
+      } catch (err) {
+        if ((err as Error).message !== "EXIT") throw err;
+      }
+
+      assert.ok(!helpOutput.includes("Usage:"));
+      assert.ok(helpOutput.includes("build"));
+      assert.ok(helpOutput.includes("deploy"));
+    });
+
     it("preserves positional values that match built-in help commands", async () => {
       const parser = object({ value: argument(string()) });
       let exited = false;

--- a/packages/run/src/run.ts
+++ b/packages/run/src/run.ts
@@ -110,6 +110,18 @@ export interface RunOptions {
   readonly showChoices?: boolean | ShowChoicesOptions;
 
   /**
+   * Whether to include the usage synopsis in full help output.
+   *
+   * This affects help pages produced by `--help`, the help command, and
+   * `aboveError: "help"`.  It does not suppress usage-only error preambles
+   * from `aboveError: "usage"`.
+   *
+   * @default `true`
+   * @since 1.2.0
+   */
+  readonly showUsage?: boolean;
+
+  /**
    * A custom comparator function to control the order of sections in the
    * help output.  When provided, it is used instead of the default smart
    * sort (command-only sections first, then mixed, then option/argument-only
@@ -824,6 +836,7 @@ function buildCoreOptions(
   const maxWidth = options.maxWidth ?? process.stdout.columns;
   const showDefault = options.showDefault;
   const showChoices = options.showChoices;
+  const showUsage = options.showUsage;
   const sectionOrder = options.sectionOrder;
   const help = options.help;
   const version = options.version;
@@ -888,6 +901,7 @@ function buildCoreOptions(
     maxWidth,
     showDefault,
     showChoices,
+    showUsage,
     sectionOrder,
     help: helpConfig,
     version: versionConfig,
@@ -921,6 +935,7 @@ const knownRunOptionsKeyList = [
   "maxWidth",
   "showDefault",
   "showChoices",
+  "showUsage",
   "sectionOrder",
   "help",
   "version",


### PR DESCRIPTION
Fixes #856.


Why
---

Large command trees often use the root help page as a command menu.  In that shape, the generated `Usage:` synopsis can become noisy before it becomes useful: it repeats the command structure that the command list already shows more clearly.

This keeps usage output on by default, but gives runners a narrow way to omit it from full help pages.  The option does not change usage-only error preambles, since those exist for a different reason: they give a compact parse hint next to an error.


How
---

The formatter now treats usage rendering as an explicit part of full help page formatting.  *packages/core/src/doc.ts* reads `showUsage` from `DocPageFormatOptions`, defaults it to `true`, and skips both the rendered `Usage:` block and its width constraint when the option is false.

Runner code passes the same option only to full help pages: `--help`, help commands, completion setup help, and `aboveError: "help"`.  It deliberately does not feed into the explicit `aboveError: "usage"` path, so existing error output stays stable unless callers opt into full help above errors.

The public runner surface is exposed through *@optique/core* and *@optique/run*. *@optique/discover* inherits the option through its existing runner-option plumbing, which keeps discovered programs aligned with hand-written runners without adding a separate option shape.


Verification
------------

Regression tests cover the formatter behavior, the core runner behavior, the *@optique/run* wrapper, and statically registered *@optique/discover* commands. The docs and Optique agent skill now describe when `showUsage: false` is a good fit.

I verified the branch with `mise check`, `mise test`, `cd docs && pnpm build`, and `git diff --check`.
