### PR TITLE
Type lifecycle hook resources

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -133,7 +133,9 @@ To be released.
     `defineCommand()` gains a matching per-command `hooks` field that nests
     inside the program-level hooks (`program.beforeEach` →
     `command.beforeEach` → handler, unwinding in reverse).  The new
-    `ProgramHooks` and `ProgramHookContext` types are exported.  [[#851]]
+    `ProgramHooks` and `ProgramHookContext` types are exported and generic over
+    the caller-defined resource, so its type flows from `beforeEach` to later
+    hooks and the command handler without casts.  [[#851], [#875], [#876]]
 
  -  `runProgram()` now accepts `showUsage: false` for compact command-list
     help.  The option is forwarded to *@optique/run* so discovered command
@@ -157,6 +159,8 @@ To be released.
 [#857]: https://github.com/dahlia/optique/issues/857
 [#858]: https://github.com/dahlia/optique/pull/858
 [#861]: https://github.com/dahlia/optique/pull/861
+[#875]: https://github.com/dahlia/optique/issues/875
+[#876]: https://github.com/dahlia/optique/pull/876
 
 ### @optique/standard-schema
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,16 +39,6 @@ To be released.
     can reuse the same hint logic without re-implementing distance
     calculation.  [[#849]]
 
- -  Added `showUsage` to `DocPageFormatOptions` and the core runner
-    `RunOptions`.  Passing `showUsage: false` omits the `Usage:` synopsis
-    from full help pages, including `aboveError: "help"` output, while leaving
-    explicit usage-only error preambles unchanged.  [[#856], [#860]]
-
- -  Added `commandList` to the core runner `RunOptions`.  The default
-    `"recursive"` mode keeps the existing flattened command list, while
-    `"top-level"` makes top-level help pages list only first-level commands so
-    users can drill down with `<command> --help`.  [[#864], [#865]]
-
  -  Added `transform()` to *@optique/core/valueparser* for reversible value
     parser transformations.  It maps parsed values to a new type while using
     the inverse mapping for formatting, fallback validation, choices, and
@@ -59,6 +49,16 @@ To be released.
     string-to-value dictionaries.  It accepts one of the dictionary's string
     keys, returns the corresponding mapped value, and rejects empty mappings
     or duplicate mapped values at construction time.  [[#866]]
+
+ -  Added `showUsage` to `DocPageFormatOptions` and the core runner
+    `RunOptions`.  Passing `showUsage: false` omits the `Usage:` synopsis
+    from full help pages, including `aboveError: "help"` output, while leaving
+    explicit usage-only error preambles unchanged.  [[#856], [#860]]
+
+ -  Added `commandList` to the core runner `RunOptions`.  The default
+    `"recursive"` mode keeps the existing flattened command list, while
+    `"top-level"` makes top-level help pages list only first-level commands so
+    users can drill down with `<command> --help`.  [[#864], [#865]]
 
  -  Added an official Agent Skill under *skills/optique/* in *@optique/core*,
     declared through the package's `agents.skills` metadata for `skills-npm` and
@@ -81,22 +81,82 @@ To be released.
 [#865]: https://github.com/dahlia/optique/pull/865
 [#866]: https://github.com/dahlia/optique/pull/866
 
-### @optique/logtape
+### @optique/run
 
- -  Added `ConsoleSinkOptions.formatter` for customizing the output emitted
-    by `createConsoleSink()` and console outputs created through
-    `createSink()`.  The option accepts LogTape's `TextFormatter` and
-    `ConsoleFormatter` types while preserving Optique's existing stderr/stdout
-    stream selection behavior.  [[#867]]
+ -  Added `showUsage` to `RunOptions`.  Passing `showUsage: false` omits the
+    `Usage:` synopsis from full help pages produced by `run()`, `runSync()`,
+    and `runAsync()`, while usage-only error output remains unchanged.
+    [[#856], [#860]]
 
- -  Added `textFormatter()` for parsing `"jsonl"`, `"logfmt"`, `"color"`,
-    and `"plain"` into LogTape's built-in text formatters.  [[#867]]
+ -  Added `commandList` to `RunOptions`.  Passing
+    `commandList: "top-level"` makes top-level help pages list only
+    first-level commands; the default `"recursive"` mode preserves the
+    existing full command list.  [[#864], [#865]]
 
- -  Added a `formatter` option to `logOutput()` and `loggingOptions()` for
-    wiring parsed or fixed text formatters into console and file sinks.
-    [[#867]]
+### @optique/discover
 
-[#867]: https://github.com/dahlia/optique/pull/867
+ -  Added `commandsFromModules()` for bundler-friendly command discovery from
+    static module maps such as eager `import.meta.glob()` results.  The helper
+    derives command paths with the same extension, entry-file, duplicate-path,
+    and explicit `path` validation rules as file-system discovery, and returns
+    command entries that can be passed directly to
+    `runProgram({ commands })`.  [[#830], [#840]]
+
+ -  Added the `optique-discover` command to generate static TypeScript command
+    modules for bundlers and single-file CLI packaging.  The generated module
+    imports discovered command files and default-exports the
+    `commandsFromModules()` result, with `--watch` support for regenerating
+    when command files are added, removed, or renamed.
+    [[#835], [#841], [#854], [#858]]
+
+ -  Added executable parent commands to file-system discovery.  Entry files
+    such as *stash/index.ts* now map to the containing command path (`stash`),
+    root *index.ts* defines the root command, and parent commands can coexist
+    with nested commands such as `stash list`.  The `entryFileName` option
+    customizes or disables the entry-file rule.  [[#838], [#839]]
+
+ -  File-system discovery, `commandsFromModules()`, and `optique-discover` now
+    skip co-located test files by default.  A file whose name ends in *.test*
+    or *.spec* before the configured extension—such as *hello.test.ts* or
+    *hello.spec.js*—is ignored the same way declaration files are, so it no
+    longer registers as a ghost command nor breaks discovery by failing the
+    `defineCommand()` check.  [[#857], [#861] by Lee Hoyeon]
+
+ -  Added lifecycle hooks to `runProgram()` for cross-cutting around-handler
+    behavior such as log scopes, tracing spans, lazy resource setup, and
+    failure reporting.  The new `hooks` option takes `beforeEach`, `afterEach`,
+    and `onError` callbacks; `beforeEach` returns a `ProgramHookContext` whose
+    `resource` is threaded forward to the handler's new second argument and to
+    `afterEach`/`onError`.  Hooks may be synchronous or asynchronous, and
+    `onError` observes failures without swallowing them, so `runProgram()`
+    re-throws the original error and process exit codes are unchanged.
+    `defineCommand()` gains a matching per-command `hooks` field that nests
+    inside the program-level hooks (`program.beforeEach` →
+    `command.beforeEach` → handler, unwinding in reverse).  The new
+    `ProgramHooks` and `ProgramHookContext` types are exported.  [[#851]]
+
+ -  `runProgram()` now accepts `showUsage: false` for compact command-list
+    help.  The option is forwarded to *@optique/run* so discovered command
+    programs can show the brief and command sections without the expanded
+    `Usage:` synopsis.  [[#856], [#860]]
+
+ -  `runProgram()` and `createProgramParser()` now accept
+    `commandList: "top-level"` for compact root command menus.  The default
+    remains recursive, while the new mode lists first-level command groups and
+    leaves nested command help available through `<command> --help`.
+    [[#864], [#865]]
+
+[#830]: https://github.com/dahlia/optique/issues/830
+[#835]: https://github.com/dahlia/optique/issues/835
+[#838]: https://github.com/dahlia/optique/issues/838
+[#839]: https://github.com/dahlia/optique/pull/839
+[#840]: https://github.com/dahlia/optique/pull/840
+[#841]: https://github.com/dahlia/optique/pull/841
+[#851]: https://github.com/dahlia/optique/pull/851
+[#854]: https://github.com/dahlia/optique/issues/854
+[#857]: https://github.com/dahlia/optique/issues/857
+[#858]: https://github.com/dahlia/optique/pull/858
+[#861]: https://github.com/dahlia/optique/pull/861
 
 ### @optique/standard-schema
 
@@ -127,83 +187,6 @@ To be released.
 [#845]: https://github.com/dahlia/optique/issues/845
 [#847]: https://github.com/dahlia/optique/pull/847
 
-### @optique/discover
-
- -  Added lifecycle hooks to `runProgram()` for cross-cutting around-handler
-    behavior such as log scopes, tracing spans, lazy resource setup, and
-    failure reporting.  The new `hooks` option takes `beforeEach`, `afterEach`,
-    and `onError` callbacks; `beforeEach` returns a `ProgramHookContext` whose
-    `resource` is threaded forward to the handler's new second argument and to
-    `afterEach`/`onError`.  Hooks may be synchronous or asynchronous, and
-    `onError` observes failures without swallowing them, so `runProgram()`
-    re-throws the original error and process exit codes are unchanged.
-    `defineCommand()` gains a matching per-command `hooks` field that nests
-    inside the program-level hooks (`program.beforeEach` →
-    `command.beforeEach` → handler, unwinding in reverse).  The new
-    `ProgramHooks` and `ProgramHookContext` types are exported.  [[#851]]
-
- -  Added `commandsFromModules()` for bundler-friendly command discovery from
-    static module maps such as eager `import.meta.glob()` results.  The helper
-    derives command paths with the same extension, entry-file, duplicate-path,
-    and explicit `path` validation rules as file-system discovery, and returns
-    command entries that can be passed directly to
-    `runProgram({ commands })`.  [[#830], [#840]]
-
- -  Added the `optique-discover` command to generate static TypeScript command
-    modules for bundlers and single-file CLI packaging.  The generated module
-    imports discovered command files and default-exports the
-    `commandsFromModules()` result, with `--watch` support for regenerating
-    when command files are added, removed, or renamed.
-    [[#835], [#841], [#854], [#858]]
-
- -  Added executable parent commands to file-system discovery.  Entry files
-    such as *stash/index.ts* now map to the containing command path (`stash`),
-    root *index.ts* defines the root command, and parent commands can coexist
-    with nested commands such as `stash list`.  The `entryFileName` option
-    customizes or disables the entry-file rule.  [[#838], [#839]]
-
- -  File-system discovery, `commandsFromModules()`, and `optique-discover` now
-    skip co-located test files by default.  A file whose name ends in *.test*
-    or *.spec* before the configured extension—such as *hello.test.ts* or
-    *hello.spec.js*—is ignored the same way declaration files are, so it no
-    longer registers as a ghost command nor breaks discovery by failing the
-    `defineCommand()` check.  [[#857], [#861] by Lee Hoyeon]
-
- -  `runProgram()` now accepts `showUsage: false` for compact command-list
-    help.  The option is forwarded to *@optique/run* so discovered command
-    programs can show the brief and command sections without the expanded
-    `Usage:` synopsis.  [[#856], [#860]]
-
- -  `runProgram()` and `createProgramParser()` now accept
-    `commandList: "top-level"` for compact root command menus.  The default
-    remains recursive, while the new mode lists first-level command groups and
-    leaves nested command help available through `<command> --help`.
-    [[#864], [#865]]
-
-[#830]: https://github.com/dahlia/optique/issues/830
-[#835]: https://github.com/dahlia/optique/issues/835
-[#838]: https://github.com/dahlia/optique/issues/838
-[#839]: https://github.com/dahlia/optique/pull/839
-[#840]: https://github.com/dahlia/optique/pull/840
-[#841]: https://github.com/dahlia/optique/pull/841
-[#851]: https://github.com/dahlia/optique/pull/851
-[#854]: https://github.com/dahlia/optique/issues/854
-[#857]: https://github.com/dahlia/optique/issues/857
-[#858]: https://github.com/dahlia/optique/pull/858
-[#861]: https://github.com/dahlia/optique/pull/861
-
-### @optique/run
-
- -  Added `showUsage` to `RunOptions`.  Passing `showUsage: false` omits the
-    `Usage:` synopsis from full help pages produced by `run()`, `runSync()`,
-    and `runAsync()`, while usage-only error output remains unchanged.
-    [[#856], [#860]]
-
- -  Added `commandList` to `RunOptions`.  Passing
-    `commandList: "top-level"` makes top-level help pages list only
-    first-level commands; the default `"recursive"` mode preserves the
-    existing full command list.  [[#864], [#865]]
-
 ### @optique/prompt
 
  -  Added the new *@optique/prompt* package for building prompt-library
@@ -228,6 +211,20 @@ To be released.
 
  -  Refactored `prompt()` to use *@optique/prompt* internally while preserving
     the existing public API and Inquirer.js config types.  [[#837], [#844]]
+
+### @optique/logtape
+
+ -  Added formatter support to *@optique/logtape*.  The new
+    `ConsoleSinkOptions.formatter` option customizes output from
+    `createConsoleSink()` and console outputs created through `createSink()`
+    using LogTape's `TextFormatter` or `ConsoleFormatter` types.  The new
+    `textFormatter()` parses `"jsonl"`, `"logfmt"`, `"color"`, and `"plain"`
+    into LogTape's built-in text formatters, while the new `formatter` option
+    on `logOutput()` and `loggingOptions()` wires parsed or fixed text
+    formatters into console and file sinks.  Existing stderr/stdout stream
+    selection behavior remains unchanged.  [[#867]]
+
+[#867]: https://github.com/dahlia/optique/pull/867
 
 
 Version 1.1.1

--- a/docs/concepts/discover.md
+++ b/docs/concepts/discover.md
@@ -377,6 +377,9 @@ awaits it.
 The type argument to `runProgram()` checks the resource returned by
 `beforeEach` and exposes the same type to the later hooks.  The `resource`
 property remains optional because `beforeEach` may return `null` or `void`.
+For statically registered commands, it also checks handlers that receive the
+program-level context; a command whose own `beforeEach` replaces that context
+keeps its independently inferred resource type.
 File-discovered command handlers live in separate modules, so annotate their
 second parameter with `ProgramHookContext<HookResource>` when they consume the
 same program-level resource.

--- a/docs/concepts/discover.md
+++ b/docs/concepts/discover.md
@@ -340,7 +340,12 @@ exactly as before.
 ~~~~ typescript twoslash
 import { runProgram } from "@optique/discover";
 
-await runProgram({
+interface HookResource {
+  readonly label: string;
+  readonly startedAt: number;
+}
+
+await runProgram<HookResource>({
   dir: new URL("./commands/", import.meta.url),
   metadata: { name: "admin", version: "1.0.0" },
   hooks: {
@@ -349,10 +354,9 @@ await runProgram({
       return { resource: { label, startedAt: Date.now() } };
     },
     afterEach(context) {
-      const { label, startedAt } = context.resource as {
-        label: string;
-        startedAt: number;
-      };
+      const resource = context.resource;
+      if (resource == null) return;
+      const { label, startedAt } = resource;
       console.log(`${label} finished in ${Date.now() - startedAt}ms.`);
     },
     onError(_context, error) {
@@ -369,6 +373,13 @@ await runProgram({
 `afterEach`/`onError`, so handlers and later hooks reach the resource without
 global state.  Each hook may be synchronous or return a promise; `runProgram()`
 awaits it.
+
+The type argument to `runProgram()` checks the resource returned by
+`beforeEach` and exposes the same type to the later hooks.  The `resource`
+property remains optional because `beforeEach` may return `null` or `void`.
+File-discovered command handlers live in separate modules, so annotate their
+second parameter with `ProgramHookContext<HookResource>` when they consume the
+same program-level resource.
 
 Hooks can also be attached to a single command through
 `defineCommand({ hooks })` for a per-command preflight.  Command-level hooks

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -2298,7 +2298,7 @@ interface Telemetry {
   readonly span: Span;
 }
 // ---cut-before---
-await runProgram({
+await runProgram<Telemetry>({
   dir: new URL("./commands/", import.meta.url),
   metadata: { name: "tasks", version: "1.0.0" },
   hooks: {
@@ -2310,12 +2310,16 @@ await runProgram({
       return { resource };
     },
     afterEach(context) {
-      const { logger, span } = context.resource as Telemetry;
+      const resource = context.resource;
+      if (resource == null) return;
+      const { logger, span } = resource;
       logger.info("Command finished.");
       span.end();
     },
     onError(context, error) {
-      const { logger, span } = context.resource as Telemetry;
+      const resource = context.resource;
+      if (resource == null) return;
+      const { logger, span } = resource;
       logger.error("Command failed.", { error });
       span.recordException(error);
       span.end();
@@ -2323,6 +2327,10 @@ await runProgram({
   },
 });
 ~~~~
+
+The `Telemetry` type argument checks what `beforeEach` returns and gives
+`afterEach` and `onError` the same resource type.  The property remains optional
+because `beforeEach` may fail or return no context.
 
 A handler reads the resource through its second parameter.  Existing
 single-argument handlers keep working unchanged; only the ones that need the
@@ -2335,7 +2343,10 @@ import { message } from "@optique/core/message";
 import { withDefault } from "@optique/core/modifiers";
 import { option } from "@optique/core/primitives";
 import { string } from "@optique/core/valueparser";
-import { defineCommand } from "@optique/discover/command";
+import {
+  defineCommand,
+  type ProgramHookContext,
+} from "@optique/discover/command";
 
 interface Telemetry {
   readonly logger: ReturnType<typeof getLogger>;
@@ -2346,9 +2357,10 @@ export default defineCommand({
     target: withDefault(option("--target", string()), "app"),
   }),
   metadata: { brief: message`Build the project.` },
-  handler(value, context) {
-    const { logger } = context?.resource as Telemetry;
-    logger.info("Building {target}.", { target: value.target });
+  handler(value, context?: ProgramHookContext<Telemetry>) {
+    context?.resource?.logger.info("Building {target}.", {
+      target: value.target,
+    });
   },
 });
 ~~~~
@@ -2382,7 +2394,7 @@ export default defineCommand({
       return { resource: refreshAuthToken() };
     },
     afterEach(context) {
-      (context.resource as TokenRefresher).release();
+      context.resource?.release();
     },
   },
   handler(value) {

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -2330,7 +2330,10 @@ await runProgram<Telemetry>({
 
 The `Telemetry` type argument checks what `beforeEach` returns and gives
 `afterEach` and `onError` the same resource type.  The property remains optional
-because `beforeEach` may fail or return no context.
+because `beforeEach` may fail or return no context.  When commands are passed
+directly, the type argument also checks handlers that fall back to the
+program-level context; a command with its own `beforeEach` keeps its separately
+inferred resource type.
 
 A handler reads the resource through its second parameter.  Existing
 single-argument handlers keep working unchanged; only the ones that need the

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -2371,7 +2371,7 @@ export default defineCommand({
 #### Per-command preflight
 
 When only one command needs its own setup—for example, a `deploy` command that
-always refreshes an auth token — put the hooks on the command definition instead
+always refreshes an auth token—put the hooks on the command definition instead
 of the program.  Command-level hooks nest inside the program-level ones, so the
 program hook still wraps every command:
 

--- a/examples/patterns/program-hooks.ts
+++ b/examples/patterns/program-hooks.ts
@@ -3,7 +3,11 @@ import { message, text } from "@optique/core/message";
 import { withDefault } from "@optique/core/modifiers";
 import { option } from "@optique/core/primitives";
 import { choice, string } from "@optique/core/valueparser";
-import { defineCommand, runProgram } from "@optique/discover";
+import {
+  defineCommand,
+  type ProgramHookContext,
+  runProgram,
+} from "@optique/discover";
 import { print } from "@optique/run";
 import process from "node:process";
 
@@ -48,9 +52,8 @@ const build = defineCommand({
   metadata: { brief: message`Build the project.` },
   // build has no command-level hooks, so its handler receives the program-level
   // scope opened by the program beforeEach below.
-  handler(value, context) {
-    const scope = context?.resource as Scope;
-    scope.log(`compiling ${value.target}`);
+  handler(value, context?: ProgramHookContext<Scope>) {
+    context?.resource?.log(`compiling ${value.target}`);
   },
 });
 
@@ -76,22 +79,19 @@ const deploy = defineCommand({
     // try/finally would: afterEach runs after a successful handler, onError
     // after a failing one.
     afterEach(context) {
-      const scope = context.resource as Scope;
-      scope.log("released auth token");
+      context.resource?.log("released auth token");
     },
     onError(context) {
-      const scope = context.resource as Scope | undefined;
-      scope?.log("released auth token");
+      context.resource?.log("released auth token");
     },
   },
   handler(value, context) {
-    const scope = context?.resource as Scope;
     const action = value.dryRun ? "planning" : "deploying";
-    scope.log(`${action} ${value.environment}`);
+    context?.resource?.log(`${action} ${value.environment}`);
   },
 });
 
-await runProgram({
+await runProgram<Scope>({
   commands: [build, deploy],
   metadata: {
     name: "tasks",
@@ -109,7 +109,8 @@ await runProgram({
       return { resource: openScope(label) };
     },
     afterEach(context) {
-      const scope = context.resource as Scope;
+      const scope = context.resource;
+      if (scope == null) return;
       print(
         message`✔ ${text(scope.label)} finished in ${
           text(`${Date.now() - scope.startedAt}ms`)
@@ -119,7 +120,7 @@ await runProgram({
     onError(context, error) {
       // beforeEach may have failed before opening a scope, so the resource can
       // be absent here.
-      const scope = context.resource as Scope | undefined;
+      const scope = context.resource;
       const label = scope?.label ?? "tasks";
       print(message`✘ ${text(label)} failed: ${text(String(error))}`);
     },

--- a/packages/discover/src/command.ts
+++ b/packages/discover/src/command.ts
@@ -503,6 +503,12 @@ export function defineCommand<M extends Mode, T, R = unknown>(
 export function defineCommand<M extends Mode, T, R = unknown>(
   command: CommandDefinition<M, T, R>,
 ): Command<M, T, R> {
+  if (Array.isArray(command)) {
+    throw new TypeError("Expected object, got array.");
+  }
+  if (command == null || typeof command !== "object") {
+    throw new TypeError("Expected object.");
+  }
   if (!isParser(command.parser)) {
     throw new TypeError("Command parser must be an Optique parser.");
   }

--- a/packages/discover/src/command.ts
+++ b/packages/discover/src/command.ts
@@ -165,6 +165,24 @@ export interface ProgramHooks<R = unknown> {
 }
 
 /**
+ * Lifecycle hooks that always create their own command context.
+ *
+ * @internal
+ */
+type ProgramHooksWithBeforeEach<R> = ProgramHooks<R> & {
+  readonly beforeEach: NonNullable<ProgramHooks<R>["beforeEach"]>;
+};
+
+/**
+ * Lifecycle hooks that do not replace the program-level command context.
+ *
+ * @internal
+ */
+type ProgramHooksWithoutBeforeEach<R> =
+  & Omit<ProgramHooks<R>, "beforeEach">
+  & { readonly beforeEach?: undefined };
+
+/**
  * Input accepted by {@link defineCommand}.
  *
  * @template M The mode of the command parser.
@@ -260,6 +278,42 @@ export interface StaticCommand<M extends Mode, T, R = unknown>
 }
 
 /**
+ * A command whose hooks always create their own command context.
+ *
+ * @internal
+ */
+type CommandWithBeforeEach<M extends Mode, T, R> = Command<M, T, R> & {
+  readonly hooks: ProgramHooksWithBeforeEach<R>;
+};
+
+/**
+ * A static command whose hooks always create their own command context.
+ *
+ * @internal
+ */
+type StaticCommandWithBeforeEach<M extends Mode, T, R> =
+  & StaticCommand<M, T, R>
+  & CommandWithBeforeEach<M, T, R>;
+
+/**
+ * A command that does not create its own command context.
+ *
+ * @internal
+ */
+type CommandWithoutBeforeEach<M extends Mode, T, R> =
+  & Omit<Command<M, T, R>, "hooks">
+  & { readonly hooks?: ProgramHooksWithoutBeforeEach<R> };
+
+/**
+ * A static command that does not create its own command context.
+ *
+ * @internal
+ */
+type StaticCommandWithoutBeforeEach<M extends Mode, T, R> =
+  & Omit<StaticCommand<M, T, R>, "hooks">
+  & CommandWithoutBeforeEach<M, T, R>;
+
+/**
  * Lifecycle hooks whose caller-defined resource type has been erased.
  *
  * @internal
@@ -268,6 +322,15 @@ interface ErasedProgramHooks {
   readonly beforeEach?: ProgramHooks<unknown>["beforeEach"];
   readonly afterEach?: ProgramHooks<never>["afterEach"];
   readonly onError?: ProgramHooks<never>["onError"];
+}
+
+/**
+ * Erased lifecycle hooks that always create their own command context.
+ *
+ * @internal
+ */
+interface ErasedProgramHooksWithBeforeEach extends ErasedProgramHooks {
+  readonly beforeEach: NonNullable<ErasedProgramHooks["beforeEach"]>;
 }
 
 /**
@@ -320,6 +383,81 @@ export type AnyStaticCommand =
   };
 
 /**
+ * A type-erased command whose handler consumes a program-level resource.
+ *
+ * @internal
+ */
+type ProgramResourceCommand<R> =
+  & Omit<Command<Mode, unknown, R>, "handler">
+  & {
+    readonly handler: (
+      value: never,
+      context?: ProgramHookContext<R>,
+    ) => void | Promise<void>;
+  };
+
+/**
+ * A type-erased command that always creates its own command context.
+ *
+ * @internal
+ */
+type OwnResourceCommand = Omit<AnyCommand, "hooks"> & {
+  readonly hooks: ErasedProgramHooksWithBeforeEach;
+};
+
+/**
+ * A type-erased static command whose handler consumes a program-level
+ * resource.
+ *
+ * @internal
+ */
+type ProgramResourceStaticCommand<R> =
+  & Omit<StaticCommand<Mode, unknown, R>, "handler">
+  & {
+    readonly handler: (
+      value: never,
+      context?: ProgramHookContext<R>,
+    ) => void | Promise<void>;
+  };
+
+/**
+ * A type-erased static command that always creates its own command context.
+ *
+ * @internal
+ */
+type OwnResourceStaticCommand = Omit<AnyStaticCommand, "hooks"> & {
+  readonly hooks: ErasedProgramHooksWithBeforeEach;
+};
+
+/**
+ * A command accepted by `runProgram()` with a program-level resource type.
+ *
+ * Commands without a command-level `beforeEach` must consume `R`.  A command
+ * that always creates its own context may use a different resource type.
+ * Untyped calls retain the fully erased command shape for compatibility.
+ *
+ * @template R The resource made available by program-level lifecycle hooks.
+ * @since 1.2.0
+ */
+export type RunProgramCommand<R = unknown> = unknown extends R ? AnyCommand
+  : ProgramResourceCommand<R> | OwnResourceCommand;
+
+/**
+ * A static command accepted by `runProgram()` with a program-level resource
+ * type.
+ *
+ * Commands without a command-level `beforeEach` must consume `R`.  A command
+ * that always creates its own context may use a different resource type.
+ * Untyped calls retain the fully erased command shape for compatibility.
+ *
+ * @template R The resource made available by program-level lifecycle hooks.
+ * @since 1.2.0
+ */
+export type RunProgramStaticCommand<R = unknown> = unknown extends R
+  ? AnyStaticCommand
+  : ProgramResourceStaticCommand<R> | OwnResourceStaticCommand;
+
+/**
  * Defines a command module for `@optique/discover`.
  *
  * This helper returns its argument unchanged while preserving parser value
@@ -334,6 +472,28 @@ export type AnyStaticCommand =
  *         malformed.
  * @since 1.1.0
  */
+export function defineCommand<M extends Mode, T, R = unknown>(
+  command:
+    & CommandDefinition<M, T, R>
+    & { readonly path: CommandPath }
+    & { readonly hooks: ProgramHooksWithBeforeEach<R> },
+): StaticCommandWithBeforeEach<M, T, R>;
+export function defineCommand<M extends Mode, T, R = unknown>(
+  command:
+    & Omit<CommandDefinition<M, T, R>, "hooks">
+    & { readonly path: CommandPath }
+    & { readonly hooks?: ProgramHooksWithoutBeforeEach<R> },
+): StaticCommandWithoutBeforeEach<M, T, R>;
+export function defineCommand<M extends Mode, T, R = unknown>(
+  command:
+    & CommandDefinition<M, T, R>
+    & { readonly hooks: ProgramHooksWithBeforeEach<R> },
+): CommandWithBeforeEach<M, T, R>;
+export function defineCommand<M extends Mode, T, R = unknown>(
+  command:
+    & Omit<CommandDefinition<M, T, R>, "hooks">
+    & { readonly hooks?: ProgramHooksWithoutBeforeEach<R> },
+): CommandWithoutBeforeEach<M, T, R>;
 export function defineCommand<M extends Mode, T, R = unknown>(
   command: CommandDefinition<M, T, R> & { readonly path: CommandPath },
 ): StaticCommand<M, T, R>;

--- a/packages/discover/src/command.ts
+++ b/packages/discover/src/command.ts
@@ -32,14 +32,15 @@ export type CommandPath = readonly string[];
  * {@link ProgramHooks.afterEach} and {@link ProgramHooks.onError} hooks.  This
  * threads handler-time resources without global state.
  *
+ * @template R The caller-defined resource stored in the context.
  * @since 1.2.0
  */
-export interface ProgramHookContext {
+export interface ProgramHookContext<R = unknown> {
   /**
    * Caller-defined resource.  Common shapes include a database pool, a logger
    * scope, or a tracing span.
    */
-  readonly resource?: unknown;
+  readonly resource?: R;
 }
 
 /**
@@ -104,9 +105,10 @@ export interface ProgramInvocation {
  * program.onError    ← command.onError    ← on failure
  * ```
  *
+ * @template R The resource returned by `beforeEach` and passed to later hooks.
  * @since 1.2.0
  */
-export interface ProgramHooks {
+export interface ProgramHooks<R = unknown> {
   /**
    * Called before the command handler runs, receiving the matched command, its
    * resolved {@link ProgramInvocation.path}, the parsed value, and the handler
@@ -125,10 +127,10 @@ export interface ProgramHooks {
   readonly beforeEach?: (
     invocation: ProgramInvocation,
   ) =>
-    | ProgramHookContext
+    | ProgramHookContext<R>
     | null
     | void
-    | Promise<ProgramHookContext | null | void>;
+    | Promise<ProgramHookContext<R> | null | void>;
 
   /**
    * Called after the handler returns successfully, receiving the context from
@@ -140,7 +142,7 @@ export interface ProgramHooks {
    * invokes {@link onError} with the thrown error.
    */
   readonly afterEach?: (
-    context: ProgramHookContext,
+    context: ProgramHookContext<R>,
     result: unknown,
   ) => void | Promise<void>;
 
@@ -157,7 +159,7 @@ export interface ProgramHooks {
    * Returning a promise is supported; the dispatcher awaits it.
    */
   readonly onError?: (
-    context: ProgramHookContext,
+    context: ProgramHookContext<R>,
     error: unknown,
   ) => void | Promise<void>;
 }
@@ -167,9 +169,10 @@ export interface ProgramHooks {
  *
  * @template M The mode of the command parser.
  * @template T The parsed value passed to the command handler.
+ * @template R The resource made available to lifecycle hooks and the handler.
  * @since 1.1.0
  */
-export interface CommandDefinition<M extends Mode, T> {
+export interface CommandDefinition<M extends Mode, T, R = unknown> {
   /**
    * Command path used when commands are passed directly to `runProgram()`.
    * Use an empty path (`[]`) to register the root command.
@@ -200,7 +203,7 @@ export interface CommandDefinition<M extends Mode, T> {
    *
    * @since 1.2.0
    */
-  readonly hooks?: ProgramHooks;
+  readonly hooks?: ProgramHooks<R>;
 
   /**
    * Handles the parsed command value.
@@ -216,7 +219,7 @@ export interface CommandDefinition<M extends Mode, T> {
    */
   readonly handler: (
     value: T,
-    context?: ProgramHookContext,
+    context?: ProgramHookContext<R>,
   ) => void | Promise<void>;
 }
 
@@ -225,9 +228,11 @@ export interface CommandDefinition<M extends Mode, T> {
  *
  * @template M The mode of the command parser.
  * @template T The parsed value passed to the command handler.
+ * @template R The resource made available to lifecycle hooks and the handler.
  * @since 1.1.0
  */
-export interface Command<M extends Mode, T> extends CommandDefinition<M, T> {
+export interface Command<M extends Mode, T, R = unknown>
+  extends CommandDefinition<M, T, R> {
   /**
    * Internal marker used to validate discovered modules.
    *
@@ -243,13 +248,26 @@ export interface Command<M extends Mode, T> extends CommandDefinition<M, T> {
  *
  * @template M The mode of the command parser.
  * @template T The parsed value passed to the command handler.
+ * @template R The resource made available to lifecycle hooks and the handler.
  * @since 1.1.0
  */
-export interface StaticCommand<M extends Mode, T> extends Command<M, T> {
+export interface StaticCommand<M extends Mode, T, R = unknown>
+  extends Command<M, T, R> {
   /**
    * Command path used by static command registration.
    */
   readonly path: CommandPath;
+}
+
+/**
+ * Lifecycle hooks whose caller-defined resource type has been erased.
+ *
+ * @internal
+ */
+interface ErasedProgramHooks {
+  readonly beforeEach?: ProgramHooks<unknown>["beforeEach"];
+  readonly afterEach?: ProgramHooks<never>["afterEach"];
+  readonly onError?: ProgramHooks<never>["onError"];
 }
 
 /**
@@ -261,13 +279,18 @@ export interface StaticCommand<M extends Mode, T> extends Command<M, T> {
  *
  * @since 1.1.0
  */
-export type AnyCommand = Omit<Command<Mode, unknown>, "handler"> & {
+export type AnyCommand = Omit<Command<Mode, unknown>, "handler" | "hooks"> & {
+  /**
+   * Lifecycle hooks with their caller-defined resource type erased.
+   */
+  readonly hooks?: ErasedProgramHooks;
+
   /**
    * Erased command handler.
    */
   readonly handler: (
     value: never,
-    context?: ProgramHookContext,
+    context?: ProgramHookContext<never>,
   ) => void | Promise<void>;
 };
 
@@ -276,15 +299,25 @@ export type AnyCommand = Omit<Command<Mode, unknown>, "handler"> & {
  *
  * @since 1.1.0
  */
-export type AnyStaticCommand = Omit<StaticCommand<Mode, unknown>, "handler"> & {
-  /**
-   * Erased command handler.
-   */
-  readonly handler: (
-    value: never,
-    context?: ProgramHookContext,
-  ) => void | Promise<void>;
-};
+export type AnyStaticCommand =
+  & Omit<
+    StaticCommand<Mode, unknown>,
+    "handler" | "hooks"
+  >
+  & {
+    /**
+     * Lifecycle hooks with their caller-defined resource type erased.
+     */
+    readonly hooks?: ErasedProgramHooks;
+
+    /**
+     * Erased command handler.
+     */
+    readonly handler: (
+      value: never,
+      context?: ProgramHookContext<never>,
+    ) => void | Promise<void>;
+  };
 
 /**
  * Defines a command module for `@optique/discover`.
@@ -294,21 +327,22 @@ export type AnyStaticCommand = Omit<StaticCommand<Mode, unknown>, "handler"> & {
  *
  * @template M The mode of the command parser.
  * @template T The parsed value passed to the command handler.
+ * @template R The resource made available to lifecycle hooks and the handler.
  * @param command The command definition.
  * @returns The same command definition with inferred types.
  * @throws {TypeError} If the parser, path, handler, or hooks are missing or
  *         malformed.
  * @since 1.1.0
  */
-export function defineCommand<M extends Mode, T>(
-  command: CommandDefinition<M, T> & { readonly path: CommandPath },
-): StaticCommand<M, T>;
-export function defineCommand<M extends Mode, T>(
-  command: CommandDefinition<M, T>,
-): Command<M, T>;
-export function defineCommand<M extends Mode, T>(
-  command: CommandDefinition<M, T>,
-): Command<M, T> {
+export function defineCommand<M extends Mode, T, R = unknown>(
+  command: CommandDefinition<M, T, R> & { readonly path: CommandPath },
+): StaticCommand<M, T, R>;
+export function defineCommand<M extends Mode, T, R = unknown>(
+  command: CommandDefinition<M, T, R>,
+): Command<M, T, R>;
+export function defineCommand<M extends Mode, T, R = unknown>(
+  command: CommandDefinition<M, T, R>,
+): Command<M, T, R> {
   if (!isParser(command.parser)) {
     throw new TypeError("Command parser must be an Optique parser.");
   }

--- a/packages/discover/src/index.test.ts
+++ b/packages/discover/src/index.test.ts
@@ -2910,6 +2910,34 @@ describe("runProgram() lifecycle hooks", () => {
     assert.equal(received, "program");
   });
 
+  it("should isolate command context when command beforeEach rejects", async () => {
+    const error = new Error("preflight failed");
+    let received: unknown;
+    const fail = defineCommand({
+      path: ["fail"],
+      parser: object({}),
+      hooks: {
+        beforeEach() {
+          throw error;
+        },
+        onError(context) {
+          received = context.resource;
+        },
+      },
+      handler() {},
+    });
+
+    await assert.rejects(
+      () =>
+        runHooked([fail], ["fail"], {
+          beforeEach: () => ({ resource: "program" }),
+        }),
+      (caught) => caught === error,
+    );
+
+    assert.equal(received, undefined);
+  });
+
   it("runs command onError before program onError on failure", async () => {
     const order: string[] = [];
     const error = new Error("boom");

--- a/packages/discover/src/index.test.ts
+++ b/packages/discover/src/index.test.ts
@@ -86,6 +86,17 @@ describe("defineCommand()", () => {
     assert.deepEqual(path, []);
   });
 
+  it("should reject non-object command definitions", () => {
+    assert.throws(
+      () => defineCommand([] as never),
+      { name: "TypeError", message: "Expected object, got array." },
+    );
+    assert.throws(
+      () => defineCommand(null as never),
+      { name: "TypeError", message: "Expected object." },
+    );
+  });
+
   it("rejects malformed command definitions", () => {
     assert.throws(
       () =>
@@ -928,6 +939,17 @@ describe("discoverCommands()", () => {
 });
 
 describe("commandsFromModules()", () => {
+  it("should reject non-object module maps", () => {
+    assert.throws(
+      () => commandsFromModules([] as never),
+      { name: "TypeError", message: "Expected object, got array." },
+    );
+    assert.throws(
+      () => commandsFromModules(null as never),
+      { name: "TypeError", message: "Expected object." },
+    );
+  });
+
   it("derives command paths from static module map keys", () => {
     const buildCommand = makeCommand();
     const addCommand = makeCommand();
@@ -1984,6 +2006,17 @@ describe("createProgramParser()", () => {
 });
 
 describe("runProgram()", () => {
+  it("should reject non-object options", async () => {
+    await assert.rejects(
+      () => runProgram([] as never),
+      { name: "TypeError", message: "Expected object, got array." },
+    );
+    await assert.rejects(
+      () => runProgram(null as never),
+      { name: "TypeError", message: "Expected object." },
+    );
+  });
+
   it("runs statically registered commands and waits for async handlers", async () => {
     const calls: unknown[] = [];
     const writeCommand = defineCommand({

--- a/packages/discover/src/index.test.ts
+++ b/packages/discover/src/index.test.ts
@@ -2830,6 +2830,53 @@ describe("runProgram() lifecycle hooks", () => {
     assert.equal(received, "program");
   });
 
+  it("should pass program context to command afterEach without beforeEach", async () => {
+    let received: unknown;
+    const deploy = defineCommand({
+      path: ["deploy"],
+      parser: object({}),
+      hooks: {
+        afterEach(context) {
+          received = context.resource;
+        },
+      },
+      handler() {},
+    });
+
+    await runHooked([deploy], ["deploy"], {
+      beforeEach: () => ({ resource: "program" }),
+    });
+
+    assert.equal(received, "program");
+  });
+
+  it("should pass program context to command onError without beforeEach", async () => {
+    const error = new Error("boom");
+    let received: unknown;
+    const fail = defineCommand({
+      path: ["fail"],
+      parser: object({}),
+      hooks: {
+        onError(context) {
+          received = context.resource;
+        },
+      },
+      handler() {
+        throw error;
+      },
+    });
+
+    await assert.rejects(
+      () =>
+        runHooked([fail], ["fail"], {
+          beforeEach: () => ({ resource: "program" }),
+        }),
+      (caught) => caught === error,
+    );
+
+    assert.equal(received, "program");
+  });
+
   it("runs command onError before program onError on failure", async () => {
     const order: string[] = [];
     const error = new Error("boom");

--- a/packages/discover/src/index.test.ts
+++ b/packages/discover/src/index.test.ts
@@ -38,6 +38,7 @@ import {
   createProgramParser,
   discoverCommands,
   getDefaultExtensions,
+  type ProgramHookContext,
   type ProgramHooks,
   runProgram,
 } from "#src/index.ts";
@@ -178,6 +179,114 @@ describe("defineCommand()", () => {
     });
     assert.equal(typeof cmd.hooks?.beforeEach, "function");
     assert.deepEqual(order, []);
+  });
+
+  it("infers command hook resources in hooks and handlers", () => {
+    const cmd = defineCommand({
+      parser: object({}),
+      hooks: {
+        beforeEach() {
+          return { resource: { label: "command" } };
+        },
+        afterEach(context) {
+          const label: string | undefined = context.resource?.label;
+          assert.equal(label, "command");
+        },
+        onError(context) {
+          const label: string | undefined = context.resource?.label;
+          assert.equal(label, "command");
+        },
+      },
+      handler(_value, context) {
+        const label: string | undefined = context?.resource?.label;
+        assert.equal(label, "command");
+      },
+    });
+
+    assert.equal(typeof cmd.hooks?.beforeEach, "function");
+  });
+
+  it("rejects mismatched command hook resources", () => {
+    interface CommandResource {
+      readonly label: string;
+    }
+
+    const hooks: ProgramHooks<CommandResource> = {
+      // @ts-expect-error: beforeEach must produce CommandResource.
+      beforeEach() {
+        return { resource: { count: 1 } };
+      },
+    };
+
+    assert.equal(typeof hooks.beforeEach, "function");
+  });
+});
+
+describe("runProgram() hook resource types", () => {
+  it("types program hooks and discovered command contexts", () => {
+    interface AppResource {
+      readonly label: string;
+    }
+
+    const run = () =>
+      runProgram<AppResource>({
+        dir: new URL("./commands/", import.meta.url),
+        metadata: { name: "tasks" },
+        hooks: {
+          beforeEach() {
+            return { resource: { label: "program" } };
+          },
+          afterEach(context) {
+            const label: string | undefined = context.resource?.label;
+            assert.equal(label, "program");
+          },
+          onError(context) {
+            const label: string | undefined = context.resource?.label;
+            assert.equal(label, "program");
+          },
+        },
+      });
+    const handle = (
+      _value: unknown,
+      context?: ProgramHookContext<AppResource>,
+    ) => {
+      const label: string | undefined = context?.resource?.label;
+      assert.equal(label, "program");
+    };
+
+    assert.equal(typeof run, "function");
+    assert.equal(typeof handle, "function");
+  });
+
+  it("rejects mismatched program hook resources", () => {
+    interface AppResource {
+      readonly label: string;
+    }
+
+    interface OtherResource {
+      readonly count: number;
+    }
+
+    const run = () =>
+      runProgram<AppResource>({
+        dir: new URL("./commands/", import.meta.url),
+        metadata: { name: "tasks" },
+        hooks: {
+          // @ts-expect-error: beforeEach must produce AppResource.
+          beforeEach() {
+            return { resource: { count: 1 } };
+          },
+        },
+      });
+    const hooks: ProgramHooks<AppResource> = {
+      // @ts-expect-error: later hooks must consume AppResource.
+      afterEach(context: ProgramHookContext<OtherResource>) {
+        assert.equal(context.resource?.count, 1);
+      },
+    };
+
+    assert.equal(typeof run, "function");
+    assert.equal(typeof hooks.afterEach, "function");
   });
 });
 

--- a/packages/discover/src/index.test.ts
+++ b/packages/discover/src/index.test.ts
@@ -258,6 +258,124 @@ describe("runProgram() hook resource types", () => {
     assert.equal(typeof handle, "function");
   });
 
+  it("should reject mismatched static command handler resources", () => {
+    interface AppResource {
+      readonly label: string;
+    }
+
+    interface OtherResource {
+      readonly count: number;
+    }
+
+    const command = defineCommand({
+      path: ["show"],
+      parser: object({}),
+      handler(
+        _value,
+        context?: ProgramHookContext<OtherResource>,
+      ) {
+        assert.equal(context?.resource?.count, 1);
+      },
+    });
+    const run = () =>
+      runProgram<AppResource>({
+        // @ts-expect-error: the handler must consume AppResource.
+        commands: [command],
+        metadata: { name: "tasks" },
+        hooks: {
+          beforeEach() {
+            return { resource: { label: "program" } };
+          },
+        },
+      });
+    const runEntry = () =>
+      runProgram<AppResource>({
+        // @ts-expect-error: command entries must preserve AppResource.
+        commands: [{ path: ["show"], command }],
+        metadata: { name: "tasks" },
+        hooks: {
+          beforeEach() {
+            return { resource: { label: "program" } };
+          },
+        },
+      });
+    const inferredRun = () =>
+      runProgram({
+        // @ts-expect-error: hooks infer AppResource for static handlers.
+        commands: [command],
+        metadata: { name: "tasks" },
+        hooks: {
+          beforeEach() {
+            return { resource: { label: "program" } };
+          },
+        },
+      });
+
+    assert.equal(typeof run, "function");
+    assert.equal(typeof runEntry, "function");
+    assert.equal(typeof inferredRun, "function");
+  });
+
+  it("should allow a static command to provide its own resource", () => {
+    interface AppResource {
+      readonly label: string;
+    }
+
+    const programCommand = defineCommand({
+      path: ["list"],
+      parser: object({}),
+      handler(
+        _value,
+        context?: ProgramHookContext<AppResource>,
+      ) {
+        assert.equal(context?.resource?.label, "program");
+      },
+    });
+    const contextFreeCommand = defineCommand({
+      path: ["help"],
+      parser: object({}),
+      handler() {},
+    });
+    const commandWithoutBeforeEach = defineCommand({
+      path: ["check"],
+      parser: object({}),
+      hooks: {
+        afterEach() {},
+      },
+      handler() {},
+    });
+    const ownResourceCommand = defineCommand({
+      path: ["show"],
+      parser: object({}),
+      hooks: {
+        beforeEach() {
+          return { resource: { count: 1 } };
+        },
+      },
+      handler(_value, context) {
+        const count: number | undefined = context?.resource?.count;
+        assert.equal(count, 1);
+      },
+    });
+    const run = () =>
+      runProgram<AppResource>({
+        commands: [
+          programCommand,
+          contextFreeCommand,
+          commandWithoutBeforeEach,
+          ownResourceCommand,
+        ],
+        metadata: { name: "tasks" },
+        hooks: {
+          beforeEach() {
+            return { resource: { label: "program" } };
+          },
+        },
+      });
+
+    assert.equal(typeof run, "function");
+  });
+
   it("rejects mismatched program hook resources", () => {
     interface AppResource {
       readonly label: string;

--- a/packages/discover/src/index.ts
+++ b/packages/discover/src/index.ts
@@ -37,13 +37,14 @@ import process from "node:process";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import {
   type AnyCommand,
-  type AnyStaticCommand,
   type CommandMetadata,
   type CommandPath,
   isCommand,
   type ProgramHookContext,
   type ProgramHooks,
   type ProgramInvocation,
+  type RunProgramCommand,
+  type RunProgramStaticCommand,
   validateHooks,
 } from "./command.ts";
 
@@ -58,6 +59,8 @@ export type {
   ProgramHookContext,
   ProgramHooks,
   ProgramInvocation,
+  RunProgramCommand,
+  RunProgramStaticCommand,
   StaticCommand,
 } from "./command.ts";
 
@@ -81,6 +84,23 @@ export interface CommandEntry {
    */
   readonly command: AnyCommand;
 }
+
+/**
+ * A command entry accepted by `runProgram()` with a program-level resource
+ * type.
+ *
+ * @template R The resource made available by program-level lifecycle hooks.
+ * @since 1.2.0
+ */
+export type RunProgramCommandEntry<R = unknown> =
+  & Omit<CommandEntry, "command">
+  & {
+    /**
+     * A command compatible with the program-level resource, or one that
+     * always creates its own command context.
+     */
+    readonly command: RunProgramCommand<R>;
+  };
 
 /**
  * A command found on disk.
@@ -107,9 +127,16 @@ export interface DiscoveredCommand extends CommandEntry {
 /**
  * A command loaded from a static module map.
  *
+ * @template R The program-level resource used by commands without their own
+ *              `beforeEach` hook.
  * @since 1.2.0
  */
-export interface ModuleCommand extends CommandEntry {
+export interface ModuleCommand<R = unknown> extends CommandEntry {
+  /**
+   * The command definition.
+   */
+  readonly command: RunProgramCommand<R>;
+
   /**
    * Module map key used to derive the command path.
    */
@@ -317,7 +344,10 @@ export interface RunProgramStaticOptions<R = unknown>
    * Pass commands that declare their own `path`, or command entries returned
    * by {@link commandsFromModules}.
    */
-  readonly commands: readonly (AnyStaticCommand | CommandEntry)[];
+  readonly commands: readonly (
+    | RunProgramStaticCommand<NoInfer<R>>
+    | RunProgramCommandEntry<NoInfer<R>>
+  )[];
 
   /**
    * File-system discovery cannot be used together with `commands`.
@@ -432,6 +462,8 @@ export async function discoverCommands(
  * see module maps, such as `import.meta.glob(..., { eager: true })`, while
  * still deriving command paths from file-like module keys.
  *
+ * @template R The program-level resource used by commands without their own
+ *             `beforeEach` hook.
  * @param modules Static module map keyed by module path.
  * @param options Module path derivation options.
  * @returns Command entries sorted by command path.
@@ -441,10 +473,10 @@ export async function discoverCommands(
  *         `path` does not match the module-derived path.
  * @since 1.2.0
  */
-export function commandsFromModules(
+export function commandsFromModules<R = unknown>(
   modules: ModuleMap,
   options: CommandsFromModulesOptions = {},
-): readonly ModuleCommand[] {
+): readonly ModuleCommand<R>[] {
   if (modules == null || typeof modules !== "object") {
     throw new TypeError("commandsFromModules() requires a module map object.");
   }
@@ -458,7 +490,7 @@ export function commandsFromModules(
   );
 
   const seen = new Map<string, string>();
-  const discovered: ModuleCommand[] = [];
+  const discovered: ModuleCommand<R>[] = [];
   for (const modulePath of modulePaths) {
     const moduleBaseName = posix.basename(modulePath);
     if (
@@ -485,10 +517,12 @@ export function commandsFromModules(
     }
     seen.set(key, modulePath);
 
+    // ModuleMap values are opaque at this boundary.  R is the caller's shared
+    // resource contract for commands whose own beforeEach does not replace it.
     const commandDefinition = commandFromModuleExport(
       modulePath,
       modules[modulePath],
-    );
+    ) as RunProgramCommand<R>;
     validateDeclaredCommandPath(
       commandDefinition,
       path,
@@ -970,8 +1004,11 @@ function isStaticRunProgramOptions<R>(
   return hasCommands;
 }
 
-function staticCommandsToEntries(
-  commands: readonly (AnyStaticCommand | CommandEntry)[],
+function staticCommandsToEntries<R>(
+  commands: readonly (
+    | RunProgramStaticCommand<R>
+    | RunProgramCommandEntry<R>
+  )[],
 ): readonly CommandEntry[] {
   return commands.map((entry) => {
     if (isCommandEntry(entry)) return entry;

--- a/packages/discover/src/index.ts
+++ b/packages/discover/src/index.ts
@@ -217,7 +217,7 @@ export interface RuntimeExtensionOptions {
   readonly nodeTypeScriptSupport?: boolean;
 }
 
-interface RunProgramBaseOptions extends
+interface RunProgramBaseOptions<R = unknown> extends
   Omit<
     RunOptions,
     "help" | "version" | "completion" | "programName"
@@ -267,15 +267,17 @@ interface RunProgramBaseOptions extends
    *
    * @since 1.2.0
    */
-  readonly hooks?: ProgramHooks;
+  readonly hooks?: ProgramHooks<R>;
 }
 
 /**
  * Options for {@link runProgram} when discovering commands from files.
  *
+ * @template R The resource made available by program-level lifecycle hooks.
  * @since 1.1.0
  */
-export interface RunProgramDiscoveryOptions extends RunProgramBaseOptions {
+export interface RunProgramDiscoveryOptions<R = unknown>
+  extends RunProgramBaseOptions<R> {
   /**
    * Directory containing command modules.
    */
@@ -304,9 +306,11 @@ export interface RunProgramDiscoveryOptions extends RunProgramBaseOptions {
 /**
  * Options for {@link runProgram} when commands are imported manually.
  *
+ * @template R The resource made available by program-level lifecycle hooks.
  * @since 1.1.0
  */
-export interface RunProgramStaticOptions extends RunProgramBaseOptions {
+export interface RunProgramStaticOptions<R = unknown>
+  extends RunProgramBaseOptions<R> {
   /**
    * Commands to compose without file-system discovery.
    *
@@ -334,11 +338,12 @@ export interface RunProgramStaticOptions extends RunProgramBaseOptions {
 /**
  * Options for {@link runProgram}.
  *
+ * @template R The resource made available by program-level lifecycle hooks.
  * @since 1.1.0
  */
-export type RunProgramOptions =
-  | RunProgramDiscoveryOptions
-  | RunProgramStaticOptions;
+export type RunProgramOptions<R = unknown> =
+  | RunProgramDiscoveryOptions<R>
+  | RunProgramStaticOptions<R>;
 
 /**
  * Returns runtime-aware command module suffixes.
@@ -531,6 +536,7 @@ export function createProgramParser(
 /**
  * Discovers and runs a command program.
  *
+ * @template R The resource made available by program-level lifecycle hooks.
  * @param options Program options.
  * @returns A promise that resolves after the selected command handler
  *          completes.
@@ -538,7 +544,9 @@ export function createProgramParser(
  *         malformed.
  * @since 1.1.0
  */
-export async function runProgram(options: RunProgramOptions): Promise<void> {
+export async function runProgram<R = unknown>(
+  options: RunProgramOptions<R>,
+): Promise<void> {
   if (options.hooks != null) validateHooks(options.hooks, "Program");
   let commands: readonly Pick<DiscoveredCommand, "path" | "command">[];
   if (isStaticRunProgramOptions(options)) {
@@ -573,11 +581,16 @@ export async function runProgram(options: RunProgramOptions): Promise<void> {
  * @throws The original error thrown by `beforeEach`, the handler, or
  *         `afterEach`, re-thrown after the `onError` hooks run.
  */
-async function dispatchInvocation(
+async function dispatchInvocation<R>(
   invocation: ProgramInvocation,
-  programHooks: ProgramHooks | undefined,
+  programHooks: ProgramHooks<R> | undefined,
 ): Promise<void> {
-  const commandHooks = invocation.command.hooks;
+  // Command collections erase each command's resource type because commands
+  // may use different resources.  The dispatcher only forwards the value
+  // between callbacks from the same hook scope.
+  const commandHooks = invocation.command.hooks as
+    | ProgramHooks<unknown>
+    | undefined;
   await runHookScope(
     programHooks,
     invocation,
@@ -609,12 +622,12 @@ async function dispatchInvocation(
  *         re-thrown after `onError` runs.  An error thrown by `onError` itself
  *         is suppressed so it cannot mask the original failure.
  */
-async function runHookScope(
-  hooks: ProgramHooks | undefined,
+async function runHookScope<R>(
+  hooks: ProgramHooks<R> | undefined,
   invocation: ProgramInvocation,
-  inner: (context: ProgramHookContext) => unknown | Promise<unknown>,
+  inner: (context: ProgramHookContext<R>) => unknown | Promise<unknown>,
 ): Promise<unknown> {
-  let context: ProgramHookContext = {};
+  let context: ProgramHookContext<R> = {};
   try {
     // Default a nullish beforeEach result to an empty context so afterEach,
     // onError, and the handler never receive null/undefined.
@@ -944,9 +957,9 @@ function sortCommands<T extends Pick<DiscoveredCommand, "path">>(
   );
 }
 
-function isStaticRunProgramOptions(
-  options: RunProgramOptions,
-): options is RunProgramStaticOptions {
+function isStaticRunProgramOptions<R>(
+  options: RunProgramOptions<R>,
+): options is RunProgramStaticOptions<R> {
   const hasCommands = "commands" in options && options.commands != null;
   const hasDir = "dir" in options && options.dir != null;
   if (hasCommands === hasDir) {
@@ -1823,7 +1836,7 @@ function commandPathHidden(
   return hidden;
 }
 
-function buildRunOptions(options: RunProgramOptions): RunOptions {
+function buildRunOptions<R>(options: RunProgramOptions<R>): RunOptions {
   const metadata = options.metadata;
   const {
     dir: _dir,

--- a/packages/discover/src/index.ts
+++ b/packages/discover/src/index.ts
@@ -477,8 +477,11 @@ export function commandsFromModules<R = unknown>(
   modules: ModuleMap,
   options: CommandsFromModulesOptions = {},
 ): readonly ModuleCommand<R>[] {
+  if (Array.isArray(modules)) {
+    throw new TypeError("Expected object, got array.");
+  }
   if (modules == null || typeof modules !== "object") {
-    throw new TypeError("commandsFromModules() requires a module map object.");
+    throw new TypeError("Expected object.");
   }
   const base = normalizeModuleBase(options.base);
   const extensions = normalizeExtensions(
@@ -581,6 +584,12 @@ export function createProgramParser(
 export async function runProgram<R = unknown>(
   options: RunProgramOptions<R>,
 ): Promise<void> {
+  if (Array.isArray(options)) {
+    throw new TypeError("Expected object, got array.");
+  }
+  if (options == null || typeof options !== "object") {
+    throw new TypeError("Expected object.");
+  }
   if (options.hooks != null) validateHooks(options.hooks, "Program");
   let commands: readonly Pick<DiscoveredCommand, "path" | "command">[];
   if (isStaticRunProgramOptions(options)) {

--- a/packages/discover/src/index.ts
+++ b/packages/discover/src/index.ts
@@ -629,19 +629,24 @@ async function dispatchInvocation<R>(
     programHooks,
     invocation,
     (programContext) =>
-      runHookScope(commandHooks, invocation, (commandContext) => {
-        // Pass the hook context only when a beforeEach actually produced one,
-        // using the most specific scope.  When no beforeEach ran, call the
-        // handler with just the value so handlers see the exact single-argument
-        // call shape of a plain runProgram() without hooks.
-        if (commandHooks?.beforeEach != null) {
-          return invocation.handler(invocation.value, commandContext);
-        }
-        if (programHooks?.beforeEach != null) {
-          return invocation.handler(invocation.value, programContext);
-        }
-        return invocation.handler(invocation.value);
-      }),
+      runHookScope(
+        commandHooks,
+        invocation,
+        (commandContext) => {
+          // Pass the hook context only when a beforeEach actually produced one,
+          // using the most specific scope.  When no beforeEach ran, call the
+          // handler with just the value so handlers see the exact single-argument
+          // call shape of a plain runProgram() without hooks.
+          if (commandHooks?.beforeEach != null) {
+            return invocation.handler(invocation.value, commandContext);
+          }
+          if (programHooks?.beforeEach != null) {
+            return invocation.handler(invocation.value, programContext);
+          }
+          return invocation.handler(invocation.value);
+        },
+        programContext,
+      ),
   );
 }
 
@@ -651,6 +656,7 @@ async function dispatchInvocation<R>(
  * @param hooks The hooks for this scope, if any.
  * @param invocation The selected command invocation passed to `beforeEach`.
  * @param inner The step to wrap; receives the context from `beforeEach`.
+ * @param fallbackContext The context used when `beforeEach` is absent.
  * @returns The value returned by `inner`.
  * @throws The original error thrown by `beforeEach`, `inner`, or `afterEach`,
  *         re-thrown after `onError` runs.  An error thrown by `onError` itself
@@ -660,8 +666,9 @@ async function runHookScope<R>(
   hooks: ProgramHooks<R> | undefined,
   invocation: ProgramInvocation,
   inner: (context: ProgramHookContext<R>) => unknown | Promise<unknown>,
+  fallbackContext: ProgramHookContext<R> = {},
 ): Promise<unknown> {
-  let context: ProgramHookContext<R> = {};
+  let context = fallbackContext;
   try {
     // Default a nullish beforeEach result to an empty context so afterEach,
     // onError, and the handler never receive null/undefined.

--- a/packages/discover/src/index.ts
+++ b/packages/discover/src/index.ts
@@ -677,7 +677,9 @@ async function runHookScope<R>(
   inner: (context: ProgramHookContext<R>) => unknown | Promise<unknown>,
   fallbackContext: ProgramHookContext<R> = {},
 ): Promise<unknown> {
-  let context = fallbackContext;
+  let context: ProgramHookContext<R> = hooks?.beforeEach == null
+    ? fallbackContext
+    : {};
   try {
     // Default a nullish beforeEach result to an empty context so afterEach,
     // onError, and the handler never receive null/undefined.


### PR DESCRIPTION
`ProgramHookContext.resource` was introduced as `unknown`, which made lifecycle resources available at runtime but erased the relationship between the value created by `beforeEach` and the value later consumed by command handlers, `afterEach`, and `onError`. Callers consequently had to cast every read, and TypeScript could not catch a producer/consumer mismatch. Declaration merging cannot narrow an already declared property, so there was no type-safe escape hatch for applications. Since these APIs have not appeared in a stable release, the upcoming 1.2.0 release is the right point to correct the contract before users begin depending on the untyped form.

This change threads one caller-defined resource type through `ProgramHookContext`, `ProgramHooks`, command definitions, run options, and `runProgram()`. The default remains `unknown` to preserve unannotated usage, while `resource` remains optional because `beforeEach` may return `null` or `void`. Command-local hooks infer the resource type from `beforeEach`; file-discovered commands use the same explicit type with `runProgram<R>()` and `ProgramHookContext<R>` because inference cannot cross module boundaries.

Discovered and statically registered command collections may contain commands with different command-local resource types. The erased-command boundary in *packages/discover/src/command.ts* therefore treats hook producers covariantly and consumers contravariantly, while *packages/discover/src/index.ts* restores the relationship only inside the hook scope that owns it. This keeps the public API sound without using `any` or pretending that every command shares one resource type.

Compile-time tests in *packages/discover/src/index.test.ts* cover inference through `beforeEach`, `afterEach`, `onError`, and command handlers, and reject mismatched producer and consumer types. The examples in *docs/concepts/discover.md*, *docs/cookbook.md*, and *examples/patterns/program-hooks.ts* now show the typed flow without casts while still handling an absent resource. Because the lifecycle APIs are still unreleased, *CHANGES.md* amends their existing 1.2.0 entry instead of presenting the corrected type design as a separate change.

Fixes #875.