### PR TITLE
Measure help term widths automatically

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,8 +13,9 @@ To be released.
  -  Added `regExp()` for compiling command-line values into `RegExp` objects
     with fixed flags and customizable parse errors.  [[#906], [#909]]
  -  Added `termWidth: "auto"` to `formatDocPage()` for aligning descriptions
-    after the widest visible term using terminal display width.  The existing
-    default and explicit numeric widths remain unchanged.  [[#904], [#911]]
+    after the widest visible term using terminal display width while reserving
+    description space under `maxWidth`.  The existing default and explicit
+    numeric widths remain unchanged.  [[#904], [#911]]
  -  Added `usageLine` to the core runner `RunOptions`.  Top-level full help can
     now replace the generated root synopsis or derive one from a callback,
     while subcommand help and usage-only error output remain unchanged.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,9 @@ To be released.
 
  -  Added `regExp()` for compiling command-line values into `RegExp` objects
     with fixed flags and customizable parse errors.  [[#906], [#909]]
+ -  Added `termWidth: "auto"` to `formatDocPage()` for aligning descriptions
+    after the widest visible term using terminal display width.  The existing
+    default and explicit numeric widths remain unchanged.  [[#904], [#911]]
  -  Added `usageLine` to the core runner `RunOptions`.  Top-level full help can
     now replace the generated root synopsis or derive one from a callback,
     while subcommand help and usage-only error output remain unchanged.
@@ -25,11 +28,16 @@ To be released.
 [#874]: https://github.com/dahlia/optique/issues/874
 [#879]: https://github.com/dahlia/optique/issues/879
 [#889]: https://github.com/dahlia/optique/pull/889
+[#904]: https://github.com/dahlia/optique/issues/904
 [#906]: https://github.com/dahlia/optique/issues/906
 [#909]: https://github.com/dahlia/optique/pull/909
+[#911]: https://github.com/dahlia/optique/pull/911
 
 ### @optique/run
 
+ -  Added `termWidth` to the core and high-level runner options.  Automatic
+    sizing measures the final help page after built-in help, version, and shell
+    completion entries have been added.  [[#904], [#911]]
  -  Added `usageLine` to `RunOptions`.  `run()`, `runSync()`, and `runAsync()`
     can now replace the root synopsis in full help without changing parsing or
     subcommand help.  [[#879]]

--- a/changes.d/core/automatic-term-width.md
+++ b/changes.d/core/automatic-term-width.md
@@ -4,5 +4,6 @@ links:
   '#911': https://github.com/dahlia/optique/pull/911
 ---
  -  Added `termWidth: "auto"` to `formatDocPage()` for aligning descriptions
-    after the widest visible term using terminal display width.  The existing
-    default and explicit numeric widths remain unchanged.  [[#904], [#911]]
+    after the widest visible term using terminal display width while reserving
+    description space under `maxWidth`.  The existing default and explicit
+    numeric widths remain unchanged.  [[#904], [#911]]

--- a/changes.d/core/automatic-term-width.md
+++ b/changes.d/core/automatic-term-width.md
@@ -1,0 +1,8 @@
+---
+links:
+  '#904': https://github.com/dahlia/optique/issues/904
+  '#911': https://github.com/dahlia/optique/pull/911
+---
+ -  Added `termWidth: "auto"` to `formatDocPage()` for aligning descriptions
+    after the widest visible term using terminal display width.  The existing
+    default and explicit numeric widths remain unchanged.  [[#904], [#911]]

--- a/changes.d/run/automatic-term-width.md
+++ b/changes.d/run/automatic-term-width.md
@@ -1,0 +1,8 @@
+---
+links:
+  '#904': https://github.com/dahlia/optique/issues/904
+  '#911': https://github.com/dahlia/optique/pull/911
+---
+ -  Added `termWidth` to the core and high-level runner options.  Automatic
+    sizing measures the final help page after built-in help, version, and shell
+    completion entries have been added.  [[#904], [#911]]

--- a/docs/concepts/runners.md
+++ b/docs/concepts/runners.md
@@ -355,9 +355,9 @@ combining sequences, after runner-provided help/version/completion entries have
 been added.  Hidden or degenerate entries and entries without descriptions,
 displayed defaults, or displayed choices do not widen the column.  Omitting
 `termWidth` keeps the default width of 26, while a number sets an explicit
-width.  If the measured term width would leave no room for descriptions under
-`maxWidth`, Optique uses the same even-split fallback as an explicit numeric
-width.
+width.  When `maxWidth` constrains the layout, automatic sizing reserves at
+least half of the available space for descriptions.  Numeric widths retain
+their existing fallback behavior.
 
 ### Explicit sync/async variants
 

--- a/docs/concepts/runners.md
+++ b/docs/concepts/runners.md
@@ -298,6 +298,7 @@ const prog = defineProgram({
 const result = runParser(prog, ["--name", "test"], {
   colors: true,           // Force colored output
   maxWidth: 80,          // Wrap text at 80 columns
+  termWidth: "auto",     // Fit the term column to visible entries
   usageLine: [{ type: "ellipsis" }], // Show a compact root synopsis
   commandList: "top-level", // Show only first-level commands
   showDefault: true,     // Show default values in help text
@@ -347,6 +348,16 @@ only first-level commands instead of recursively listing every nested leaf
 command.  The default, `commandList: "recursive"`, preserves the full command
 list.  The setting does not change subcommand help pages, so users can still
 drill down with `<command> --help`.
+
+Pass `termWidth: "auto"` to fit the help term column to its visible content.
+Optique measures terminal display width, including CJK characters, emoji, and
+combining sequences, after runner-provided help/version/completion entries have
+been added.  Hidden or degenerate entries and entries without descriptions,
+displayed defaults, or displayed choices do not widen the column.  Omitting
+`termWidth` keeps the default width of 26, while a number sets an explicit
+width.  If the measured term width would leave no room for descriptions under
+`maxWidth`, Optique uses the same even-split fallback as an explicit numeric
+width.
 
 ### Explicit sync/async variants
 
@@ -499,6 +510,7 @@ const config = run(prog, {
   args: ["custom", "args"],   // Override process.argv
   colors: true,               // Force colored output
   maxWidth: 100,              // Set output width
+  termWidth: "auto",          // Fit terms before descriptions
   stdout: console.log,        // Inject output writer for help/version/completion
   stderr: console.error,      // Inject error writer
   onExit: process.exit,       // Inject exit handler

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -1128,6 +1128,7 @@ const config = run(prog, {
 
   colors: true,           // Force colored output (auto-detected by default)
   maxWidth: 100,          // Set help text width (terminal width by default)
+  termWidth: "auto",      // Fit the term column to visible help entries
   errorExitCode: 2        // Custom exit code for errors (default: 1)
 });
 
@@ -1135,6 +1136,10 @@ const config = run(prog, {
 // $ my-tool --help
 // $ my-tool help
 ~~~~
+
+With `termWidth: "auto"`, Optique measures the terminal display width of
+visible terms after built-in help/version/completion entries have been added.
+The default remains a fixed 26-column term width when this option is omitted.
 
 ### Complete CLI application
 

--- a/packages/core/skills/optique/SKILL.md
+++ b/packages/core/skills/optique/SKILL.md
@@ -64,6 +64,9 @@ Core rules
     brief and command or option sections without the `Usage:` synopsis.
     For deeply nested command trees, add `commandList: "top-level"` when root
     help should list only first-level command groups.
+ -  Use `termWidth: "auto"` in runner options when descriptions should align
+    after the widest visible help term. Optique measures terminal display
+    width after adding built-in help/version/completion entries.
 
 
 Canonical app shape
@@ -97,6 +100,7 @@ const config = run(parser, {
   brief: message`Process a file.`,
   completion: "both",
   showDefault: true,
+  termWidth: "auto",
 });
 
 console.log(`Processing ${config.input} on port ${config.port}.`);

--- a/packages/core/src/doc.test.ts
+++ b/packages/core/src/doc.test.ts
@@ -554,6 +554,40 @@ describe("formatDocPage", () => {
       }
       assert.ok(result.includes("description words"));
     });
+
+    it("should validate prefixes against the automatic maxWidth layout", () => {
+      const page: DocPage = {
+        sections: [{
+          entries: [{
+            term: {
+              type: "option",
+              names: ["--package-manager"],
+              metavar: "PACKAGE_ID",
+            },
+            choices: valueSet(["npm", "pnpm"], {
+              fallback: "",
+              type: "unit",
+            }),
+          }],
+        }],
+      };
+
+      const result = formatDocPage("myapp", page, {
+        termWidth: "auto",
+        maxWidth: 40,
+        showChoices: true,
+      });
+
+      for (const line of result.split("\n")) {
+        assert.ok(
+          getDisplayWidth(line) <= 40,
+          `Line display width exceeds 40: "${line}"`,
+        );
+      }
+      assert.ok(result.includes("choices:"));
+      assert.ok(result.includes("npm,"));
+      assert.ok(result.includes("pnpm"));
+    });
   });
 
   it("should respect maxWidth option with brief", () => {

--- a/packages/core/src/doc.test.ts
+++ b/packages/core/src/doc.test.ts
@@ -456,8 +456,16 @@ describe("formatDocPage", () => {
       const automaticResult = formatDocPage("myapp", page, {
         termWidth: "auto",
       });
+      const constrainedDefaultResult = formatDocPage("myapp", page, {
+        maxWidth: 40,
+      });
+      const constrainedAutomaticResult = formatDocPage("myapp", page, {
+        termWidth: "auto",
+        maxWidth: 40,
+      });
 
       assert.equal(automaticResult, defaultResult);
+      assert.equal(constrainedAutomaticResult, constrainedDefaultResult);
     });
 
     it("should measure entries with displayed defaults and choices", () => {
@@ -517,6 +525,34 @@ describe("formatDocPage", () => {
         );
       }
       assert.ok(result.includes("\n--longname"));
+    });
+
+    it("should reserve description space under maxWidth", () => {
+      const page: DocPage = {
+        sections: [{
+          entries: [{
+            term: {
+              type: "option",
+              names: ["--package-manager"],
+              metavar: "PACKAGE_MANAGER",
+            },
+            description: message`description words`,
+          }],
+        }],
+      };
+
+      const result = formatDocPage("myapp", page, {
+        termWidth: "auto",
+        maxWidth: 40,
+      });
+
+      for (const line of result.split("\n")) {
+        assert.ok(
+          getDisplayWidth(line) <= 40,
+          `Line display width exceeds 40: "${line}"`,
+        );
+      }
+      assert.ok(result.includes("description words"));
     });
   });
 

--- a/packages/core/src/doc.test.ts
+++ b/packages/core/src/doc.test.ts
@@ -311,6 +311,215 @@ describe("formatDocPage", () => {
     assert.equal(result, expected);
   });
 
+  describe("automatic term width", () => {
+    it("should align descriptions to the widest relevant term", () => {
+      const page: DocPage = {
+        sections: [{
+          entries: [
+            {
+              term: { type: "option", names: ["-v"] },
+              description: message`Enable verbose output.`,
+            },
+            {
+              term: { type: "option", names: ["--configuration"] },
+              description: message`Load configuration.`,
+            },
+          ],
+        }],
+      };
+
+      const result = formatDocPage("myapp", page, { termWidth: "auto" });
+
+      assert.equal(
+        result,
+        "\n  -v               Enable verbose output.\n" +
+          "  --configuration  Load configuration.\n",
+      );
+    });
+
+    it("should measure CJK, emoji, and combining sequences by display width", () => {
+      const page: DocPage = {
+        sections: [{
+          entries: [
+            {
+              term: { type: "argument", metavar: "ABC" },
+              description: message`ASCII`,
+            },
+            {
+              term: { type: "argument", metavar: "한글" },
+              description: message`Korean`,
+            },
+            {
+              term: { type: "argument", metavar: "👨‍👩‍👧‍👦" },
+              description: message`Family`,
+            },
+            {
+              term: { type: "argument", metavar: "e\u0301" },
+              description: message`Combined`,
+            },
+          ],
+        }],
+      };
+
+      const result = formatDocPage("myapp", page, { termWidth: "auto" });
+
+      assert.equal(
+        result,
+        "\n  ABC   ASCII\n" +
+          "  한글  Korean\n" +
+          "  👨‍👩‍👧‍👦    Family\n" +
+          "  e\u0301     Combined\n",
+      );
+    });
+
+    it("should ignore ANSI styling when measuring colored terms", () => {
+      const page: DocPage = {
+        sections: [{
+          entries: [
+            {
+              term: { type: "option", names: ["-v"] },
+              description: message`Enable verbose output.`,
+            },
+            {
+              term: { type: "option", names: ["--configuration"] },
+              description: message`Load configuration.`,
+            },
+          ],
+        }],
+      };
+
+      const plain = formatDocPage("myapp", page, {
+        termWidth: "auto",
+        colors: false,
+      });
+      const colored = formatDocPage("myapp", page, {
+        termWidth: "auto",
+        colors: true,
+      });
+      // deno-lint-ignore no-control-regex
+      const withoutAnsi = colored.replace(/\x1B\[[0-9;:]*[@-~]/g, "");
+
+      assert.ok(colored.includes("\x1b["));
+      assert.equal(withoutAnsi, plain);
+    });
+
+    it("should ignore hidden, degenerate, and bare entries when measuring", () => {
+      const page: DocPage = {
+        sections: [{
+          entries: [
+            {
+              term: {
+                type: "option",
+                names: ["--hidden-and-extremely-long"],
+                hidden: true,
+              },
+              description: message`Hidden`,
+            },
+            {
+              term: {
+                type: "option",
+                names: [],
+                metavar: "DEGENERATE_AND_EXTREMELY_LONG",
+              },
+              description: message`Degenerate`,
+            },
+            {
+              term: {
+                type: "command",
+                name: "bare-and-extremely-long-command",
+              },
+            },
+            {
+              term: { type: "option", names: ["-v"] },
+              description: message`Visible`,
+            },
+          ],
+        }],
+      };
+
+      const result = formatDocPage("myapp", page, { termWidth: "auto" });
+
+      assert.equal(
+        result,
+        "\n  bare-and-extremely-long-command\n  -v  Visible\n",
+      );
+    });
+
+    it("should preserve default formatting when no entry has content", () => {
+      const page: DocPage = {
+        sections: [{
+          entries: [{ term: { type: "command", name: "status" } }],
+        }],
+      };
+
+      const defaultResult = formatDocPage("myapp", page);
+      const automaticResult = formatDocPage("myapp", page, {
+        termWidth: "auto",
+      });
+
+      assert.equal(automaticResult, defaultResult);
+    });
+
+    it("should measure entries with displayed defaults and choices", () => {
+      const page: DocPage = {
+        sections: [{
+          entries: [
+            {
+              term: { type: "option", names: ["--output"] },
+              default: message`result.txt`,
+            },
+            {
+              term: { type: "option", names: ["--format-long"] },
+              choices: valueSet(["json", "yaml"], {
+                fallback: "",
+                type: "unit",
+              }),
+            },
+          ],
+        }],
+      };
+
+      const result = formatDocPage("myapp", page, {
+        termWidth: "auto",
+        showDefault: true,
+        showChoices: true,
+      });
+
+      assert.equal(
+        result,
+        "\n  --output        [result.txt]\n" +
+          "  --format-long   (choices: json, yaml)\n",
+      );
+    });
+
+    it("should retain maxWidth layout reduction", () => {
+      const page: DocPage = {
+        sections: [{
+          entries: [{
+            term: {
+              type: "option",
+              names: ["-s", "--longname"],
+            },
+            description: message`A B C D E F`,
+          }],
+        }],
+      };
+
+      const result = formatDocPage("myapp", page, {
+        termWidth: "auto",
+        maxWidth: 15,
+      });
+
+      for (const line of result.split("\n")) {
+        assert.ok(
+          getDisplayWidth(line) <= 15,
+          `Line display width exceeds 15: "${line}"`,
+        );
+      }
+      assert.ok(result.includes("\n--longname"));
+    });
+  });
+
   it("should respect maxWidth option with brief", () => {
     const page: DocPage = {
       brief: [{

--- a/packages/core/src/doc.ts
+++ b/packages/core/src/doc.ts
@@ -641,13 +641,13 @@ export function formatDocPage(
   const termWidth = options.termWidth === "auto"
     ? automaticTermWidth() ?? 26
     : options.termWidth ?? 26;
+  const hasEntries = page.sections.some((s) => s.entries.length > 0);
+  const needsDescColumn = hasEntries &&
+    page.sections.some((s) => s.entries.some(needsDescriptionColumn));
   if (options.maxWidth != null) {
-    const hasEntries = page.sections.some((s) => s.entries.length > 0);
     // The formatter skips empty default/choices arrays, so the
     // validation must match: use hasContent() (which checks length > 0)
     // rather than just `!= null`.
-    const needsDescColumn = hasEntries &&
-      page.sections.some((s) => s.entries.some(needsDescriptionColumn));
     // Compute minimum description column width for showDefault/showChoices.
     // When the rendered content is non-empty, only the prefix (or
     // prefix + label for choices) must fit on one line; the suffix
@@ -748,17 +748,24 @@ export function formatDocPage(
   // When maxWidth constrains the layout, shrink the term column so that
   // the description column gets a reasonable share of the available width.
   // Layout: <termIndent><term><2-space gap><description>
-  // When the normal termWidth fits (leaving >= 1 char for description),
-  // keep it unchanged.  Otherwise, split the available space evenly
-  // between term and description columns.
+  // Automatic sizing reserves at least half of the available space for the
+  // description.  Explicit numeric widths retain their existing behavior:
+  // keep the requested width when it leaves >= 1 char for the description,
+  // otherwise split the available space evenly between the two columns.
   let effectiveTermWidth: number;
   if (options.maxWidth == null) {
     effectiveTermWidth = termWidth;
   } else {
     const availableForColumns = options.maxWidth - termIndent - 2;
-    effectiveTermWidth = availableForColumns >= termWidth + 1
+    const evenlySplitTermWidth = Math.max(
+      1,
+      Math.floor(availableForColumns / 2),
+    );
+    effectiveTermWidth = options.termWidth === "auto" && needsDescColumn
+      ? Math.min(termWidth, evenlySplitTermWidth)
+      : availableForColumns >= termWidth + 1
       ? termWidth
-      : Math.max(1, Math.floor(availableForColumns / 2));
+      : evenlySplitTermWidth;
   }
   let output = "";
   if (hasContent(page.brief)) {

--- a/packages/core/src/doc.ts
+++ b/packages/core/src/doc.ts
@@ -644,6 +644,28 @@ export function formatDocPage(
   const hasEntries = page.sections.some((s) => s.entries.length > 0);
   const needsDescColumn = hasEntries &&
     page.sections.some((s) => s.entries.some(needsDescriptionColumn));
+  // When maxWidth constrains the layout, shrink the term column so that
+  // the description column gets a reasonable share of the available width.
+  // Layout: <termIndent><term><2-space gap><description>
+  // Automatic sizing reserves at least half of the available space for the
+  // description.  Explicit numeric widths retain their existing behavior:
+  // keep the requested width when it leaves >= 1 char for the description,
+  // otherwise split the available space evenly between the two columns.
+  let effectiveTermWidth: number;
+  if (options.maxWidth == null) {
+    effectiveTermWidth = termWidth;
+  } else {
+    const availableForColumns = options.maxWidth - termIndent - 2;
+    const evenlySplitTermWidth = Math.max(
+      1,
+      Math.floor(availableForColumns / 2),
+    );
+    effectiveTermWidth = options.termWidth === "auto" && needsDescColumn
+      ? Math.min(termWidth, evenlySplitTermWidth)
+      : availableForColumns >= termWidth + 1
+      ? termWidth
+      : evenlySplitTermWidth;
+  }
   if (options.maxWidth != null) {
     // The formatter skips empty default/choices arrays, so the
     // validation must match: use hasContent() (which checks length > 0)
@@ -728,44 +750,17 @@ export function formatDocPage(
       );
     }
     // Second check: even if maxWidth passes the formula-based minimum,
-    // the actual layout may use the full termWidth, giving a description
-    // column of only maxWidth - termIndent - termWidth - 2 chars.  When
-    // this is smaller than minDescWidth, the fixed prefixes overflow.
+    // the effective layout may leave too little room for fixed prefixes.
     if (needsDescColumn && minDescWidth > 1) {
       const avail = options.maxWidth - termIndent - 2;
-      const effTW = avail >= termWidth + 1
-        ? termWidth
-        : Math.max(1, Math.floor(avail / 2));
-      const descW = avail - effTW;
+      const descW = avail - effectiveTermWidth;
       if (descW < minDescWidth) {
-        const needed = termIndent + termWidth + 2 + minDescWidth;
+        const needed = termIndent + effectiveTermWidth + 2 + minDescWidth;
         throw new RangeError(
           `maxWidth must be at least ${needed}, got ${options.maxWidth}.`,
         );
       }
     }
-  }
-  // When maxWidth constrains the layout, shrink the term column so that
-  // the description column gets a reasonable share of the available width.
-  // Layout: <termIndent><term><2-space gap><description>
-  // Automatic sizing reserves at least half of the available space for the
-  // description.  Explicit numeric widths retain their existing behavior:
-  // keep the requested width when it leaves >= 1 char for the description,
-  // otherwise split the available space evenly between the two columns.
-  let effectiveTermWidth: number;
-  if (options.maxWidth == null) {
-    effectiveTermWidth = termWidth;
-  } else {
-    const availableForColumns = options.maxWidth - termIndent - 2;
-    const evenlySplitTermWidth = Math.max(
-      1,
-      Math.floor(availableForColumns / 2),
-    );
-    effectiveTermWidth = options.termWidth === "auto" && needsDescColumn
-      ? Math.min(termWidth, evenlySplitTermWidth)
-      : availableForColumns >= termWidth + 1
-      ? termWidth
-      : evenlySplitTermWidth;
   }
   let output = "";
   if (hasContent(page.brief)) {

--- a/packages/core/src/doc.ts
+++ b/packages/core/src/doc.ts
@@ -389,10 +389,14 @@ export interface DocPageFormatOptions {
   termIndent?: number;
 
   /**
-   * Width allocated for terms before descriptions start.
+   * Width allocated for terms before descriptions start.  Set to `"auto"`
+   * to align descriptions after the widest visible term that has content.
+   * Terminal display width is used for automatic measurement.
+   *
    * @default `26`
+   * @since 1.3.0 Added automatic term width.
    */
-  termWidth?: number;
+  termWidth?: number | "auto";
 
   /**
    * Maximum width of the entire formatted output.
@@ -565,7 +569,6 @@ export function formatDocPage(
 ): string {
   validateProgramName(programName);
   const termIndent = options.termIndent ?? 2;
-  const termWidth = options.termWidth ?? 26;
   const showUsage = options.showUsage ?? true;
   if (
     options.maxWidth != null &&
@@ -611,19 +614,40 @@ export function formatDocPage(
   //  - Examples:/Author:/Bugs: labels are 9/7/5 chars on their own lines.
   const hasContent = (msg: unknown): msg is readonly unknown[] =>
     Array.isArray(msg) && msg.length > 0;
+  const needsDescriptionColumn = (entry: DocEntry): boolean =>
+    hasContent(entry.description) ||
+    (options.showDefault === true || typeof options.showDefault === "object") &&
+      hasContent(entry.default) ||
+    (options.showChoices === true || typeof options.showChoices === "object") &&
+      hasContent(entry.choices);
+  const automaticTermWidth = (): number | undefined => {
+    let widest: number | undefined;
+    for (const section of page.sections) {
+      for (const entry of section.entries) {
+        if (!needsDescriptionColumn(entry)) continue;
+        const rendered = formatUsageTerm(entry.term, {
+          colors: options.colors,
+          optionsSeparator: ", ",
+          context: "doc",
+        });
+        const width = Math.max(
+          ...rendered.split("\n").map((line) => getDisplayWidth(line)),
+        );
+        widest = widest == null ? width : Math.max(widest, width);
+      }
+    }
+    return widest;
+  };
+  const termWidth = options.termWidth === "auto"
+    ? automaticTermWidth() ?? 26
+    : options.termWidth ?? 26;
   if (options.maxWidth != null) {
     const hasEntries = page.sections.some((s) => s.entries.length > 0);
     // The formatter skips empty default/choices arrays, so the
     // validation must match: use hasContent() (which checks length > 0)
     // rather than just `!= null`.
     const needsDescColumn = hasEntries &&
-      page.sections.some((s) =>
-        s.entries.some((e) =>
-          hasContent(e.description) ||
-          (options.showDefault && hasContent(e.default)) ||
-          (options.showChoices && hasContent(e.choices))
-        )
-      );
+      page.sections.some((s) => s.entries.some(needsDescriptionColumn));
     // Compute minimum description column width for showDefault/showChoices.
     // When the rendered content is non-empty, only the prefix (or
     // prefix + label for choices) must fit on one line; the suffix

--- a/packages/core/src/facade.test.ts
+++ b/packages/core/src/facade.test.ts
@@ -2202,6 +2202,27 @@ describe("runParser", () => {
       // With a very narrow width, output should contain line breaks
       assert.ok(helpOutput.includes("\n"));
     });
+
+    it("should include runner-provided meta-options in automatic term width", () => {
+      const parser = object({
+        execute: flag("-x", { description: message`Execute.` }),
+      });
+      let helpOutput = "";
+
+      runParser(parser, "tool", ["--help"], {
+        help: {
+          option: true,
+          onShow: () => "help-shown",
+        },
+        termWidth: "auto",
+        stdout: (text) => {
+          helpOutput = text;
+        },
+      });
+
+      assert.ok(helpOutput.includes("  -x      Execute."));
+      assert.ok(helpOutput.includes("  --help  Show help information."));
+    });
   });
 
   describe("callback functions", () => {

--- a/packages/core/src/facade.ts
+++ b/packages/core/src/facade.ts
@@ -1341,6 +1341,15 @@ export interface RunOptions<THelp, TError> {
   readonly maxWidth?: number;
 
   /**
+   * Width allocated for help terms before descriptions start.  Set to
+   * `"auto"` to align descriptions after the widest visible term.
+   *
+   * @default `26`
+   * @since 1.3.0
+   */
+  readonly termWidth?: number | "auto";
+
+  /**
    * Whether and how to display default values for options and arguments.
    *
    * - `boolean`: When `true`, displays defaults using format `[value]`
@@ -1592,6 +1601,7 @@ function handleCompletion<M extends Mode, THelp, TError>(
   availableShells: Record<string, ShellCompletion>,
   colors?: boolean,
   maxWidth?: number,
+  termWidth?: number | "auto",
   completionCommandDisplayName?: string,
   completionOptionDisplayName?: string,
   isOptionMode?: boolean,
@@ -1621,6 +1631,7 @@ function handleCompletion<M extends Mode, THelp, TError>(
           formatDocPage(programName, doc, {
             colors,
             maxWidth,
+            termWidth,
             sectionOrder,
             showUsage,
           }),
@@ -2418,6 +2429,7 @@ export function runParser<
   const {
     colors,
     maxWidth,
+    termWidth,
     showDefault,
     showChoices,
     sectionOrder,
@@ -2737,6 +2749,7 @@ export function runParser<
           availableShells,
           colors,
           maxWidth,
+          termWidth,
           completionCommandNames[0],
           completionOptionNames[0],
           classified.source === "option",
@@ -2872,6 +2885,7 @@ export function runParser<
             stdout(formatDocPage(programName, renderedDoc, {
               colors,
               maxWidth,
+              termWidth,
               showDefault,
               showChoices,
               sectionOrder,
@@ -3005,6 +3019,7 @@ export function runParser<
               stderr(formatDocPage(programName, renderedDoc, {
                 colors,
                 maxWidth,
+                termWidth,
                 showDefault,
                 showChoices,
                 sectionOrder,

--- a/packages/run/src/run.test.ts
+++ b/packages/run/src/run.test.ts
@@ -638,6 +638,32 @@ describe("run", () => {
       assert.ok(helpOutput.includes("--verbose"));
       assert.equal(exitCode, 0);
     });
+
+    it("should forward automatic term width to the core runner", () => {
+      const parser = option("-x", { description: message`Execute.` });
+      let helpOutput = "";
+
+      assert.throws(
+        () => {
+          run(parser, {
+            args: ["--help"],
+            programName: "tool",
+            help: "option",
+            termWidth: "auto",
+            stdout: (text) => {
+              helpOutput = text;
+            },
+            onExit: () => {
+              throw new Error("EXIT");
+            },
+          });
+        },
+        /EXIT/,
+      );
+
+      assert.ok(helpOutput.includes("  -x      Execute."));
+      assert.ok(helpOutput.includes("  --help  Show help information."));
+    });
   });
 
   describe("version functionality", () => {

--- a/packages/run/src/run.ts
+++ b/packages/run/src/run.ts
@@ -83,6 +83,15 @@ export interface RunOptions {
   readonly maxWidth?: number;
 
   /**
+   * Width allocated for help terms before descriptions start.  Set to
+   * `"auto"` to align descriptions after the widest visible term.
+   *
+   * @default `26`
+   * @since 1.3.0
+   */
+  readonly termWidth?: number | "auto";
+
+  /**
    * Whether and how to display default values for options and arguments.
    *
    * - `boolean`: When `true`, displays defaults using format `[value]`
@@ -862,6 +871,7 @@ function buildCoreOptions(
     ((exitCode: number) => process.exit(exitCode) as never);
   const colors = options.colors ?? process.stdout.isTTY;
   const maxWidth = options.maxWidth ?? process.stdout.columns;
+  const termWidth = options.termWidth;
   const showDefault = options.showDefault;
   const showChoices = options.showChoices;
   const showUsage = options.showUsage;
@@ -929,6 +939,7 @@ function buildCoreOptions(
     stdout,
     colors,
     maxWidth,
+    termWidth,
     showDefault,
     showChoices,
     showUsage,
@@ -965,6 +976,7 @@ const knownRunOptionsKeyList = [
   "onExit",
   "colors",
   "maxWidth",
+  "termWidth",
   "showDefault",
   "showChoices",
   "showUsage",


### PR DESCRIPTION
Applications should not have to duplicate Optique's visibility and term-rendering rules just to align help text. JavaScript string length also misstates terminal width for CJK text, emoji, and combining sequences.

`termWidth: "auto"` measures rendered terms after hidden/degenerate entries are filtered and runner-provided help/version/completion entries are added. It reuses Optique's existing display-width algorithm and ignores bare terms that do not use the description column. The fixed default, numeric overrides, and `maxWidth` fallback remain unchanged.

Closes #904.
