### PR TITLE
Support LogTape formatter selection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -87,6 +87,9 @@ To be released.
     `ConsoleFormatter` types while preserving Optique's existing stderr/stdout
     stream selection behavior.  [[#867]]
 
+ -  Added `textFormatter()` for parsing `"jsonl"`, `"logfmt"`, `"color"`,
+    and `"plain"` into LogTape's built-in text formatters.  [[#867]]
+
 [#867]: https://github.com/dahlia/optique/pull/867
 
 ### @optique/standard-schema

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -90,6 +90,10 @@ To be released.
  -  Added `textFormatter()` for parsing `"jsonl"`, `"logfmt"`, `"color"`,
     and `"plain"` into LogTape's built-in text formatters.  [[#867]]
 
+ -  Added a `formatter` option to `logOutput()` and `loggingOptions()` for
+    wiring parsed or fixed text formatters into console and file sinks.
+    [[#867]]
+
 [#867]: https://github.com/dahlia/optique/pull/867
 
 ### @optique/standard-schema

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -79,6 +79,16 @@ To be released.
 [#865]: https://github.com/dahlia/optique/pull/865
 [#866]: https://github.com/dahlia/optique/pull/866
 
+### @optique/logtape
+
+ -  Added `ConsoleSinkOptions.formatter` for customizing the output emitted
+    by `createConsoleSink()` and console outputs created through
+    `createSink()`.  The option accepts LogTape's `TextFormatter` and
+    `ConsoleFormatter` types while preserving Optique's existing stderr/stdout
+    stream selection behavior.  [[#867]]
+
+[#867]: https://github.com/dahlia/optique/pull/867
+
 ### @optique/standard-schema
 
  -  Added the new *@optique/standard-schema* package for using any Standard

--- a/deno.json
+++ b/deno.json
@@ -6,8 +6,8 @@
   "imports": {
     "@clack/prompts": "npm:@clack/prompts@^1.6.0",
     "@inquirer/prompts": "npm:@inquirer/prompts@^8.3.0",
-    "@logtape/file": "jsr:@logtape/file@^2.0.4",
-    "@logtape/logtape": "jsr:@logtape/logtape@^2.0.4",
+    "@logtape/file": "jsr:@logtape/file@^2.2.2",
+    "@logtape/logtape": "jsr:@logtape/logtape@^2.2.2",
     "@standard-schema/spec": "npm:@standard-schema/spec@^1.1.0",
     "@std/fs": "jsr:@std/fs@^1.0.19",
     "@std/path": "jsr:@std/path@^1.1.1",

--- a/deno.lock
+++ b/deno.lock
@@ -1,13 +1,13 @@
 {
   "version": "5",
   "specifiers": {
-    "jsr:@logtape/file@*": "2.0.4",
-    "jsr:@logtape/file@^2.0.4": "2.0.4",
-    "jsr:@logtape/logtape@^2.0.4": "2.0.4",
-    "jsr:@std/fs@^1.0.19": "1.0.19",
-    "jsr:@std/internal@^1.0.9": "1.0.9",
-    "jsr:@std/path@^1.1.0": "1.1.1",
-    "jsr:@std/path@^1.1.1": "1.1.1",
+    "jsr:@logtape/file@^2.2.2": "2.2.2",
+    "jsr:@logtape/logtape@^2.2.2": "2.2.2",
+    "jsr:@std/fs@^1.0.19": "1.0.24",
+    "jsr:@std/internal@^1.0.14": "1.0.14",
+    "jsr:@std/path@^1.1.0": "1.1.5",
+    "jsr:@std/path@^1.1.1": "1.1.5",
+    "jsr:@std/path@^1.1.5": "1.1.5",
     "jsr:@valibot/valibot@^1.2.0": "1.2.0",
     "npm:@clack/prompts@^1.6.0": "1.6.0",
     "npm:@inquirer/prompts@^8.3.0": "8.3.0_@types+node@24.12.4",
@@ -47,28 +47,28 @@
     "npm:zod@4.1.12": "4.1.12"
   },
   "jsr": {
-    "@logtape/file@2.0.4": {
-      "integrity": "d75c290a8907fde16e13cb69f6159a14c8fc811c5117bedadcee7af0529c61de",
+    "@logtape/file@2.2.2": {
+      "integrity": "6d4e39c2bcfcd298fe4e92e162d2e6eb5d5dc222886f674bfc8db654dbe55439",
       "dependencies": [
         "jsr:@logtape/logtape",
         "jsr:@std/path@^1.1.0"
       ]
     },
-    "@logtape/logtape@2.0.4": {
-      "integrity": "d4b6e85d82954f3d58014d85e4c0f93d6a836181ef4fbb4a852da7ed47979acb"
+    "@logtape/logtape@2.2.2": {
+      "integrity": "cd588b690ed7d401b9913f54fc39ff5faa955483f14d79c115f487a5a656955e"
     },
-    "@std/fs@1.0.19": {
-      "integrity": "051968c2b1eae4d2ea9f79a08a3845740ef6af10356aff43d3e2ef11ed09fb06",
+    "@std/fs@1.0.24": {
+      "integrity": "f3061b45b81673a2bece689da041df32d174be064c89eb6397fb5718d3fb7877",
       "dependencies": [
         "jsr:@std/internal",
-        "jsr:@std/path@^1.1.1"
+        "jsr:@std/path@^1.1.5"
       ]
     },
-    "@std/internal@1.0.9": {
-      "integrity": "bdfb97f83e4db7a13e8faab26fb1958d1b80cc64366501af78a0aee151696eb8"
+    "@std/internal@1.0.14": {
+      "integrity": "291516b3d4c35024d6ffbc0a9df5bf4c64116e05b50012cf846710152d2ffdf7"
     },
-    "@std/path@1.1.1": {
-      "integrity": "fe00026bd3a7e6a27f73709b83c607798be40e20c81dde655ce34052fd82ec76",
+    "@std/path@1.1.5": {
+      "integrity": "ccea00982ea28c36becaf6e62f855406c76a8c32d462f66f415bbb7d83a271bc",
       "dependencies": [
         "jsr:@std/internal"
       ]
@@ -2322,8 +2322,8 @@
   },
   "workspace": {
     "dependencies": [
-      "jsr:@logtape/file@^2.0.4",
-      "jsr:@logtape/logtape@^2.0.4",
+      "jsr:@logtape/file@^2.2.2",
+      "jsr:@logtape/logtape@^2.2.2",
       "jsr:@std/fs@^1.0.19",
       "jsr:@std/path@^1.1.1",
       "jsr:@valibot/valibot@^1.2.0",
@@ -2351,7 +2351,7 @@
       },
       "packages/logtape": {
         "dependencies": [
-          "jsr:@logtape/file@^2.0.4"
+          "jsr:@logtape/file@^2.2.2"
         ]
       },
       "packages/man": {

--- a/docs/.vitepress/theme/components/ParserCatalog.vue
+++ b/docs/.vitepress/theme/components/ParserCatalog.vue
@@ -64,6 +64,11 @@ const valueParsers = [
     ],
   },
   {
+    group: "LogTape",
+    base: "/integrations/logtape",
+    items: [["textFormatter", "text-formatter-value-parser"]],
+  },
+  {
     group: "Zod",
     base: "/integrations/zod",
     items: [

--- a/docs/index.md
+++ b/docs/index.md
@@ -311,7 +311,7 @@ const host = prompt(
 <LandingSection
   eyebrow="Batteries included"
   title="Reach for a parser before you write one."
-  lead="Forty-nine built-in value parsers, from <code>integer()</code> and
+  lead="Fifty built-in value parsers, from <code>integer()</code> and
   <code>ip()</code> to schema validators, Temporal dates, and async Git refs,
   plus the combinators that assemble them. Every one returns an ordinary parser
   that composes with the rest."

--- a/docs/integrations/logtape.md
+++ b/docs/integrations/logtape.md
@@ -114,6 +114,48 @@ const level = logLevel({
 ~~~~
 
 
+Text formatter value parser
+---------------------------
+
+*This API is available since Optique 1.2.0.*
+
+The `textFormatter()` function creates a value parser for LogTape formatter
+functions. It accepts `"jsonl"`, `"logfmt"`, `"color"`, and `"plain"` and maps
+them to LogTape's built-in formatter functions.
+
+~~~~ typescript twoslash
+import { object } from "@optique/core/constructs";
+import { option } from "@optique/core/primitives";
+import { parse } from "@optique/core/parser";
+import { textFormatter } from "@optique/logtape";
+
+const parser = object({
+  formatter: option("--log-format", textFormatter()),
+});
+
+const result = parse(parser, ["--log-format=logfmt"]);
+~~~~
+
+### Formats
+
+`"jsonl"`
+:   [JSON Lines][LogTape JSON Lines formatter] output
+
+`"logfmt"`
+:   [logfmt][LogTape logfmt formatter] key-value output
+
+`"color"`
+:   [ANSI-colored][LogTape ANSI color formatter] console output
+
+`"plain"`
+:   [LogTape's default text][LogTape default text formatter] output
+
+[LogTape JSON Lines formatter]: https://logtape.org/manual/formatters#json-lines-formatter
+[LogTape logfmt formatter]: https://logtape.org/manual/formatters#logfmt-formatter
+[LogTape ANSI color formatter]: https://logtape.org/manual/formatters#ansi-color-formatter
+[LogTape default text formatter]: https://logtape.org/manual/formatters#default-text-formatter
+
+
 Verbosity parser
 ----------------
 

--- a/docs/integrations/logtape.md
+++ b/docs/integrations/logtape.md
@@ -290,13 +290,51 @@ const none = parse(parser, []);
 ### Options
 
 ~~~~ typescript twoslash
+import { logfmtFormatter } from "@logtape/logtape";
 import { logOutput } from "@optique/logtape";
 // ---cut-before---
 const output = logOutput({
   long: "--log-output",   // Long option (default: "--log-output")
   short: "-o",            // Optional short option
   metavar: "FILE",        // Metavar for help text (default: "FILE")
+  formatter: "--log-format", // Optional text formatter option
+  // formatter: logfmtFormatter, // Or a fixed text formatter
 });
+~~~~
+
+When `formatter` is a string, `logOutput()` also parses LogTape text formatter
+names and stores the selected formatter in the `LogOutput` value. If the
+formatter option is used without `--log-output`, the output defaults to
+console.
+
+~~~~ typescript twoslash
+import { logOutput } from "@optique/logtape";
+import { object } from "@optique/core/constructs";
+import { parse } from "@optique/core/parser";
+
+const parser = object({
+  output: logOutput({ formatter: "--log-format" }),
+});
+
+const result = parse(parser, ["--log-format=logfmt"]);
+// result.value.output is a console LogOutput with logfmtFormatter
+~~~~
+
+When `formatter` is a LogTape text formatter, `logOutput()` applies that fixed
+formatter to the selected output without adding another command-line option.
+
+~~~~ typescript twoslash
+import { logfmtFormatter } from "@logtape/logtape";
+import { logOutput } from "@optique/logtape";
+import { object } from "@optique/core/constructs";
+import { parse } from "@optique/core/parser";
+
+const parser = object({
+  output: logOutput({ formatter: logfmtFormatter }),
+});
+
+const result = parse(parser, ["--log-output=/var/log/app.log"]);
+// result.value.output is a file LogOutput with logfmtFormatter
 ~~~~
 
 
@@ -386,7 +424,27 @@ All three modes share these options:
 | ---------------- | ------------------- | ---------------------------- |
 | `output.enabled` | `true`              | Enable `--log-output` option |
 | `output.long`    | `"--log-output"`    | Long option name for output  |
+| `formatter`      | `undefined`         | Output formatter or option   |
 | `groupLabel`     | `"Logging options"` | Help text group label        |
+
+Set `formatter` at the top level to share the same formatter behavior as
+`logOutput()` while using the preset:
+
+~~~~ typescript twoslash
+import { loggingOptions } from "@optique/logtape";
+import { object } from "@optique/core/constructs";
+import { parse } from "@optique/core/parser";
+
+const parser = object({
+  logging: loggingOptions({
+    level: "option",
+    formatter: "--log-format",
+  }),
+});
+
+const result = parse(parser, ["--log-format=jsonl"]);
+// result.value.logging.logOutput is a console LogOutput with jsonLinesFormatter
+~~~~
 
 
 Creating LogTape configuration
@@ -510,13 +568,21 @@ const sink5 = createConsoleSink({
 The `createSink()` function creates a LogTape sink from a `LogOutput` value:
 
 ~~~~ typescript twoslash
+import { logfmtFormatter } from "@logtape/logtape";
 import { createSink, type LogOutput } from "@optique/logtape";
 
-// Console sink
-const consoleSink = await createSink({ type: "console" });
+// Console sink with a formatter selected by logOutput()
+const consoleSink = await createSink({
+  type: "console",
+  formatter: logfmtFormatter,
+});
 
 // File sink (requires @logtape/file package)
-const fileSink = await createSink({ type: "file", path: "/var/log/app.log" });
+const fileSink = await createSink({
+  type: "file",
+  path: "/var/log/app.log",
+  formatter: logfmtFormatter,
+});
 ~~~~
 
 > [!NOTE]

--- a/docs/integrations/logtape.md
+++ b/docs/integrations/logtape.md
@@ -433,6 +433,7 @@ The `createConsoleSink()` function creates a console sink with configurable
 stream selection:
 
 ~~~~ typescript twoslash
+import { logfmtFormatter } from "@logtape/logtape";
 import { createConsoleSink } from "@optique/logtape";
 
 // Default: write to stderr
@@ -445,6 +446,20 @@ const sink2 = createConsoleSink({ stream: "stdout" });
 const sink3 = createConsoleSink({
   streamResolver: (level) =>
     level === "error" || level === "fatal" ? "stderr" : "stdout",
+});
+
+// Structured logfmt output
+const sink4 = createConsoleSink({
+  formatter: logfmtFormatter,
+});
+
+// Custom console formatting with multiple console arguments
+const sink5 = createConsoleSink({
+  formatter: (record) => [
+    "%s %o",
+    record.level.toUpperCase(),
+    record.properties,
+  ],
 });
 ~~~~
 

--- a/packages/core/skills/optique/SKILL.md
+++ b/packages/core/skills/optique/SKILL.md
@@ -242,19 +242,19 @@ Reference links
 Integration packages
 --------------------
 
-| Package                     | Use for                                   | Docs                                                  |
-| --------------------------- | ----------------------------------------- | ----------------------------------------------------- |
-| `@optique/env`              | Environment variable fallbacks            | <https://optique.dev/integrations/env.md>             |
-| `@optique/config`           | Configuration file fallbacks              | <https://optique.dev/integrations/config.md>          |
-| `@optique/derived-defaults` | Defaults computed from first-pass results | <https://optique.dev/concepts/derived-defaults.md>    |
-| `@optique/prompt`           | Generic prompt adapter foundation         | <https://optique.dev/integrations/prompt.md>          |
-| `@optique/clack`            | Clack interactive fallback prompts        | <https://optique.dev/integrations/clack.md>           |
-| `@optique/inquirer`         | Inquirer.js interactive fallback prompts  | <https://optique.dev/integrations/inquirer.md>        |
-| `@optique/standard-schema`  | Portable schema-backed value parsing      | <https://optique.dev/integrations/standard-schema.md> |
-| `@optique/zod`              | Zod-backed value parsing                  | <https://optique.dev/integrations/zod.md>             |
-| `@optique/valibot`          | Valibot-backed value parsing              | <https://optique.dev/integrations/valibot.md>         |
-| `@optique/temporal`         | Temporal date and time parsers            | <https://optique.dev/integrations/temporal.md>        |
-| `@optique/git`              | Async Git reference validation            | <https://optique.dev/integrations/git.md>             |
-| `@optique/logtape`          | LogTape levels and textFormatter()        | <https://optique.dev/integrations/logtape.md>         |
-| `@optique/man`              | Man page generation                       | <https://optique.dev/concepts/man.md>                 |
-| `@optique/discover`         | File-based command discovery              | <https://optique.dev/concepts/discover.md>            |
+| Package                     | Use for                                     | Docs                                                  |
+| --------------------------- | ------------------------------------------- | ----------------------------------------------------- |
+| `@optique/env`              | Environment variable fallbacks              | <https://optique.dev/integrations/env.md>             |
+| `@optique/config`           | Configuration file fallbacks                | <https://optique.dev/integrations/config.md>          |
+| `@optique/derived-defaults` | Defaults computed from first-pass results   | <https://optique.dev/concepts/derived-defaults.md>    |
+| `@optique/prompt`           | Generic prompt adapter foundation           | <https://optique.dev/integrations/prompt.md>          |
+| `@optique/clack`            | Clack interactive fallback prompts          | <https://optique.dev/integrations/clack.md>           |
+| `@optique/inquirer`         | Inquirer.js interactive fallback prompts    | <https://optique.dev/integrations/inquirer.md>        |
+| `@optique/standard-schema`  | Portable schema-backed value parsing        | <https://optique.dev/integrations/standard-schema.md> |
+| `@optique/zod`              | Zod-backed value parsing                    | <https://optique.dev/integrations/zod.md>             |
+| `@optique/valibot`          | Valibot-backed value parsing                | <https://optique.dev/integrations/valibot.md>         |
+| `@optique/temporal`         | Temporal date and time parsers              | <https://optique.dev/integrations/temporal.md>        |
+| `@optique/git`              | Async Git reference validation              | <https://optique.dev/integrations/git.md>             |
+| `@optique/logtape`          | LogTape levels and formatter/output options | <https://optique.dev/integrations/logtape.md>         |
+| `@optique/man`              | Man page generation                         | <https://optique.dev/concepts/man.md>                 |
+| `@optique/discover`         | File-based command discovery                | <https://optique.dev/concepts/discover.md>            |

--- a/packages/core/skills/optique/SKILL.md
+++ b/packages/core/skills/optique/SKILL.md
@@ -255,6 +255,6 @@ Integration packages
 | `@optique/valibot`          | Valibot-backed value parsing              | <https://optique.dev/integrations/valibot.md>         |
 | `@optique/temporal`         | Temporal date and time parsers            | <https://optique.dev/integrations/temporal.md>        |
 | `@optique/git`              | Async Git reference validation            | <https://optique.dev/integrations/git.md>             |
-| `@optique/logtape`          | LogTape verbosity and log-level options   | <https://optique.dev/integrations/logtape.md>         |
+| `@optique/logtape`          | LogTape levels and textFormatter()        | <https://optique.dev/integrations/logtape.md>         |
 | `@optique/man`              | Man page generation                       | <https://optique.dev/concepts/man.md>                 |
 | `@optique/discover`         | File-based command discovery              | <https://optique.dev/concepts/discover.md>            |

--- a/packages/core/skills/optique/SKILL.test.ts
+++ b/packages/core/skills/optique/SKILL.test.ts
@@ -331,6 +331,7 @@ describe("Optique agent skill", () => {
     assert.match(skill, /https:\/\/optique\.dev\/llms\.txt/);
     assert.match(skill, /https:\/\/optique\.dev\/pitfalls\.md/);
     assert.match(skill, /https:\/\/optique\.dev\/concepts\/valueparsers\.md/);
+    assert.match(skill, /LogTape levels and textFormatter\(\)/);
   });
 
   it("should type-check TypeScript examples in the skill", async () => {

--- a/packages/core/skills/optique/SKILL.test.ts
+++ b/packages/core/skills/optique/SKILL.test.ts
@@ -331,7 +331,7 @@ describe("Optique agent skill", () => {
     assert.match(skill, /https:\/\/optique\.dev\/llms\.txt/);
     assert.match(skill, /https:\/\/optique\.dev\/pitfalls\.md/);
     assert.match(skill, /https:\/\/optique\.dev\/concepts\/valueparsers\.md/);
-    assert.match(skill, /LogTape levels and textFormatter\(\)/);
+    assert.match(skill, /LogTape levels and formatter\/output options/);
   });
 
   it("should type-check TypeScript examples in the skill", async () => {

--- a/packages/logtape/README.md
+++ b/packages/logtape/README.md
@@ -188,6 +188,37 @@ const result2 = parse(parser, ["--log-output=/var/log/app.log"]);
 const sink = await createSink(result1.value.output);
 ~~~~
 
+Use `formatter` to add a text formatter option and wire it through the
+resulting `LogOutput`:
+
+~~~~ typescript
+import { logOutput } from "@optique/logtape";
+import { object, parse } from "@optique/core";
+
+const parser = object({
+  output: logOutput({ formatter: "--log-format" }),
+});
+
+const result = parse(parser, ["--log-format=logfmt"]);
+// result.value.output is a console LogOutput with logfmtFormatter
+~~~~
+
+You can also pass a fixed LogTape text formatter. In that case no additional
+command-line option is added:
+
+~~~~ typescript
+import { logfmtFormatter } from "@logtape/logtape";
+import { logOutput } from "@optique/logtape";
+import { object, parse } from "@optique/core";
+
+const parser = object({
+  output: logOutput({ formatter: logfmtFormatter }),
+});
+
+const result = parse(parser, ["--log-output=/var/log/app.log"]);
+// result.value.output is a file LogOutput with logfmtFormatter
+~~~~
+
 ### `loggingOptions()`
 
 A preset that combines log level and log output options into a single group.
@@ -242,8 +273,20 @@ Common options:
 
  -  `output.enabled`: Whether to enable log output option (default: `true`)
  -  `output.long`: Long option name for output (default: `"--log-output"`)
+ -  `formatter`: Text formatter or long option name for output format
  -  `groupLabel`: Label for option group in help text (default:
     `"Logging options"`)
+
+Set `formatter` at the top level when using the preset:
+
+~~~~ typescript
+const parser = object({
+  logging: loggingOptions({
+    level: "option",
+    formatter: "--log-format",
+  }),
+});
+~~~~
 
 ### `createLoggingConfig()`
 
@@ -311,13 +354,21 @@ const sink5 = createConsoleSink({
 Creates a LogTape sink from a `LogOutput` value.
 
 ~~~~ typescript
+import { logfmtFormatter } from "@logtape/logtape";
 import { createSink, type LogOutput } from "@optique/logtape";
 
-// Console sink
-const consoleSink = await createSink({ type: "console" });
+// Console sink with a formatter selected by logOutput()
+const consoleSink = await createSink({
+  type: "console",
+  formatter: logfmtFormatter,
+});
 
 // File sink (requires @logtape/file package)
-const fileSink = await createSink({ type: "file", path: "/var/log/app.log" });
+const fileSink = await createSink({
+  type: "file",
+  path: "/var/log/app.log",
+  formatter: logfmtFormatter,
+});
 ~~~~
 
 > [!NOTE]

--- a/packages/logtape/README.md
+++ b/packages/logtape/README.md
@@ -240,6 +240,7 @@ if (result.success) {
 Creates a console sink with configurable stream selection.
 
 ~~~~ typescript
+import { logfmtFormatter } from "@logtape/logtape";
 import { createConsoleSink } from "@optique/logtape";
 
 // Write to stderr (default)
@@ -252,6 +253,20 @@ const sink2 = createConsoleSink({ stream: "stdout" });
 const sink3 = createConsoleSink({
   streamResolver: (level) =>
     level === "error" || level === "fatal" ? "stderr" : "stdout",
+});
+
+// Structured logfmt output
+const sink4 = createConsoleSink({
+  formatter: logfmtFormatter,
+});
+
+// Custom console formatting with multiple console arguments
+const sink5 = createConsoleSink({
+  formatter: (record) => [
+    "%s %o",
+    record.level.toUpperCase(),
+    record.properties,
+  ],
 });
 ~~~~
 

--- a/packages/logtape/README.md
+++ b/packages/logtape/README.md
@@ -70,6 +70,42 @@ Features:
     `"fatal"`
  -  Provides suggestions for shell completion
 
+### `textFormatter()`
+
+A value parser for LogTape text formatters. Parses `"jsonl"`, `"logfmt"`,
+`"color"`, and `"plain"` into LogTape formatter functions.
+
+~~~~ typescript
+import { textFormatter } from "@optique/logtape";
+import { object, option, parse } from "@optique/core";
+
+const parser = object({
+  formatter: option("--log-format", textFormatter()),
+});
+
+const result = parse(parser, ["--log-format=logfmt"]);
+// result.value.formatter is LogTape's logfmtFormatter
+~~~~
+
+Formats:
+
+`"jsonl"`
+:   [JSON Lines][LogTape JSON Lines formatter] output
+
+`"logfmt"`
+:   [logfmt][LogTape logfmt formatter] key-value output
+
+`"color"`
+:   [ANSI-colored][LogTape ANSI color formatter] console output
+
+`"plain"`
+:   [LogTape's default text][LogTape default text formatter] output
+
+[LogTape JSON Lines formatter]: https://logtape.org/manual/formatters#json-lines-formatter
+[LogTape logfmt formatter]: https://logtape.org/manual/formatters#logfmt-formatter
+[LogTape ANSI color formatter]: https://logtape.org/manual/formatters#ansi-color-formatter
+[LogTape default text formatter]: https://logtape.org/manual/formatters#default-text-formatter
+
 ### `verbosity()`
 
 A parser for accumulating `-v` flags to determine log level.

--- a/packages/logtape/deno.json
+++ b/packages/logtape/deno.json
@@ -7,7 +7,7 @@
   },
   "imports": {
     "#src/": "./src/",
-    "@logtape/file": "jsr:@logtape/file@^2.0.4"
+    "@logtape/file": "jsr:@logtape/file@^2.2.2"
   },
   "exclude": [
     "dist/",

--- a/packages/logtape/src/index.test.ts
+++ b/packages/logtape/src/index.test.ts
@@ -1118,6 +1118,38 @@ describe("createConsoleSink()", () => {
     ]);
   });
 
+  it("should tolerate invalid custom formatter return values", () => {
+    const objectSink = createConsoleSink({
+      stream: "stdout",
+      formatter: (() => ({ message: "started" })) as never,
+    });
+    const undefinedSink = createConsoleSink({
+      stream: "stdout",
+      formatter: (() => undefined) as never,
+    });
+
+    const calls = captureConsoleLogCalls(() => {
+      objectSink({
+        category: ["app", "worker"],
+        level: "warning",
+        message: ["started"],
+        rawMessage: "started",
+        properties: {},
+        timestamp: 0,
+      });
+      undefinedSink({
+        category: ["app", "worker"],
+        level: "warning",
+        message: ["started"],
+        rawMessage: "started",
+        properties: {},
+        timestamp: 0,
+      });
+    });
+
+    assert.deepEqual(calls, [[{ message: "started" }], []]);
+  });
+
   it("should route by stream resolver", () => {
     const sink = createConsoleSink({
       streamResolver: (level) => level === "error" ? "stderr" : "stdout",

--- a/packages/logtape/src/index.test.ts
+++ b/packages/logtape/src/index.test.ts
@@ -31,6 +31,24 @@ import {
   verbosity,
 } from "#src/index.ts";
 
+function captureConsoleLog(run: () => void): string[] {
+  return captureConsoleLogCalls(run).map((args) => String(args[0]));
+}
+
+function captureConsoleLogCalls(run: () => void): Array<readonly unknown[]> {
+  const originalLog = console.log;
+  const calls: Array<readonly unknown[]> = [];
+  console.log = (...args: readonly unknown[]) => {
+    calls.push(args);
+  };
+  try {
+    run();
+  } finally {
+    console.log = originalLog;
+  }
+  return calls;
+}
+
 describe("logLevel()", () => {
   describe("parsing", () => {
     it("should parse valid log levels", () => {
@@ -998,12 +1016,7 @@ describe("createConsoleSink()", () => {
 
   it("should format timestamp 0 as Unix epoch", () => {
     const sink = createConsoleSink({ stream: "stdout" });
-    const originalLog = console.log;
-    const lines: string[] = [];
-    console.log = (line?: unknown) => {
-      lines.push(String(line));
-    };
-    try {
+    const lines = captureConsoleLog(() => {
       sink({
         category: ["test"],
         level: "info",
@@ -1012,9 +1025,7 @@ describe("createConsoleSink()", () => {
         properties: {},
         timestamp: 0,
       });
-    } finally {
-      console.log = originalLog;
-    }
+    });
     assert.equal(lines.length, 1);
     assert.match(
       lines[0],
@@ -1024,12 +1035,7 @@ describe("createConsoleSink()", () => {
 
   it("should fall back to current time for NaN timestamp", () => {
     const sink = createConsoleSink({ stream: "stdout" });
-    const originalLog = console.log;
-    const lines: string[] = [];
-    console.log = (line?: unknown) => {
-      lines.push(String(line));
-    };
-    try {
+    const lines = captureConsoleLog(() => {
       sink({
         category: ["test"],
         level: "info",
@@ -1038,9 +1044,7 @@ describe("createConsoleSink()", () => {
         properties: {},
         timestamp: NaN,
       });
-    } finally {
-      console.log = originalLog;
-    }
+    });
     assert.equal(lines.length, 1);
     // Should not throw RangeError; should produce a valid ISO timestamp
     assert.match(
@@ -1055,12 +1059,7 @@ describe("createConsoleSink()", () => {
       formatter: (record) =>
         `${record.level}:${record.category.join("/")}:${record.rawMessage}`,
     });
-    const originalLog = console.log;
-    const lines: string[] = [];
-    console.log = (line?: unknown) => {
-      lines.push(String(line));
-    };
-    try {
+    const lines = captureConsoleLog(() => {
       sink({
         category: ["app", "worker"],
         level: "info",
@@ -1069,9 +1068,7 @@ describe("createConsoleSink()", () => {
         properties: {},
         timestamp: 0,
       });
-    } finally {
-      console.log = originalLog;
-    }
+    });
     assert.deepEqual(lines, ["info:app/worker:started"]);
   });
 
@@ -1080,12 +1077,7 @@ describe("createConsoleSink()", () => {
       stream: "stdout",
       formatter: (record) => `${record.level} ${record.rawMessage}\n`,
     });
-    const originalLog = console.log;
-    const lines: string[] = [];
-    console.log = (line?: unknown) => {
-      lines.push(String(line));
-    };
-    try {
+    const lines = captureConsoleLog(() => {
       sink({
         category: ["app", "worker"],
         level: "info",
@@ -1094,9 +1086,7 @@ describe("createConsoleSink()", () => {
         properties: {},
         timestamp: 0,
       });
-    } finally {
-      console.log = originalLog;
-    }
+    });
     assert.deepEqual(lines, ["info started"]);
   });
 
@@ -1109,12 +1099,7 @@ describe("createConsoleSink()", () => {
         { category: record.category, message: record.rawMessage },
       ],
     });
-    const originalLog = console.log;
-    const calls: Array<readonly unknown[]> = [];
-    console.log = (...args: readonly unknown[]) => {
-      calls.push(args);
-    };
-    try {
+    const calls = captureConsoleLogCalls(() => {
       sink({
         category: ["app", "worker"],
         level: "warning",
@@ -1123,9 +1108,7 @@ describe("createConsoleSink()", () => {
         properties: {},
         timestamp: 0,
       });
-    } finally {
-      console.log = originalLog;
-    }
+    });
     assert.deepEqual(calls, [
       [
         "%s %o",
@@ -1276,12 +1259,7 @@ describe("createConsoleSink()", () => {
       stream: "stdrr" as never,
       streamResolver: () => "stdout",
     });
-    const originalLog = console.log;
-    const lines: string[] = [];
-    console.log = (line?: unknown) => {
-      lines.push(String(line));
-    };
-    try {
+    const lines = captureConsoleLog(() => {
       sink({
         category: ["test"],
         level: "info",
@@ -1290,9 +1268,7 @@ describe("createConsoleSink()", () => {
         properties: {},
         timestamp: 1,
       });
-    } finally {
-      console.log = originalLog;
-    }
+    });
     assert.equal(lines.length, 1);
   });
 
@@ -1344,12 +1320,7 @@ describe("createSink()", () => {
       type: "console",
       formatter: (record) => `formatted ${record.rawMessage}`,
     }, { stream: "stdout" });
-    const originalLog = console.log;
-    const lines: string[] = [];
-    console.log = (line?: unknown) => {
-      lines.push(String(line));
-    };
-    try {
+    const lines = captureConsoleLog(() => {
       sink({
         category: ["test"],
         level: "info",
@@ -1358,9 +1329,7 @@ describe("createSink()", () => {
         properties: {},
         timestamp: 1,
       });
-    } finally {
-      console.log = originalLog;
-    }
+    });
     assert.deepEqual(lines, ["formatted hello"]);
   });
 
@@ -1372,12 +1341,7 @@ describe("createSink()", () => {
       stream: "stdout",
       formatter: () => "from sink options",
     });
-    const originalLog = console.log;
-    const lines: string[] = [];
-    console.log = (line?: unknown) => {
-      lines.push(String(line));
-    };
-    try {
+    const lines = captureConsoleLog(() => {
       sink({
         category: ["test"],
         level: "info",
@@ -1386,9 +1350,7 @@ describe("createSink()", () => {
         properties: {},
         timestamp: 1,
       });
-    } finally {
-      console.log = originalLog;
-    }
+    });
     assert.deepEqual(lines, ["from sink options"]);
   });
 

--- a/packages/logtape/src/index.test.ts
+++ b/packages/logtape/src/index.test.ts
@@ -832,6 +832,92 @@ describe("createConsoleSink()", () => {
     );
   });
 
+  it("should format records with a custom text formatter", () => {
+    const sink = createConsoleSink({
+      stream: "stdout",
+      formatter: (record) =>
+        `${record.level}:${record.category.join("/")}:${record.rawMessage}`,
+    });
+    const originalLog = console.log;
+    const lines: string[] = [];
+    console.log = (line?: unknown) => {
+      lines.push(String(line));
+    };
+    try {
+      sink({
+        category: ["app", "worker"],
+        level: "info",
+        message: ["started"],
+        rawMessage: "started",
+        properties: {},
+        timestamp: 0,
+      });
+    } finally {
+      console.log = originalLog;
+    }
+    assert.deepEqual(lines, ["info:app/worker:started"]);
+  });
+
+  it("should trim text formatter line endings before console output", () => {
+    const sink = createConsoleSink({
+      stream: "stdout",
+      formatter: (record) => `${record.level} ${record.rawMessage}\n`,
+    });
+    const originalLog = console.log;
+    const lines: string[] = [];
+    console.log = (line?: unknown) => {
+      lines.push(String(line));
+    };
+    try {
+      sink({
+        category: ["app", "worker"],
+        level: "info",
+        message: ["started"],
+        rawMessage: "started",
+        properties: {},
+        timestamp: 0,
+      });
+    } finally {
+      console.log = originalLog;
+    }
+    assert.deepEqual(lines, ["info started"]);
+  });
+
+  it("should format records with a custom console formatter", () => {
+    const sink = createConsoleSink({
+      stream: "stdout",
+      formatter: (record) => [
+        "%s %o",
+        record.level.toUpperCase(),
+        { category: record.category, message: record.rawMessage },
+      ],
+    });
+    const originalLog = console.log;
+    const calls: Array<readonly unknown[]> = [];
+    console.log = (...args: readonly unknown[]) => {
+      calls.push(args);
+    };
+    try {
+      sink({
+        category: ["app", "worker"],
+        level: "warning",
+        message: ["started"],
+        rawMessage: "started",
+        properties: {},
+        timestamp: 0,
+      });
+    } finally {
+      console.log = originalLog;
+    }
+    assert.deepEqual(calls, [
+      [
+        "%s %o",
+        "WARNING",
+        { category: ["app", "worker"], message: "started" },
+      ],
+    ]);
+  });
+
   it("should route by stream resolver", () => {
     const sink = createConsoleSink({
       streamResolver: (level) => level === "error" ? "stderr" : "stdout",

--- a/packages/logtape/src/index.test.ts
+++ b/packages/logtape/src/index.test.ts
@@ -15,6 +15,7 @@ import {
   jsonLinesFormatter,
   logfmtFormatter,
   type LogLevel,
+  type Sink,
 } from "@logtape/logtape";
 
 import {
@@ -384,6 +385,95 @@ describe("logOutput()", () => {
       output: logOutput(),
     });
     const result = parse(parser, []);
+    assert.ok(result.success);
+    assert.equal(result.value.output, undefined);
+  });
+
+  it("should parse formatter option with console output", () => {
+    const parser = object({
+      output: logOutput({ formatter: "--log-format" }),
+    });
+    const result = parse(parser, ["--log-output=-", "--log-format=logfmt"]);
+
+    assert.ok(result.success);
+    assert.deepEqual(result.value.output, {
+      type: "console",
+      formatter: logfmtFormatter,
+    });
+  });
+
+  it("should parse formatter option with file output", () => {
+    const parser = object({
+      output: logOutput({ formatter: "--log-format" }),
+    });
+    const result = parse(parser, [
+      "--log-output=/var/log/app.log",
+      "--log-format=jsonl",
+    ]);
+
+    assert.ok(result.success);
+    assert.deepEqual(result.value.output, {
+      type: "file",
+      path: "/var/log/app.log",
+      formatter: jsonLinesFormatter,
+    });
+  });
+
+  it("should default to console output when only formatter is specified", () => {
+    const parser = object({
+      output: logOutput({ formatter: "--log-format" }),
+    });
+    const result = parse(parser, ["--log-format=plain"]);
+
+    assert.ok(result.success);
+    assert.deepEqual(result.value.output, {
+      type: "console",
+      formatter: defaultTextFormatter,
+    });
+  });
+
+  it("should suggest formatter names for formatter option", () => {
+    const parser = object({
+      output: logOutput({ formatter: "--log-format" }),
+    });
+    const suggestions = suggestSync(parser, ["--log-format", "lo"]);
+
+    assert.deepEqual(suggestions, [{ kind: "literal", text: "logfmt" }]);
+  });
+
+  it("should apply fixed formatter to console output", () => {
+    const parser = object({
+      output: logOutput({ formatter: logfmtFormatter }),
+    });
+    const result = parse(parser, ["--log-output=-"]);
+
+    assert.ok(result.success);
+    assert.deepEqual(result.value.output, {
+      type: "console",
+      formatter: logfmtFormatter,
+    });
+  });
+
+  it("should apply fixed formatter to file output", () => {
+    const parser = object({
+      output: logOutput({ formatter: jsonLinesFormatter }),
+    });
+    const result = parse(parser, ["--log-output=/var/log/app.log"]);
+
+    assert.ok(result.success);
+    assert.deepEqual(result.value.output, {
+      type: "file",
+      path: "/var/log/app.log",
+      formatter: jsonLinesFormatter,
+    });
+  });
+
+  it("should not default to console for fixed formatter alone", () => {
+    const parser = object({
+      output: logOutput({ formatter: logfmtFormatter }),
+    });
+    const result = parse(parser, []);
+
     assert.ok(result.success);
     assert.equal(result.value.output, undefined);
   });
@@ -771,6 +861,72 @@ describe("loggingOptions()", () => {
       assert.deepEqual(result.value.logging.logOutput, {
         type: "file",
         path: "/tmp/custom.log",
+      });
+    });
+
+    it("should parse log output formatter option", () => {
+      const parser = object({
+        logging: loggingOptions({
+          level: "option",
+          formatter: "--log-format",
+        }),
+      });
+      const result = parse(parser, ["--log-format=color"]);
+
+      assert.ok(result.success);
+      assert.deepEqual(result.value.logging.logOutput, {
+        type: "console",
+        formatter: ansiColorFormatter,
+      });
+    });
+
+    it("should apply fixed formatter to default output", () => {
+      const parser = object({
+        logging: loggingOptions({
+          level: "option",
+          formatter: logfmtFormatter,
+        }),
+      });
+      const result = parse(parser, []);
+
+      assert.ok(result.success);
+      assert.deepEqual(result.value.logging.logOutput, {
+        type: "console",
+        formatter: logfmtFormatter,
+      });
+    });
+
+    it("should parse formatter option when output option is disabled", () => {
+      const parser = object({
+        logging: loggingOptions({
+          level: "verbosity",
+          formatter: "--log-format",
+          output: { enabled: false },
+        }),
+      });
+      const result = parse(parser, ["-v", "--log-format=logfmt"]);
+
+      assert.ok(result.success);
+      assert.deepEqual(result.value.logging.logOutput, {
+        type: "console",
+        formatter: logfmtFormatter,
+      });
+    });
+
+    it("should apply fixed formatter when output option is disabled", () => {
+      const parser = object({
+        logging: loggingOptions({
+          level: "verbosity",
+          formatter: jsonLinesFormatter,
+          output: { enabled: false },
+        }),
+      });
+      const result = parse(parser, ["-v"]);
+
+      assert.ok(result.success);
+      assert.deepEqual(result.value.logging.logOutput, {
+        type: "console",
+        formatter: jsonLinesFormatter,
       });
     });
 
@@ -1183,6 +1339,59 @@ describe("createSink()", () => {
     assert.equal(typeof sink, "function");
   });
 
+  it("should use formatter from console log output", async () => {
+    const sink = await createSink({
+      type: "console",
+      formatter: (record) => `formatted ${record.rawMessage}`,
+    }, { stream: "stdout" });
+    const originalLog = console.log;
+    const lines: string[] = [];
+    console.log = (line?: unknown) => {
+      lines.push(String(line));
+    };
+    try {
+      sink({
+        category: ["test"],
+        level: "info",
+        message: ["hello"],
+        rawMessage: "hello",
+        properties: {},
+        timestamp: 1,
+      });
+    } finally {
+      console.log = originalLog;
+    }
+    assert.deepEqual(lines, ["formatted hello"]);
+  });
+
+  it("should prefer explicit console sink formatter", async () => {
+    const sink = await createSink({
+      type: "console",
+      formatter: () => "from output",
+    }, {
+      stream: "stdout",
+      formatter: () => "from sink options",
+    });
+    const originalLog = console.log;
+    const lines: string[] = [];
+    console.log = (line?: unknown) => {
+      lines.push(String(line));
+    };
+    try {
+      sink({
+        category: ["test"],
+        level: "info",
+        message: ["hello"],
+        rawMessage: "hello",
+        properties: {},
+        timestamp: 1,
+      });
+    } finally {
+      console.log = originalLog;
+    }
+    assert.deepEqual(lines, ["from sink options"]);
+  });
+
   it("should create file sink for file output", async () => {
     const dir = await mkdtemp(join(tmpdir(), "optique-test-"));
     const sink = await createSink({
@@ -1190,6 +1399,27 @@ describe("createSink()", () => {
       path: join(dir, "test-sink.log"),
     });
     assert.equal(typeof sink, "function");
+  });
+
+  it("should use formatter from file log output", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "optique-test-"));
+    const path = join(dir, "formatted.log");
+    const sink = await createSink({
+      type: "file",
+      path,
+      formatter: (record) => `formatted ${record.rawMessage}\n`,
+    });
+    sink({
+      category: ["test"],
+      level: "info",
+      message: ["hello"],
+      rawMessage: "hello",
+      properties: {},
+      timestamp: 1,
+    });
+    (sink as Sink & Disposable)[Symbol.dispose]();
+
+    assert.equal(await readFile(path, "utf-8"), "formatted hello\n");
   });
 
   it("should propagate getFileSink() errors as-is", async () => {

--- a/packages/logtape/src/index.test.ts
+++ b/packages/logtape/src/index.test.ts
@@ -9,7 +9,13 @@ import { runParser } from "@optique/core/facade";
 import { option } from "@optique/core/primitives";
 import { withDefault } from "@optique/core/modifiers";
 import { message } from "@optique/core/message";
-import type { LogLevel } from "@logtape/logtape";
+import {
+  ansiColorFormatter,
+  defaultTextFormatter,
+  jsonLinesFormatter,
+  logfmtFormatter,
+  type LogLevel,
+} from "@logtape/logtape";
 
 import {
   createConsoleSink,
@@ -20,6 +26,7 @@ import {
   loggingOptions,
   logLevel,
   logOutput,
+  textFormatter,
   verbosity,
 } from "#src/index.ts";
 
@@ -125,6 +132,60 @@ describe("logLevel()", () => {
         assert.ok(text.includes("Unknown level:"));
       }
     });
+  });
+});
+
+describe("textFormatter()", () => {
+  it("should parse formatter names", () => {
+    const parser = textFormatter();
+    const testCases = [
+      ["jsonl", jsonLinesFormatter],
+      ["logfmt", logfmtFormatter],
+      ["color", ansiColorFormatter],
+      ["plain", defaultTextFormatter],
+    ] as const;
+
+    for (const [input, expected] of testCases) {
+      const result = parser.parse(input);
+      assert.ok(result.success, `Failed to parse ${input}`);
+      assert.equal(result.value, expected);
+    }
+  });
+
+  it("should reject invalid formatter names", () => {
+    const parser = textFormatter();
+    const invalidNames = ["json", "text", "pretty", ""];
+
+    for (const name of invalidNames) {
+      const result = parser.parse(name);
+      assert.ok(!result.success, `Should have rejected ${name}`);
+    }
+  });
+
+  it("should suggest formatter names", () => {
+    const parser = textFormatter();
+    const suggestions = [...parser.suggest!("lo")];
+
+    assert.deepEqual(suggestions, [{ kind: "literal", text: "logfmt" }]);
+  });
+
+  it("should format formatter values back to names", () => {
+    const parser = textFormatter();
+
+    assert.equal(parser.format(jsonLinesFormatter), "jsonl");
+    assert.equal(parser.format(logfmtFormatter), "logfmt");
+    assert.equal(parser.format(ansiColorFormatter), "color");
+    assert.equal(parser.format(defaultTextFormatter), "plain");
+  });
+
+  it("should work with option parsers", () => {
+    const parser = object({
+      formatter: option("--log-format", textFormatter()),
+    });
+    const result = parse(parser, ["--log-format=logfmt"]);
+
+    assert.ok(result.success);
+    assert.equal(result.value.formatter, logfmtFormatter);
   });
 });
 

--- a/packages/logtape/src/index.ts
+++ b/packages/logtape/src/index.ts
@@ -45,6 +45,9 @@ export type { LogLevel, LogRecord, Sink } from "@logtape/logtape";
 // Log level value parser
 export { LOG_LEVELS, logLevel, type LogLevelOptions } from "./loglevel.ts";
 
+// Text formatter value parser
+export { textFormatter, type TextFormatterName } from "./textformatter.ts";
+
 // Verbosity parser
 export { verbosity, type VerbosityOptions } from "./verbosity.ts";
 

--- a/packages/logtape/src/output.ts
+++ b/packages/logtape/src/output.ts
@@ -1,6 +1,7 @@
 import { basename } from "node:path";
 import { option } from "@optique/core/primitives";
 import { optional } from "@optique/core/modifiers";
+import { object } from "@optique/core/constructs";
 import type { FluentParser } from "@optique/core/fluent";
 import { ensureNonEmptyString } from "@optique/core/nonempty";
 import type {
@@ -18,6 +19,7 @@ import type {
   Sink,
   TextFormatter,
 } from "@logtape/logtape";
+import { textFormatter } from "./textformatter.ts";
 
 /**
  * Represents a log output destination.
@@ -27,8 +29,12 @@ import type {
  * @since 0.8.0
  */
 export type LogOutput =
-  | { readonly type: "console" }
-  | { readonly type: "file"; readonly path: string };
+  | { readonly type: "console"; readonly formatter?: TextFormatter }
+  | {
+    readonly type: "file";
+    readonly path: string;
+    readonly formatter?: TextFormatter;
+  };
 
 /**
  * Options for configuring console sink creation.
@@ -95,6 +101,27 @@ export interface LogOutputOptions {
    * Description to show in help text.
    */
   readonly description?: Message;
+
+  /**
+   * Text formatter to apply to the selected log output, or a long option name
+   * for selecting the text formatter from the command line.
+   *
+   * When a string is specified, this adds an option that accepts `"jsonl"`,
+   * `"logfmt"`, `"color"`, and `"plain"` and stores the selected formatter in
+   * the resulting {@link LogOutput}. If the formatter option is specified
+   * without a log output option, the output defaults to console.
+   *
+   * When a formatter function is specified, it is applied to the resulting
+   * {@link LogOutput} only when the log output option itself is present.
+   *
+   * @example
+   * ```typescript
+   * logOutput({ formatter: "--log-format" })
+   * ```
+   *
+   * @since 1.2.0
+   */
+  readonly formatter?: string | TextFormatter;
 
   /**
    * Custom error messages.
@@ -198,13 +225,40 @@ export function logOutput(
 
   if (options.short) {
     const short = options.short as OptionName;
-    return optional(
+    const outputParser = optional(
       option(short, long, valueParser, { description }),
     );
+    return withFormatter(outputParser, options.formatter);
   }
-  return optional(
+  const outputParser = optional(
     option(long, valueParser, { description }),
   );
+  return withFormatter(outputParser, options.formatter);
+}
+
+function withFormatter(
+  outputParser: FluentParser<"sync", LogOutput | undefined, unknown>,
+  formatter: string | TextFormatter | undefined,
+): FluentParser<"sync", LogOutput | undefined, unknown> {
+  if (formatter == null) return outputParser;
+  if (typeof formatter !== "string") {
+    return outputParser.map((output) =>
+      output == null ? undefined : { ...output, formatter }
+    );
+  }
+
+  const formatterParser = optional(
+    option(formatter as OptionName, textFormatter(), {
+      description: message`Log output format.`,
+    }),
+  );
+  return object({
+    output: outputParser,
+    formatter: formatterParser,
+  }).map(({ output, formatter }) => {
+    if (formatter == null) return output;
+    return { ...(output ?? { type: "console" as const }), formatter };
+  });
 }
 
 /**
@@ -348,10 +402,16 @@ export async function createSink(
   consoleSinkOptions: ConsoleSinkOptions = {},
 ): Promise<Sink> {
   if (output.type === "console") {
-    return createConsoleSink(consoleSinkOptions);
+    return createConsoleSink({
+      ...consoleSinkOptions,
+      formatter: consoleSinkOptions.formatter ?? output.formatter,
+    });
   }
 
-  let getFileSink: (path: string) => Sink;
+  let getFileSink: (
+    path: string,
+    options?: { readonly formatter?: TextFormatter },
+  ) => Sink;
   try {
     ({ getFileSink } = await import("@logtape/file"));
   } catch (e) {
@@ -363,5 +423,10 @@ export async function createSink(
         `Original error: ${e}`,
     );
   }
-  return getFileSink(output.path);
+  return getFileSink(
+    output.path,
+    output.formatter == null ? undefined : {
+      formatter: output.formatter,
+    },
+  );
 }

--- a/packages/logtape/src/output.ts
+++ b/packages/logtape/src/output.ts
@@ -257,6 +257,15 @@ function withFormatter(
   });
 }
 
+/**
+ * Creates an optional parser for a text formatter option.
+ *
+ * @param long The long option name for selecting the formatter.
+ * @returns A parser that produces the selected {@link TextFormatter}, or
+ *   `undefined` when the option is not present.
+ * @throws {TypeError} If `long` is not a valid option name.
+ * @since 1.2.0
+ */
 export function createTextFormatterOption(
   long: string,
 ): FluentParser<"sync", TextFormatter | undefined, unknown> {

--- a/packages/logtape/src/output.ts
+++ b/packages/logtape/src/output.ts
@@ -247,11 +247,7 @@ function withFormatter(
     );
   }
 
-  const formatterParser = optional(
-    option(formatter as OptionName, textFormatter(), {
-      description: message`Log output format.`,
-    }),
-  );
+  const formatterParser = createTextFormatterOption(formatter);
   return object({
     output: outputParser,
     formatter: formatterParser,
@@ -259,6 +255,16 @@ function withFormatter(
     if (formatter == null) return output;
     return { ...(output ?? { type: "console" as const }), formatter };
   });
+}
+
+export function createTextFormatterOption(
+  long: string,
+): FluentParser<"sync", TextFormatter | undefined, unknown> {
+  return optional(
+    option(long as OptionName, textFormatter(), {
+      description: message`Log output format.`,
+    }),
+  );
 }
 
 /**

--- a/packages/logtape/src/output.ts
+++ b/packages/logtape/src/output.ts
@@ -356,8 +356,10 @@ export function createConsoleSink(options: ConsoleSinkOptions = {}): Sink {
   };
 }
 
-function toConsoleArgs(value: string | readonly unknown[]): readonly unknown[] {
-  return typeof value === "string" ? [value.replace(/\r?\n$/, "")] : value;
+function toConsoleArgs(value: unknown): readonly unknown[] {
+  if (typeof value === "string") return [value.replace(/\r?\n$/, "")];
+  if (Array.isArray(value)) return value;
+  return value == null ? [] : [value];
 }
 
 function defaultConsoleFormatter(record: LogRecord): string {

--- a/packages/logtape/src/output.ts
+++ b/packages/logtape/src/output.ts
@@ -11,7 +11,13 @@ import type {
 import type { Suggestion } from "@optique/core/parser";
 import { type Message, message } from "@optique/core/message";
 import type { OptionName } from "@optique/core/usage";
-import type { LogLevel, LogRecord, Sink } from "@logtape/logtape";
+import type {
+  ConsoleFormatter,
+  LogLevel,
+  LogRecord,
+  Sink,
+  TextFormatter,
+} from "@logtape/logtape";
 
 /**
  * Represents a log output destination.
@@ -50,6 +56,17 @@ export interface ConsoleSinkOptions {
    * ```
    */
   readonly streamResolver?: (level: LogLevel) => "stdout" | "stderr";
+
+  /**
+   * A formatter for converting log records to console output.
+   * Text formatters return one string argument, while console formatters
+   * return the full argument list passed to the selected console method.
+   *
+   * If omitted, records are formatted as
+   * `ISO_TIMESTAMP [LEVEL] category: message`.
+   * @since 1.2.0
+   */
+  readonly formatter?: TextFormatter | ConsoleFormatter;
 }
 
 /**
@@ -226,6 +243,7 @@ export function logOutput(
 export function createConsoleSink(options: ConsoleSinkOptions = {}): Sink {
   const streamResolver = options.streamResolver;
   const defaultStream = options.stream ?? "stderr";
+  const formatter = options.formatter ?? defaultConsoleFormatter;
 
   const invalidStreamError = (value: unknown): TypeError => {
     let repr: string;
@@ -259,34 +277,39 @@ export function createConsoleSink(options: ConsoleSinkOptions = {}): Sink {
       throw invalidStreamError(stream);
     }
 
-    // Format the message
-    const messageParts: string[] = [];
-    for (let i = 0; i < record.message.length; i++) {
-      const part = record.message[i];
-      if (typeof part === "string") {
-        messageParts.push(part);
-      } else {
-        // It's a placeholder value from template literal
-        messageParts.push(String(part));
-      }
-    }
-    const formattedMessage = messageParts.join("");
-
-    // Format the log line
-    const ts = record.timestamp;
-    const timestamp = new Date(
-      ts != null && !Number.isNaN(ts) ? ts : Date.now(),
-    ).toISOString();
-    const category = record.category.join(".");
-    const level = record.level.toUpperCase().padEnd(7);
-    const line = `${timestamp} [${level}] ${category}: ${formattedMessage}`;
+    const args = toConsoleArgs(formatter(record));
 
     if (stream === "stderr") {
-      console.error(line);
+      console.error(...args);
     } else {
-      console.log(line);
+      console.log(...args);
     }
   };
+}
+
+function toConsoleArgs(value: string | readonly unknown[]): readonly unknown[] {
+  return typeof value === "string" ? [value.replace(/\r?\n$/, "")] : value;
+}
+
+function defaultConsoleFormatter(record: LogRecord): string {
+  const messageParts: string[] = [];
+  for (let i = 0; i < record.message.length; i++) {
+    const part = record.message[i];
+    if (typeof part === "string") {
+      messageParts.push(part);
+    } else {
+      messageParts.push(String(part));
+    }
+  }
+  const formattedMessage = messageParts.join("");
+
+  const ts = record.timestamp;
+  const timestamp = new Date(
+    ts != null && !Number.isNaN(ts) ? ts : Date.now(),
+  ).toISOString();
+  const category = record.category.join(".");
+  const level = record.level.toUpperCase().padEnd(7);
+  return `${timestamp} [${level}] ${category}: ${formattedMessage}`;
 }
 
 /**

--- a/packages/logtape/src/preset.ts
+++ b/packages/logtape/src/preset.ts
@@ -1,14 +1,16 @@
 import { option } from "@optique/core/primitives";
 import { group, object } from "@optique/core/constructs";
-import { withDefault } from "@optique/core/modifiers";
+import { optional, withDefault } from "@optique/core/modifiers";
 import type { FluentParser } from "@optique/core/fluent";
 import type { Parser } from "@optique/core/parser";
 import type { OptionName } from "@optique/core/usage";
-import type { Config, LogLevel } from "@logtape/logtape";
+import { message } from "@optique/core/message";
+import type { Config, LogLevel, TextFormatter } from "@logtape/logtape";
 
 import { logLevel, validateLogLevel } from "./loglevel.ts";
 import { verbosity, type VerbosityOptions } from "./verbosity.ts";
 import { debug, type DebugOptions } from "./debug.ts";
+import { textFormatter } from "./textformatter.ts";
 import {
   type ConsoleSinkOptions,
   createSink,
@@ -84,6 +86,14 @@ export interface LoggingOptionsWithLevel {
   readonly output?: LogOutputConfig;
 
   /**
+   * Text formatter to apply to the generated sink, or a long option name for
+   * selecting the text formatter from the command line.
+   *
+   * @since 1.2.0
+   */
+  readonly formatter?: string | TextFormatter;
+
+  /**
    * Label for the option group in help text.
    * @default `"Logging options"`
    */
@@ -122,6 +132,14 @@ export interface LoggingOptionsWithVerbosity {
    * Configuration for log output option.
    */
   readonly output?: LogOutputConfig;
+
+  /**
+   * Text formatter to apply to the generated sink, or a long option name for
+   * selecting the text formatter from the command line.
+   *
+   * @since 1.2.0
+   */
+  readonly formatter?: string | TextFormatter;
 
   /**
    * Label for the option group in help text.
@@ -168,6 +186,14 @@ export interface LoggingOptionsWithDebug {
    * Configuration for log output option.
    */
   readonly output?: LogOutputConfig;
+
+  /**
+   * Text formatter to apply to the generated sink, or a long option name for
+   * selecting the text formatter from the command line.
+   *
+   * @since 1.2.0
+   */
+  readonly formatter?: string | TextFormatter;
 
   /**
    * Label for the option group in help text.
@@ -251,6 +277,7 @@ export function loggingOptions(
   const groupLabel = config.groupLabel ?? "Logging options";
   const outputEnabled = config.output?.enabled !== false;
   const outputLong = config.output?.long ?? "--log-output";
+  const outputFormatter = config.formatter;
 
   // Create log level parser based on the configuration
   let levelParser: Parser<"sync", LogLevel, unknown>;
@@ -299,18 +326,27 @@ export function loggingOptions(
   }
 
   // Default log output is console
-  const defaultOutput: LogOutput = { type: "console" };
+  const defaultOutput: LogOutput = typeof outputFormatter === "function"
+    ? { type: "console", formatter: outputFormatter }
+    : { type: "console" };
 
-  // Parser that always produces LogOutput (not undefined)
-  // Use type assertion since withDefault(optional(x), y) guarantees non-undefined
-  const outputParser = withDefault(
-    logOutput({ long: outputLong }),
-    defaultOutput,
-  ) as unknown as Parser<"sync", LogOutput, unknown>;
-
-  // If output is disabled, create a parser that always returns default
-  if (!outputEnabled) {
-    const constantOutputParser: Parser<"sync", LogOutput, unknown> = {
+  let outputParser: Parser<"sync", LogOutput, unknown>;
+  if (outputEnabled) {
+    // Use type assertion since withDefault(optional(x), y) guarantees non-undefined
+    outputParser = withDefault(
+      logOutput({ long: outputLong, formatter: outputFormatter }),
+      defaultOutput,
+    ) as unknown as Parser<"sync", LogOutput, unknown>;
+  } else if (typeof outputFormatter === "string") {
+    outputParser = optional(
+      option(outputFormatter as OptionName, textFormatter(), {
+        description: message`Log output format.`,
+      }),
+    ).map((formatter) =>
+      formatter == null ? defaultOutput : { type: "console", formatter }
+    );
+  } else {
+    outputParser = {
       mode: "sync",
       $valueType: [] as readonly LogOutput[],
       $stateType: [],
@@ -328,14 +364,6 @@ export function loggingOptions(
       *suggest() {},
       getDocFragments: () => ({ fragments: [] }),
     };
-
-    return group(
-      groupLabel,
-      object({
-        logLevel: levelParser,
-        logOutput: constantOutputParser,
-      }),
-    );
   }
 
   // Combine into a grouped parser

--- a/packages/logtape/src/preset.ts
+++ b/packages/logtape/src/preset.ts
@@ -1,19 +1,18 @@
 import { option } from "@optique/core/primitives";
 import { group, object } from "@optique/core/constructs";
-import { optional, withDefault } from "@optique/core/modifiers";
+import { withDefault } from "@optique/core/modifiers";
 import type { FluentParser } from "@optique/core/fluent";
 import type { Parser } from "@optique/core/parser";
 import type { OptionName } from "@optique/core/usage";
-import { message } from "@optique/core/message";
 import type { Config, LogLevel, TextFormatter } from "@logtape/logtape";
 
 import { logLevel, validateLogLevel } from "./loglevel.ts";
 import { verbosity, type VerbosityOptions } from "./verbosity.ts";
 import { debug, type DebugOptions } from "./debug.ts";
-import { textFormatter } from "./textformatter.ts";
 import {
   type ConsoleSinkOptions,
   createSink,
+  createTextFormatterOption,
   type LogOutput,
   logOutput,
 } from "./output.ts";
@@ -338,11 +337,7 @@ export function loggingOptions(
       defaultOutput,
     ) as unknown as Parser<"sync", LogOutput, unknown>;
   } else if (typeof outputFormatter === "string") {
-    outputParser = optional(
-      option(outputFormatter as OptionName, textFormatter(), {
-        description: message`Log output format.`,
-      }),
-    ).map((formatter) =>
+    outputParser = createTextFormatterOption(outputFormatter).map((formatter) =>
       formatter == null ? defaultOutput : { type: "console", formatter }
     );
   } else {

--- a/packages/logtape/src/textformatter.ts
+++ b/packages/logtape/src/textformatter.ts
@@ -1,0 +1,45 @@
+import {
+  ansiColorFormatter,
+  defaultTextFormatter,
+  jsonLinesFormatter,
+  logfmtFormatter,
+  type TextFormatter,
+} from "@logtape/logtape";
+import { biject, type ValueParser } from "@optique/core/valueparser";
+
+/**
+ * The names accepted by {@link textFormatter}.
+ * @since 1.2.0
+ */
+export type TextFormatterName = "jsonl" | "logfmt" | "color" | "plain";
+
+const textFormatters: Record<TextFormatterName, TextFormatter> = {
+  jsonl: jsonLinesFormatter,
+  logfmt: logfmtFormatter,
+  color: ansiColorFormatter,
+  plain: defaultTextFormatter,
+};
+
+/**
+ * Creates a {@link ValueParser} for LogTape text formatters.
+ *
+ * This parser accepts `"jsonl"`, `"logfmt"`, `"color"`, and `"plain"` and
+ * maps them to LogTape's `jsonLinesFormatter`, `logfmtFormatter`,
+ * `ansiColorFormatter`, and `defaultTextFormatter` respectively.
+ *
+ * @returns A {@link ValueParser} that converts formatter names to
+ *   LogTape text formatter functions.
+ *
+ * @example
+ * ```typescript
+ * import { option } from "@optique/core";
+ * import { textFormatter } from "@optique/logtape";
+ *
+ * const parser = option("--log-format", textFormatter());
+ * ```
+ *
+ * @since 1.2.0
+ */
+export function textFormatter(): ValueParser<"sync", TextFormatter> {
+  return biject(textFormatters);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,11 +13,11 @@ catalogs:
       specifier: ^8.3.0
       version: 8.3.0
     '@logtape/file':
-      specifier: ^2.0.4
-      version: 2.0.4
+      specifier: ^2.2.2
+      version: 2.2.2
     '@logtape/logtape':
-      specifier: ^2.0.4
-      version: 2.0.4
+      specifier: ^2.2.2
+      version: 2.2.2
     '@standard-schema/spec':
       specifier: ^1.1.0
       version: 1.1.0
@@ -65,7 +65,7 @@ importers:
         version: 5.2.10
       '@logtape/logtape':
         specifier: 'catalog:'
-        version: 2.0.4
+        version: 2.2.2
       '@optique/clack':
         specifier: 'workspace:'
         version: link:../packages/clack
@@ -329,7 +329,7 @@ importers:
     dependencies:
       '@logtape/logtape':
         specifier: 'catalog:'
-        version: 2.0.4
+        version: 2.2.2
       '@optique/core':
         specifier: 'workspace:'
         version: link:../core
@@ -389,10 +389,10 @@ importers:
     devDependencies:
       '@logtape/file':
         specifier: 'catalog:'
-        version: 2.0.4(@logtape/logtape@2.0.4)
+        version: 2.2.2(@logtape/logtape@2.2.2)
       '@logtape/logtape':
         specifier: 'catalog:'
-        version: 2.0.4
+        version: 2.2.2
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.4
@@ -1172,13 +1172,13 @@ packages:
     resolution: {integrity: sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ==}
     engines: {node: '>=12'}
 
-  '@logtape/file@2.0.4':
-    resolution: {integrity: sha512-T4ajSQR19kae/MLic4dLXehsB5nfMSUdNAIgQcdgToog9E8PGaYT0IINw+v4clD25AYogeCmn30V7/s2ieV3GA==}
+  '@logtape/file@2.2.2':
+    resolution: {integrity: sha512-HrK8K/bVh331g2GKm4LWIwBUiuOMQiHXLQjieFAGd0v9qaM+uSj79x0WAZn9wjTFJX8Ih1Q1o/OhQrRkVPaRTw==}
     peerDependencies:
-      '@logtape/logtape': ^2.0.4
+      '@logtape/logtape': ^2.2.2
 
-  '@logtape/logtape@2.0.4':
-    resolution: {integrity: sha512-Z4COeAMdedcBFuFkXaPFvDPOVuHoEom1hwNnPCIkSyojyikuNguplwPoSG+kZthWrS7GiOJo1USQyjWwIFfTKA==}
+  '@logtape/logtape@2.2.2':
+    resolution: {integrity: sha512-4BOSQDaWWWqINO/mcFhZxtJDcnK97I+JxLlcd1Nfjbv74o2JLGeRRnLd62Tz1+Qf9rZ3sGNa5cTBhTWPq6XFzQ==}
 
   '@mermaid-js/mermaid-mindmap@9.3.0':
     resolution: {integrity: sha512-IhtYSVBBRYviH1Ehu8gk69pMDF8DSRqXBRDMWrEfHoaMruHeaP2DXA3PBnuwsMaCdPQhlUUcy/7DBLAEIXvCAw==}
@@ -3685,11 +3685,11 @@ snapshots:
     dependencies:
       jsbi: 4.3.2
 
-  '@logtape/file@2.0.4(@logtape/logtape@2.0.4)':
+  '@logtape/file@2.2.2(@logtape/logtape@2.2.2)':
     dependencies:
-      '@logtape/logtape': 2.0.4
+      '@logtape/logtape': 2.2.2
 
-  '@logtape/logtape@2.0.4': {}
+  '@logtape/logtape@2.2.2': {}
 
   '@mermaid-js/mermaid-mindmap@9.3.0':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,8 +6,8 @@ packages:
 catalog:
   "@clack/prompts": ^1.6.0
   "@inquirer/prompts": ^8.3.0
-  "@logtape/file": ^2.0.4
-  "@logtape/logtape": ^2.0.4
+  "@logtape/file": ^2.2.2
+  "@logtape/logtape": ^2.2.2
   "@standard-schema/spec": ^1.1.0
   "@types/node": ^24.0.0
   fast-check: ^4.7.0


### PR DESCRIPTION
Why this shape
--------------

`@optique/logtape` already had enough structure to choose a log level and an output destination, but the output format still had to be wired by hand. That left a gap between the parser result and the sink that actually writes records: the CLI could choose where logs go, but not how records are rendered there.

This PR keeps that choice in the same data flow. `textFormatter()` is a value parser for LogTape's built-in text formatter names, and `LogOutput` can now carry the selected formatter to `createSink()`. That means a CLI can parse:

~~~~ ts
logOutput({ formatter: "--log-format" })
~~~~

and the selected formatter is applied later when the console or file sink is created.

The preset follows the same model, but keeps `formatter` at the `loggingOptions()` top level:

~~~~ ts
loggingOptions({
  level: "option",
  formatter: "--log-format",
})
~~~~

That placement is intentional. The formatter affects the generated sink, not only the `--log-output` destination option. It also keeps formatter parsing available when `output.enabled` is `false`, while fixed formatter values still apply to the default console output.


How it works
------------

`textFormatter()` accepts `jsonl`, `logfmt`, `color`, and `plain`, returning LogTape's `jsonLinesFormatter`, `logfmtFormatter`, `ansiColorFormatter`, and `defaultTextFormatter`.

`logOutput()` now accepts `formatter?: string | TextFormatter`. A string adds a formatter option such as `--log-format`; a `TextFormatter` applies a fixed formatter to whichever output the user selects.

`createSink()` now passes formatter values through to both console and file sinks. The console path still lets explicit `ConsoleSinkOptions.formatter` override a formatter carried by `LogOutput`, so call-site sink configuration remains the final say.

The docs in *docs/integrations/logtape.md* and *packages/logtape/README.md* show both forms, and *packages/core/skills/optique/SKILL.md* now describes the LogTape integration as covering formatter/output options.


Verification
------------

The branch has been checked with:

 -  `mise test:deno packages/logtape`
 -  `pnpm --filter @optique/logtape build`
 -  `pnpm --filter @optique/logtape test`
 -  `pnpm --filter @optique/logtape test:bun`
 -  `pnpm build` in *docs/*
 -  `mise check`
