### PR TITLE
Remove unused dependency value origins

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,8 +14,15 @@ To be released.
     now replace the generated root synopsis or derive one from a callback,
     while subcommand help and usage-only error output remain unchanged.
     [[#879]]
+ -  Removed the unused `DependencyValueOrigin` type and `registerSource()`
+    origin argument from `@optique/core/dependency-runtime`.  Both APIs were
+    marked `@internal`; dependency resolution behavior is unchanged.
+    [[#869], [#874], [#889]]
 
+[#869]: https://github.com/dahlia/optique/issues/869
+[#874]: https://github.com/dahlia/optique/issues/874
 [#879]: https://github.com/dahlia/optique/issues/879
+[#889]: https://github.com/dahlia/optique/pull/889
 
 ### @optique/run
 

--- a/changes.d/core/dependency-source-origin.md
+++ b/changes.d/core/dependency-source-origin.md
@@ -1,0 +1,10 @@
+---
+links:
+  '#869': https://github.com/dahlia/optique/issues/869
+  '#874': https://github.com/dahlia/optique/issues/874
+  '#889': https://github.com/dahlia/optique/pull/889
+---
+ -  Removed the unused `DependencyValueOrigin` type and `registerSource()`
+    origin argument from `@optique/core/dependency-runtime`.  Both APIs were
+    marked `@internal`; dependency resolution behavior is unchanged.
+    [[#869], [#874], [#889]]

--- a/packages/core/src/constructs.test.ts
+++ b/packages/core/src/constructs.test.ts
@@ -18805,7 +18805,6 @@ describe("branch coverage: constructs.ts edge cases", () => {
         exec?.dependencyRuntime?.registerSource(
           dep,
           "fast",
-          "derived-precomplete",
         );
         return createDependencySourceState(
           { success: true as const, value: "fast" },
@@ -19313,7 +19312,6 @@ describe("branch coverage: constructs.ts edge cases", () => {
         exec?.dependencyRuntime?.registerSource(
           dep,
           "fast",
-          "derived-precomplete",
         );
         return Promise.resolve(
           createDependencySourceState(

--- a/packages/core/src/dependency-runtime.test.ts
+++ b/packages/core/src/dependency-runtime.test.ts
@@ -51,7 +51,7 @@ describe("DependencyRuntimeContext", () => {
   test("registerSource and getSource roundtrip", () => {
     const runtime = createDependencyRuntimeContext();
     const id = Symbol("env");
-    runtime.registerSource(id, "prod", "cli");
+    runtime.registerSource(id, "prod");
     assert.ok(runtime.hasSource(id));
     assert.equal(runtime.getSource(id), "prod");
   });
@@ -66,14 +66,14 @@ describe("DependencyRuntimeContext", () => {
     assert.equal(runtime.getSource(Symbol("missing")), undefined);
   });
 
-  test("registerSource with different origins", () => {
+  test("registerSource registers multiple values", () => {
     const runtime = createDependencyRuntimeContext();
     const id1 = Symbol("a");
     const id2 = Symbol("b");
     const id3 = Symbol("c");
-    runtime.registerSource(id1, "v1", "cli");
-    runtime.registerSource(id2, "v2", "default");
-    runtime.registerSource(id3, "v3", "config");
+    runtime.registerSource(id1, "v1");
+    runtime.registerSource(id2, "v2");
+    runtime.registerSource(id3, "v3");
     assert.equal(runtime.getSource(id1), "v1");
     assert.equal(runtime.getSource(id2), "v2");
     assert.equal(runtime.getSource(id3), "v3");
@@ -83,8 +83,8 @@ describe("DependencyRuntimeContext", () => {
     const runtime = createDependencyRuntimeContext();
     const id1 = Symbol("env");
     const id2 = Symbol("region");
-    runtime.registerSource(id1, "prod", "cli");
-    runtime.registerSource(id2, "us-east", "cli");
+    runtime.registerSource(id1, "prod");
+    runtime.registerSource(id2, "us-east");
     const result = runtime.resolveDependencies({
       dependencyIds: [id1, id2],
     });
@@ -97,7 +97,7 @@ describe("DependencyRuntimeContext", () => {
     const runtime = createDependencyRuntimeContext();
     const id1 = Symbol("env");
     const id2 = Symbol("region");
-    runtime.registerSource(id1, "prod", "cli");
+    runtime.registerSource(id1, "prod");
     // id2 is missing
     const result = runtime.resolveDependencies({
       dependencyIds: [id1, id2],
@@ -123,7 +123,7 @@ describe("DependencyRuntimeContext", () => {
     const runtime = createDependencyRuntimeContext();
     const id1 = Symbol("env");
     const id2 = Symbol("region");
-    runtime.registerSource(id1, "prod", "cli");
+    runtime.registerSource(id1, "prod");
     // id2 missing, no defaults provided for it
     const result = runtime.resolveDependencies({
       dependencyIds: [id1, id2],
@@ -147,7 +147,7 @@ describe("DependencyRuntimeContext", () => {
   test("getSuggestionDependencies mirrors resolveDependencies", () => {
     const runtime = createDependencyRuntimeContext();
     const id = Symbol("env");
-    runtime.registerSource(id, "prod", "cli");
+    runtime.registerSource(id, "prod");
     const result = runtime.getSuggestionDependencies({
       dependencyIds: [id],
     });
@@ -167,7 +167,7 @@ describe("DependencyRuntimeContext", () => {
   test("preserves failed sources when wrapping a cloned registry", () => {
     const sourceId = Symbol("env");
     const runtime = createDependencyRuntimeContext();
-    runtime.registerSource(sourceId, "prod", "cli");
+    runtime.registerSource(sourceId, "prod");
     runtime.markSourceFailed(sourceId);
 
     const cloned = createDependencyRuntimeContext(runtime.registry.clone());
@@ -214,7 +214,7 @@ describe("DependencyRuntimeContext", () => {
     );
 
     runtime.markSourceFailed(sourceId);
-    assert.throws(() => runtime.registerSource(sourceId, "fresh", "cli"), {
+    assert.throws(() => runtime.registerSource(sourceId, "fresh"), {
       name: "TypeError",
       message: "Registry exploded.",
     });
@@ -762,7 +762,7 @@ describe("fillMissingSourceDefaults", () => {
   test("does not overwrite existing source", () => {
     const runtime = createDependencyRuntimeContext();
     const sourceId = Symbol("env");
-    runtime.registerSource(sourceId, "prod", "cli");
+    runtime.registerSource(sourceId, "prod");
     const nodes: RuntimeNode[] = [{
       path: ["env"],
       parser: {
@@ -1023,7 +1023,7 @@ describe("fillMissingSourceDefaultsAsync", () => {
     const matchedId = Symbol("matched");
     const transformedId = Symbol("transformed");
     const missingGetterId = Symbol("missing-getter");
-    runtime.registerSource(existingId, "cli", "cli");
+    runtime.registerSource(existingId, "cli");
     runtime.markSourceFailed(failedId);
 
     const calls: string[] = [];
@@ -1116,7 +1116,7 @@ describe("replayDerivedParser", () => {
   test("replays sync derived parser", () => {
     const runtime = createDependencyRuntimeContext();
     const sourceId = Symbol("env");
-    runtime.registerSource(sourceId, "prod", "cli");
+    runtime.registerSource(sourceId, "prod");
     const metadata: ParserDependencyMetadata = {
       derived: {
         kind: "derived",
@@ -1202,7 +1202,7 @@ describe("replayDerivedParser", () => {
   test("throws when sync replay receives a thenable", () => {
     const runtime = createDependencyRuntimeContext();
     const sourceId = Symbol("env");
-    runtime.registerSource(sourceId, "prod", "cli");
+    runtime.registerSource(sourceId, "prod");
     const metadata: ParserDependencyMetadata = {
       derived: {
         kind: "derived",
@@ -1235,7 +1235,7 @@ describe("replayDerivedParserAsync", () => {
   test("replays async derived parser", async () => {
     const runtime = createDependencyRuntimeContext();
     const sourceId = Symbol("env");
-    runtime.registerSource(sourceId, "prod", "cli");
+    runtime.registerSource(sourceId, "prod");
     const metadata: ParserDependencyMetadata = {
       derived: {
         kind: "derived",
@@ -1330,9 +1330,9 @@ describe("resolveStateWithRuntime", () => {
     const firstId = Symbol("first");
     const secondId = Symbol("second");
     const runtime = createDependencyRuntimeContext();
-    runtime.registerSource(singleId, "prod", "cli");
-    runtime.registerSource(firstId, "us", "cli");
-    runtime.registerSource(secondId, "blue", "cli");
+    runtime.registerSource(singleId, "prod");
+    runtime.registerSource(firstId, "us");
+    runtime.registerSource(secondId, "blue");
 
     const single = createDeferredParseState(
       "warn",
@@ -1391,7 +1391,7 @@ describe("resolveStateWithRuntime", () => {
   test("preserves dependency source states and clones only changed containers", () => {
     const sourceId = Symbol("env");
     const runtime = createDependencyRuntimeContext();
-    runtime.registerSource(sourceId, "prod", "cli");
+    runtime.registerSource(sourceId, "prod");
     const source = createDependencySourceState(
       { success: true, value: "prod" },
       sourceId,
@@ -1463,7 +1463,7 @@ describe("resolveStateWithRuntime", () => {
       },
     );
     const runtime = createDependencyRuntimeContext();
-    runtime.registerSource(depId, "prod", "cli");
+    runtime.registerSource(depId, "prod");
 
     assert.throws(
       () => resolveStateWithRuntime(deferred, runtime),
@@ -1481,7 +1481,7 @@ describe("resolveStateWithRuntimeAsync", () => {
     const explicitId = Symbol("explicit");
     const defaultId = Symbol("default");
     const runtime = createDependencyRuntimeContext();
-    runtime.registerSource(explicitId, "prod", "cli");
+    runtime.registerSource(explicitId, "prod");
     let defaultReplays = 0;
     const state = [
       createDeferredParseState(
@@ -1546,7 +1546,7 @@ describe("resolveStateWithRuntimeAsync", () => {
   test("resolves a shared async deferred state at every reference", async () => {
     const sourceId = Symbol("env");
     const runtime = createDependencyRuntimeContext();
-    runtime.registerSource(sourceId, "prod", "cli");
+    runtime.registerSource(sourceId, "prod");
     const deferred = createDeferredParseState(
       "warn",
       makeDerivedValueParser(
@@ -1783,7 +1783,7 @@ describe("replayDerivedParser—additional branches", () => {
     const runtime = createDependencyRuntimeContext();
     const id1 = Symbol("a");
     const id2 = Symbol("b");
-    runtime.registerSource(id1, "present", "cli");
+    runtime.registerSource(id1, "present");
     // id2 is missing with no defaults
 
     const metadata: ParserDependencyMetadata = {
@@ -1880,7 +1880,7 @@ describe("replayDerivedParserAsync—additional branches", () => {
     const runtime = createDependencyRuntimeContext();
     const id1 = Symbol("a");
     const id2 = Symbol("b");
-    runtime.registerSource(id1, "present", "cli");
+    runtime.registerSource(id1, "present");
     // id2 missing → partial
 
     const metadata: ParserDependencyMetadata = {
@@ -2024,7 +2024,7 @@ describe("DependencyRuntimeContext—FailedAwareRegistry clone", () => {
     const sourceA = Symbol("envA");
     const sourceB = Symbol("envB");
     const runtime = createDependencyRuntimeContext();
-    runtime.registerSource(sourceA, "prod", "cli");
+    runtime.registerSource(sourceA, "prod");
     runtime.markSourceFailed(sourceA);
     runtime.markSourceFailed(sourceB);
 

--- a/packages/core/src/dependency-runtime.ts
+++ b/packages/core/src/dependency-runtime.ts
@@ -53,20 +53,6 @@ function stableSymbolKey(sym: symbol): string {
 // =============================================================================
 
 /**
- * The origin of a dependency source value.
- *
- * @internal
- * @since 1.0.0
- */
-export type DependencyValueOrigin =
-  | "cli"
-  | "default"
-  | "config"
-  | "env"
-  | "prompt"
-  | "derived-precomplete";
-
-/**
  * A request to resolve one or more dependency values.
  *
  * @internal
@@ -192,12 +178,8 @@ export interface DependencyRuntimeContext {
   /** The underlying registry (for bridge interop). */
   readonly registry: DependencyRegistryLike;
 
-  /** Register a source value with its origin. */
-  registerSource(
-    sourceId: symbol,
-    value: unknown,
-    origin: DependencyValueOrigin,
-  ): void;
+  /** Register a source value. */
+  registerSource(sourceId: symbol, value: unknown): void;
 
   /** Check if a source has been registered. */
   hasSource(sourceId: symbol): boolean;
@@ -250,11 +232,7 @@ class DependencyRuntimeContextImpl implements DependencyRuntimeContext {
     this.registry = new FailedAwareRegistry(registry, this.#failedSources);
   }
 
-  registerSource(
-    sourceId: symbol,
-    value: unknown,
-    _origin: DependencyValueOrigin,
-  ): void {
+  registerSource(sourceId: symbol, value: unknown): void {
     this.registry.set(sourceId, value);
   }
 
@@ -596,7 +574,7 @@ function registerExplicitSourceValue(
   // { success: true, value } = source value (value may be undefined).
   if (result == null) return;
   if (result.success) {
-    runtime.registerSource(sourceId, result.value, "cli");
+    runtime.registerSource(sourceId, result.value);
   } else {
     // Mark the source as explicitly failed so that derived parsers
     // do not fall back to defaults for this source.
@@ -700,11 +678,7 @@ export function fillMissingSourceDefaults(
       );
     }
     if (result.success) {
-      runtime.registerSource(
-        meta.source.sourceId,
-        result.value,
-        "default",
-      );
+      runtime.registerSource(meta.source.sourceId, result.value);
     } else {
       // Default thunk returned a failure—propagate it.
       failures.push({
@@ -757,11 +731,7 @@ export async function fillMissingSourceDefaultsAsync(
       continue;
     }
     if (result.success) {
-      runtime.registerSource(
-        meta.source.sourceId,
-        result.value,
-        "default",
-      );
+      runtime.registerSource(meta.source.sourceId, result.value);
     } else {
       failures.push({
         sourceId: meta.source.sourceId,
@@ -1042,7 +1012,7 @@ export function collectSourcesFromState(
     if (depId != null && result.success) {
       // Always overwrite so that later values win (e.g., multiple()
       // where the last tag value should be used as the dependency).
-      runtime.registerSource(depId, result.value, "cli");
+      runtime.registerSource(depId, result.value);
     } else if (depId != null) {
       // Mark the source as explicitly failed so that derived parsers
       // do not fall back to defaults for this source.

--- a/packages/core/src/modifiers.test.ts
+++ b/packages/core/src/modifiers.test.ts
@@ -6742,7 +6742,7 @@ describe("branch coverage: modifiers edge cases", () => {
       async complete(state, exec) {
         started.push(state);
         await gates.get(state)?.promise;
-        exec?.dependencyRuntime?.registerSource(sourceId, state, "cli");
+        exec?.dependencyRuntime?.registerSource(sourceId, state);
         return { success: true as const, value: `item-${state}` };
       },
       async *suggest() {},
@@ -6810,7 +6810,7 @@ describe("branch coverage: modifiers edge cases", () => {
       async complete(state, exec) {
         started.push(state);
         await gates.get(state)?.promise;
-        exec?.dependencyRuntime?.registerSource(sourceId, state, "cli");
+        exec?.dependencyRuntime?.registerSource(sourceId, state);
         return { success: true as const, value: `item-${state}` };
       },
       async *suggest(context) {


### PR DESCRIPTION
`DependencyValueOrigin` implied that the runtime might choose between competing sources by comparing provenance. The scheduler planned in #870 makes precedence structural instead: higher-precedence values prevent lower-precedence completions from publishing, so origins never need to be compared.

Removing that unused contract before the scheduler work keeps `@optique/core` from naming integration-specific sources and gives #870 a smaller runtime boundary. Source registration and its tests now express the existing value-only behavior, without changing dependency resolution.

Closes #874. Part of #869.
