### PR TITLE
Reversible value parser mapping

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -55,6 +55,12 @@ To be released.
     `"top-level"` makes top-level help pages list only first-level commands so
     users can drill down with `<command> --help`.  [[#864], [#865]]
 
+ -  Added `transform()` to *@optique/core/valueparser* for reversible value
+    parser transformations.  The wrapper maps parsed values to a new type while
+    using the inverse mapping for formatting, fallback validation, choices, and
+    placeholders, and it preserves the wrapped parser's sync or async mode.
+    [[#866]]
+
 [#842]: https://github.com/dahlia/optique/issues/842
 [#843]: https://github.com/dahlia/optique/pull/843
 [#846]: https://github.com/dahlia/optique/issues/846
@@ -66,6 +72,7 @@ To be released.
 [#860]: https://github.com/dahlia/optique/pull/860
 [#864]: https://github.com/dahlia/optique/issues/864
 [#865]: https://github.com/dahlia/optique/pull/865
+[#866]: https://github.com/dahlia/optique/pull/866
 
 ### @optique/standard-schema
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -56,10 +56,15 @@ To be released.
     users can drill down with `<command> --help`.  [[#864], [#865]]
 
  -  Added `transform()` to *@optique/core/valueparser* for reversible value
-    parser transformations.  The wrapper maps parsed values to a new type while
-    using the inverse mapping for formatting, fallback validation, choices, and
+    parser transformations.  It maps parsed values to a new type while using
+    the inverse mapping for formatting, fallback validation, choices, and
     placeholders, and it preserves the wrapped parser's sync or async mode.
     [[#866]]
+
+ -  Added `biject()` to *@optique/core/valueparser* for one-to-one
+    string-to-value dictionaries.  It accepts one of the dictionary's string
+    keys, returns the corresponding mapped value, and rejects empty mappings
+    or duplicate mapped values at construction time.  [[#866]]
 
 [#842]: https://github.com/dahlia/optique/issues/842
 [#843]: https://github.com/dahlia/optique/pull/843

--- a/docs/.vitepress/theme/components/ParserCatalog.vue
+++ b/docs/.vitepress/theme/components/ParserCatalog.vue
@@ -10,6 +10,7 @@ const valueParsers = [
     items: [
       ["string", "string-parser"],
       ["choice", "choice-parser"],
+      ["biject", "biject-parser"],
       ["transform", "transform-combinator"],
       ["firstOf", "firstof-combinator"],
       ["keyValue", "keyvalue-parser"],

--- a/docs/.vitepress/theme/components/ParserCatalog.vue
+++ b/docs/.vitepress/theme/components/ParserCatalog.vue
@@ -10,6 +10,7 @@ const valueParsers = [
     items: [
       ["string", "string-parser"],
       ["choice", "choice-parser"],
+      ["transform", "transform-combinator"],
       ["firstOf", "firstof-combinator"],
       ["keyValue", "keyvalue-parser"],
     ],

--- a/docs/concepts/valueparsers.md
+++ b/docs/concepts/valueparsers.md
@@ -37,6 +37,7 @@ with Optique's type system.
 | `fileSize()`                     | *@optique/core*            | `number` or `bigint`           | Human-readable data size (bytes)                      |
 | `color()`                        | *@optique/core*            | `Color`                        | CSS color (hex, rgb, hsl, or named)                   |
 | `choice()`                       | *@optique/core*            | string or number literal union | Enumerated values                                     |
+| `biject()`                       | *@optique/core*            | mapped value type              | One-to-one string-to-value choices                    |
 | `transform()`                    | *@optique/core*            | mapped value type              | Reversible value parser transformation                |
 | `firstOf()`                      | *@optique/core*            | union of constituent types     | First-match union of value parsers                    |
 | `json()`                         | *@optique/core*            | `Json`                         | Any JSON value, with optional root type restriction   |
@@ -710,6 +711,84 @@ The `suggest` option accepts:
 > for details.
 
 
+`biject()` parser
+-----------------
+
+*This parser is available since Optique 1.2.0.*
+
+The `biject()` parser accepts one of an object's string keys and returns the
+corresponding value.  It is useful when the CLI spelling is a stable public
+token, but the application wants to work with another value such as a numeric
+code, a symbol, or a domain object.
+
+~~~~ typescript twoslash
+import { biject } from "@optique/core/valueparser";
+
+const status = biject({
+  ok: 0,
+  warning: 1,
+  error: 2,
+});
+
+const result = status.parse("warning");
+if (result.success) {
+  result.value;
+  //     ^?
+
+
+
+
+
+
+
+
+
+
+
+
+  // result.value is inferred as 0 | 1 | 2.
+}
+~~~~
+
+The mapping must be one-to-one: keys are unique by JavaScript object rules,
+and values must also be unique according to the same equality semantics used
+by `Map` and `Set`.  Arrays are rejected; use a plain object so the key set
+matches the CLI tokens.  This lets `format(value)` recover the original CLI
+key:
+
+~~~~ typescript twoslash
+import { biject } from "@optique/core/valueparser";
+
+const status = biject({
+  ok: 0,
+  warning: 1,
+  error: 2,
+});
+
+status.format(2);
+// "error"
+~~~~
+
+Duplicate values and empty mappings are rejected when the parser is created:
+
+~~~~ typescript twoslash
+import { biject } from "@optique/core/valueparser";
+
+biject({});
+// Throws RangeError: Expected at least one biject entry.
+
+biject({
+  foo: "dup",
+  bar: "dup",
+});
+// Throws RangeError: Duplicate biject value for key "bar".
+~~~~
+
+The parser exposes the mapped values through `choices`, while completion
+suggestions remain based on the input keys.  For example, `biject({ ok: 0 })`
+suggests `ok` to the shell but produces the value `0`.
+
+
 `transform()` combinator
 ------------------------
 
@@ -738,6 +817,21 @@ const result = level.parse("debug");
 if (result.success) {
   result.value;
   //     ^?
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -788,6 +882,21 @@ const mode = transform(choice(["dev", "prod"] as const), {
 
 const choices = mode.choices;
 //    ^?
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 

--- a/docs/concepts/valueparsers.md
+++ b/docs/concepts/valueparsers.md
@@ -37,6 +37,7 @@ with Optique's type system.
 | `fileSize()`                     | *@optique/core*            | `number` or `bigint`           | Human-readable data size (bytes)                      |
 | `color()`                        | *@optique/core*            | `Color`                        | CSS color (hex, rgb, hsl, or named)                   |
 | `choice()`                       | *@optique/core*            | string or number literal union | Enumerated values                                     |
+| `transform()`                    | *@optique/core*            | mapped value type              | Reversible value parser transformation                |
 | `firstOf()`                      | *@optique/core*            | union of constituent types     | First-match union of value parsers                    |
 | `json()`                         | *@optique/core*            | `Json`                         | Any JSON value, with optional root type restriction   |
 | `cron()`                         | *@optique/core*            | `CronExpression`               | Cron schedule expression                              |
@@ -707,6 +708,92 @@ The `suggest` option accepts:
 > option in your runner configuration.  See the
 > [choice display](./runners.md#choice-display) section in the runners guide
 > for details.
+
+
+`transform()` combinator
+------------------------
+
+*This combinator is available since Optique 1.2.0.*
+
+The `transform()` combinator wraps an existing value parser and maps its
+successful result to another type.  Use it when the accepted command-line
+spelling is already described by a parser such as `choice()` or `integer()`,
+but your application wants a domain-specific value.
+
+~~~~ typescript twoslash
+import { choice, transform } from "@optique/core/valueparser";
+
+type LogLevel = "DEBUG" | "INFO" | "WARN" | "ERROR";
+
+const level = transform(choice(["debug", "info", "warn", "error"] as const), {
+  map(value): LogLevel {
+    return value.toUpperCase() as LogLevel;
+  },
+  unmap(value) {
+    return value.toLowerCase() as "debug" | "info" | "warn" | "error";
+  },
+});
+
+const result = level.parse("debug");
+if (result.success) {
+  result.value;
+  //     ^?
+
+
+
+
+
+  // result.value is inferred as LogLevel.
+}
+~~~~
+
+Unlike parser-level `map()`, `transform()` needs both directions:
+
+`map(value)`
+:   Converts the wrapped parser's result into the public value type.
+
+`unmap(value)`
+:   Converts the public value back to the wrapped parser's type.  This is
+    used by `format()`, fallback validation, default handling, and help text
+    that needs to display a value as command-line input.
+
+The two functions should be inverses for the values your CLI accepts.
+For example, `unmap(map(value))` should still satisfy the wrapped parser,
+and `map(unmap(value))` should preserve valid transformed values.  A lossy
+mapping can still parse CLI input, but formatting and default validation may
+not behave the way users expect.
+
+The wrapped parser's mode is preserved.  If you transform an async value
+parser, the returned parser is async too, but the mapping functions themselves
+must be synchronous.
+
+### Metadata
+
+`transform()` preserves the wrapped parser's metavar and suggestions because
+those describe the accepted input string.  When the wrapped parser exposes
+`choices`, the transformed parser exposes those choices after applying
+`map()`:
+
+~~~~ typescript twoslash
+import { choice, transform } from "@optique/core/valueparser";
+// ---cut-before---
+const mode = transform(choice(["dev", "prod"] as const), {
+  map(value) {
+    return { name: value };
+  },
+  unmap(value: { readonly name: "dev" | "prod" }) {
+    return value.name;
+  },
+});
+
+const choices = mode.choices;
+//    ^?
+
+
+
+
+// choices is inferred from the transformed value type.
+~~~~
 
 
 `firstOf()` combinator

--- a/docs/index.md
+++ b/docs/index.md
@@ -311,7 +311,7 @@ const host = prompt(
 <LandingSection
   eyebrow="Batteries included"
   title="Reach for a parser before you write one."
-  lead="Forty-seven built-in value parsers, from <code>integer()</code> and
+  lead="Forty-eight built-in value parsers, from <code>integer()</code> and
   <code>ip()</code> to schema validators, Temporal dates, and async Git refs,
   plus the combinators that assemble them. Every one returns an ordinary parser
   that composes with the rest."

--- a/docs/index.md
+++ b/docs/index.md
@@ -311,7 +311,7 @@ const host = prompt(
 <LandingSection
   eyebrow="Batteries included"
   title="Reach for a parser before you write one."
-  lead="Forty-eight built-in value parsers, from <code>integer()</code> and
+  lead="Forty-nine built-in value parsers, from <code>integer()</code> and
   <code>ip()</code> to schema validators, Temporal dates, and async Git refs,
   plus the combinators that assemble them. Every one returns an ordinary parser
   that composes with the rest."

--- a/packages/core/skills/optique/SKILL.md
+++ b/packages/core/skills/optique/SKILL.md
@@ -41,10 +41,11 @@ Core rules
     custom errors. Prefer semantic message helpers such as `optionName()` and
     `metavar()` over string concatenation when naming CLI elements.
  -  Use value parsers such as `integer()`, `choice()`, `url()`, and `uuid()`
-    instead of validating raw strings after parsing. Use `path()` from
-    `@optique/run/valueparser` for file-system paths. Write a custom
-    `{ mode, metavar, parse, format }` value parser only when the catalog does
-    not cover the domain.
+    instead of validating raw strings after parsing. Use `transform()` when an
+    existing value parser describes the accepted CLI spelling but your app
+    needs a different result type. Use `path()` from `@optique/run/valueparser`
+    for file-system paths. Write a custom `{ mode, metavar, parse, format }`
+    value parser only when the catalog does not cover the domain.
  -  Async value parsers make the containing parser async. If you use packages
     such as *@optique/git*, remember to `await run(...)`, `await parse(...)`, or
     `await runParser(...)` as appropriate.
@@ -138,9 +139,24 @@ if (result.success) {
 Custom value parsers
 --------------------
 
-Prefer the built-in catalog first. When a custom domain is needed, keep the
-validation in a value parser so help, errors, defaults, prompts, and completion
-all see the same typed value.
+Prefer the built-in catalog first. If an existing parser already accepts the
+right input syntax, wrap it with `transform()` before writing a custom parser:
+
+~~~~ typescript
+import { choice, transform } from "@optique/core/valueparser";
+
+const logLevel = transform(choice(["debug", "info", "warn", "error"] as const), {
+  map(value) {
+    return value.toUpperCase() as "DEBUG" | "INFO" | "WARN" | "ERROR";
+  },
+  unmap(value) {
+    return value.toLowerCase() as "debug" | "info" | "warn" | "error";
+  },
+});
+~~~~
+
+When a custom domain is needed, keep the validation in a value parser so help,
+errors, defaults, prompts, and completion all see the same typed value.
 
 ~~~~ typescript
 import { message } from "@optique/core/message";

--- a/packages/core/skills/optique/SKILL.md
+++ b/packages/core/skills/optique/SKILL.md
@@ -40,12 +40,14 @@ Core rules
  -  Use `message` from *@optique/core/message* for descriptions, help text, and
     custom errors. Prefer semantic message helpers such as `optionName()` and
     `metavar()` over string concatenation when naming CLI elements.
- -  Use value parsers such as `integer()`, `choice()`, `url()`, and `uuid()`
-    instead of validating raw strings after parsing. Use `transform()` when an
-    existing value parser describes the accepted CLI spelling but your app
-    needs a different result type. Use `path()` from `@optique/run/valueparser`
-    for file-system paths. Write a custom `{ mode, metavar, parse, format }`
-    value parser only when the catalog does not cover the domain.
+ -  Use value parsers such as `integer()`, `choice()`, `biject()`, `url()`,
+    and `uuid()` instead of validating raw strings after parsing. Use
+    `biject()` for one-to-one string-to-value choices, and use `transform()`
+    when an existing value parser describes the accepted CLI spelling but your
+    app needs a different result type. Use `path()` from
+    `@optique/run/valueparser` for file-system paths. Write a custom
+    `{ mode, metavar, parse, format }` value parser only when the catalog does
+    not cover the domain.
  -  Async value parsers make the containing parser async. If you use packages
     such as *@optique/git*, remember to `await run(...)`, `await parse(...)`, or
     `await runParser(...)` as appropriate.
@@ -139,11 +141,19 @@ if (result.success) {
 Custom value parsers
 --------------------
 
-Prefer the built-in catalog first. If an existing parser already accepts the
-right input syntax, wrap it with `transform()` before writing a custom parser:
+Prefer the built-in catalog first. If a one-to-one dictionary can describe the
+input tokens and domain values, use `biject()`. If an existing parser already
+accepts the right input syntax, wrap it with `transform()` before writing a
+custom parser:
 
 ~~~~ typescript
-import { choice, transform } from "@optique/core/valueparser";
+import { biject, choice, transform } from "@optique/core/valueparser";
+
+const exitCode = biject({
+  ok: 0,
+  warning: 1,
+  error: 2,
+});
 
 const logLevel = transform(choice(["debug", "info", "warn", "error"] as const), {
   map(value) {

--- a/packages/core/src/internal/mode-dispatch.test.ts
+++ b/packages/core/src/internal/mode-dispatch.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { wrapIterableForMode } from "./mode-dispatch.ts";
+
+describe("wrapIterableForMode", () => {
+  it("should reject non-object sync values without in-operator errors", () => {
+    assert.throws(() => {
+      try {
+        [...wrapIterableForMode("sync", null as never)];
+      } catch (error) {
+        assert.ok(error instanceof TypeError);
+        assert.ok(!error.message.includes("in' operator"));
+        throw error;
+      }
+    }, TypeError);
+  });
+});

--- a/packages/core/src/internal/mode-dispatch.test.ts
+++ b/packages/core/src/internal/mode-dispatch.test.ts
@@ -15,4 +15,18 @@ describe("wrapIterableForMode", () => {
       }
     }, TypeError);
   });
+
+  it("should reject non-object async values without in-operator errors", async () => {
+    await assert.rejects(async () => {
+      try {
+        for await (const _ of wrapIterableForMode("async", null as never)) {
+          // Iteration triggers the wrapped async generator body.
+        }
+      } catch (error) {
+        assert.ok(error instanceof TypeError);
+        assert.ok(!error.message.includes("in' operator"));
+        throw error;
+      }
+    }, TypeError);
+  });
 });

--- a/packages/core/src/internal/mode-dispatch.ts
+++ b/packages/core/src/internal/mode-dispatch.ts
@@ -126,10 +126,12 @@ export function wrapIterableForMode<M extends Mode, T>(
   mode: M,
   value: Iterable<T> | AsyncIterable<T>,
 ): ModeIterable<M, T> {
+  const canCheckAsyncIterator = value != null &&
+    (typeof value === "object" || typeof value === "function");
   return dispatchIterableByMode(
     mode,
     () => {
-      if (Symbol.asyncIterator in value) {
+      if (canCheckAsyncIterator && Symbol.asyncIterator in value) {
         throw new TypeError(
           "Synchronous mode cannot wrap AsyncIterable value.",
         );
@@ -137,7 +139,7 @@ export function wrapIterableForMode<M extends Mode, T>(
       return value;
     },
     () => {
-      if (Symbol.asyncIterator in value) return value;
+      if (canCheckAsyncIterator && Symbol.asyncIterator in value) return value;
       return (async function* () {
         yield* value;
       })();

--- a/packages/core/src/internal/mode-dispatch.ts
+++ b/packages/core/src/internal/mode-dispatch.ts
@@ -128,10 +128,12 @@ export function wrapIterableForMode<M extends Mode, T>(
 ): ModeIterable<M, T> {
   const canCheckAsyncIterator = value != null &&
     (typeof value === "object" || typeof value === "function");
+  const isAsyncIterable = canCheckAsyncIterator &&
+    Symbol.asyncIterator in value;
   return dispatchIterableByMode(
     mode,
     () => {
-      if (canCheckAsyncIterator && Symbol.asyncIterator in value) {
+      if (isAsyncIterable) {
         throw new TypeError(
           "Synchronous mode cannot wrap AsyncIterable value.",
         );
@@ -139,7 +141,7 @@ export function wrapIterableForMode<M extends Mode, T>(
       return value;
     },
     () => {
-      if (canCheckAsyncIterator && Symbol.asyncIterator in value) return value;
+      if (isAsyncIterable) return value;
       return (async function* () {
         yield* value;
       })();

--- a/packages/core/src/internal/mode-dispatch.ts
+++ b/packages/core/src/internal/mode-dispatch.ts
@@ -93,6 +93,59 @@ export function mapModeValue<M extends Mode, T, U>(
 }
 
 /**
+ * Maps a value or promise while preserving the declared execution mode.
+ *
+ * Some internal extension hooks predate `ModeValue` and expose a plain
+ * `T | Promise<T>` return type. This helper adapts those hooks back into the
+ * mode-dispatch boundary before applying a mapping function.
+ *
+ * @param mode The execution mode.
+ * @param value The value or promise to transform.
+ * @param mapFn Mapping function applied to the unwrapped value.
+ * @returns The mapped value with correct mode wrapping.
+ * @internal
+ */
+export function mapMaybePromiseByMode<M extends Mode, T, U>(
+  mode: M,
+  value: T | Promise<T>,
+  mapFn: (value: T) => U,
+): ModeValue<M, U> {
+  return mapModeValue(mode, wrapForMode(mode, value), mapFn);
+}
+
+/**
+ * Adapts an iterable or async iterable to the declared execution mode.
+ *
+ * @param mode The execution mode.
+ * @param value The iterable to adapt.
+ * @returns The iterable with correct mode wrapping.
+ * @throws {TypeError} If a synchronous mode receives an async iterable.
+ * @internal
+ */
+export function wrapIterableForMode<M extends Mode, T>(
+  mode: M,
+  value: Iterable<T> | AsyncIterable<T>,
+): ModeIterable<M, T> {
+  return dispatchIterableByMode(
+    mode,
+    () => {
+      if (Symbol.asyncIterator in value) {
+        throw new TypeError(
+          "Synchronous mode cannot wrap AsyncIterable value.",
+        );
+      }
+      return value;
+    },
+    () => {
+      if (Symbol.asyncIterator in value) return value;
+      return (async function* () {
+        yield* value;
+      })();
+    },
+  );
+}
+
+/**
  * Dispatches iterable to sync or async implementation based on mode.
  *
  * @param mode The execution mode.

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -2846,6 +2846,21 @@ describe("transform", () => {
     ]);
   });
 
+  it("should reject fallback values that format to non-strings", () => {
+    const parser = transform(string(), {
+      map: (value) => ({ value }),
+      unmap: (value: { readonly value: string }) => value.value,
+    });
+
+    const result = parser.validate?.({} as never);
+
+    assert.ok(result != null);
+    assert.ok(!result.success);
+    assert.deepEqual(result.error, [
+      { type: "text", text: "Failed to transform value." },
+    ]);
+  });
+
   it("should transform placeholder and choices metadata", () => {
     const parser = transform(choice(["foo", "bar"] as const), {
       map: (value) => value === "foo" ? "FOO" as const : "BAR" as const,
@@ -2972,6 +2987,32 @@ describe("transform", () => {
 
     assert.throws(
       () => parser.parse("abcd"),
+      {
+        name: "TypeError",
+        message: "Synchronous mode cannot wrap Promise value.",
+      },
+    );
+  });
+
+  it("should reject promises from sync inner parser validation", () => {
+    const inner: ValueParser<"sync", string> = {
+      mode: "sync",
+      metavar: "WORD",
+      placeholder: "foo",
+      parse(input: string): ValueParserResult<string> {
+        return Promise.resolve({ success: true, value: input }) as never;
+      },
+      format(value: string): string {
+        return value;
+      },
+    };
+    const parser = transform(inner, {
+      map: (value) => value.length,
+      unmap: (value) => "x".repeat(value),
+    });
+
+    assert.throws(
+      () => parser.validate?.(3),
       {
         name: "TypeError",
         message: "Synchronous mode cannot wrap Promise value.",

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -34,9 +34,11 @@ import {
   type SemVerString,
   socketAddress,
   string,
+  transform,
   url,
   uuid,
   type ValueParser,
+  type ValueParserResult,
 } from "@optique/core/valueparser";
 import {
   formatMessage,
@@ -46,10 +48,12 @@ import {
   text,
   values,
 } from "@optique/core/message";
+import { object } from "#src/constructs.ts";
 import { dependency } from "#src/dependency.ts";
+import { getSnapshottedDefaultDependencyValues } from "#src/internal/dependency.ts";
 import { argument, option } from "#src/primitives.ts";
 import { withDefault } from "#src/modifiers.ts";
-import { parse } from "#src/parser.ts";
+import { parse, suggestSync } from "#src/parser.ts";
 import assert from "node:assert/strict";
 import * as fc from "fast-check";
 import { describe, it } from "node:test";
@@ -2644,6 +2648,277 @@ describe("non-choice parsers should not have choices metadata", () => {
   it("float() should not have choices", () => {
     const parser = float({});
     assert.equal(parser.choices, undefined);
+  });
+});
+
+describe("transform", () => {
+  it("should transform parsed values", () => {
+    const parser = transform(choice(["foo", "bar"] as const), {
+      map: (value) => value === "foo" ? "FOO" as const : "BAR" as const,
+      unmap: (value) => value === "FOO" ? "foo" as const : "bar" as const,
+    });
+
+    const result = parser.parse("foo");
+
+    assert.ok(result.success);
+    assert.equal(result.value, "FOO");
+  });
+
+  it("should preserve parse failures from the inner parser", () => {
+    const parser = transform(choice(["foo", "bar"] as const), {
+      map: (value) => value === "foo" ? "FOO" as const : "BAR" as const,
+      unmap: (value) => value === "FOO" ? "foo" as const : "bar" as const,
+    });
+
+    const result = parser.parse("baz");
+
+    assert.ok(!result.success);
+    assert.deepEqual(result.error, [
+      { type: "text", text: "Expected one of " },
+      { type: "value", value: "foo" },
+      { type: "text", text: " and " },
+      { type: "value", value: "bar" },
+      { type: "text", text: ", but got " },
+      { type: "value", value: "baz" },
+      { type: "text", text: "." },
+    ]);
+  });
+
+  it("should format values through the inverse mapping", () => {
+    const parser = transform(choice(["foo", "bar"] as const), {
+      map: (value) => value === "foo" ? "FOO" as const : "BAR" as const,
+      unmap: (value) => value === "FOO" ? "foo" as const : "bar" as const,
+    });
+
+    const formatted = parser.format("BAR");
+
+    assert.equal(formatted, "bar");
+  });
+
+  it("should validate transformed values through the inner parser", () => {
+    const parser = transform(integer({ min: 1, max: 10 }), {
+      map: (value) => ({ count: value }),
+      unmap: (value: { readonly count: number }) => value.count,
+    });
+
+    const valid = parser.validate?.({ count: 3 });
+    const invalid = parser.validate?.({ count: 12 });
+
+    assert.deepEqual(valid, { success: true, value: { count: 3 } });
+    assert.ok(invalid != null);
+    assert.ok(!invalid.success);
+    assert.deepEqual(invalid.error, [
+      { type: "text", text: "Expected a value less than or equal to " },
+      { type: "text", text: "10" },
+      { type: "text", text: ", but got " },
+      { type: "value", value: "12" },
+      { type: "text", text: "." },
+    ]);
+  });
+
+  it("should transform placeholder and choices metadata", () => {
+    const parser = transform(choice(["foo", "bar"] as const), {
+      map: (value) => value === "foo" ? "FOO" as const : "BAR" as const,
+      unmap: (value) => value === "FOO" ? "foo" as const : "bar" as const,
+    });
+
+    assert.equal(parser.placeholder, "FOO");
+    assert.deepEqual(parser.choices, ["FOO", "BAR"]);
+  });
+
+  it("should delegate suggestions as input strings", () => {
+    const parser = transform(choice(["foo", "bar"] as const), {
+      map: (value) => value === "foo" ? "FOO" as const : "BAR" as const,
+      unmap: (value) => value === "FOO" ? "foo" as const : "bar" as const,
+    });
+
+    const suggestions = [...(parser.suggest?.("f") ?? [])];
+
+    assert.deepEqual(suggestions, [{ kind: "literal", text: "foo" }]);
+  });
+
+  it("should preserve async value parser mode", async () => {
+    const inner: ValueParser<"async", string> = {
+      mode: "async",
+      metavar: "WORD",
+      placeholder: "foo",
+      parse(input: string): Promise<ValueParserResult<string>> {
+        return Promise.resolve({ success: true, value: input });
+      },
+      format(value: string): string {
+        return value;
+      },
+      async *suggest(prefix: string) {
+        yield { kind: "literal" as const, text: `${prefix}-value` };
+      },
+    };
+    const parser = transform(inner, {
+      map: (value) => value.length,
+      unmap: (value) => "x".repeat(value),
+    });
+
+    const result = await parser.parse("abcd");
+    const suggestions = [];
+    for await (const suggestion of parser.suggest?.("x") ?? []) {
+      suggestions.push(suggestion);
+    }
+
+    parser satisfies ValueParser<"async", number>;
+    assert.equal(parser.mode, "async");
+    assert.ok(result.success);
+    assert.equal(result.value, 4);
+    assert.deepEqual(suggestions, [{ kind: "literal", text: "x-value" }]);
+  });
+
+  it("should lazily map dependency-derived placeholders", () => {
+    const mode = dependency(choice(["dev", "prod"] as const));
+    const level = mode.derive({
+      metavar: "LEVEL",
+      mode: "sync",
+      factory: () => choice(["debug", "info"] as const),
+      defaultValue() {
+        throw new Error("Default mode is unavailable.");
+      },
+    });
+    const parser = transform(level, {
+      map(value) {
+        return value.toUpperCase() as "DEBUG" | "INFO";
+      },
+      unmap(value) {
+        return value.toLowerCase() as "debug" | "info";
+      },
+    });
+
+    assert.equal(parser.placeholder, undefined);
+    const result = parser.parse("debug");
+
+    assert.ok(!result.success);
+    assert.deepEqual(result.error, [
+      { type: "text", text: "Derived parser error: " },
+      { type: "value", value: "Default mode is unavailable." },
+    ]);
+  });
+
+  it("should preserve dependency-derived default snapshots", () => {
+    let defaultCalls = 0;
+    const mode = dependency(choice(["dev", "prod"] as const));
+    const level = mode.derive({
+      metavar: "LEVEL",
+      mode: "sync",
+      factory: (value) =>
+        choice(
+          value === "dev"
+            ? (["debug", "info"] as const)
+            : (["warn", "error"] as const),
+        ),
+      defaultValue() {
+        defaultCalls++;
+        return defaultCalls === 1 ? "dev" as const : "prod" as const;
+      },
+    });
+    const parser = transform(level, {
+      map(value) {
+        return value.toUpperCase() as "DEBUG" | "INFO" | "WARN" | "ERROR";
+      },
+      unmap(value) {
+        return value.toLowerCase() as "debug" | "info" | "warn" | "error";
+      },
+    });
+
+    const result = parser.parse("debug");
+
+    assert.ok(result.success);
+    assert.equal(result.value, "DEBUG");
+    assert.deepEqual(
+      getSnapshottedDefaultDependencyValues(result),
+      ["dev"],
+    );
+    assert.equal(defaultCalls, 1);
+  });
+
+  it("should preserve dependency-derived parser replay behavior", () => {
+    const mode = dependency(choice(["dev", "prod"] as const));
+    const level = mode.derive({
+      metavar: "LEVEL",
+      mode: "sync",
+      factory: (value) =>
+        choice(
+          value === "dev"
+            ? (["debug", "info"] as const)
+            : (["warn", "error"] as const),
+        ),
+      defaultValue: () => "dev" as const,
+    });
+    const parser = object({
+      mode: withDefault(option("--mode", mode), "prod" as const),
+      level: option(
+        "--level",
+        transform(level, {
+          map(value) {
+            return value.toUpperCase() as "DEBUG" | "INFO" | "WARN" | "ERROR";
+          },
+          unmap(value) {
+            return value.toLowerCase() as
+              | "debug"
+              | "info"
+              | "warn"
+              | "error";
+          },
+        }),
+      ),
+    });
+
+    const result = parse(parser, ["--mode", "prod", "--level", "warn"]);
+
+    assert.ok(result.success);
+    assert.equal(result.value.level, "WARN");
+  });
+
+  it("should preserve dependency-derived suggestion replay behavior", () => {
+    const mode = dependency(choice(["dev", "prod"] as const));
+    const level = mode.derive({
+      metavar: "LEVEL",
+      mode: "sync",
+      factory: (value) =>
+        choice(
+          value === "dev"
+            ? (["debug", "info"] as const)
+            : (["warn", "error"] as const),
+        ),
+      defaultValue: () => "dev" as const,
+    });
+    const parser = object({
+      mode: withDefault(option("--mode", mode), "prod" as const),
+      level: option(
+        "--level",
+        transform(level, {
+          map(value) {
+            return value.toUpperCase() as "DEBUG" | "INFO" | "WARN" | "ERROR";
+          },
+          unmap(value) {
+            return value.toLowerCase() as
+              | "debug"
+              | "info"
+              | "warn"
+              | "error";
+          },
+        }),
+      ),
+    });
+
+    const suggestions = suggestSync(parser, [
+      "--mode",
+      "prod",
+      "--level",
+      "",
+    ]);
+
+    assert.deepEqual(
+      suggestions.map((suggestion) =>
+        suggestion.kind === "literal" ? suggestion.text : suggestion.pattern
+      ),
+      ["warn", "error"],
+    );
   });
 });
 

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -2717,6 +2717,54 @@ describe("transform", () => {
     ]);
   });
 
+  it("should reject parsed values when mapping throws", () => {
+    const parser = transform(string(), {
+      map() {
+        throw new TypeError("Cannot map value.");
+      },
+      unmap: () => "foo",
+    });
+
+    const result = parser.parse("foo");
+
+    assert.ok(!result.success);
+    assert.deepEqual(result.error, [
+      { type: "text", text: "Failed to transform value." },
+    ]);
+  });
+
+  it("should reject validated values when mapping throws", () => {
+    const parser = transform(integer({ min: 1, max: 10 }), {
+      map() {
+        throw new TypeError("Cannot map value.");
+      },
+      unmap: (value: { readonly count: number }) => value.count,
+    });
+
+    const result = parser.validate?.({ count: 3 });
+
+    assert.ok(result != null);
+    assert.ok(!result.success);
+    assert.deepEqual(result.error, [
+      { type: "text", text: "Failed to transform value." },
+    ]);
+  });
+
+  it("should preserve fallback values when validate unmapping throws", () => {
+    const sentinel = { count: 3 };
+    const parser = transform(integer({ min: 1, max: 10 }), {
+      map: (value) => ({ count: value }),
+      unmap(value: { readonly count: number }) {
+        if (value === sentinel) throw new TypeError("Cannot unmap sentinel.");
+        return value.count;
+      },
+    });
+
+    const result = parser.validate?.(sentinel);
+
+    assert.deepEqual(result, { success: true, value: sentinel });
+  });
+
   it("should preserve fallback values when round-trip validation throws", () => {
     const sentinel = { count: 12 };
     const parser = transform(

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -1,4 +1,5 @@
 import {
+  biject,
   checkBooleanOption,
   checkEnumOption,
   choice,
@@ -2918,6 +2919,270 @@ describe("transform", () => {
         suggestion.kind === "literal" ? suggestion.text : suggestion.pattern
       ),
       ["warn", "error"],
+    );
+  });
+});
+
+describe("biject", () => {
+  it("should parse keys into mapped values", () => {
+    const parser = biject({
+      foo: 123,
+      bar: 456,
+      baz: 789,
+    });
+
+    const result = parser.parse("bar");
+
+    assert.ok(result.success);
+    assert.equal(result.value, 456);
+  });
+
+  it("should infer literal value types from inline mappings", () => {
+    const parser = biject({
+      foo: 123,
+      bar: "enabled",
+      baz: true,
+    });
+
+    parser satisfies ValueParser<"sync", 123 | "enabled" | true>;
+  });
+
+  it("should accept typed mappings without string index signatures", () => {
+    interface StatusMap {
+      readonly ok: 0;
+      readonly error: 1;
+    }
+    const mapping: StatusMap = {
+      ok: 0,
+      error: 1,
+    };
+
+    const parser = biject(mapping);
+    const result = parser.parse("ok");
+
+    parser satisfies ValueParser<"sync", 0 | 1>;
+    assert.ok(result.success);
+    assert.equal(result.value, 0);
+  });
+
+  it("should preserve value types for numeric object keys", () => {
+    const parser = biject(
+      {
+        1: "one",
+        2: "two",
+      } as const,
+    );
+
+    const result = parser.parse("1");
+
+    parser satisfies ValueParser<"sync", "one" | "two">;
+    assert.ok(result.success);
+    assert.equal(result.value, "one");
+    assert.equal(parser.format("two"), "2");
+    assert.deepEqual(parser.choices, ["one", "two"]);
+  });
+
+  it("should reject array mappings", () => {
+    assert.throws(
+      () => {
+        const parser = biject(["one", "two"] as const);
+        parser satisfies never;
+      },
+      {
+        name: "TypeError",
+        message: "Expected biject mapping to be a non-array object.",
+      },
+    );
+  });
+
+  it("should reject inputs outside the mapping keys", () => {
+    const parser = biject({
+      foo: 123,
+      bar: 456,
+    });
+
+    const result = parser.parse("baz");
+
+    assert.ok(!result.success);
+    assert.deepEqual(result.error, [
+      { type: "text", text: "Expected one of " },
+      { type: "value", value: "foo" },
+      { type: "text", text: " and " },
+      { type: "value", value: "bar" },
+      { type: "text", text: ", but got " },
+      { type: "value", value: "baz" },
+      { type: "text", text: "." },
+    ]);
+  });
+
+  it("should format mapped values back to keys", () => {
+    const parser = biject({
+      foo: 123,
+      bar: 456,
+    });
+
+    const formatted = parser.format(456);
+
+    assert.equal(formatted, "bar");
+  });
+
+  it("should expose key-based metadata and suggestions", () => {
+    const parser = biject({
+      foo: 123,
+      bar: 456,
+      baz: 789,
+    });
+
+    const suggestions = [...(parser.suggest?.("ba") ?? [])];
+
+    assert.equal(parser.placeholder, 123);
+    assert.deepEqual(parser.choices, [123, 456, 789]);
+    assert.deepEqual(suggestions, [
+      { kind: "literal", text: "bar" },
+      { kind: "literal", text: "baz" },
+    ]);
+  });
+
+  it("should snapshot mappings at construction time", () => {
+    const mapping = {
+      foo: 123,
+      bar: 456,
+    };
+    const parser = biject(mapping);
+
+    mapping.foo = 456;
+    mapping.bar = 789;
+
+    const result = parser.parse("foo");
+
+    assert.ok(result.success);
+    assert.equal(result.value, 123);
+    assert.deepEqual(parser.choices, [123, 456]);
+    assert.deepEqual(parser.validate?.(123), { success: true, value: 123 });
+    assert.ok(!parser.validate?.(789)?.success);
+  });
+
+  it("should validate mapped values through the reverse mapping", () => {
+    const mapping: Readonly<Record<string, number>> = {
+      foo: 123,
+      bar: 456,
+    };
+    const parser = biject(mapping);
+
+    const valid = parser.validate?.(123);
+    const invalid = parser.validate?.(789);
+
+    assert.deepEqual(valid, { success: true, value: 123 });
+    assert.ok(invalid != null);
+    assert.ok(!invalid.success);
+    assert.deepEqual(invalid.error, [
+      { type: "text", text: "Expected one of " },
+      { type: "value", value: "foo" },
+      { type: "text", text: " and " },
+      { type: "value", value: "bar" },
+      { type: "text", text: ", but got " },
+      { type: "value", value: "789" },
+      { type: "text", text: "." },
+    ]);
+  });
+
+  it("should reject fallback values that stringify to input keys", () => {
+    const parser = biject({
+      foo: 123,
+    });
+
+    const result = parser.validate?.("foo" as never);
+
+    assert.ok(result != null);
+    assert.ok(!result.success);
+  });
+
+  it("should not throw when validating unlisted values that cannot stringify", () => {
+    const listed = { id: "listed" };
+    const parser = biject({
+      listed,
+    });
+    const unlisted = Object.create(null, {
+      toString: {
+        get() {
+          throw new Error("Cannot stringify.");
+        },
+      },
+    });
+
+    const result = parser.validate?.(unlisted);
+
+    assert.ok(result != null);
+    assert.ok(!result.success);
+  });
+
+  it("should throw RangeError for duplicate mapped values", () => {
+    assert.throws(
+      () =>
+        biject({
+          foo: "dup",
+          bar: "dup",
+        }),
+      {
+        name: "RangeError",
+        message: 'Duplicate biject value for key "bar".',
+      },
+    );
+  });
+
+  it("should use Map key equality for duplicate values", () => {
+    assert.throws(
+      () =>
+        biject({
+          positiveZero: 0,
+          negativeZero: -0,
+        }),
+      RangeError,
+    );
+    assert.throws(
+      () =>
+        biject({
+          first: NaN,
+          second: NaN,
+        }),
+      RangeError,
+    );
+  });
+
+  it("should compare object values by identity", () => {
+    const shared = { id: "shared" };
+    const first = { id: "same-shape" };
+    const second = { id: "same-shape" };
+
+    const parser = biject({
+      first,
+      second,
+    });
+
+    assert.equal(parser.format(second), "second");
+    assert.throws(
+      () => biject({ first: shared, second: shared }),
+      RangeError,
+    );
+  });
+
+  it("should throw RangeError for empty mappings", () => {
+    assert.throws(
+      () => biject({}),
+      {
+        name: "RangeError",
+        message: "Expected at least one biject entry.",
+      },
+    );
+  });
+
+  it("should reject empty keys through the choice parser", () => {
+    assert.throws(
+      () => biject({ "": "empty" }),
+      {
+        name: "TypeError",
+        message: "Empty strings are not allowed as choices.",
+      },
     );
   });
 });

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -2717,6 +2717,32 @@ describe("transform", () => {
     ]);
   });
 
+  it("should preserve fallback values when round-trip validation throws", () => {
+    const sentinel = { count: 12 };
+    const parser = transform(
+      {
+        mode: "sync" as const,
+        metavar: "COUNT",
+        placeholder: 1,
+        parse(input: string): ValueParserResult<number> {
+          return { success: true, value: Number(input) };
+        },
+        format(value: number): string {
+          if (value > 10) throw new TypeError("Cannot format sentinel.");
+          return value.toString();
+        },
+      },
+      {
+        map: (value) => ({ count: value }),
+        unmap: (value: { readonly count: number }) => value.count,
+      },
+    );
+
+    const result = parser.validate?.(sentinel);
+
+    assert.deepEqual(result, { success: true, value: sentinel });
+  });
+
   it("should transform placeholder and choices metadata", () => {
     const parser = transform(choice(["foo", "bar"] as const), {
       map: (value) => value === "foo" ? "FOO" as const : "BAR" as const,
@@ -3196,7 +3222,10 @@ describe("biject", () => {
           positiveZero: 0,
           negativeZero: -0,
         }),
-      RangeError,
+      {
+        name: "RangeError",
+        message: 'Duplicate biject value for key "negativeZero".',
+      },
     );
     assert.throws(
       () =>
@@ -3204,7 +3233,10 @@ describe("biject", () => {
           first: NaN,
           second: NaN,
         }),
-      RangeError,
+      {
+        name: "RangeError",
+        message: 'Duplicate biject value for key "second".',
+      },
     );
   });
 

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -2750,7 +2750,7 @@ describe("transform", () => {
     ]);
   });
 
-  it("should preserve fallback values when validate unmapping throws", () => {
+  it("should reject fallback values when validate unmapping throws", () => {
     const sentinel = { count: 3 };
     const parser = transform(integer({ min: 1, max: 10 }), {
       map: (value) => ({ count: value }),
@@ -2762,10 +2762,14 @@ describe("transform", () => {
 
     const result = parser.validate?.(sentinel);
 
-    assert.deepEqual(result, { success: true, value: sentinel });
+    assert.ok(result != null);
+    assert.ok(!result.success);
+    assert.deepEqual(result.error, [
+      { type: "text", text: "Failed to transform value." },
+    ]);
   });
 
-  it("should preserve fallback values when round-trip validation throws", () => {
+  it("should reject fallback values when round-trip validation throws", () => {
     const sentinel = { count: 12 };
     const parser = transform(
       {
@@ -2788,7 +2792,26 @@ describe("transform", () => {
 
     const result = parser.validate?.(sentinel);
 
-    assert.deepEqual(result, { success: true, value: sentinel });
+    assert.ok(result != null);
+    assert.ok(!result.success);
+    assert.deepEqual(result.error, [
+      { type: "text", text: "Failed to transform value." },
+    ]);
+  });
+
+  it("should reject malformed fallback values", () => {
+    const parser = transform(integer(), {
+      map: (value) => ({ count: value }),
+      unmap: (value: { readonly count: number }) => value.count,
+    });
+
+    const result = parser.validate?.("3" as never);
+
+    assert.ok(result != null);
+    assert.ok(!result.success);
+    assert.deepEqual(result.error, [
+      { type: "text", text: "Failed to transform value." },
+    ]);
   });
 
   it("should transform placeholder and choices metadata", () => {
@@ -2810,6 +2833,37 @@ describe("transform", () => {
     const suggestions = [...(parser.suggest?.("f") ?? [])];
 
     assert.deepEqual(suggestions, [{ kind: "literal", text: "foo" }]);
+  });
+
+  it("should reject async suggestions from sync inner parsers", () => {
+    const inner: ValueParser<"sync", string> = {
+      mode: "sync",
+      metavar: "WORD",
+      placeholder: "foo",
+      parse(input: string): ValueParserResult<string> {
+        return { success: true, value: input };
+      },
+      format(value: string): string {
+        return value;
+      },
+      suggest() {
+        return (async function* () {
+          yield { kind: "literal" as const, text: "foo" };
+        })() as never;
+      },
+    };
+    const parser = transform(inner, {
+      map: (value) => value.length,
+      unmap: (value) => "x".repeat(value),
+    });
+
+    assert.throws(
+      () => [...(parser.suggest?.("f") ?? [])],
+      {
+        name: "TypeError",
+        message: "Synchronous mode cannot wrap AsyncIterable value.",
+      },
+    );
   });
 
   it("should preserve async value parser mode", async () => {
@@ -2902,6 +2956,8 @@ describe("transform", () => {
 
     assert.ok(isValueParser(transformed));
     assert.ok(isValueParser(mapped));
+    assert.ok(Object.keys(transformed).includes("placeholder"));
+    assert.ok(Object.keys(mapped).includes("placeholder"));
   });
 
   it("should lazily map dependency-derived placeholders", () => {

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -2757,7 +2757,7 @@ describe("transform", () => {
     ]);
   });
 
-  it("should reject fallback values when validate unmapping throws", () => {
+  it("should preserve fallback values when round-trip unmapping throws", () => {
     const sentinel = { count: 3 };
     const parser = transform(integer({ min: 1, max: 10 }), {
       map: (value) => ({ count: value }),
@@ -2769,14 +2769,10 @@ describe("transform", () => {
 
     const result = parser.validate?.(sentinel);
 
-    assert.ok(result != null);
-    assert.ok(!result.success);
-    assert.deepEqual(result.error, [
-      { type: "text", text: "Failed to transform value." },
-    ]);
+    assert.deepEqual(result, { success: true, value: sentinel });
   });
 
-  it("should reject fallback values when round-trip validation throws", () => {
+  it("should preserve fallback values when round-trip formatting throws", () => {
     const sentinel = { count: 12 };
     const parser = transform(
       {
@@ -2799,11 +2795,7 @@ describe("transform", () => {
 
     const result = parser.validate?.(sentinel);
 
-    assert.ok(result != null);
-    assert.ok(!result.success);
-    assert.deepEqual(result.error, [
-      { type: "text", text: "Failed to transform value." },
-    ]);
+    assert.deepEqual(result, { success: true, value: sentinel });
   });
 
   it("should reject malformed fallback values", () => {

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -3080,6 +3080,30 @@ describe("biject", () => {
     );
   });
 
+  it("should reject null or primitive mappings", () => {
+    assert.throws(
+      () => biject(null as never),
+      {
+        name: "TypeError",
+        message: "Expected object.",
+      },
+    );
+    assert.throws(
+      () => biject(42 as never),
+      {
+        name: "TypeError",
+        message: "Expected object.",
+      },
+    );
+    assert.throws(
+      () => biject("abc" as never),
+      {
+        name: "TypeError",
+        message: "Expected object.",
+      },
+    );
+  });
+
   it("should reject inputs outside the mapping keys", () => {
     const parser = biject({
       foo: 123,

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -51,7 +51,14 @@ import {
 } from "@optique/core/message";
 import { object } from "#src/constructs.ts";
 import { dependency } from "#src/dependency.ts";
-import { getSnapshottedDefaultDependencyValues } from "#src/internal/dependency.ts";
+import {
+  dependencyId,
+  type DerivedValueParser,
+  derivedValueParserMarker,
+  getSnapshottedDefaultDependencyValues,
+  parseWithDependency,
+  suggestWithDependency,
+} from "#src/internal/dependency.ts";
 import { argument, option } from "#src/primitives.ts";
 import { withDefault } from "#src/modifiers.ts";
 import { parse, suggestSync } from "#src/parser.ts";
@@ -3109,6 +3116,48 @@ describe("transform", () => {
       ),
       ["warn", "error"],
     );
+  });
+
+  it("should preserve this context for derived suggestions", () => {
+    const derived: DerivedValueParser<"sync", string, unknown> = {
+      mode: "sync",
+      metavar: "LEVEL",
+      placeholder: "debug",
+      [derivedValueParserMarker]: true,
+      [dependencyId]: Symbol("mode"),
+      parse(input: string): ValueParserResult<string> {
+        return { success: true, value: input };
+      },
+      [parseWithDependency](
+        input: string,
+        _dependencyValue: unknown,
+      ): ValueParserResult<string> {
+        return { success: true, value: input };
+      },
+      format(value: string): string {
+        return value;
+      },
+      *[suggestWithDependency](
+        this: { readonly prefix: string },
+        prefix: string,
+      ) {
+        yield { kind: "literal" as const, text: `${this.prefix}-${prefix}` };
+      },
+      prefix: "ctx",
+    } as DerivedValueParser<"sync", string, unknown> & {
+      readonly prefix: string;
+    };
+    const parser = transform(derived, {
+      map: (value) => value.toUpperCase(),
+      unmap: (value) => value.toLowerCase(),
+    });
+
+    const transformed = parser as DerivedValueParser<"sync", string, unknown>;
+    const suggest = transformed[suggestWithDependency];
+    assert.ok(suggest != null);
+    const suggestions = [...suggest("", undefined) as Iterable<unknown>];
+
+    assert.deepEqual(suggestions, [{ kind: "literal", text: "ctx-" }]);
   });
 });
 

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -2772,6 +2772,39 @@ describe("transform", () => {
     assert.deepEqual(result, { success: true, value: sentinel });
   });
 
+  it("should preserve fallback values when validate unmapping throws", () => {
+    const sentinel = { count: 3 };
+    const parser = transform(
+      {
+        mode: "sync" as const,
+        metavar: "COUNT",
+        placeholder: 1,
+        parse(input: string): ValueParserResult<number> {
+          return { success: true, value: Number(input) };
+        },
+        format(value: number): string {
+          return value.toString();
+        },
+        validate(value: number): ValueParserResult<number> {
+          return value < 1
+            ? { success: false, error: message`Expected positive count.` }
+            : { success: true, value };
+        },
+      },
+      {
+        map: (value) => ({ count: value }),
+        unmap(value: { readonly count: number }) {
+          if (value === sentinel) throw new TypeError("Cannot unmap sentinel.");
+          return value.count;
+        },
+      },
+    );
+
+    const result = parser.validate?.(sentinel);
+
+    assert.deepEqual(result, { success: true, value: sentinel });
+  });
+
   it("should preserve fallback values when round-trip formatting throws", () => {
     const sentinel = { count: 12 };
     const parser = transform(

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -2771,6 +2771,65 @@ describe("transform", () => {
     assert.deepEqual(suggestions, [{ kind: "literal", text: "x-value" }]);
   });
 
+  it("should reject promises from sync inner parsers", () => {
+    const inner: ValueParser<"sync", string> = {
+      mode: "sync",
+      metavar: "WORD",
+      placeholder: "foo",
+      parse(input: string): ValueParserResult<string> {
+        return Promise.resolve({ success: true, value: input }) as never;
+      },
+      format(value: string): string {
+        return value;
+      },
+    };
+    const parser = transform(inner, {
+      map: (value) => value.length,
+      unmap: (value) => "x".repeat(value),
+    });
+
+    assert.throws(
+      () => parser.parse("abcd"),
+      {
+        name: "TypeError",
+        message: "Synchronous mode cannot wrap Promise value.",
+      },
+    );
+  });
+
+  it("should not map missing placeholders", () => {
+    const inner: ValueParser<"sync", string | undefined> = {
+      mode: "sync",
+      metavar: "WORD",
+      placeholder: undefined,
+      parse(input: string): ValueParserResult<string | undefined> {
+        return { success: true, value: input };
+      },
+      format(value: string | undefined): string {
+        return value ?? "";
+      },
+    };
+    const parser = transform(inner, {
+      map: (value) => ({ value }),
+      unmap: (value: { readonly value: string | undefined }) => value.value,
+    });
+
+    assert.equal(parser.placeholder, undefined);
+  });
+
+  it("should keep transformed placeholders enumerable for dependencies", () => {
+    const transformed = dependency(
+      transform(choice(["dev", "prod"] as const), {
+        map: (value) => value.toUpperCase() as "DEV" | "PROD",
+        unmap: (value) => value.toLowerCase() as "dev" | "prod",
+      }),
+    );
+    const mapped = dependency(biject({ dev: "DEV", prod: "PROD" } as const));
+
+    assert.ok(isValueParser(transformed));
+    assert.ok(isValueParser(mapped));
+  });
+
   it("should lazily map dependency-derived placeholders", () => {
     const mode = dependency(choice(["dev", "prod"] as const));
     const level = mode.derive({
@@ -2990,7 +3049,7 @@ describe("biject", () => {
       },
       {
         name: "TypeError",
-        message: "Expected biject mapping to be a non-array object.",
+        message: "Expected object, got array.",
       },
     );
   });

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -2831,6 +2831,28 @@ describe("transform", () => {
     assert.deepEqual(parser.choices, ["FOO", "BAR"]);
   });
 
+  it("should tolerate throwing placeholder getters", () => {
+    const inner: ValueParser<"sync", string> = {
+      mode: "sync",
+      metavar: "WORD",
+      get placeholder(): string {
+        throw new TypeError("Cannot resolve placeholder.");
+      },
+      parse(input: string): ValueParserResult<string> {
+        return { success: true, value: input };
+      },
+      format(value: string): string {
+        return value;
+      },
+    };
+    const parser = transform(inner, {
+      map: (value) => value.toUpperCase(),
+      unmap: (value) => value.toLowerCase(),
+    });
+
+    assert.equal(parser.placeholder, undefined);
+  });
+
   it("should delegate suggestions as input strings", () => {
     const parser = transform(choice(["foo", "bar"] as const), {
       map: (value) => value === "foo" ? "FOO" as const : "BAR" as const,

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -2979,6 +2979,39 @@ describe("transform", () => {
     );
   });
 
+  it("should preserve deferred results when mapping throws", () => {
+    const inner: ValueParser<"sync", string> = {
+      mode: "sync",
+      metavar: "WORD",
+      placeholder: "placeholder",
+      parse(): ValueParserResult<string> {
+        return { success: true, value: "placeholder", deferred: true };
+      },
+      format(value: string): string {
+        return value;
+      },
+    };
+    const parser = transform(inner, {
+      map(value) {
+        if (value === "placeholder") {
+          throw new TypeError("Cannot map placeholder.");
+        }
+        return value.toUpperCase();
+      },
+      unmap(value) {
+        return value.toLowerCase();
+      },
+    });
+
+    const result = parser.parse("ignored");
+
+    assert.deepEqual(result, {
+      success: true,
+      value: undefined,
+      deferred: true,
+    });
+  });
+
   it("should not map missing placeholders", () => {
     const inner: ValueParser<"sync", string | undefined> = {
       mode: "sync",
@@ -3012,6 +3045,22 @@ describe("transform", () => {
     assert.ok(isValueParser(mapped));
     assert.ok(Object.keys(transformed).includes("placeholder"));
     assert.ok(Object.keys(mapped).includes("placeholder"));
+  });
+
+  it("should reject direct dependency source transforms", () => {
+    const mode = dependency(choice(["dev", "prod"] as const));
+
+    assert.throws(
+      () =>
+        transform(mode, {
+          map: (value) => value.toUpperCase() as "DEV" | "PROD",
+          unmap: (value) => value.toLowerCase() as "dev" | "prod",
+        }),
+      {
+        name: "TypeError",
+        message: "Cannot transform a dependency source directly.",
+      },
+    );
   });
 
   it("should lazily map dependency-derived placeholders", () => {

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -24,6 +24,7 @@ import {
 } from "./internal/dependency.ts";
 import {
   mapMaybePromiseByMode,
+  wrapForMode,
   wrapIterableForMode,
 } from "./internal/mode-dispatch.ts";
 import { ensureNonEmptyString, type NonEmptyString } from "./nonempty.ts";
@@ -1066,10 +1067,17 @@ export function transform<M extends Mode, T, U>(
           if (unmapped === undefined) return transformMappingFailure();
           return { success: true as const, value };
         }
+        if (typeof formatted !== "string") return transformMappingFailure();
         let result: ValueParserResult<T>;
         try {
-          result = syncParser.parse(formatted);
-        } catch {
+          result = wrapForMode("sync", syncParser.parse(formatted));
+        } catch (error) {
+          if (
+            error instanceof TypeError &&
+            error.message.includes("Promise")
+          ) {
+            throw error;
+          }
           return transformMappingFailure();
         }
         if (!result.success) return result;

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -1025,9 +1025,12 @@ export function transform<M extends Mode, T, U>(
     const syncParser = parser as ValueParser<"sync", T>;
     Object.defineProperty(transformed, "validate", {
       value(value: U): ValueParserResult<U> {
-        const result = syncParser.parse(
-          syncParser.format(mapping.unmap(value)),
-        );
+        let result: ValueParserResult<T>;
+        try {
+          result = syncParser.parse(syncParser.format(mapping.unmap(value)));
+        } catch {
+          return { success: true as const, value };
+        }
         return result.success
           ? { success: true as const, value: mapping.map(result.value) }
           : result;

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -1041,9 +1041,22 @@ export function transform<M extends Mode, T, U>(
     const syncParser = parser as ValueParser<"sync", T>;
     Object.defineProperty(transformed, "validate", {
       value(value: U): ValueParserResult<U> {
+        let unmapped: T;
+        try {
+          unmapped = mapping.unmap(value);
+        } catch {
+          return { success: true as const, value };
+        }
+        let formatted: string;
+        try {
+          formatted = syncParser.format(unmapped);
+        } catch {
+          if (unmapped === undefined) return transformMappingFailure();
+          return { success: true as const, value };
+        }
         let result: ValueParserResult<T>;
         try {
-          result = syncParser.parse(syncParser.format(mapping.unmap(value)));
+          result = syncParser.parse(formatted);
         } catch {
           return transformMappingFailure();
         }

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -8,7 +8,24 @@ import {
   text,
   valueSet,
 } from "./message.ts";
-import { isDerivedValueParser } from "./internal/dependency.ts";
+import {
+  defaultValues,
+  dependencyId,
+  dependencyIds,
+  type DerivedValueParser,
+  derivedValueParserMarker,
+  getSnapshottedDefaultDependencyValues,
+  isDerivedValueParser,
+  parseWithDependency,
+  singleDefaultValue,
+  snapshotDefaultDependencyValues,
+  suggestWithDependency,
+} from "./internal/dependency.ts";
+import {
+  mapMaybePromiseByMode,
+  mapModeValue,
+  wrapIterableForMode,
+} from "./internal/mode-dispatch.ts";
 import { ensureNonEmptyString, type NonEmptyString } from "./nonempty.ts";
 import type { Mode, ModeIterable, ModeValue, Suggestion } from "./parser.ts";
 import {
@@ -385,6 +402,65 @@ export interface ChoiceOptionsNumber extends ChoiceOptionsBase {
  *             {@link ChoiceOptionsNumber} for number choices.
  */
 export type ChoiceOptions = ChoiceOptionsString;
+
+/**
+ * Mapping functions for the {@link transform} value parser combinator.
+ *
+ * `map` converts values produced by the wrapped parser into the public result
+ * type.  `unmap` converts public values back to the wrapped parser's type so
+ * `format()`, `validate()`, and default-value handling can keep using the
+ * wrapped parser's own validation and formatting rules.
+ *
+ * The two functions should be inverses for the values your CLI accepts:
+ * `unmap(map(input))` should return a value accepted by the wrapped parser,
+ * and `map(unmap(output))` should preserve valid public values.
+ *
+ * @template T The value type produced by the wrapped parser.
+ * @template U The value type produced by the transformed parser.
+ * @since 1.2.0
+ */
+export interface TransformMapping<T, U> {
+  /**
+   * Converts a value produced by the wrapped parser into the transformed
+   * parser's public value type.
+   */
+  map(value: T): U;
+
+  /**
+   * Converts a public transformed value back into the wrapped parser's value
+   * type for formatting and fallback validation.
+   */
+  unmap(value: U): T;
+}
+
+function transformValueParserResult<T, U>(
+  result: ValueParserResult<T>,
+  mapping: TransformMapping<T, U>,
+): ValueParserResult<U> {
+  if (!result.success) return result;
+  const preserveSnapshot = (mapped: ValueParserResult<U>) => {
+    const snapshot = getSnapshottedDefaultDependencyValues(result);
+    return snapshot == null
+      ? mapped
+      : snapshotDefaultDependencyValues(mapped, snapshot);
+  };
+  if (result.deferred) {
+    try {
+      return preserveSnapshot({
+        success: true,
+        value: mapping.map(result.value),
+        deferred: true as const,
+      });
+    } catch {
+      return preserveSnapshot({
+        success: true,
+        value: undefined as unknown as U,
+        deferred: true as const,
+      });
+    }
+  }
+  return preserveSnapshot({ success: true, value: mapping.map(result.value) });
+}
 
 /**
  * A predicate function that checks if an object is a {@link ValueParser}.
@@ -765,6 +841,181 @@ export function choice<const T extends string | number>(
         .map((value) => ({ kind: "literal" as const, text: value }));
     },
   };
+}
+
+/**
+ * Creates a value parser that transforms the result of another value parser.
+ *
+ * This is useful when an existing value parser already describes the accepted
+ * CLI spelling, suggestions, and error messages, but your application wants a
+ * different result type.  For example, a string `choice()` can be transformed
+ * into an internal enum, tagged object, or other domain type.
+ *
+ * Unlike parser-level `map()`, value parser transformation needs an inverse
+ * mapping.  The `unmap` function lets the transformed parser format values,
+ * validate fallback/default values, and reuse the wrapped parser's metadata
+ * without guessing how to serialize the transformed type.
+ *
+ * Transform functions are synchronous.  If the wrapped parser is async, the
+ * returned parser is async too, but `map` and `unmap` still run synchronously
+ * after the wrapped parser resolves.
+ *
+ * @template M The execution mode of the wrapped parser.
+ * @template T The value type produced by the wrapped parser.
+ * @template U The value type produced by the transformed parser.
+ * @param parser The value parser to transform.
+ * @param mapping Mapping functions between the wrapped and transformed value
+ *                types.
+ * @returns A value parser that accepts the same input as `parser` and produces
+ *          transformed values.
+ * @since 1.2.0
+ */
+export function transform<M extends Mode, T, U>(
+  parser: ValueParser<M, T>,
+  mapping: TransformMapping<T, U>,
+): ValueParser<M, U> {
+  const normalize = parser.normalize?.bind(parser);
+  const suggest = parser.suggest?.bind(parser);
+  const transformedChoices = parser.choices == null
+    ? undefined
+    : Object.freeze(parser.choices.map((choice) => mapping.map(choice)));
+  const transformed: ValueParser<M, U> = {
+    mode: parser.mode,
+    metavar: parser.metavar,
+    placeholder: undefined as U,
+    ...(transformedChoices == null ? {} : { choices: transformedChoices }),
+    parse(input: string): ModeValue<M, ValueParserResult<U>> {
+      return mapModeValue(
+        parser.mode,
+        parser.parse(input),
+        (result) => transformValueParserResult(result, mapping),
+      );
+    },
+    format(value: U): string {
+      return parser.format(mapping.unmap(value));
+    },
+    ...(normalize == null ? {} : {
+      normalize(value: U): U {
+        return mapping.map(normalize(mapping.unmap(value)));
+      },
+    }),
+    ...(suggest == null ? {} : {
+      suggest(prefix: string): ModeIterable<M, Suggestion> {
+        return suggest(prefix);
+      },
+    }),
+  };
+  Object.defineProperty(transformed, "placeholder", {
+    get() {
+      try {
+        return mapping.map(parser.placeholder);
+      } catch {
+        return undefined;
+      }
+    },
+    configurable: true,
+    enumerable: false,
+  });
+  if (typeof parser.validate === "function") {
+    const validate = parser.validate.bind(parser);
+    Object.defineProperty(transformed, "validate", {
+      value(value: U): ValueParserResult<U> {
+        const result = validate(mapping.unmap(value));
+        return result.success
+          ? { success: true as const, value: mapping.map(result.value) }
+          : result;
+      },
+      configurable: true,
+      enumerable: true,
+    });
+  } else if (parser.mode === "sync") {
+    const syncParser = parser as ValueParser<"sync", T>;
+    Object.defineProperty(transformed, "validate", {
+      value(value: U): ValueParserResult<U> {
+        const result = syncParser.parse(
+          syncParser.format(mapping.unmap(value)),
+        );
+        return result.success
+          ? { success: true as const, value: mapping.map(result.value) }
+          : result;
+      },
+      configurable: true,
+      enumerable: true,
+    });
+  }
+  if (isDerivedValueParser(parser)) {
+    preserveTransformedDerivedMetadata(transformed, parser, mapping);
+  }
+  return transformed;
+}
+
+function preserveTransformedDerivedMetadata<M extends Mode, T, U>(
+  transformed: ValueParser<M, U>,
+  parser: DerivedValueParser<M, T, unknown>,
+  mapping: TransformMapping<T, U>,
+): void {
+  Object.defineProperties(transformed, {
+    [derivedValueParserMarker]: {
+      value: true,
+      enumerable: true,
+    },
+    [dependencyId]: {
+      value: parser[dependencyId],
+      enumerable: true,
+    },
+    [parseWithDependency]: {
+      value(
+        input: string,
+        dependencyValue: unknown,
+      ): ModeValue<M, ValueParserResult<U>> {
+        return mapMaybePromiseByMode(
+          parser.mode,
+          parser[parseWithDependency](
+            input,
+            dependencyValue,
+          ),
+          (result) => transformValueParserResult(result, mapping),
+        );
+      },
+      enumerable: true,
+    },
+  });
+  if (dependencyIds in parser && parser[dependencyIds] != null) {
+    Object.defineProperty(transformed, dependencyIds, {
+      value: parser[dependencyIds],
+      enumerable: true,
+    });
+  }
+  if (defaultValues in parser && parser[defaultValues] != null) {
+    Object.defineProperty(transformed, defaultValues, {
+      value: parser[defaultValues],
+      enumerable: true,
+    });
+  }
+  if (singleDefaultValue in parser && parser[singleDefaultValue] != null) {
+    Object.defineProperty(transformed, singleDefaultValue, {
+      value: parser[singleDefaultValue],
+      enumerable: true,
+    });
+  }
+  if (
+    suggestWithDependency in parser &&
+    parser[suggestWithDependency] != null
+  ) {
+    const suggest = parser[suggestWithDependency];
+    Object.defineProperty(transformed, suggestWithDependency, {
+      value(
+        prefix: string,
+        dependencyValue: unknown,
+      ): ModeIterable<M, Suggestion> {
+        return wrapIterableForMode(
+          parser.mode,
+          suggest(prefix, dependencyValue),
+        );
+      },
+      enumerable: true,
+    });
+  }
 }
 
 /**

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -891,12 +891,7 @@ export function biject<const T extends object>(
   if (Array.isArray(mapping)) {
     throw new TypeError("Expected object, got array.");
   }
-  const keys: StringKeyOf<T>[] = [];
-  for (const key in mapping) {
-    if (Object.prototype.hasOwnProperty.call(mapping, key)) {
-      keys.push(key as StringKeyOf<T>);
-    }
-  }
+  const keys = Object.keys(mapping) as StringKeyOf<T>[];
   if (keys.length < 1) {
     throw new RangeError("Expected at least one biject entry.");
   }
@@ -1006,7 +1001,7 @@ export function transform<M extends Mode, T, U>(
     }),
     ...(suggest == null ? {} : {
       suggest(prefix: string): ModeIterable<M, Suggestion> {
-        return suggest(prefix);
+        return wrapIterableForMode(parser.mode, suggest(prefix));
       },
     }),
   };
@@ -1030,7 +1025,7 @@ export function transform<M extends Mode, T, U>(
         try {
           result = validate(mapping.unmap(value));
         } catch {
-          return { success: true as const, value };
+          return transformMappingFailure();
         }
         if (!result.success) return result;
         try {
@@ -1050,7 +1045,7 @@ export function transform<M extends Mode, T, U>(
         try {
           result = syncParser.parse(syncParser.format(mapping.unmap(value)));
         } catch {
-          return { success: true as const, value };
+          return transformMappingFailure();
         }
         if (!result.success) return result;
         try {

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -23,7 +23,6 @@ import {
 } from "./internal/dependency.ts";
 import {
   mapMaybePromiseByMode,
-  mapModeValue,
   wrapIterableForMode,
 } from "./internal/mode-dispatch.ts";
 import { ensureNonEmptyString, type NonEmptyString } from "./nonempty.ts";
@@ -877,7 +876,7 @@ export function biject<const T extends object>(
   mapping: T,
 ): ValueParser<"sync", BijectValue<T>> {
   if (Array.isArray(mapping)) {
-    throw new TypeError("Expected biject mapping to be a non-array object.");
+    throw new TypeError("Expected object, got array.");
   }
   const keys: StringKeyOf<T>[] = [];
   for (const key in mapping) {
@@ -978,7 +977,7 @@ export function transform<M extends Mode, T, U>(
     placeholder: undefined as U,
     ...(transformedChoices == null ? {} : { choices: transformedChoices }),
     parse(input: string): ModeValue<M, ValueParserResult<U>> {
-      return mapModeValue(
+      return mapMaybePromiseByMode(
         parser.mode,
         parser.parse(input),
         (result) => transformValueParserResult(result, mapping),
@@ -1000,6 +999,7 @@ export function transform<M extends Mode, T, U>(
   };
   Object.defineProperty(transformed, "placeholder", {
     get() {
+      if (parser.placeholder === undefined) return undefined;
       try {
         return mapping.map(parser.placeholder);
       } catch {
@@ -1007,7 +1007,7 @@ export function transform<M extends Mode, T, U>(
       }
     },
     configurable: true,
-    enumerable: false,
+    enumerable: true,
   });
   if (typeof parser.validate === "function") {
     const validate = parser.validate.bind(parser);

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -1007,9 +1007,9 @@ export function transform<M extends Mode, T, U>(
   };
   Object.defineProperty(transformed, "placeholder", {
     get() {
-      if (parser.placeholder === undefined) return undefined;
       try {
-        return mapping.map(parser.placeholder);
+        const placeholder = parser.placeholder;
+        return placeholder === undefined ? undefined : mapping.map(placeholder);
       } catch {
         return undefined;
       }

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -1021,9 +1021,15 @@ export function transform<M extends Mode, T, U>(
     const validate = parser.validate.bind(parser);
     Object.defineProperty(transformed, "validate", {
       value(value: U): ValueParserResult<U> {
+        let unmapped: T;
+        try {
+          unmapped = mapping.unmap(value);
+        } catch {
+          return { success: true as const, value };
+        }
         let result: ValueParserResult<T>;
         try {
-          result = validate(mapping.unmap(value));
+          result = validate(unmapped);
         } catch {
           return transformMappingFailure();
         }

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -15,6 +15,7 @@ import {
   type DerivedValueParser,
   derivedValueParserMarker,
   getSnapshottedDefaultDependencyValues,
+  isDependencySource,
   isDerivedValueParser,
   parseWithDependency,
   singleDefaultValue,
@@ -462,7 +463,11 @@ function transformValueParserResult<T, U>(
         deferred: true as const,
       });
     } catch {
-      return preserveSnapshot(transformMappingFailure());
+      return preserveSnapshot({
+        success: true,
+        value: undefined as U,
+        deferred: true as const,
+      });
     }
   }
   try {
@@ -933,8 +938,6 @@ export function biject<const T extends object>(
       } catch {
         input = "";
       }
-      const result = source.parse(input);
-      if (!result.success) return result;
       return { success: false, error: formatDefaultChoiceError(input, keys) };
     },
     configurable: true,
@@ -974,6 +977,9 @@ export function transform<M extends Mode, T, U>(
   parser: ValueParser<M, T>,
   mapping: TransformMapping<T, U>,
 ): ValueParser<M, U> {
+  if (isDependencySource(parser)) {
+    throw new TypeError("Cannot transform a dependency source directly.");
+  }
   const normalize = parser.normalize?.bind(parser);
   const suggest = parser.suggest?.bind(parser);
   const transformedChoices = parser.choices == null

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -433,6 +433,10 @@ export interface TransformMapping<T, U> {
   unmap(value: U): T;
 }
 
+type BijectKey<T> = Extract<keyof T, string | number>;
+type StringKeyOf<T> = `${BijectKey<T>}`;
+type BijectValue<T> = T[BijectKey<T>];
+
 function transformValueParserResult<T, U>(
   result: ValueParserResult<T>,
   mapping: TransformMapping<T, U>,
@@ -841,6 +845,95 @@ export function choice<const T extends string | number>(
         .map((value) => ({ kind: "literal" as const, text: value }));
     },
   };
+}
+
+/**
+ * Creates a value parser from a one-to-one mapping of CLI spellings to values.
+ *
+ * The mapping's string keys are accepted as command-line input, and each key
+ * is parsed into its corresponding value.  Values must also be unique using
+ * the same equality semantics as `Map` keys, so the parser can format a value
+ * back to the original key.
+ *
+ * This is a convenience wrapper around `choice(Object.keys(mapping))` and
+ * {@link transform}.  It keeps the input-side metadata from `choice()` while
+ * exposing the mapped values as the parser result type.
+ *
+ * @template T The one-to-one mapping from input strings to parsed values.
+ * @param mapping A mapping whose own enumerable string keys are valid inputs.
+ * @returns A value parser that accepts one of the mapping keys and returns the
+ *          corresponding value.
+ * @throws {TypeError} If `mapping` is an array, or if any key is the empty
+ *         string.
+ * @throws {RangeError} If the mapping has no own enumerable string keys, or if
+ *         two keys map to the same value according to `Map` key equality.
+ * @since 1.2.0
+ */
+export function biject<const T extends readonly unknown[]>(mapping: T): never;
+export function biject<const T extends object>(
+  mapping: T,
+): ValueParser<"sync", BijectValue<T>>;
+export function biject<const T extends object>(
+  mapping: T,
+): ValueParser<"sync", BijectValue<T>> {
+  if (Array.isArray(mapping)) {
+    throw new TypeError("Expected biject mapping to be a non-array object.");
+  }
+  const keys: StringKeyOf<T>[] = [];
+  for (const key in mapping) {
+    if (Object.prototype.hasOwnProperty.call(mapping, key)) {
+      keys.push(key as StringKeyOf<T>);
+    }
+  }
+  if (keys.length < 1) {
+    throw new RangeError("Expected at least one biject entry.");
+  }
+  const source = choice(keys);
+  const forward = new Map<StringKeyOf<T>, BijectValue<T>>();
+  const reverse = new Map<BijectValue<T>, StringKeyOf<T>>();
+  for (const key of keys) {
+    const value = mapping[key as BijectKey<T>] as BijectValue<T>;
+    if (reverse.has(value)) {
+      throw new RangeError(
+        `Duplicate biject value for key ${JSON.stringify(key)}.`,
+      );
+    }
+    forward.set(key, value);
+    reverse.set(value, key);
+  }
+  const parser = transform(source, {
+    map(value) {
+      return forward.get(value) as BijectValue<T>;
+    },
+    unmap(value) {
+      const key = reverse.get(value);
+      if (key !== undefined) return key;
+      // Let the wrapped choice parser produce the validation failure for
+      // invalid fallback/default values that are outside the bijection.
+      try {
+        return String(value) as StringKeyOf<T>;
+      } catch {
+        return "" as StringKeyOf<T>;
+      }
+    },
+  });
+  Object.defineProperty(parser, "validate", {
+    value(value: BijectValue<T>): ValueParserResult<BijectValue<T>> {
+      if (reverse.has(value)) return { success: true, value };
+      let input: string;
+      try {
+        input = String(value);
+      } catch {
+        input = "";
+      }
+      const result = source.parse(input);
+      if (!result.success) return result;
+      return { success: false, error: formatDefaultChoiceError(input, keys) };
+    },
+    configurable: true,
+    enumerable: true,
+  });
+  return parser;
 }
 
 /**

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -862,8 +862,8 @@ export function choice<const T extends string | number>(
  * @param mapping A mapping whose own enumerable string keys are valid inputs.
  * @returns A value parser that accepts one of the mapping keys and returns the
  *          corresponding value.
- * @throws {TypeError} If `mapping` is an array, or if any key is the empty
- *         string.
+ * @throws {TypeError} If `mapping` is not an object, if it is an array, or if
+ *         any key is the empty string.
  * @throws {RangeError} If the mapping has no own enumerable string keys, or if
  *         two keys map to the same value according to `Map` key equality.
  * @since 1.2.0
@@ -875,6 +875,9 @@ export function biject<const T extends object>(
 export function biject<const T extends object>(
   mapping: T,
 ): ValueParser<"sync", BijectValue<T>> {
+  if (mapping === null || typeof mapping !== "object") {
+    throw new TypeError("Expected object.");
+  }
   if (Array.isArray(mapping)) {
     throw new TypeError("Expected object, got array.");
   }

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -436,6 +436,13 @@ type BijectKey<T> = Extract<keyof T, string | number>;
 type StringKeyOf<T> = `${BijectKey<T>}`;
 type BijectValue<T> = T[BijectKey<T>];
 
+function transformMappingFailure<T>(): ValueParserResult<T> {
+  return {
+    success: false as const,
+    error: message`Failed to transform value.`,
+  };
+}
+
 function transformValueParserResult<T, U>(
   result: ValueParserResult<T>,
   mapping: TransformMapping<T, U>,
@@ -455,14 +462,17 @@ function transformValueParserResult<T, U>(
         deferred: true as const,
       });
     } catch {
-      return preserveSnapshot({
-        success: true,
-        value: undefined as unknown as U,
-        deferred: true as const,
-      });
+      return preserveSnapshot(transformMappingFailure());
     }
   }
-  return preserveSnapshot({ success: true, value: mapping.map(result.value) });
+  try {
+    return preserveSnapshot({
+      success: true,
+      value: mapping.map(result.value),
+    });
+  } catch {
+    return preserveSnapshot(transformMappingFailure());
+  }
 }
 
 /**
@@ -1016,10 +1026,18 @@ export function transform<M extends Mode, T, U>(
     const validate = parser.validate.bind(parser);
     Object.defineProperty(transformed, "validate", {
       value(value: U): ValueParserResult<U> {
-        const result = validate(mapping.unmap(value));
-        return result.success
-          ? { success: true as const, value: mapping.map(result.value) }
-          : result;
+        let result: ValueParserResult<T>;
+        try {
+          result = validate(mapping.unmap(value));
+        } catch {
+          return { success: true as const, value };
+        }
+        if (!result.success) return result;
+        try {
+          return { success: true as const, value: mapping.map(result.value) };
+        } catch {
+          return transformMappingFailure();
+        }
       },
       configurable: true,
       enumerable: true,
@@ -1034,9 +1052,12 @@ export function transform<M extends Mode, T, U>(
         } catch {
           return { success: true as const, value };
         }
-        return result.success
-          ? { success: true as const, value: mapping.map(result.value) }
-          : result;
+        if (!result.success) return result;
+        try {
+          return { success: true as const, value: mapping.map(result.value) };
+        } catch {
+          return transformMappingFailure();
+        }
       },
       configurable: true,
       enumerable: true,

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -1117,7 +1117,7 @@ function preserveTransformedDerivedMetadata<M extends Mode, T, U>(
     suggestWithDependency in parser &&
     parser[suggestWithDependency] != null
   ) {
-    const suggest = parser[suggestWithDependency];
+    const suggest = parser[suggestWithDependency].bind(parser);
     Object.defineProperty(transformed, suggestWithDependency, {
       value(
         prefix: string,


### PR DESCRIPTION
Value parsers already know how to parse, validate fallbacks, format values, and expose completion metadata, but parser-level `map()` cannot carry those contracts through a value-only conversion.  This PR adds two helpers that make that conversion explicit instead of asking callers to rebuild the same parser behavior by hand.

The lower-level helper is `transform()`.  It wraps an existing value parser with a reversible mapping, so the forward direction is used after parsing and the reverse direction is used for formatting, fallback validation, placeholders, choices, suggestions, and dependency replay.  Keeping both directions in the API is the important part: without the reverse mapping, Optique would have to guess how a domain value should be serialized back into the original CLI-facing value.

The second helper is `biject()`, which covers the common one-to-one dictionary case.  It builds on `choice()` plus `transform()`, but snapshots the mapping at construction time and validates the dictionary before any parsing happens. Empty dictionaries, empty input keys, array mappings, and duplicate mapped values fail early because they would make the public parser contract ambiguous. Mapped values are compared with the same equality rules as `Map`/`Set`, which keeps the runtime behavior familiar for primitives, `NaN`, and object identity.

The implementation also preserves the metadata that dependency-aware parsers need.  A transformed derived parser keeps its dependency markers and default snapshots, and placeholder mapping stays lazy so a missing derived placeholder does not throw during parser construction.  That lets `transform()` behave like a value-parser counterpart to parser-level `map()` without weakening the two-pass parse path.

Tests cover the straightforward parse and format cases, but also the edges that define the API shape: dynamic dependency defaults, lazy placeholders, fallback validation, mutated input mappings, numeric object keys, typed interfaces without index signatures, duplicate values, `NaN`, object identity, and invalid array input.  The docs in *docs/concepts/valueparsers.md* describe both helpers, and the value parser catalog, landing page count, changelog, and Optique agent skill were updated so the new surface is discoverable.