### PR TITLE
Allow compact root command lists in help output

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -50,6 +50,11 @@ To be released.
     from full help pages, including `aboveError: "help"` output, while leaving
     explicit usage-only error preambles unchanged.  [[#856], [#860]]
 
+ -  Added `commandList` to the core runner `RunOptions`.  The default
+    `"recursive"` mode keeps the existing flattened command list, while
+    `"top-level"` makes top-level help pages list only first-level commands so
+    users can drill down with `<command> --help`.  [[#864], [#865]]
+
 [#842]: https://github.com/dahlia/optique/issues/842
 [#843]: https://github.com/dahlia/optique/pull/843
 [#846]: https://github.com/dahlia/optique/issues/846
@@ -59,6 +64,8 @@ To be released.
 [#852]: https://github.com/dahlia/optique/pull/852
 [#856]: https://github.com/dahlia/optique/issues/856
 [#860]: https://github.com/dahlia/optique/pull/860
+[#864]: https://github.com/dahlia/optique/issues/864
+[#865]: https://github.com/dahlia/optique/pull/865
 
 ### @optique/standard-schema
 
@@ -136,6 +143,12 @@ To be released.
     programs can show the brief and command sections without the expanded
     `Usage:` synopsis.  [[#856], [#860]]
 
+ -  `runProgram()` and `createProgramParser()` now accept
+    `commandList: "top-level"` for compact root command menus.  The default
+    remains recursive, while the new mode lists first-level command groups and
+    leaves nested command help available through `<command> --help`.
+    [[#864], [#865]]
+
 [#830]: https://github.com/dahlia/optique/issues/830
 [#835]: https://github.com/dahlia/optique/issues/835
 [#838]: https://github.com/dahlia/optique/issues/838
@@ -154,6 +167,11 @@ To be released.
     `Usage:` synopsis from full help pages produced by `run()`, `runSync()`,
     and `runAsync()`, while usage-only error output remains unchanged.
     [[#856], [#860]]
+
+ -  Added `commandList` to `RunOptions`.  Passing
+    `commandList: "top-level"` makes top-level help pages list only
+    first-level commands; the default `"recursive"` mode preserves the
+    existing full command list.  [[#864], [#865]]
 
 ### @optique/prompt
 

--- a/docs/concepts/discover.md
+++ b/docs/concepts/discover.md
@@ -131,6 +131,7 @@ await runProgram({
   },
   help: { option: true },
   showUsage: false,
+  commandList: "top-level",
   version: false,
   completion: false,
 });
@@ -139,7 +140,9 @@ await runProgram({
 `showUsage: false` is useful for larger command trees because root help can
 act as a compact command menu: the program brief and command list remain, but
 the expanded `Usage:` synopsis is omitted.  The same setting applies when
-`aboveError: "help"` renders a full help page above a parse error.
+`aboveError: "help"` renders a full help page above a parse error.  Pass
+`commandList: "top-level"` when the root command menu should list only
+first-level command groups and let users drill down with `<command> --help`.
 
 
 Running with static module maps

--- a/docs/concepts/runners.md
+++ b/docs/concepts/runners.md
@@ -299,6 +299,7 @@ const result = runParser(prog, ["--name", "test"], {
   colors: true,           // Force colored output
   maxWidth: 80,          // Wrap text at 80 columns
   showUsage: false,      // Hide Usage: in full help pages
+  commandList: "top-level", // Show only first-level commands
   showDefault: true,     // Show default values in help text
   help: {                // Grouped help API
     option: true,        // Only --help option, no help command
@@ -329,6 +330,12 @@ description, and generated sections without the `Usage:` synopsis.  The
 setting applies to full help pages, including help rendered above parse
 errors with `aboveError: "help"`.  It does not change the explicit
 usage-only preamble from `aboveError: "usage"`.
+
+Pass `commandList: "top-level"` when a top-level command menu should show
+only first-level commands instead of recursively listing every nested leaf
+command.  The default, `commandList: "recursive"`, preserves the full command
+list.  The setting does not change subcommand help pages, so users can still
+drill down with `<command> --help`.
 
 ### Explicit sync/async variants
 

--- a/packages/core/skills/optique/SKILL.md
+++ b/packages/core/skills/optique/SKILL.md
@@ -55,6 +55,8 @@ Core rules
     apps. Do not hand-write completion scripts from parser metadata.
  -  Use `showUsage: false` in runner options when full help should show the
     brief and command or option sections without the `Usage:` synopsis.
+    For deeply nested command trees, add `commandList: "top-level"` when root
+    help should list only first-level command groups.
 
 
 Canonical app shape

--- a/packages/core/src/facade.test.ts
+++ b/packages/core/src/facade.test.ts
@@ -136,6 +136,86 @@ function createPhaseTwoSeedParser(
   };
 }
 
+function createFlatCommandDocParser(): Parser<"sync", undefined, undefined> {
+  return {
+    mode: "sync",
+    $valueType: [] as readonly undefined[],
+    $stateType: [] as readonly undefined[],
+    priority: 0,
+    usage: [],
+    leadingNames: new Set(),
+    acceptingAnyToken: false,
+    initialState: undefined,
+    parse(context) {
+      return {
+        success: true as const,
+        next: context,
+        consumed: [],
+      };
+    },
+    complete() {
+      return {
+        success: true as const,
+        value: undefined,
+      };
+    },
+    *suggest() {},
+    getDocFragments() {
+      return {
+        fragments: [{
+          type: "section",
+          entries: [
+            {
+              term: { type: "command", name: "remote" },
+              description: message`Manage remotes.`,
+            },
+            {
+              term: { type: "command", name: "remote add" },
+              description: message`Add a remote.`,
+            },
+            {
+              term: { type: "command", name: "remote remove" },
+              description: message`Remove a remote.`,
+            },
+            {
+              term: { type: "command", name: "config" },
+              description: message`Manage configuration.`,
+            },
+            {
+              term: { type: "command", name: "config get" },
+              description: message`Read configuration.`,
+            },
+          ],
+        }],
+      };
+    },
+  };
+}
+
+function createFailingFlatCommandDocParser(): Parser<
+  "sync",
+  undefined,
+  undefined
+> {
+  const parser = createFlatCommandDocParser();
+  return {
+    ...parser,
+    parse() {
+      return {
+        success: false as const,
+        consumed: 0,
+        error: message`Unknown option.`,
+      };
+    },
+    complete() {
+      return {
+        success: false as const,
+        error: message`Unknown option.`,
+      };
+    },
+  };
+}
+
 function createSyncStallingPhaseTwoParser(
   tokenKey: symbol,
 ): Parser<"sync", string, string | undefined> {
@@ -10329,6 +10409,74 @@ describe("runWithAsync", () => {
       assert.ok(!helpOutput.includes("Usage:"));
       assert.ok(helpOutput.includes("build"));
       assert.ok(helpOutput.includes("deploy"));
+    });
+
+    it("should list only top-level commands when commandList is top-level", () => {
+      const parser = createFlatCommandDocParser();
+      let helpOutput = "";
+
+      const result = runParser(parser, "myapp", ["--help"], {
+        commandList: "top-level",
+        help: {
+          option: true,
+          onShow: () => "shown",
+        },
+        showUsage: false,
+        stdout: (text) => {
+          helpOutput = text;
+        },
+      });
+
+      assert.equal(result, "shown");
+      assert.match(helpOutput, /remote\s+Manage remotes\./);
+      assert.match(helpOutput, /config\s+Manage configuration\./);
+      assert.doesNotMatch(helpOutput, /remote add/);
+      assert.doesNotMatch(helpOutput, /remote remove/);
+      assert.doesNotMatch(helpOutput, /config get/);
+    });
+
+    it("should list only top-level commands in help above root errors", () => {
+      const parser = createFailingFlatCommandDocParser();
+      let errorOutput = "";
+
+      const result = runParser(parser, "myapp", ["--bad"], {
+        aboveError: "help",
+        commandList: "top-level",
+        onError: () => "handled",
+        showUsage: false,
+        stderr: (text) => {
+          errorOutput += text;
+        },
+      });
+
+      assert.equal(result, "handled");
+      assert.match(errorOutput, /remote\s+Manage remotes\./);
+      assert.match(errorOutput, /config\s+Manage configuration\./);
+      assert.doesNotMatch(errorOutput, /remote add/);
+      assert.doesNotMatch(errorOutput, /remote remove/);
+      assert.doesNotMatch(errorOutput, /config get/);
+      assert.match(errorOutput, /Error:/);
+    });
+
+    it("should recursively list commands by default", () => {
+      const parser = createFlatCommandDocParser();
+      let helpOutput = "";
+
+      const result = runParser(parser, "myapp", ["--help"], {
+        help: {
+          option: true,
+          onShow: () => "shown",
+        },
+        showUsage: false,
+        stdout: (text) => {
+          helpOutput = text;
+        },
+      });
+
+      assert.equal(result, "shown");
+      assert.match(helpOutput, /remote add\s+Add a remote\./);
+      assert.match(helpOutput, /remote remove\s+Remove a remote\./);
+      assert.match(helpOutput, /config get\s+Read configuration\./);
     });
 
     it("should use custom sectionOrder comparator to control section ordering in help output", () => {

--- a/packages/core/src/facade.ts
+++ b/packages/core/src/facade.ts
@@ -13,6 +13,7 @@ import {
   object,
 } from "./constructs.ts";
 import {
+  type DocEntry,
   type DocPage,
   type DocSection,
   formatDocPage,
@@ -743,6 +744,18 @@ interface MetaParseResult {
 }
 
 /**
+ * Controls how command lists are rendered in top-level help pages.
+ *
+ * - `"recursive"`: Shows the full flattened command list, including nested
+ *   leaf commands such as `remote add`.
+ * - `"top-level"`: Shows only first-level command names such as `remote`,
+ *   letting users drill down with `remote --help`.
+ *
+ * @since 1.2.0
+ */
+export type CommandListMode = "recursive" | "top-level";
+
+/**
  * Sub-configuration for a meta command's command form.
  *
  * @since 1.0.0
@@ -925,7 +938,11 @@ type ParsedResult =
     readonly commandPath?: readonly string[];
     readonly args: readonly string[];
   }
-  | { readonly type: "error"; readonly error: Message };
+  | {
+    readonly type: "error";
+    readonly error: Message;
+    readonly commandPath: readonly string[];
+  };
 
 /**
  * Systematically combines the original parser with help, version, and completion parsers.
@@ -1191,7 +1208,11 @@ function classifyParseFailure(
   completionCommandNames: readonly string[],
 ): Exclude<ParsedResult, { readonly type: "success" }> {
   if (failure.remainingArgs.length < 1) {
-    return { type: "error", error: failure.error };
+    return {
+      type: "error",
+      error: failure.error,
+      commandPath: failure.commandPath,
+    };
   }
 
   const hasConsumedPrefix = failure.consumedCount > 0;
@@ -1240,7 +1261,11 @@ function classifyParseFailure(
     ) {
       return { type: "version" };
     }
-    return { type: "error", error: failure.error };
+    return {
+      type: "error",
+      error: failure.error,
+      commandPath: failure.commandPath,
+    };
   }
 
   let commandAction: MetaAction | undefined;
@@ -1286,7 +1311,11 @@ function classifyParseFailure(
     };
   }
 
-  return { type: "error", error: failure.error };
+  return {
+    type: "error",
+    error: failure.error,
+    commandPath: failure.commandPath,
+  };
 }
 
 /**
@@ -1349,6 +1378,17 @@ export interface RunOptions<THelp, TError> {
    * @since 1.2.0
    */
   readonly showUsage?: boolean;
+
+  /**
+   * How to render command lists in top-level help pages.
+   *
+   * Pass `"top-level"` to show only first-level commands in the command menu
+   * while keeping nested command help available through `<command> --help`.
+   *
+   * @default `"recursive"`
+   * @since 1.2.0
+   */
+  readonly commandList?: CommandListMode;
 
   /**
    * A custom comparator function to control the order of sections in the
@@ -2365,6 +2405,7 @@ export function runParser<
     showChoices,
     sectionOrder,
     showUsage,
+    commandList = "recursive",
     aboveError = "usage",
     onError = () => {
       throw new RunParserError("Failed to parse command line arguments.");
@@ -2803,26 +2844,30 @@ export function runParser<
             // so that operators can add global footer notes across all help
             // pages.
             const shouldOverride = !isMetaCommandHelp && !isSubcommandHelp;
-            const augmentedDoc = {
-              ...doc,
-              brief: shouldOverride ? (brief ?? doc.brief) : doc.brief,
-              description: shouldOverride
-                ? (description ?? doc.description)
-                : doc.description,
-              // Only show examples, author, and bugs for top-level help
-              examples: isTopLevel && !isMetaCommandHelp
-                ? (examples ?? doc.examples)
-                : undefined,
-              author: isTopLevel && !isMetaCommandHelp
-                ? (author ?? doc.author)
-                : undefined,
-              bugs: isTopLevel && !isMetaCommandHelp
-                ? (bugs ?? doc.bugs)
-                : undefined,
-              footer: shouldOverride
-                ? (footer ?? doc.footer)
-                : (doc.footer ?? footer),
-            };
+            const augmentedDoc = maybeCollapseCommandList(
+              {
+                ...doc,
+                brief: shouldOverride ? (brief ?? doc.brief) : doc.brief,
+                description: shouldOverride
+                  ? (description ?? doc.description)
+                  : doc.description,
+                // Only show examples, author, and bugs for top-level help
+                examples: isTopLevel && !isMetaCommandHelp
+                  ? (examples ?? doc.examples)
+                  : undefined,
+                author: isTopLevel && !isMetaCommandHelp
+                  ? (author ?? doc.author)
+                  : undefined,
+                bugs: isTopLevel && !isMetaCommandHelp
+                  ? (bugs ?? doc.bugs)
+                  : undefined,
+                footer: shouldOverride
+                  ? (footer ?? doc.footer)
+                  : (doc.footer ?? footer),
+              },
+              commandList,
+              isTopLevel,
+            );
             stdout(formatDocPage(programName, augmentedDoc, {
               colors,
               maxWidth,
@@ -2931,15 +2976,19 @@ export function runParser<
             if (doc == null) effectiveAboveError = "usage";
             else {
               // Augment the doc page with provided options
-              const augmentedDoc = {
-                ...doc,
-                brief: brief ?? doc.brief,
-                description: description ?? doc.description,
-                examples: examples ?? doc.examples,
-                author: author ?? doc.author,
-                bugs: bugs ?? doc.bugs,
-                footer: footer ?? doc.footer,
-              };
+              const augmentedDoc = maybeCollapseCommandList(
+                {
+                  ...doc,
+                  brief: brief ?? doc.brief,
+                  description: description ?? doc.description,
+                  examples: examples ?? doc.examples,
+                  author: author ?? doc.author,
+                  bugs: bugs ?? doc.bugs,
+                  footer: footer ?? doc.footer,
+                },
+                commandList,
+                classified.commandPath.length < 1,
+              );
               stderr(formatDocPage(programName, augmentedDoc, {
                 colors,
                 maxWidth,
@@ -3102,6 +3151,54 @@ export function runParserAsync<
 ): Promise<InferValue<TParser>> {
   const result = runParser(parser, programName, args, options);
   return Promise.resolve(result) as Promise<InferValue<TParser>>;
+}
+
+function maybeCollapseCommandList(
+  doc: DocPage,
+  commandList: CommandListMode,
+  isTopLevel: boolean,
+): DocPage {
+  if (commandList !== "top-level" || !isTopLevel) return doc;
+  return {
+    ...doc,
+    sections: doc.sections.map((section) => ({
+      ...section,
+      entries: collapseTopLevelCommandEntries(section.entries),
+    })),
+  };
+}
+
+function collapseTopLevelCommandEntries(
+  entries: readonly DocEntry[],
+): readonly DocEntry[] {
+  const collapsed: DocEntry[] = [];
+  const commandIndexes = new Map<string, number>();
+  for (const entry of entries) {
+    if (entry.term.type !== "command") {
+      collapsed.push(entry);
+      continue;
+    }
+
+    const topLevelName = getTopLevelCommandName(entry.term.name);
+    const existingIndex = commandIndexes.get(topLevelName);
+    const isTopLevel = entry.term.name === topLevelName;
+    if (existingIndex == null) {
+      commandIndexes.set(topLevelName, collapsed.length);
+      collapsed.push(
+        isTopLevel ? entry : {
+          term: { ...entry.term, name: topLevelName },
+        },
+      );
+      continue;
+    }
+
+    if (isTopLevel) collapsed[existingIndex] = entry;
+  }
+  return collapsed;
+}
+
+function getTopLevelCommandName(name: string): string {
+  return name.split(" ", 1)[0] ?? name;
 }
 
 /**

--- a/packages/discover/README.md
+++ b/packages/discover/README.md
@@ -69,6 +69,7 @@ await runProgram({
     version: "1.0.0",
     brief: message`Administrative command-line tools.`,
   },
+  commandList: "top-level",
 });
 ~~~~
 
@@ -156,6 +157,9 @@ Entry files named `index` map to their containing command path, so
 defines `user`.  Use `entryFileName` to choose another entry name or disable
 this rule.  `commandsFromModules()` applies the same path rules to module map
 keys after stripping its `base` option.
+For large command trees, pass `commandList: "top-level"` to keep root help
+focused on first-level command groups while subcommand help remains available
+through `<command> --help`.
 
 For more resources, see the [docs] and the [*examples/*](/examples/)
 directory.

--- a/packages/discover/src/index.test.ts
+++ b/packages/discover/src/index.test.ts
@@ -1122,6 +1122,45 @@ describe("createProgramParser()", () => {
     ]);
   });
 
+  it("lists only top-level commands in root docs when commandList is top-level", async () => {
+    const parser = createProgramParser([
+      {
+        path: ["user"],
+        command: defineCommand({
+          parser: object({}),
+          metadata: { brief: message`Manage users.` },
+          handler() {},
+        }),
+      },
+      {
+        path: ["user", "add"],
+        command: defineCommand({
+          parser: object({}),
+          metadata: { brief: message`Add a user.` },
+          handler() {},
+        }),
+      },
+      {
+        path: ["user", "remove"],
+        command: defineCommand({
+          parser: object({}),
+          metadata: { brief: message`Remove a user.` },
+          handler() {},
+        }),
+      },
+    ], {
+      commandList: "top-level",
+    });
+
+    const page = await getDocPageAsync(parser);
+    assert.ok(page);
+    const output = formatDocPage("tool", page, { showUsage: false });
+
+    assert.match(output, /user\s+Manage users\./);
+    assert.doesNotMatch(output, /user add/);
+    assert.doesNotMatch(output, /user remove/);
+  });
+
   it("preserves source annotations for executable parent commands", async () => {
     const sourceId = Symbol("source");
     const context = createStringSourceContext(sourceId, "from-source");
@@ -1876,6 +1915,73 @@ describe("runProgram()", () => {
     assert.doesNotMatch(stdout, /Usage:/);
     assert.match(stdout, /user add\s+Add a user\./);
     assert.match(stdout, /user remove\s+Remove a user\./);
+  });
+
+  it("lists only top-level commands in root help when commandList is top-level", async () => {
+    const userCommand = defineCommand({
+      path: ["user"],
+      parser: object({}),
+      metadata: { brief: message`Manage users.` },
+      handler() {},
+    });
+    const addCommand = defineCommand({
+      path: ["user", "add"],
+      parser: object({}),
+      metadata: { brief: message`Add a user.` },
+      handler() {},
+    });
+    const removeCommand = defineCommand({
+      path: ["user", "remove"],
+      parser: object({}),
+      metadata: { brief: message`Remove a user.` },
+      handler() {},
+    });
+    let rootStdout = "";
+    let userStdout = "";
+
+    await assert.rejects(
+      () =>
+        runProgram({
+          commands: [userCommand, addCommand, removeCommand],
+          metadata: { name: "tool", version: "1.0.0" },
+          args: ["--help"],
+          commandList: "top-level",
+          showUsage: false,
+          stdout(text) {
+            rootStdout += `${text}\n`;
+          },
+          stderr() {},
+          onExit(exitCode): never {
+            throw new ExitSignal(exitCode);
+          },
+        }),
+      ExitSignal,
+    );
+
+    await assert.rejects(
+      () =>
+        runProgram({
+          commands: [userCommand, addCommand, removeCommand],
+          metadata: { name: "tool", version: "1.0.0" },
+          args: ["user", "--help"],
+          commandList: "top-level",
+          showUsage: false,
+          stdout(text) {
+            userStdout += `${text}\n`;
+          },
+          stderr() {},
+          onExit(exitCode): never {
+            throw new ExitSignal(exitCode);
+          },
+        }),
+      ExitSignal,
+    );
+
+    assert.match(rootStdout, /user\s+Manage users\./);
+    assert.doesNotMatch(rootStdout, /user add/);
+    assert.doesNotMatch(rootStdout, /user remove/);
+    assert.match(userStdout, /add\s+Add a user\./);
+    assert.match(userStdout, /remove\s+Remove a user\./);
   });
 
   it("passes static command values to phase-two source contexts", async () => {

--- a/packages/discover/src/index.ts
+++ b/packages/discover/src/index.ts
@@ -1772,7 +1772,9 @@ function rootListedCommands(
   commandList: RunOptions["commandList"],
 ): readonly CommandEntry[] {
   const listedCommands = commands.filter((entry) => entry.path.length > 0);
-  if (commandList !== "top-level") return listedCommands;
+  if (commandList !== "top-level" || listedCommands.length < 1) {
+    return listedCommands;
+  }
 
   const topLevelEntries = new Map<string, CommandEntry>();
   for (const entry of listedCommands) {
@@ -1780,26 +1782,20 @@ function rootListedCommands(
     if (segment == null) continue;
     const path = [segment];
     const key = commandPathKey(path);
+    if (topLevelEntries.has(key)) continue;
+
     const command = commandsByPath.get(key);
     if (command != null) {
       topLevelEntries.set(key, { path, command });
-    } else if (
-      !topLevelEntries.has(key) &&
-      !isDocHidden(commandPathHidden(entry.path, commandsByPath))
-    ) {
+    } else if (!isDocHidden(commandPathHidden(entry.path, commandsByPath))) {
       topLevelEntries.set(key, {
         path,
-        command: entry.command,
+        command: withoutCommandDocs(entry.command),
       });
     }
   }
 
-  return [...topLevelEntries.values()].map((entry) => {
-    const command = commandsByPath.get(commandPathKey(entry.path));
-    return command == null
-      ? { ...entry, command: withoutCommandDocs(entry.command) }
-      : entry;
-  });
+  return [...topLevelEntries.values()];
 }
 
 function withoutCommandDocs(commandDefinition: AnyCommand): AnyCommand {

--- a/packages/discover/src/index.ts
+++ b/packages/discover/src/index.ts
@@ -24,7 +24,11 @@ import type {
 } from "@optique/core/parser";
 import type { ProgramMetadata } from "@optique/core/program";
 import { command } from "@optique/core/primitives";
-import { type HiddenVisibility, mergeHidden } from "@optique/core/usage";
+import {
+  type HiddenVisibility,
+  isDocHidden,
+  mergeHidden,
+} from "@optique/core/usage";
 import { runAsync } from "@optique/run";
 import type { RunOptions } from "@optique/run";
 import { readdir, realpath, stat } from "node:fs/promises";
@@ -507,7 +511,7 @@ export function commandsFromModules(
  */
 export function createProgramParser(
   commands: readonly CommandEntry[],
-  metadata: ProgramHelpMetadata = {},
+  options: CreateProgramParserOptions = {},
 ): FluentParser<Mode, ProgramInvocation, unknown> {
   if (commands.length < 1) {
     throw new TypeError("createProgramParser() requires at least one command.");
@@ -521,7 +525,7 @@ export function createProgramParser(
   );
   const rootNode = buildCommandTree(sortedCommands);
   const parser = buildNodeParser(rootNode);
-  return fluent(withRootDocs(parser, sortedCommands, metadata));
+  return fluent(withRootDocs(parser, sortedCommands, options));
 }
 
 /**
@@ -546,7 +550,10 @@ export async function runProgram(options: RunProgramOptions): Promise<void> {
       entryFileName: options.entryFileName,
     });
   }
-  const parser = createProgramParser(commands, options.metadata);
+  const parser = createProgramParser(commands, {
+    ...options.metadata,
+    commandList: options.commandList,
+  });
   const invocation = await runAsync(parser, buildRunOptions(options));
   await dispatchInvocation(invocation, options.hooks);
 }
@@ -651,6 +658,20 @@ export interface ProgramHelpMetadata {
    * Footer text shown after the command list.
    */
   readonly footer?: Message;
+}
+
+/**
+ * Options for {@link createProgramParser}.
+ *
+ * @since 1.2.0
+ */
+export interface CreateProgramParserOptions extends ProgramHelpMetadata {
+  /**
+   * How to render command lists in top-level help pages.
+   *
+   * @default `"recursive"`
+   */
+  readonly commandList?: RunOptions["commandList"];
 }
 
 interface CommandTreeNode {
@@ -1690,13 +1711,17 @@ function createLeafParser(
 function withRootDocs(
   parser: Parser<Mode, ProgramInvocation, unknown>,
   commands: readonly CommandEntry[],
-  metadata: ProgramHelpMetadata,
+  metadata: CreateProgramParserOptions,
 ): Parser<Mode, ProgramInvocation, unknown> {
   const rootState = parser.initialState;
   const rootCommand = commands.find((entry) => entry.path.length < 1);
-  const listedCommands = commands.filter((entry) => entry.path.length > 0);
   const commandsByPath = new Map(
     commands.map((entry) => [commandPathKey(entry.path), entry.command]),
+  );
+  const listedCommands = rootListedCommands(
+    commands,
+    commandsByPath,
+    metadata.commandList ?? "recursive",
   );
   const rootDocs = (): DocFragments => {
     const fragments: DocFragment[] = [
@@ -1738,6 +1763,52 @@ function withRootDocs(
       }
       return parser.getDocFragments(state, defaultValue);
     },
+  };
+}
+
+function rootListedCommands(
+  commands: readonly CommandEntry[],
+  commandsByPath: ReadonlyMap<string, AnyCommand>,
+  commandList: RunOptions["commandList"],
+): readonly CommandEntry[] {
+  const listedCommands = commands.filter((entry) => entry.path.length > 0);
+  if (commandList !== "top-level") return listedCommands;
+
+  const topLevelEntries = new Map<string, CommandEntry>();
+  for (const entry of listedCommands) {
+    const segment = entry.path[0];
+    if (segment == null) continue;
+    const path = [segment];
+    const key = commandPathKey(path);
+    const command = commandsByPath.get(key);
+    if (command != null) {
+      topLevelEntries.set(key, { path, command });
+    } else if (
+      !topLevelEntries.has(key) &&
+      !isDocHidden(commandPathHidden(entry.path, commandsByPath))
+    ) {
+      topLevelEntries.set(key, {
+        path,
+        command: entry.command,
+      });
+    }
+  }
+
+  return [...topLevelEntries.values()].map((entry) => {
+    const command = commandsByPath.get(commandPathKey(entry.path));
+    return command == null
+      ? { ...entry, command: withoutCommandDocs(entry.command) }
+      : entry;
+  });
+}
+
+function withoutCommandDocs(commandDefinition: AnyCommand): AnyCommand {
+  if (commandDefinition.metadata == null) return commandDefinition;
+  const { brief: _brief, description: _description, ...metadata } =
+    commandDefinition.metadata;
+  return {
+    ...commandDefinition,
+    metadata,
   };
 }
 

--- a/packages/run/src/run.test.ts
+++ b/packages/run/src/run.test.ts
@@ -13,6 +13,7 @@ import {
   fail,
   option,
 } from "@optique/core/primitives";
+import type { Parser } from "@optique/core/parser";
 import type { Program } from "@optique/core/program";
 import type { OptionName } from "@optique/core/usage";
 import type { ValueParser, ValueParserResult } from "@optique/core/valueparser";
@@ -65,6 +66,62 @@ function createPassthroughConfigSchema<T>(): Parameters<
       validate(input: unknown) {
         return { value: input as T };
       },
+    },
+  };
+}
+
+function createFlatCommandDocParser(): Parser<"sync", undefined, undefined> {
+  return {
+    mode: "sync",
+    $valueType: [] as readonly undefined[],
+    $stateType: [] as readonly undefined[],
+    priority: 0,
+    usage: [],
+    leadingNames: new Set(),
+    acceptingAnyToken: false,
+    initialState: undefined,
+    parse(context) {
+      return {
+        success: true as const,
+        next: context,
+        consumed: [],
+      };
+    },
+    complete() {
+      return {
+        success: true as const,
+        value: undefined,
+      };
+    },
+    *suggest() {},
+    getDocFragments() {
+      return {
+        fragments: [{
+          type: "section",
+          entries: [
+            {
+              term: { type: "command", name: "remote" },
+              description: message`Manage remotes.`,
+            },
+            {
+              term: { type: "command", name: "remote add" },
+              description: message`Add a remote.`,
+            },
+            {
+              term: { type: "command", name: "remote remove" },
+              description: message`Remove a remote.`,
+            },
+            {
+              term: { type: "command", name: "config" },
+              description: message`Manage configuration.`,
+            },
+            {
+              term: { type: "command", name: "config get" },
+              description: message`Read configuration.`,
+            },
+          ],
+        }],
+      };
     },
   };
 }
@@ -1695,6 +1752,35 @@ describe("runAsync", () => {
       assert.ok(!helpOutput.includes("Usage:"));
       assert.ok(helpOutput.includes("build"));
       assert.ok(helpOutput.includes("deploy"));
+    });
+
+    it("should list only top-level commands when commandList is top-level", () => {
+      const parser = createFlatCommandDocParser();
+      let helpOutput = "";
+
+      try {
+        run(parser, {
+          args: ["--help"],
+          commandList: "top-level",
+          help: "option",
+          programName: "myapp",
+          showUsage: false,
+          stdout: (text) => {
+            helpOutput += `${text}\n`;
+          },
+          onExit: () => {
+            throw new Error("EXIT");
+          },
+        });
+      } catch (err) {
+        if ((err as Error).message !== "EXIT") throw err;
+      }
+
+      assert.match(helpOutput, /remote\s+Manage remotes\./);
+      assert.match(helpOutput, /config\s+Manage configuration\./);
+      assert.doesNotMatch(helpOutput, /remote add/);
+      assert.doesNotMatch(helpOutput, /remote remove/);
+      assert.doesNotMatch(helpOutput, /config get/);
     });
 
     it("preserves positional values that match built-in help commands", async () => {

--- a/packages/run/src/run.ts
+++ b/packages/run/src/run.ts
@@ -2,6 +2,7 @@ import type { ShellCompletion } from "@optique/core/completion";
 import type { SourceContext } from "@optique/core/context";
 import { runParser, runWith, runWithSync } from "@optique/core/facade";
 import type {
+  CommandListMode,
   CommandSubConfig,
   ContextOptionsParam,
   OptionSubConfig,
@@ -120,6 +121,17 @@ export interface RunOptions {
    * @since 1.2.0
    */
   readonly showUsage?: boolean;
+
+  /**
+   * How to render command lists in top-level help pages.
+   *
+   * Pass `"top-level"` to show only first-level commands in the command menu
+   * while keeping nested command help available through `<command> --help`.
+   *
+   * @default `"recursive"`
+   * @since 1.2.0
+   */
+  readonly commandList?: CommandListMode;
 
   /**
    * A custom comparator function to control the order of sections in the
@@ -837,6 +849,7 @@ function buildCoreOptions(
   const showDefault = options.showDefault;
   const showChoices = options.showChoices;
   const showUsage = options.showUsage;
+  const commandList = options.commandList;
   const sectionOrder = options.sectionOrder;
   const help = options.help;
   const version = options.version;
@@ -902,6 +915,7 @@ function buildCoreOptions(
     showDefault,
     showChoices,
     showUsage,
+    commandList,
     sectionOrder,
     help: helpConfig,
     version: versionConfig,
@@ -936,6 +950,7 @@ const knownRunOptionsKeyList = [
   "showDefault",
   "showChoices",
   "showUsage",
+  "commandList",
   "sectionOrder",
   "help",
   "version",


### PR DESCRIPTION
This pull request adds a `commandList` option for command-line surfaces that need root help to work as a compact command menu instead of a full recursive index.

The default stays `"recursive"` so existing help output does not change. When set to `"top-level"`, the root help page lists only the first command segment, for example `remote` instead of `remote add` and `remote remove`. The detailed command list is still available by drilling into that group with `remote --help`.

I kept this as a help-rendering option rather than changing parser discovery or the command tree itself. In *@optique/core*, the final `DocPage` is collapsed only when the page is known to be top-level help, so subcommand help keeps its local command list. The same rule is applied to `aboveError: "help"` output. That path tracks the parse failure's command path, not whether argv is empty, because root-level errors such as `--bad` still need root help.

*@optique/run* forwards the option through its existing runner option normalization. *@optique/discover* applies the same idea earlier, while building root docs for discovered command trees. If a first-level command exists, its own metadata is used. If only deeper leaf commands exist, the synthetic first-level entry is shown without borrowing a leaf command's description.

The public API additions are recorded separately in *CHANGES.md* for *@optique/core*, *@optique/run*, and *@optique/discover*. The docs in *docs/concepts/runners.md*, *docs/concepts/discover.md*, the *@optique/discover* README, and the Optique agent skill mention the new option where users would naturally look for help shaping runner output.

Fixes #864.