### PR TITLE
`regExp()` value parser

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@ To be released.
 
 ### @optique/core
 
+ -  Added `regExp()` for compiling command-line values into `RegExp` objects
+    with fixed flags and customizable parse errors.  [[#906], [#909]]
  -  Added `usageLine` to the core runner `RunOptions`.  Top-level full help can
     now replace the generated root synopsis or derive one from a callback,
     while subcommand help and usage-only error output remain unchanged.
@@ -23,6 +25,8 @@ To be released.
 [#874]: https://github.com/dahlia/optique/issues/874
 [#879]: https://github.com/dahlia/optique/issues/879
 [#889]: https://github.com/dahlia/optique/pull/889
+[#906]: https://github.com/dahlia/optique/issues/906
+[#909]: https://github.com/dahlia/optique/pull/909
 
 ### @optique/run
 

--- a/changes.d/core/regexp-parser.md
+++ b/changes.d/core/regexp-parser.md
@@ -1,0 +1,7 @@
+---
+links:
+  '#906': https://github.com/dahlia/optique/issues/906
+  '#909': https://github.com/dahlia/optique/pull/909
+---
+ -  Added `regExp()` for compiling command-line values into `RegExp` objects
+    with fixed flags and customizable parse errors.  [[#906], [#909]]

--- a/docs/.vitepress/theme/components/ParserCatalog.vue
+++ b/docs/.vitepress/theme/components/ParserCatalog.vue
@@ -9,6 +9,7 @@ const valueParsers = [
     base: "/concepts/valueparsers",
     items: [
       ["string", "string-parser"],
+      ["regExp", "regexp-parser"],
       ["choice", "choice-parser"],
       ["biject", "biject-parser"],
       ["transform", "transform-combinator"],

--- a/docs/concepts/valueparsers.md
+++ b/docs/concepts/valueparsers.md
@@ -31,6 +31,7 @@ with Optique's type system.
 | Parser                           | Module                     | Return type                    | Description                                           |
 | -------------------------------- | -------------------------- | ------------------------------ | ----------------------------------------------------- |
 | `string()`                       | *@optique/core*            | `string`                       | Any string, with optional pattern validation          |
+| `regExp()`                       | *@optique/core*            | `RegExp`                       | Regular expression source with fixed flags            |
 | `keyValue()`                     | *@optique/core*            | readonly `[key, value]`        | Key–value pair such as `KEY=VALUE`                    |
 | `integer()`                      | *@optique/core*            | `number` or `bigint`           | Integer with range validation                         |
 | `float()`                        | *@optique/core*            | `number`                       | Floating-point number                                 |
@@ -120,6 +121,69 @@ Error: Expected a string matching pattern ^\d+\.\d+\.\d+$, but got 1.2.
 
 The `string()` parser uses `"STRING"` as its default metavar, which appears in
 help text to indicate what kind of input is expected.
+
+
+`regExp()` parser
+-----------------
+
+*This API is available since Optique 1.3.0.*
+
+The `regExp()` parser compiles a command-line value as the source of a
+JavaScript [`RegExp`].  It returns a `RegExp` object instead of the original
+string, so the pattern is ready to use after parsing.
+
+~~~~ typescript twoslash
+import { regExp } from "@optique/core/valueparser";
+
+const pattern = regExp();
+const insensitivePattern = regExp({ flags: "iu" });
+
+const result = insensitivePattern.parse("^café$");
+if (result.success) {
+  result.value.test("CAFÉ"); // true
+}
+~~~~
+
+The parser treats the entire input token as the source.  It does not interpret
+slash-delimited notation, so `/foo/i` matches that literal text rather than
+creating the source `foo` with the `i` flag.  Set fixed flags when constructing
+the parser instead:
+
+~~~~ typescript twoslash
+import { regExp } from "@optique/core/valueparser";
+
+const pattern = regExp({
+  flags: "giu",
+  metavar: "PATTERN",
+});
+~~~~
+
+Invalid, duplicate, and incompatible flags throw a `SyntaxError` immediately
+when `regExp()` is called.  An invalid input source produces a normal parse
+failure.  Customize that failure with `errors.invalidRegExp`:
+
+~~~~ typescript twoslash
+import { message } from "@optique/core/message";
+import { regExp } from "@optique/core/valueparser";
+
+const pattern = regExp({
+  errors: {
+    invalidRegExp: (input) => message`Invalid search pattern: ${input}.`,
+  },
+});
+~~~~
+
+`format()` returns the value's `RegExp.source`; flags remain part of the
+parser's fixed configuration.  The default metavar is `"REGEXP"`.
+
+> [!CAUTION]
+> `regExp()` only checks whether the source compiles.  It cannot determine
+> whether a pattern is safe to execute.  Untrusted patterns can cause Regular
+> Expression Denial of Service (ReDoS) through excessive backtracking when
+> matched.  Limit pattern and subject lengths, execute matches in an environment
+> that can be terminated, or use a linear-time regular expression engine.
+
+[`RegExp`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp
 
 
 `keyValue()` parser

--- a/docs/index.md
+++ b/docs/index.md
@@ -311,7 +311,7 @@ const host = prompt(
 <LandingSection
   eyebrow="Batteries included"
   title="Reach for a parser before you write one."
-  lead="Fifty built-in value parsers, from <code>integer()</code> and
+  lead="Fifty-one built-in value parsers, from <code>integer()</code> and
   <code>ip()</code> to schema validators, Temporal dates, and async Git refs,
   plus the combinators that assemble them. Every one returns an ordinary parser
   that composes with the rest."

--- a/packages/core/skills/optique/SKILL.md
+++ b/packages/core/skills/optique/SKILL.md
@@ -40,11 +40,12 @@ Core rules
  -  Use `message` from *@optique/core/message* for descriptions, help text, and
     custom errors. Prefer semantic message helpers such as `optionName()` and
     `metavar()` over string concatenation when naming CLI elements.
- -  Use value parsers such as `integer()`, `choice()`, `biject()`, `url()`,
-    and `uuid()` instead of validating raw strings after parsing. Use
-    `biject()` for one-to-one string-to-value choices, and use `transform()`
-    when an existing value parser describes the accepted CLI spelling but your
-    app needs a different result type. Use `path()` from
+ -  Use value parsers such as `integer()`, `choice()`, `biject()`, `regExp()`,
+    `url()`, and `uuid()` instead of validating raw strings after parsing. Use
+    `regExp({ flags })` for user-supplied regular expression sources,
+    `biject()` for one-to-one string-to-value choices, and `transform()` when
+    an existing value parser describes the accepted CLI spelling but your app
+    needs a different result type. Use `path()` from
     `@optique/run/valueparser` for file-system paths. Write a custom
     `{ mode, metavar, parse, format }` value parser only when the catalog does
     not cover the domain.

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -30,6 +30,7 @@ import {
   type NonEmptyString,
   port,
   portRange,
+  regExp,
   type SemVer,
   semVer,
   type SemVerString,
@@ -6531,6 +6532,156 @@ describe("string", () => {
       const result2 = parser.parse("b");
       assert.ok(!result2.success);
       if (!result2.success) assert.equal(result2.error, "original error");
+    });
+  });
+});
+
+describe("regExp()", () => {
+  describe("constructor", () => {
+    it("should expose sync parser metadata", () => {
+      const parser = regExp();
+
+      assert.equal(parser.mode, "sync");
+      assert.equal(parser.metavar, "REGEXP");
+      assert.ok(parser.placeholder instanceof RegExp);
+      assert.equal(parser.placeholder.source, "(?:)");
+      assert.equal(parser.placeholder.flags, "");
+    });
+
+    it("should return a fresh placeholder for each access", () => {
+      const parser = regExp({ flags: "gy" });
+      const first = parser.placeholder;
+
+      first.lastIndex = 3;
+      const second = parser.placeholder;
+
+      assert.notStrictEqual(second, first);
+      assert.equal(second.source, "(?:)");
+      assert.equal(second.flags, "gy");
+      assert.equal(second.lastIndex, 0);
+    });
+
+    it("should accept a custom metavar", () => {
+      const parser = regExp({ metavar: "PATTERN" });
+
+      assert.equal(parser.metavar, "PATTERN");
+    });
+
+    it("should reject an empty metavar", () => {
+      assert.throws(
+        () => regExp({ metavar: "" as NonEmptyString }),
+        {
+          name: "TypeError",
+          message: "Expected a non-empty string.",
+        },
+      );
+    });
+
+    it("should reject invalid flags when constructed", () => {
+      assert.throws(() => regExp({ flags: "x" }), SyntaxError);
+    });
+
+    it("should reject non-string flags when constructed", () => {
+      assert.throws(
+        () => regExp({ flags: 1 as never }),
+        {
+          name: "TypeError",
+          message: "Expected flags to be a string, but got number: 1.",
+        },
+      );
+    });
+
+    it("should reject duplicate flags when constructed", () => {
+      assert.throws(() => regExp({ flags: "gg" }), SyntaxError);
+    });
+
+    it("should reject incompatible flags when constructed", () => {
+      assert.throws(() => regExp({ flags: "uv" }), SyntaxError);
+    });
+  });
+
+  describe("parse()", () => {
+    it("should compile a valid regular expression source", () => {
+      const result = regExp().parse("^[a-z]+$");
+
+      assert.ok(result.success);
+      assert.ok(result.value instanceof RegExp);
+      assert.equal(result.value.source, "^[a-z]+$");
+      assert.equal(result.value.flags, "");
+    });
+
+    it("should compile an empty source", () => {
+      const result = regExp().parse("");
+
+      assert.ok(result.success);
+      assert.equal(result.value.source, "(?:)");
+    });
+
+    it("should preserve an escaped slash in the source", () => {
+      const result = regExp().parse(String.raw`foo\/bar`);
+
+      assert.ok(result.success);
+      assert.equal(result.value.source, String.raw`foo\/bar`);
+      assert.ok(result.value.test("foo/bar"));
+    });
+
+    it("should treat slash notation as a raw source", () => {
+      const result = regExp().parse("/foo/i");
+
+      assert.ok(result.success);
+      assert.equal(result.value.source, String.raw`\/foo\/i`);
+      assert.equal(result.value.flags, "");
+      assert.ok(result.value.test("/foo/i"));
+      assert.ok(!result.value.test("FOO"));
+    });
+
+    it("should compile sources with fixed flags", () => {
+      const result = regExp({ flags: "iu" }).parse("café");
+
+      assert.ok(result.success);
+      assert.equal(result.value.source, "café");
+      assert.equal(result.value.flags, "iu");
+      assert.ok(result.value.test("CAFÉ"));
+    });
+
+    it("should return a structured error for an invalid source", () => {
+      const result = regExp().parse("[");
+
+      assert.ok(!result.success);
+      assert.deepEqual(
+        result.error,
+        message`Invalid regular expression: ${"["}.`,
+      );
+    });
+
+    it("should use a static custom error", () => {
+      const result = regExp({
+        errors: {
+          invalidRegExp: message`Pattern could not be compiled.`,
+        },
+      }).parse("[");
+
+      assert.ok(!result.success);
+      assert.deepEqual(result.error, message`Pattern could not be compiled.`);
+    });
+
+    it("should pass the source to a custom error callback", () => {
+      const result = regExp({
+        errors: {
+          invalidRegExp: (input) => message`Bad pattern: ${input}.`,
+        },
+      }).parse("[");
+
+      assert.ok(!result.success);
+      assert.equal(formatMessage(result.error), 'Bad pattern: "[".');
+    });
+  });
+
+  describe("format()", () => {
+    it("should format a regular expression with RegExp.source", () => {
+      const parser = regExp({ flags: "gi" });
+
+      assert.equal(parser.format(/foo\/bar/m), String.raw`foo\/bar`);
     });
   });
 });

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -6713,6 +6713,44 @@ describe("regExp()", () => {
         assert.ok(!result.success);
       }
     });
+
+    it("should stay synchronous when spread into an async parser", () => {
+      const syncParser = regExp({ flags: "i" });
+      const { suggest: _suggest, ...spreadable } = syncParser;
+      const parser: ValueParser<"async", RegExp> = {
+        ...spreadable,
+        mode: "async",
+        // deno-lint-ignore require-await -- async promotes the parser mode
+        async parse(input: string) {
+          return syncParser.parse(input);
+        },
+      };
+      assert.ok(typeof parser.validate === "function");
+
+      const result = parser.validate(/foo/g);
+
+      assert.ok(result.success);
+      assert.equal(result.value.flags, "i");
+    });
+  });
+
+  describe("normalize()", () => {
+    it("should normalize defaults with the configured flags", () => {
+      const value = /foo/g;
+      value.lastIndex = 3;
+      const parser = withDefault(
+        option("--pattern", regExp({ flags: "i" })),
+        value,
+      );
+
+      const result = parse(parser, []);
+
+      assert.ok(result.success);
+      assert.notStrictEqual(result.value, value);
+      assert.equal(result.value.source, "foo");
+      assert.equal(result.value.flags, "i");
+      assert.equal(result.value.lastIndex, 0);
+    });
   });
 
   describe("format()", () => {

--- a/packages/core/src/valueparser.test.ts
+++ b/packages/core/src/valueparser.test.ts
@@ -6677,6 +6677,44 @@ describe("regExp()", () => {
     });
   });
 
+  describe("validate()", () => {
+    it("should reject non-RegExp values", () => {
+      const parser = regExp();
+      assert.ok(typeof parser.validate === "function");
+
+      for (const value of ["foo", null]) {
+        const result = parser.validate(value as never);
+        assert.ok(!result.success);
+        assert.deepEqual(result.error, message`Expected a RegExp value.`);
+      }
+    });
+
+    it("should recompile valid values with the configured flags", () => {
+      const parser = regExp({ flags: "gi" });
+      const value = /foo/m;
+      value.lastIndex = 3;
+      assert.ok(typeof parser.validate === "function");
+
+      const result = parser.validate(value);
+
+      assert.ok(result.success);
+      assert.notStrictEqual(result.value, value);
+      assert.equal(result.value.source, "foo");
+      assert.equal(result.value.flags, "gi");
+      assert.equal(result.value.lastIndex, 0);
+    });
+
+    it("should reject non-RegExp option fallback values", () => {
+      const parser = option("--pattern", regExp());
+      assert.ok(typeof parser.validateValue === "function");
+
+      for (const value of ["foo", null]) {
+        const result = parser.validateValue(value as never);
+        assert.ok(!result.success);
+      }
+    });
+  });
+
   describe("format()", () => {
     it("should format a regular expression with RegExp.source", () => {
       const parser = regExp({ flags: "gi" });

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -1414,6 +1414,104 @@ export function string(
   };
 }
 
+/**
+ * Options for creating a {@link regExp} value parser.
+ *
+ * @since 1.3.0
+ */
+export interface RegExpOptions {
+  /**
+   * The metavariable name for this parser.  This is used in help messages to
+   * indicate what kind of value this parser expects.
+   * @default `"REGEXP"`
+   * @since 1.3.0
+   */
+  readonly metavar?: NonEmptyString;
+
+  /**
+   * Fixed flags used to compile every input source.
+   * @default `""`
+   * @since 1.3.0
+   */
+  readonly flags?: string;
+
+  /**
+   * Custom error messages for regular expression parsing failures.
+   * @since 1.3.0
+   */
+  readonly errors?: {
+    /**
+     * Custom error message when the input is not a valid regular expression
+     * source.  Can be a static message or a function that receives the input.
+     * @since 1.3.0
+     */
+    readonly invalidRegExp?: Message | ((input: string) => Message);
+  };
+}
+
+/**
+ * Creates a {@link ValueParser} that compiles regular expression sources.
+ *
+ * The entire input is treated as the source.  Slash-delimited notation such
+ * as `/pattern/flags` is not interpreted; use {@link RegExpOptions.flags} to
+ * configure fixed flags for the parser.
+ *
+ * **Security note**: Compiling a source does not establish that it is safe to
+ * execute.  Patterns from untrusted input can cause Regular Expression Denial
+ * of Service (ReDoS) when matched.  Limit pattern and subject lengths, execute
+ * matches in an environment that can be terminated, or use a linear-time
+ * regular expression engine when accepting untrusted patterns.
+ *
+ * @param options Configuration options for the regular expression parser.
+ * @returns A sync value parser producing JavaScript {@link RegExp} objects.
+ * @throws {TypeError} If `options.metavar` is an empty string or
+ *   `options.flags` is not a string.
+ * @throws {SyntaxError} If `options.flags` contains invalid, duplicate, or
+ *   incompatible regular expression flags.
+ * @since 1.3.0
+ */
+export function regExp(
+  options: RegExpOptions = {},
+): ValueParser<"sync", RegExp> {
+  const metavar = options.metavar ?? "REGEXP";
+  ensureNonEmptyString(metavar);
+  if (options.flags !== undefined && typeof options.flags !== "string") {
+    throw new TypeError(
+      `Expected flags to be a string, but got ${typeof options.flags}: ${
+        String(options.flags)
+      }.`,
+    );
+  }
+
+  const flags = new RegExp("", options.flags ?? "").flags;
+  const invalidRegExp = options.errors?.invalidRegExp;
+  return {
+    mode: "sync",
+    metavar,
+    get placeholder() {
+      return new RegExp("", flags);
+    },
+    parse(input: string): ValueParserResult<RegExp> {
+      try {
+        return { success: true, value: new RegExp(input, flags) };
+      } catch (error) {
+        if (!(error instanceof SyntaxError)) throw error;
+        return {
+          success: false,
+          error: invalidRegExp
+            ? (typeof invalidRegExp === "function"
+              ? invalidRegExp(input)
+              : invalidRegExp)
+            : message`Invalid regular expression: ${input}.`,
+        };
+      }
+    },
+    format(value: RegExp): string {
+      return value.source;
+    },
+  };
+}
+
 interface KeyValueOptionsBase {
   /**
    * The metavariable name for this parser.  Used in help messages to

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -1443,6 +1443,10 @@ export interface RegExpOptions {
     /**
      * Custom error message when the input is not a valid regular expression
      * source.  Can be a static message or a function that receives the input.
+     *
+     * **Security note**: Successful compilation does not guarantee safe
+     * execution. Vulnerable patterns can cause catastrophic backtracking when
+     * later matched against untrusted data.
      * @since 1.3.0
      */
     readonly invalidRegExp?: Message | ((input: string) => Message);

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -1506,6 +1506,15 @@ export function regExp(
         };
       }
     },
+    validate(value: RegExp): ValueParserResult<RegExp> {
+      if (!(value instanceof RegExp)) {
+        return {
+          success: false,
+          error: message`Expected a RegExp value.`,
+        };
+      }
+      return this.parse(value.source);
+    },
     format(value: RegExp): string {
       return value.source;
     },

--- a/packages/core/src/valueparser.ts
+++ b/packages/core/src/valueparser.ts
@@ -1485,27 +1485,28 @@ export function regExp(
 
   const flags = new RegExp("", options.flags ?? "").flags;
   const invalidRegExp = options.errors?.invalidRegExp;
+  const parseRegExp = (input: string): ValueParserResult<RegExp> => {
+    try {
+      return { success: true, value: new RegExp(input, flags) };
+    } catch (error) {
+      if (!(error instanceof SyntaxError)) throw error;
+      return {
+        success: false,
+        error: invalidRegExp
+          ? (typeof invalidRegExp === "function"
+            ? invalidRegExp(input)
+            : invalidRegExp)
+          : message`Invalid regular expression: ${input}.`,
+      };
+    }
+  };
   return {
     mode: "sync",
     metavar,
     get placeholder() {
       return new RegExp("", flags);
     },
-    parse(input: string): ValueParserResult<RegExp> {
-      try {
-        return { success: true, value: new RegExp(input, flags) };
-      } catch (error) {
-        if (!(error instanceof SyntaxError)) throw error;
-        return {
-          success: false,
-          error: invalidRegExp
-            ? (typeof invalidRegExp === "function"
-              ? invalidRegExp(input)
-              : invalidRegExp)
-            : message`Invalid regular expression: ${input}.`,
-        };
-      }
-    },
+    parse: parseRegExp,
     validate(value: RegExp): ValueParserResult<RegExp> {
       if (!(value instanceof RegExp)) {
         return {
@@ -1513,7 +1514,12 @@ export function regExp(
           error: message`Expected a RegExp value.`,
         };
       }
-      return this.parse(value.source);
+      return parseRegExp(value.source);
+    },
+    normalize(value: RegExp): RegExp {
+      if (!(value instanceof RegExp)) return value;
+      const result = parseRegExp(value.source);
+      return result.success ? result.value : value;
     },
     format(value: RegExp): string {
       return value.source;


### PR DESCRIPTION
`string({ pattern })` validates against a pattern chosen by the application, but accepting the pattern itself still required every caller to rebuild the same `ValueParser` and error handling. `regExp()` provides that parser in *@optique/core*.

It treats each token as raw source and keeps flags in parser configuration. This avoids the ambiguity of `/pattern/flags` syntax and rejects invalid flag sets when the parser is built. Invalid sources remain ordinary parse failures.

Deferred parsing reads a fresh placeholder each time because `RegExp` carries mutable match state. The documentation also separates successful compilation from safe execution when patterns come from untrusted input.

Closes #906.
