### PR TITLE
Skip co-located test files during discovery

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -102,6 +102,13 @@ To be released.
     with nested commands such as `stash list`.  The `entryFileName` option
     customizes or disables the entry-file rule.  [[#838], [#839]]
 
+ -  File-system discovery, `commandsFromModules()`, and `optique-discover` now
+    skip co-located test files by default.  A file whose name ends in *.test*
+    or *.spec* before the configured extension—such as *hello.test.ts* or
+    *hello.spec.js*—is ignored the same way declaration files are, so it no
+    longer registers as a ghost command nor breaks discovery by failing the
+    `defineCommand()` check.  [[#857]]
+
 [#830]: https://github.com/dahlia/optique/issues/830
 [#835]: https://github.com/dahlia/optique/issues/835
 [#838]: https://github.com/dahlia/optique/issues/838
@@ -110,6 +117,7 @@ To be released.
 [#841]: https://github.com/dahlia/optique/pull/841
 [#851]: https://github.com/dahlia/optique/pull/851
 [#854]: https://github.com/dahlia/optique/issues/854
+[#857]: https://github.com/dahlia/optique/issues/857
 [#858]: https://github.com/dahlia/optique/pull/858
 
 ### @optique/prompt

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -114,7 +114,7 @@ To be released.
     or *.spec* before the configured extension—such as *hello.test.ts* or
     *hello.spec.js*—is ignored the same way declaration files are, so it no
     longer registers as a ghost command nor breaks discovery by failing the
-    `defineCommand()` check.  [[#857]]
+    `defineCommand()` check.  [[#857], [#861] by Lee Hoyeon]
 
  -  `runProgram()` now accepts `showUsage: false` for compact command-list
     help.  The option is forwarded to *@optique/run* so discovered command
@@ -131,6 +131,7 @@ To be released.
 [#854]: https://github.com/dahlia/optique/issues/854
 [#857]: https://github.com/dahlia/optique/issues/857
 [#858]: https://github.com/dahlia/optique/pull/858
+[#861]: https://github.com/dahlia/optique/pull/861
 
 ### @optique/run
 

--- a/docs/concepts/discover.md
+++ b/docs/concepts/discover.md
@@ -425,8 +425,9 @@ Node.js also includes *.ts*, *.mts*, and *.cts* when it appears to be running
 with native TypeScript support, a TypeScript loader such as `tsx`, `ts-node`,
 `tsimp`, or `jiti`, or Node's built-in type-stripping flags.
 
-TypeScript declaration files (*.d.ts*, *.d.mts*, and *.d.cts*) and test files (*.spec.*, *.test.*) are ignored even
-when their suffix matches the configured extension list.
+TypeScript declaration files (*.d.ts*, *.d.mts*, and *.d.cts*) and test files
+(*.spec.*, *.test.*) are ignored even when their suffix matches the configured
+extension list.
 
 Pass `extensions` when you want an explicit policy:
 

--- a/docs/concepts/discover.md
+++ b/docs/concepts/discover.md
@@ -419,7 +419,7 @@ Node.js also includes *.ts*, *.mts*, and *.cts* when it appears to be running
 with native TypeScript support, a TypeScript loader such as `tsx`, `ts-node`,
 `tsimp`, or `jiti`, or Node's built-in type-stripping flags.
 
-TypeScript declaration files (*.d.ts*, *.d.mts*, and *.d.cts*) are ignored even
+TypeScript declaration files (*.d.ts*, *.d.mts*, and *.d.cts*) and test files (*.spec.*, *.test.*) are ignored even
 when their suffix matches the configured extension list.
 
 Pass `extensions` when you want an explicit policy:

--- a/packages/discover/README.md
+++ b/packages/discover/README.md
@@ -149,6 +149,8 @@ By default, Deno and Bun discover `.ts`, `.mts`, `.js`, and `.mjs` files.
 Node.js discovers `.js`, `.mjs`, and `.cjs` files, plus `.ts`, `.mts`, and
 `.cts` when it reports native TypeScript support or runs with a recognized
 TypeScript loader.  TypeScript declaration files such as `.d.ts` are ignored.
+Co-located test files whose names end in `.test` or `.spec` before the
+extension (such as `user.test.ts`) are ignored too.
 Entry files named `index` map to their containing command path, so
 `commands/index.ts` defines the root command and `commands/user/index.ts`
 defines `user`.  Use `entryFileName` to choose another entry name or disable

--- a/packages/discover/src/generator.test.ts
+++ b/packages/discover/src/generator.test.ts
@@ -86,6 +86,31 @@ export default commandsFromModules(
     }
   });
 
+  it("should ignore co-located test and spec files", async () => {
+    const dir = await makeTempDir();
+    try {
+      const commandsDir = join(dir, "commands");
+      const outputFile = join(dir, "generated.ts");
+      await writeText(join(commandsDir, "add.ts"), "");
+      await writeText(join(commandsDir, "add.test.ts"), "");
+      await writeText(join(commandsDir, "add.spec.ts"), "");
+
+      const result = await generateCommandsModule({
+        dir: commandsDir,
+        outputFile,
+        extensions: [".ts"],
+      });
+
+      assert.deepEqual(result.files.map((file) => file.modulePath), [
+        "./commands/add.ts",
+      ]);
+      assert.doesNotMatch(result.code, /add\.test\.ts/);
+      assert.doesNotMatch(result.code, /add\.spec\.ts/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it("should include custom entry file options", async () => {
     const dir = await makeTempDir();
     try {

--- a/packages/discover/src/generator.ts
+++ b/packages/discover/src/generator.ts
@@ -414,6 +414,7 @@ async function collectCommandFiles(
       entryType === "file" &&
       path !== excludedFile &&
       !isDeclarationFile(entry.name) &&
+      !isTestFile(entry.name, extensions) &&
       extensions.some((ext) => entry.name.endsWith(ext))
     ) {
       files.push(path);
@@ -445,6 +446,22 @@ async function getCommandFileEntryType(
 
 function isDeclarationFile(fileName: string): boolean {
   return /\.d\.[cm]?ts$/.test(fileName);
+}
+
+/**
+ * Checks whether a file name belongs to a co-located test or spec module, such
+ * as *hello.test.ts* or *hello.spec.js*.  The `.test`/`.spec` marker is matched
+ * against the suffix that precedes the configured command extension, so a file
+ * named *test.ts* or *latest.ts* stays an ordinary command.
+ */
+function isTestFile(
+  fileName: string,
+  extensions: readonly string[],
+): boolean {
+  const matchedExtension = extensions.find((ext) => fileName.endsWith(ext));
+  if (matchedExtension == null) return false;
+  const base = fileName.slice(0, -matchedExtension.length);
+  return base.endsWith(".test") || base.endsWith(".spec");
 }
 
 function rejectDuplicateCommandPaths(

--- a/packages/discover/src/index.test.ts
+++ b/packages/discover/src/index.test.ts
@@ -591,6 +591,71 @@ describe("discoverCommands()", () => {
     }
   });
 
+  it("skips co-located test and spec files", async () => {
+    const dir = await makeTempDir();
+    try {
+      await writeCommand(dir, ["build.ts"], "build");
+      await writeFile(join(dir, "build.test.ts"), "export default {};\n");
+      await writeFile(join(dir, "build.spec.ts"), "export default {};\n");
+
+      const commands = await discoverCommands({ dir, extensions: [".ts"] });
+
+      assert.deepEqual(commands.map((command) => command.path), [["build"]]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("skips test files even when they export a command", async () => {
+    const dir = await makeTempDir();
+    try {
+      await writeCommand(dir, ["greet.ts"], "greet");
+      await writeCommand(dir, ["greet.test.ts"], "greet test");
+
+      const commands = await discoverCommands({ dir, extensions: [".ts"] });
+
+      assert.deepEqual(commands.map((command) => command.path), [["greet"]]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("skips test and spec files for non-TypeScript extensions", async () => {
+    const dir = await makeTempDir();
+    try {
+      await writeCommand(dir, ["build.js"], "build");
+      await writeFile(join(dir, "build.test.js"), "export default {};\n");
+      await writeFile(join(dir, "build.spec.js"), "export default {};\n");
+
+      const commands = await discoverCommands({ dir, extensions: [".js"] });
+
+      assert.deepEqual(commands.map((command) => command.path), [["build"]]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not skip command files whose names merely contain test or spec", async () => {
+    const dir = await makeTempDir();
+    try {
+      await writeCommand(dir, ["test.ts"], "test");
+      await writeCommand(dir, ["spec.ts"], "spec");
+      await writeCommand(dir, ["latest.ts"], "latest");
+      await writeCommand(dir, ["manifest.ts"], "manifest");
+
+      const commands = await discoverCommands({ dir, extensions: [".ts"] });
+
+      assert.deepEqual(commands.map((command) => command.path), [
+        ["latest"],
+        ["manifest"],
+        ["spec"],
+        ["test"],
+      ]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it("returns runtime-aware extension defaults", () => {
     const nodeDefaults = getDefaultExtensions({
       runtime: "node",
@@ -699,6 +764,22 @@ describe("commandsFromModules()", () => {
     ]);
     assert.equal(commands[0]?.command, commandCommand);
     assert.equal(commands[1]?.command, zzzCommand);
+  });
+
+  it("ignores co-located test and spec module keys", () => {
+    const buildCommand = makeCommand();
+
+    const commands = commandsFromModules({
+      "./commands/build.ts": { default: buildCommand },
+      "./commands/build.test.ts": { default: makeCommand() },
+      "./commands/build.spec.ts": { default: makeCommand() },
+    }, {
+      base: "./commands",
+      extensions: [".ts"],
+    });
+
+    assert.deepEqual(commands.map((command) => command.path), [["build"]]);
+    assert.equal(commands[0]?.command, buildCommand);
   });
 
   it("supports custom and disabled entry file names", () => {

--- a/packages/discover/src/index.ts
+++ b/packages/discover/src/index.ts
@@ -451,8 +451,10 @@ export function commandsFromModules(
   const seen = new Map<string, string>();
   const discovered: ModuleCommand[] = [];
   for (const modulePath of modulePaths) {
+    const moduleBaseName = posix.basename(modulePath);
     if (
-      isDeclarationFile(posix.basename(modulePath)) ||
+      isDeclarationFile(moduleBaseName) ||
+      isTestFile(moduleBaseName, extensions) ||
       !extensions.some((ext) => modulePath.endsWith(ext))
     ) {
       continue;
@@ -766,6 +768,7 @@ async function collectCommandFiles(
     } else if (
       entryType === "file" &&
       !isDeclarationFile(entry.name) &&
+      !isTestFile(entry.name, extensions) &&
       extensions.some((ext) => entry.name.endsWith(ext))
     ) {
       files.push(path);
@@ -797,6 +800,16 @@ async function getCommandFileEntryType(
 
 function isDeclarationFile(fileName: string): boolean {
   return /\.d\.[cm]?ts$/.test(fileName);
+}
+
+function isTestFile(
+  fileName: string,
+  extensions: readonly string[],
+): boolean {
+  const matchedExtension = extensions.find((ext) => fileName.endsWith(ext));
+  if (matchedExtension == null) return false;
+  const base = fileName.slice(0, -matchedExtension.length);
+  return base.endsWith(".test") || base.endsWith(".spec");
 }
 
 function commandPathFromFile(


### PR DESCRIPTION
Fixes https://github.com/dahlia/optique/issues/857

## Summary

Command discovery in *@optique/discover* treated every file matching a
configured extension as a command and only skipped `.d.ts` declaration files.
Co-located unit tests therefore broke discovery in two ways:

- A test file without a command export (e.g. `user.test.ts`) failed discovery
  with `Module .../user.test.ts default export must be created with defineCommand().`
- A test file with a command-shaped export registered as a *ghost* command
  named `user.test`, because `stripCommandExtension()` only removes the active
  extension and leaves the `.test` suffix.

This change skips files whose name ends in `.test` or `.spec` *before* the
configured extension, mirroring the existing declaration-file skip. The check
strips the matched extension first, so it is extension-aware (handles compound
suffixes like `.cmd.ts` and custom extension lists) and does not misfire on a
command literally named `test.ts` or `latest.ts`.

## Scope

The skip is applied consistently across all three discovery surfaces, exactly
where `.d.ts` is already skipped:

- file-system `discoverCommands()`
- `commandsFromModules()`
- the `optique-discover` generator

No new configuration option is introduced — the issue treats this as a bug fix,
and broader configurability (predicates, exclude globs) is left for a separate
issue.

## Tests

Added regression tests under *packages/discover/src/*:

- `discoverCommands()` skips co-located `.test`/`.spec` files, including the
  ghost-command case and non-TypeScript extensions.
- A false-positive guard confirms `test.ts`, `spec.ts`, `latest.ts`, and
  `manifest.ts` are still discovered.
- `commandsFromModules()` ignores `.test`/`.spec` module-map keys.
- `generateCommandsModule()` excludes test files from the generated module.

## Docs

Updated *CHANGES.md*, *docs/concepts/discover.md*, and the package *README.md*
to document that co-located test files are skipped.

## AI assistance

Implemented with Claude Code (claude-opus-4-8). AI drafted the implementation,
tests, and docs under human direction and review; the behavior was verified with
a manual repro and the test suite.