### PR TITLE
Register prompted values as dependency sources

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,12 +20,31 @@ To be released.
     now replace the generated root synopsis or derive one from a callback,
     while subcommand help and usage-only error output remain unchanged.
     [[#879]]
+ -  Fixed dependency sources completed by a prompt fallback to register
+    their value in the dependency runtime, so a parser derived from such a
+    source now sees the value the user actually selected instead of the
+    source's default.  A derived parser now behaves identically whether its
+    dependency value came from the command line or from an interactive
+    prompt, across `object()`, `tuple()`, `seq()`, `concat()`, and
+    `merge()` compositions—including sources nested in child constructs
+    such as `concat()` child tuples, and sources transformed with `map()`,
+    which register their pre-transform value.  Interactive source
+    completions run serially in
+    declaration order before dependency replay, at most once per parse
+    operation, and never during help, suggestion, or probe phases; a
+    cancelled prompt fails the parse without running later prompts.  Under
+    `runWith()` with two-pass source contexts, a source prompt now runs at
+    most once per run: it runs during the seed pass only when a phase-one
+    consumer demands its value and otherwise defers to the final pass, so
+    an undemanded source prompt no longer exposes its value to phase-two
+    contexts.  [[#869], [#870], [#912]]
  -  Removed the unused `DependencyValueOrigin` type and `registerSource()`
     origin argument from `@optique/core/dependency-runtime`.  Both APIs were
     marked `@internal`; dependency resolution behavior is unchanged.
     [[#869], [#874], [#889]]
 
 [#869]: https://github.com/dahlia/optique/issues/869
+[#870]: https://github.com/dahlia/optique/issues/870
 [#874]: https://github.com/dahlia/optique/issues/874
 [#879]: https://github.com/dahlia/optique/issues/879
 [#889]: https://github.com/dahlia/optique/pull/889
@@ -33,6 +52,7 @@ To be released.
 [#906]: https://github.com/dahlia/optique/issues/906
 [#909]: https://github.com/dahlia/optique/pull/909
 [#911]: https://github.com/dahlia/optique/pull/911
+[#912]: https://github.com/dahlia/optique/pull/912
 
 ### @optique/run
 
@@ -69,6 +89,13 @@ To be released.
     now skip a fallback with a synchronous or asynchronous `when` check and
     return a typed `otherwise` value.  The check runs only when parsing reaches
     the prompt fallback.  [[#882]]
+ -  Fixed `prompt()` so that a prompted value for a wrapped dependency
+    source registers in the dependency runtime, letting derived parsers
+    observe the selected value during the same parse operation.  The fix
+    applies to every adapter built on `createPromptAdapter()`, including
+    *@optique/inquirer* and *@optique/clack*.  A dependency-source prompt
+    now runs before dependency replay, so it may be displayed before an
+    earlier-declared non-source prompt.  [[#869], [#870], [#912]]
 
 
 Version 1.2.4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -252,7 +252,11 @@ This project follows test-driven development (TDD) practices:
 
 Optique uses [Sacho] to keep unreleased changelog entries as small Markdown
 fragments in *changes.d/*.  Add a fragment for every user-visible change and
-commit it with the code it describes.  Do not edit the unreleased section of
+commit it with the code it describes.  Because *sacho.toml* sets
+`materialize = true`, the unreleased section of *CHANGES.md* is a generated
+mirror of those fragments: `sacho sync` regenerates it, and the regenerated
+section is committed together with the fragments it reflects.  The fragments
+remain the single source of truth, so do not edit the unreleased section of
 *CHANGES.md* directly.
 
 Create a fragment with a short, topic-based name:
@@ -277,10 +281,13 @@ user-visible effect, such as an internal refactor or a test-only change, do not
 need an entry.  If a branch-level changelog check requires an explicit
 exemption, add `Changelog: none` to the commit message.
 
-Format the fragments, preview the compiled result, and check it before
-committing:
+Format the fragments, synchronize the materialized unreleased section of
+*CHANGES.md*, preview the compiled result, and check it before committing
+(`sacho fmt` refuses to run while the materialized section is out of sync,
+so run `sacho sync` first after changing fragments):
 
 ~~~~ bash
+sacho sync
 sacho fmt
 sacho preview
 sacho check

--- a/changes.d/core/prompted-dependency-sources.md
+++ b/changes.d/core/prompted-dependency-sources.md
@@ -1,0 +1,24 @@
+---
+links:
+  '#869': https://github.com/dahlia/optique/issues/869
+  '#870': https://github.com/dahlia/optique/issues/870
+  '#912': https://github.com/dahlia/optique/pull/912
+---
+ -  Fixed dependency sources completed by a prompt fallback to register
+    their value in the dependency runtime, so a parser derived from such a
+    source now sees the value the user actually selected instead of the
+    source's default.  A derived parser now behaves identically whether its
+    dependency value came from the command line or from an interactive
+    prompt, across `object()`, `tuple()`, `seq()`, `concat()`, and
+    `merge()` compositions—including sources nested in child constructs
+    such as `concat()` child tuples, and sources transformed with `map()`,
+    which register their pre-transform value.  Interactive source
+    completions run serially in
+    declaration order before dependency replay, at most once per parse
+    operation, and never during help, suggestion, or probe phases; a
+    cancelled prompt fails the parse without running later prompts.  Under
+    `runWith()` with two-pass source contexts, a source prompt now runs at
+    most once per run: it runs during the seed pass only when a phase-one
+    consumer demands its value and otherwise defers to the final pass, so
+    an undemanded source prompt no longer exposes its value to phase-two
+    contexts.  [[#869], [#870], [#912]]

--- a/changes.d/prompt/prompted-dependency-sources.md
+++ b/changes.d/prompt/prompted-dependency-sources.md
@@ -1,0 +1,13 @@
+---
+links:
+  '#869': https://github.com/dahlia/optique/issues/869
+  '#870': https://github.com/dahlia/optique/issues/870
+  '#912': https://github.com/dahlia/optique/pull/912
+---
+ -  Fixed `prompt()` so that a prompted value for a wrapped dependency
+    source registers in the dependency runtime, letting derived parsers
+    observe the selected value during the same parse operation.  The fix
+    applies to every adapter built on `createPromptAdapter()`, including
+    *@optique/inquirer* and *@optique/clack*.  A dependency-source prompt
+    now runs before dependency replay, so it may be displayed before an
+    earlier-declared non-source prompt.  [[#869], [#870], [#912]]

--- a/docs/concepts/dependencies.md
+++ b/docs/concepts/dependencies.md
@@ -454,6 +454,64 @@ const pushCommand = object({
 ~~~~
 
 
+Interactive sources
+-------------------
+
+*This behavior is available since Optique 1.3.0.*
+
+A dependency source can be wrapped in a prompt fallback such as `prompt()`
+from *@optique/inquirer* or *@optique/clack*.  When the command line omits
+the source option and the prompt supplies the value interactively, the
+prompted value registers as the dependency value, so derived parsers observe
+the value the user actually selected:
+
+~~~~ typescript twoslash
+import { object } from "@optique/core/constructs";
+import { dependency } from "@optique/core/dependency";
+import { option } from "@optique/core/primitives";
+import { choice } from "@optique/core/valueparser";
+import { prompt } from "@optique/inquirer";
+
+const modeParser = dependency(choice(["dev", "prod"] as const));
+
+const portParser = modeParser.derive({
+  metavar: "PORT",
+  mode: "sync",
+  factory: (mode) =>
+    choice(mode === "dev" ? ["3000", "8080"] : ["80", "443"]),
+  defaultValue: () => "dev" as const,
+});
+
+const parser = object({
+  mode: prompt(option("--mode", modeParser), {
+    type: "select",
+    message: "Select mode:",
+    choices: ["dev", "prod"],
+  }),
+  port: option("--port", portParser),
+});
+// With --port 443 and no --mode, the prompt asks for the mode first, and
+// the answer determines which ports --port accepts.
+~~~~
+
+A derived parser behaves identically whether the dependency value came from
+the command line, an environment or configuration binding, or a prompt.
+Existing precedence is unchanged: the prompt runs only after the command
+line and earlier fallback sources fail to produce a value.
+
+A prompted source and its consumers can live anywhere within the same
+`object()`, `tuple()`, `seq()`, `concat()`, or `merge()` composition,
+including fields contributed through `merge()` children and sources nested
+in child constructs such as `concat()` child tuples.  A prompted source
+transformed with `map()` registers its pre-transform value, so consumers
+derive from the value the prompt produced rather than the mapped result.
+To make its value available before derived parsers re-evaluate, a
+dependency-source prompt runs before ordinary prompts, so it may be
+displayed before a non-source prompt declared earlier in the same object.
+When the user cancels a source prompt, the parse fails immediately and
+later prompts do not run.
+
+
 Limitations
 -----------
 

--- a/docs/integrations/prompt.md
+++ b/docs/integrations/prompt.md
@@ -565,7 +565,10 @@ dependency-source prompt runs earlier than ordinary prompts: source prompts
 run serially in declaration order before dependency replay, while non-source
 prompts keep running after the other fields complete.  As a consequence, a
 dependency-source prompt may be displayed before a non-source prompt declared
-earlier in the same object.
+earlier in the same object.  Structural precedence applies per field: a
+prompted field whose own value already came from the command line or a
+source binding does not prompt, while another prompted field sharing the
+same source still does, and its answer registers last.
 
 Each source prompt runs at most once per parse operation, and never during
 help, shell suggestion, or probe phases.  When the user cancels a source

--- a/docs/integrations/prompt.md
+++ b/docs/integrations/prompt.md
@@ -549,6 +549,56 @@ The wrapper preserves parser metadata used by dependency-aware completions and
 metadata themselves.
 
 
+Dependency sources
+------------------
+
+*This behavior is available since Optique 1.3.0.*
+
+When `prompt()` wraps a [dependency source](../concepts/dependencies.md), the
+prompted value registers in the dependency runtime, so parsers derived from
+that source observe the value the user actually selected.  A derived parser
+behaves identically whether its dependency value came from the command line,
+a source binding, or an interactive prompt.
+
+To make the value available before derived parsers re-evaluate, a
+dependency-source prompt runs earlier than ordinary prompts: source prompts
+run serially in declaration order before dependency replay, while non-source
+prompts keep running after the other fields complete.  As a consequence, a
+dependency-source prompt may be displayed before a non-source prompt declared
+earlier in the same object.
+
+Each source prompt runs at most once per parse operation, and never during
+help, shell suggestion, or probe phases.  When the user cancels a source
+prompt, the parse fails immediately and later prompts do not run.  A source
+prompt transformed with `map()` registers its pre-transform value, and a
+source prompt nested in a child construct (such as a `concat()` child tuple)
+still completes before sibling consumers.  A source prompt wrapped in
+`optional()` follows `optional()`'s suppression: an unmatched field
+resolves to `undefined` without prompting, just as for a non-source
+prompt.  Note the direction of `map()`: `prompt(...).map(...)` registers
+the pre-transform prompt answer, while `prompt()` around an
+already-transformed source cannot recover the pre-transform value and
+registers nothing.  When distinct prompts wrap the
+same source in duplicate `merge()` fields, each prompt runs in its own
+child and the later field's value wins, as with other duplicate fields.
+Likewise, when several prompted fields share one dependency source, every
+prompt runs and the last occurrence's value registers, matching how
+repeated command-line source occurrences overwrite earlier ones.
+
+Under `runWith()` with two-pass source contexts, a source prompt runs at most
+once per run.  During the phase-two seed pass it runs only when another
+parser's command-line input demands the source value; otherwise it defers to
+the final pass, and phase-two contexts see the field as deferred.
+
+One pre-existing limitation carries over: a prompt used directly as an
+`or()`/`longestMatch()` branch never executes when no command-line input
+matches, because the parse fails before any branch is chosen.  Prompts
+inside a branch still run once other input commits that branch.
+
+Concrete integrations built on `createPromptAdapter()` get this behavior
+automatically.
+
+
 Testing adapters
 ----------------
 

--- a/packages/clack/src/index.test.ts
+++ b/packages/clack/src/index.test.ts
@@ -1,11 +1,12 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { object } from "@optique/core/constructs";
+import { dependency } from "@optique/core/dependency";
 import { message } from "@optique/core/message";
 import { multiple } from "@optique/core/modifiers";
 import { parseAsync } from "@optique/core/parser";
 import { fail, flag, option } from "@optique/core/primitives";
-import { integer, string } from "@optique/core/valueparser";
+import { choice, integer, string } from "@optique/core/valueparser";
 import { bindEnv, createEnvContext } from "@optique/env";
 import { prompt } from "@optique/clack";
 
@@ -331,5 +332,56 @@ describe("prompt()", () => {
       () => parseAsync(parser, []),
       new TypeError("Unsupported prompt type: input."),
     );
+  });
+});
+
+// https://github.com/dahlia/optique/issues/870
+describe("prompt() with dependency sources", () => {
+  const mode = dependency(choice(["dev", "prod"] as const));
+  const level = mode.derive({
+    metavar: "LEVEL",
+    mode: "sync",
+    factory: (value: "dev" | "prod") =>
+      choice(
+        value === "dev"
+          ? (["debug", "verbose"] as const)
+          : (["silent", "strict"] as const),
+      ),
+    defaultValue: () => "dev" as const,
+  });
+
+  it("prompted dependency source resolves the derived parser", async () => {
+    const parser = object({
+      mode: prompt(option("--mode", mode), {
+        type: "select",
+        message: "Select mode:",
+        options: ["dev", "prod"],
+        prompter: () => Promise.resolve("prod"),
+      }),
+      level: option("--level", level),
+    });
+
+    const result = await parseAsync(parser, ["--level", "silent"]);
+
+    assert.ok(result.success);
+    assert.equal(result.value.mode, "prod");
+    assert.equal(result.value.level, "silent");
+  });
+
+  it("prompted dependency source rejects invalid derived value", async () => {
+    const parser = object({
+      mode: prompt(option("--mode", mode), {
+        type: "select",
+        message: "Select mode:",
+        options: ["dev", "prod"],
+        prompter: () => Promise.resolve("prod"),
+      }),
+      level: option("--level", level),
+    });
+
+    // "debug" is only valid for "dev", but the prompt answers "prod".
+    const result = await parseAsync(parser, ["--level", "debug"]);
+
+    assert.ok(!result.success);
   });
 });

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -972,6 +972,21 @@ export function bindConfig<
           parser,
         );
       },
+      // Rebind the inner effectful completion (e.g.,
+      // bindConfig(prompt(...))) to this wrapper's own complete() so the
+      // wrapper's fallback precedence (CLI → configuration → inner
+      // prompt) is honored when a parent construct schedules the
+      // completion directly.  When the wrapped parser transforms the
+      // source value, this wrapper's completion lives in the transformed
+      // domain and must never register under the raw source ID, so no
+      // completion is exposed.
+      completeSource: sourceMetadata.completeSource == null ||
+          sourceMetadata.preservesSourceValue === false
+        ? undefined
+        : (state: unknown, exec) =>
+          Promise.resolve(
+            boundParser.complete(state as TState, exec),
+          ) as Promise<ValueParserResult<unknown> | undefined>,
     }),
   );
   if (dependencyMetadata != null) {

--- a/packages/core/src/constructs.ts
+++ b/packages/core/src/constructs.ts
@@ -306,7 +306,11 @@ function settledPreCompletedKeys(
 ): ReadonlySet<string | symbol> {
   const keys = new Set<string | symbol>();
   for (const [key, result] of preCompleted) {
-    if (isDeferredCompletionResult(result)) continue;
+    // Legacy pre-completion cases store DependencySourceState wrappers
+    // with the completion result under `result`; classify the inner
+    // result, not the wrapper.
+    const completion = isDependencySourceState(result) ? result.result : result;
+    if (isDeferredCompletionResult(completion)) continue;
     keys.add(key);
   }
   return keys;
@@ -325,13 +329,15 @@ function firstPreCompletedFailure(
   preCompleted: ReadonlyMap<string | symbol, unknown>,
 ): Message | undefined {
   for (const result of preCompleted.values()) {
+    // See settledPreCompletedKeys() for the wrapper unwrap rationale.
+    const completion = isDependencySourceState(result) ? result.result : result;
     if (
-      typeof result === "object" && result !== null &&
-      "success" in result &&
-      (result as { readonly success: unknown }).success === false &&
-      "error" in result
+      typeof completion === "object" && completion !== null &&
+      "success" in completion &&
+      (completion as { readonly success: unknown }).success === false &&
+      "error" in completion
     ) {
-      return (result as { readonly error: Message }).error;
+      return (completion as { readonly error: Message }).error;
     }
   }
   return undefined;

--- a/packages/core/src/constructs.ts
+++ b/packages/core/src/constructs.ts
@@ -198,6 +198,34 @@ function filterPreCompletedRuntimeNodes<
 }
 
 /**
+ * Filters a construct's runtime nodes for the effectful scheduling pass.
+ *
+ * A settled Phase 1 pre-completion excludes an *effectful* node: its
+ * completion already ran and must not run again.  Structural
+ * (non-effectful) nodes always stay in the pass, whether pre-completed
+ * or not: the scheduler re-registers their extracted values so that
+ * registration order follows declaration order across structural and
+ * effectful occurrences of a shared source.
+ */
+function filterSchedulableRuntimeNodes(
+  nodes: readonly RuntimeNode[],
+  preCompleted: ReadonlyMap<string | symbol, unknown>,
+): readonly RuntimeNode[] {
+  const settledKeys = settledPreCompletedKeys(preCompleted);
+  if (settledKeys.size < 1) return nodes;
+  return nodes.filter((node) => {
+    if (node.parser.dependencyMetadata?.source?.completeSource == null) {
+      return true;
+    }
+    const segment = node.path.at(-1);
+    if (typeof segment === "number") {
+      return !settledKeys.has(String(segment));
+    }
+    return segment == null || !settledKeys.has(segment);
+  });
+}
+
+/**
  * Runs the effectful source completion pass for a construct's direct
  * children and merges the completed results into the construct's
  * pre-completed cache so its final completion phase reuses them instead
@@ -7049,9 +7077,9 @@ export function object<
           // Deferred Phase 1 results stay schedulable so a demand-only
           // prompt can still complete once demand is discovered here.
           const effectfulFailure = await scheduleEffectfulSourceCompletions(
-            filterPreCompletedRuntimeNodes(
+            filterSchedulableRuntimeNodes(
               allRuntimeNodes,
-              settledPreCompletedKeys(preCompleted),
+              preCompleted,
             ),
             annotatedState,
             runtime,
@@ -7334,9 +7362,9 @@ export function object<
           // demand-only prompt can still complete once demand is
           // discovered here.
           const effectfulFailure = await scheduleEffectfulSourceCompletions(
-            filterPreCompletedRuntimeNodes(
+            filterSchedulableRuntimeNodes(
               allRuntimeNodes,
-              settledPreCompletedKeys(preCompleted),
+              preCompleted,
             ),
             annotatedState,
             runtime,
@@ -8231,9 +8259,9 @@ function createSeqComplete(
         // Deferred Phase 1 results stay schedulable so a demand-only
         // prompt can still complete once demand is discovered here.
         const effectfulFailure = await scheduleEffectfulSourceCompletions(
-          filterPreCompletedRuntimeNodes(
+          filterSchedulableRuntimeNodes(
             allRuntimeNodes,
-            settledPreCompletedKeys(preCompleted),
+            preCompleted,
           ),
           stateArray,
           runtime,
@@ -9330,9 +9358,9 @@ export function tuple<
           // Deferred Phase 1 results stay schedulable so a demand-only
           // prompt can still complete once demand is discovered here.
           const effectfulFailure = await scheduleEffectfulSourceCompletions(
-            filterPreCompletedRuntimeNodes(
+            filterSchedulableRuntimeNodes(
               allRuntimeNodes,
-              settledPreCompletedKeys(preCompleted),
+              preCompleted,
             ),
             stateArray,
             runtime,
@@ -9533,9 +9561,9 @@ export function tuple<
           // demand-only prompt can still complete once demand is
           // discovered here.
           const effectfulFailure = await scheduleEffectfulSourceCompletions(
-            filterPreCompletedRuntimeNodes(
+            filterSchedulableRuntimeNodes(
               allRuntimeNodes,
-              settledPreCompletedKeys(preCompleted),
+              preCompleted,
             ),
             stateArray,
             runtime,
@@ -10161,9 +10189,9 @@ export function seq<
           // demand-only prompt can still complete once demand is
           // discovered here.
           const effectfulFailure = await scheduleEffectfulSourceCompletions(
-            filterPreCompletedRuntimeNodes(
+            filterSchedulableRuntimeNodes(
               allRuntimeNodes,
-              settledPreCompletedKeys(preCompleted),
+              preCompleted,
             ),
             stateArray,
             runtime,
@@ -13623,9 +13651,9 @@ export function concat(
     // Deferred Phase 1 results stay schedulable so a demand-only
     // prompt can still complete once demand is discovered here.
     const effectfulFailure = await scheduleEffectfulSourceCompletions(
-      filterPreCompletedRuntimeNodes(
+      filterSchedulableRuntimeNodes(
         allRuntimeNodes,
-        settledPreCompletedKeys(preCompleted),
+        preCompleted,
       ),
       stateArray,
       runtime,
@@ -13861,9 +13889,9 @@ export function concat(
           // demand-only prompt can still complete once demand is
           // discovered here.
           const effectfulFailure = await scheduleEffectfulSourceCompletions(
-            filterPreCompletedRuntimeNodes(
+            filterSchedulableRuntimeNodes(
               allRuntimeNodes,
-              settledPreCompletedKeys(preCompleted),
+              preCompleted,
             ),
             stateArray,
             runtime,

--- a/packages/core/src/constructs.ts
+++ b/packages/core/src/constructs.ts
@@ -19,7 +19,10 @@ import {
   collectExplicitSourceValues,
   collectExplicitSourceValuesAsync,
   collectSourcesFromState,
+  completeEffectfulSourcesAsync,
   createDependencyRuntimeContext,
+  type EffectfulSchedulingNodesFn,
+  effectfulSchedulingNodesKey,
   fillMissingSourceDefaults,
   fillMissingSourceDefaultsAsync,
   resolveStateWithRuntime,
@@ -192,6 +195,187 @@ function filterPreCompletedRuntimeNodes<
     }
     return segment == null || !preCompletedKeys.has(segment);
   });
+}
+
+/**
+ * Runs the effectful source completion pass for a construct's direct
+ * children and merges the completed results into the construct's
+ * pre-completed cache so its final completion phase reuses them instead
+ * of completing the same field twice.
+ *
+ * Returns a failure when an effectful completion fails (e.g., a cancelled
+ * prompt); the construct should propagate it as its own completion
+ * failure.  Returns `undefined` on success.
+ */
+/**
+ * Expands runtime nodes through nested constructs for effectful source
+ * scheduling and demand detection.
+ *
+ * A node without effectful-source or consumer metadata whose parser
+ * exposes child field pairs (e.g., a `tuple()` child of `concat()`, or a
+ * nested `object()` field) is replaced by nodes for its children so that
+ * an effectful source nested one or more constructs deep is still
+ * completed before any sibling consumer completes.  Array states use
+ * numeric path segments and record states use their field keys, matching
+ * the paths that child completion (and parse-time tracing) uses.
+ */
+function expandEffectfulRuntimeNodes(
+  nodes: readonly RuntimeNode[],
+): readonly RuntimeNode[] {
+  const expanded: RuntimeNode[] = [];
+  const visit = (node: RuntimeNode): void => {
+    const meta = node.parser.dependencyMetadata;
+    if (meta?.source?.completeSource != null || meta?.derived != null) {
+      expanded.push(node);
+      return;
+    }
+    // A nested merge() supplies its own scheduling nodes so that the
+    // expansion uses the same child-indexed paths, declaration order,
+    // and duplicate-field exclusion as the merge's direct scheduling.
+    const schedulingNodes = (node.parser as {
+      readonly [effectfulSchedulingNodesKey]?: EffectfulSchedulingNodesFn;
+    })[effectfulSchedulingNodesKey];
+    if (schedulingNodes != null) {
+      for (const child of schedulingNodes(node.state, node.path)) {
+        visit(child);
+      }
+      return;
+    }
+    const pairs = (node.parser as {
+      readonly [fieldParsersKey]?: ReadonlyArray<
+        readonly [string | symbol, Parser<Mode, unknown, unknown>]
+      >;
+    })[fieldParsersKey];
+    if (
+      pairs == null || node.state == null || typeof node.state !== "object"
+    ) {
+      expanded.push(node);
+      return;
+    }
+    // A nested merge() exposes duplicate field keys through its pairs.
+    // Sources behind duplicated fields must stay local to their own
+    // merge() child (which completes them with a cloned runtime), so
+    // they are never expanded into the parent's scheduling pass.
+    const duplicateFieldNames = collectDuplicateFieldNames(pairs);
+    const state = node.state as
+      | readonly unknown[]
+      | Record<string | symbol, unknown>;
+    for (const [field, childParser] of pairs) {
+      if (duplicateFieldNames.has(field)) continue;
+      const segment: PropertyKey =
+        Array.isArray(state) && typeof field === "string"
+          ? Number(field)
+          : field;
+      const childState = Array.isArray(state)
+        ? state[segment as number]
+        : (state as Record<string | symbol, unknown>)[field];
+      visit({
+        path: [...node.path, segment],
+        parser: childParser,
+        // Propagate parent annotations so source bindings (e.g.,
+        // bindEnv()) can read their values when completed through the
+        // expansion.
+        state: getAnnotatedChildState(state, childState, childParser),
+      });
+    }
+  };
+  for (const node of nodes) visit(node);
+  return expanded;
+}
+
+function isDeferredCompletionResult(result: unknown): boolean {
+  return typeof result === "object" && result !== null &&
+    "success" in result &&
+    (result as { readonly success: unknown }).success === true &&
+    "deferred" in result &&
+    (result as { readonly deferred?: unknown }).deferred === true;
+}
+
+/**
+ * Returns the keys of pre-completed results that are settled (not
+ * deferred).
+ *
+ * A deferred pre-completion—e.g., a demand-only prompt invoked during
+ * Phase 1 through a source binding wrapper, before consumer demand was
+ * known—must remain visible to the effectful scheduling pass so it can
+ * complete once demand is discovered; the scheduler then replaces the
+ * cached placeholder result with the real one.
+ */
+function settledPreCompletedKeys(
+  preCompleted: ReadonlyMap<string | symbol, unknown>,
+): ReadonlySet<string | symbol> {
+  const keys = new Set<string | symbol>();
+  for (const [key, result] of preCompleted) {
+    if (isDeferredCompletionResult(result)) continue;
+    keys.add(key);
+  }
+  return keys;
+}
+
+/**
+ * Returns the first failure among pre-completed results, if any.
+ *
+ * A failed pre-completion (e.g., a prompt cancelled during Phase 1
+ * through a source binding wrapper) fails the construct in its final
+ * completion phase anyway, so the scheduling pass must not run further
+ * effectful completions after it—cancellation stops later prompts
+ * immediately.
+ */
+function firstPreCompletedFailure(
+  preCompleted: ReadonlyMap<string | symbol, unknown>,
+): Message | undefined {
+  for (const result of preCompleted.values()) {
+    if (
+      typeof result === "object" && result !== null &&
+      "success" in result &&
+      (result as { readonly success: unknown }).success === false &&
+      "error" in result
+    ) {
+      return (result as { readonly error: Message }).error;
+    }
+  }
+  return undefined;
+}
+
+async function scheduleEffectfulSourceCompletions(
+  nodes: readonly RuntimeNode[],
+  state: unknown,
+  runtime: ReturnType<typeof createDependencyRuntimeContext>,
+  exec: ExecutionContext | undefined,
+  preCompleted: Map<string | symbol, unknown>,
+  demandNodes?: readonly RuntimeNode[],
+): Promise<{ readonly success: false; readonly error: Message } | undefined> {
+  // A failed Phase 1 pre-completion (e.g., a cancelled prompt) fails the
+  // construct anyway; abort before running any further effects so
+  // cancellation stops later prompts immediately.
+  const preCompletedFailure = firstPreCompletedFailure(preCompleted);
+  if (preCompletedFailure != null) {
+    return { success: false, error: preCompletedFailure };
+  }
+  // Only direct children can feed the construct's own pre-completed
+  // cache; expanded descendants are deduplicated through the run-scoped
+  // session instead.
+  const direct = new Set<RuntimeNode>(nodes);
+  const effectful = await completeEffectfulSourcesAsync(
+    expandEffectfulRuntimeNodes(nodes),
+    state,
+    runtime,
+    exec,
+    {
+      ...(demandNodes != null
+        ? { demandNodes: expandEffectfulRuntimeNodes(demandNodes) }
+        : {}),
+      isReusable: (node) => direct.has(node),
+    },
+  );
+  if (!effectful.success) {
+    return { success: false, error: effectful.error };
+  }
+  for (const { key, result } of effectful.completed) {
+    const cacheKey = typeof key === "number" ? String(key) : key;
+    preCompleted.set(cacheKey as string | symbol, result);
+  }
+  return undefined;
 }
 
 function buildIndexedParserPairs<
@@ -1697,6 +1881,35 @@ function getNoMatchError(
     : generateNoMatchError(noMatchContext);
 }
 
+/**
+ * Installs the effectful scheduling hook on an exclusive parser
+ * (`or()`/`longestMatch()`), exposing the committed branch so a parent
+ * construct's scheduling expansion can complete a source nested in the
+ * selected branch before parent-level dependency replay.  The branch
+ * node's path appends the branch index, matching the execution path used
+ * when the committed branch completes.
+ */
+function defineExclusiveSchedulingNodes(
+  exclusiveParser: object,
+  parsers: readonly Parser<Mode, unknown, unknown>[],
+): void {
+  Object.defineProperty(exclusiveParser, effectfulSchedulingNodesKey, {
+    value: ((state, parentPath) => {
+      const active = normalizeExclusiveState(state);
+      if (active == null) return [];
+      const [index, result] = active;
+      if (result?.success !== true) return [];
+      return [{
+        path: [...(parentPath ?? []), index],
+        parser: parsers[index],
+        state: result.next.state,
+      }];
+    }) satisfies EffectfulSchedulingNodesFn,
+    configurable: true,
+    enumerable: false,
+  });
+}
+
 function composeExclusiveDependencyMetadata(
   parsers: readonly Parser<Mode, unknown, unknown>[],
 ): ParserDependencyMetadata | undefined {
@@ -1709,13 +1922,21 @@ function composeExclusiveDependencyMetadata(
   );
   if (sourceIds.size !== 1) return undefined;
   const sharedSource = sourceBranches[0].dependencyMetadata!.source!;
+  // A mixed alternative (some branches are not the source) completes in
+  // the union domain, so its completion result is not the source value:
+  // the union is treated as non-preserving, which also keeps wrappers
+  // such as prompt() from originating an effectful completion for it.
+  // Committed-branch extraction below remains safe either way, because
+  // it only reads the selected branch's own source state.
+  const everyBranchPreserves = sourceBranches.length === parsers.length &&
+    sourceBranches.every((parser) =>
+      parser.dependencyMetadata?.source?.preservesSourceValue !== false
+    );
   return {
     source: {
       ...sharedSource,
       getMissingSourceValue: undefined,
-      preservesSourceValue: sourceBranches.every((parser) =>
-        parser.dependencyMetadata?.source?.preservesSourceValue !== false
-      ),
+      preservesSourceValue: everyBranchPreserves,
       extractSourceValue(state) {
         if (
           !Array.isArray(state) || state.length !== 2 ||
@@ -1728,6 +1949,23 @@ function composeExclusiveDependencyMetadata(
         const branchSource = parsers[index].dependencyMetadata?.source;
         if (branchSource?.extractSourceValue == null) return undefined;
         return branchSource.extractSourceValue(parserResult.next.state);
+      },
+      completeSource(state, exec) {
+        // Delegate to the committed branch only; an uncommitted state
+        // offers nothing to complete effectfully.
+        if (
+          !Array.isArray(state) || state.length !== 2 ||
+          typeof state[0] !== "number"
+        ) {
+          return Promise.resolve(undefined);
+        }
+        const [index, parserResult] = state as [number, ParserResult<unknown>];
+        if (!parserResult?.success) return Promise.resolve(undefined);
+        const branchSource = parsers[index].dependencyMetadata?.source;
+        if (branchSource?.completeSource == null) {
+          return Promise.resolve(undefined);
+        }
+        return branchSource.completeSource(parserResult.next.state, exec);
       },
     },
   };
@@ -4158,6 +4396,7 @@ export function or(
     (singleResult as Record<string, unknown>).dependencyMetadata =
       singleDependencyMetadata;
   }
+  defineExclusiveSchedulingNodes(singleResult, parsers);
   defineInheritedAnnotationParser(singleResult);
 
   // or() does NOT forward normalizeValue because the active branch is
@@ -4847,6 +5086,7 @@ function createLongestMatch(
     (multiResult as Record<string, unknown>).dependencyMetadata =
       multiDependencyMetadata;
   }
+  defineExclusiveSchedulingNodes(multiResult, parsers);
   defineInheritedAnnotationParser(multiResult);
 
   // longestMatch() does NOT forward normalizeValue because the winning
@@ -5239,12 +5479,20 @@ async function* suggestObjectAsync<
 function registerCompletedDependency(
   completed: unknown,
   registry: DependencyRegistryLike,
+  exec?: ExecutionContext,
 ): void {
-  if (
-    isDependencySourceState(completed) && completed.result.success &&
-    !registry.has(completed[dependencyId])
-  ) {
-    registry.set(completed[dependencyId], completed.result.value);
+  if (!isDependencySourceState(completed) || !completed.result.success) {
+    return;
+  }
+  const sourceId = completed[dependencyId];
+  // Structural pre-completions keep first-write-wins semantics, but a
+  // value produced by an effectful completion (a prompt that actually
+  // executed) follows the last-occurrence-wins rule instead, matching
+  // how repeated command-line source occurrences overwrite earlier ones.
+  const effectful = exec?.effectfulCompletionSession?.effectfulSources
+    .has(sourceId) === true;
+  if (effectful || !registry.has(sourceId)) {
+    registry.set(sourceId, completed.result.value);
   }
 }
 
@@ -5396,6 +5644,10 @@ function wrapAsDependencySourceState(
   const hasDep = metadataSource != null ||
     isWrappedDependencySource(parser) ||
     isPendingDependencySourceState(parser.initialState);
+  // Deferred results carry placeholder stand-ins for values that an
+  // effectful completion (e.g., a prompt) has not produced yet; they
+  // must never register as dependency values.
+  if (isDeferredCompletionResult(completed)) return undefined;
   if (
     hasDep &&
     typeof completed === "object" && completed !== null &&
@@ -5704,10 +5956,27 @@ async function preCompleteAndRegisterDependenciesAsync(
   const preCompleted = new Map<string | symbol, unknown>();
   const parentResults = exec?.preCompletedByParser;
   for (const [field, fieldParser] of fieldParserPairs) {
+    // Async pre-completions may be effectful (e.g., a prompt reached
+    // through a source binding wrapper).  Once one has failed—such as a
+    // cancelled prompt—no further pre-completion may run: cancellation
+    // stops later prompts immediately, and the construct fails on the
+    // stored failure anyway.
+    if (firstPreCompletedFailure(preCompleted) != null) break;
+
     const cached = parentResults?.get(field);
     if (cached !== undefined) {
       preCompleted.set(field, cached);
-      registerCompletedDependency(cached, registry);
+      registerCompletedDependency(cached, registry, exec);
+      continue;
+    }
+
+    // A field with an effectful completion (e.g., a prompt, possibly
+    // reached through a source binding wrapper) is completed by the
+    // unified declaration-order effectful scheduling pass instead of
+    // being pre-completed here, so that direct, bound, and nested
+    // prompts share one ordering and the last occurrence of a shared
+    // source wins.
+    if (fieldParser.dependencyMetadata?.source?.completeSource != null) {
       continue;
     }
 
@@ -5727,7 +5996,7 @@ async function preCompleteAndRegisterDependenciesAsync(
       );
       preCompleted.set(field, completed);
       const depState = wrapAsDependencySourceState(completed, fieldParser);
-      if (depState) registerCompletedDependency(depState, registry);
+      if (depState) registerCompletedDependency(depState, registry, exec);
       continue;
     }
 
@@ -5743,7 +6012,7 @@ async function preCompleteAndRegisterDependenciesAsync(
       );
       preCompleted.set(field, completed);
       const depState = wrapAsDependencySourceState(completed, fieldParser);
-      if (depState) registerCompletedDependency(depState, registry);
+      if (depState) registerCompletedDependency(depState, registry, exec);
       continue;
     }
 
@@ -5760,7 +6029,7 @@ async function preCompleteAndRegisterDependenciesAsync(
       );
       preCompleted.set(field, completed);
       if (isDependencySourceState(completed)) {
-        registerCompletedDependency(completed, registry);
+        registerCompletedDependency(completed, registry, exec);
       }
     } else if (
       fieldState === undefined &&
@@ -5772,7 +6041,7 @@ async function preCompleteAndRegisterDependenciesAsync(
       );
       preCompleted.set(field, completed);
       if (isDependencySourceState(completed)) {
-        registerCompletedDependency(completed, registry);
+        registerCompletedDependency(completed, registry, exec);
       }
     } else if (
       fieldState === undefined &&
@@ -5785,7 +6054,7 @@ async function preCompleteAndRegisterDependenciesAsync(
       );
       preCompleted.set(field, completed);
       if (isDependencySourceState(completed)) {
-        registerCompletedDependency(completed, registry);
+        registerCompletedDependency(completed, registry, exec);
       }
     } // Case 4: force-wrap for bindEnv/bindConfig.
     else if (
@@ -5806,7 +6075,7 @@ async function preCompleteAndRegisterDependenciesAsync(
       );
       preCompleted.set(field, completed);
       const depState = wrapAsDependencySourceState(completed, fieldParser);
-      if (depState) registerCompletedDependency(depState, registry);
+      if (depState) registerCompletedDependency(depState, registry, exec);
     }
   }
   return preCompleted;
@@ -6759,17 +7028,31 @@ export function object<
             const fieldParser = parsers[field];
             annotatedState[fieldKey] = getFieldState(field, fieldParser);
           }
-          await collectExplicitSourceValuesAsync(
-            filterPreCompletedRuntimeNodes(
-              buildRuntimeNodesFromPairs(
-                asyncParserPairs,
-                annotatedState,
-                exec?.path,
-              ),
-              new Set(preCompleted.keys()),
-            ),
-            runtime,
+          const allRuntimeNodes = buildRuntimeNodesFromPairs(
+            asyncParserPairs,
+            annotatedState,
+            exec?.path,
           );
+          const runtimeNodes = filterPreCompletedRuntimeNodes(
+            allRuntimeNodes,
+            new Set(preCompleted.keys()),
+          );
+          await collectExplicitSourceValuesAsync(runtimeNodes, runtime);
+          // Phase 2b: Run effectful source completions (e.g., prompts)
+          // serially so their values register before deferred replay.
+          // Deferred Phase 1 results stay schedulable so a demand-only
+          // prompt can still complete once demand is discovered here.
+          const effectfulFailure = await scheduleEffectfulSourceCompletions(
+            filterPreCompletedRuntimeNodes(
+              allRuntimeNodes,
+              settledPreCompletedKeys(preCompleted),
+            ),
+            annotatedState,
+            runtime,
+            childExec,
+            preCompleted,
+          );
+          if (effectfulFailure != null) return effectfulFailure;
           const resolvedFieldStates = await resolveStateWithRuntimeAsync(
             annotatedState,
             runtime,
@@ -7027,17 +7310,34 @@ export function object<
             const fieldParser = parsers[field];
             annotatedState[fieldKey] = getFieldState(field, fieldParser);
           }
-          await collectExplicitSourceValuesAsync(
-            filterPreCompletedRuntimeNodes(
-              buildRuntimeNodesFromPairs(
-                asyncParserPairs,
-                annotatedState,
-                exec?.path,
-              ),
-              new Set(preCompleted.keys()),
-            ),
-            runtime,
+          const allRuntimeNodes = buildRuntimeNodesFromPairs(
+            asyncParserPairs,
+            annotatedState,
+            exec?.path,
           );
+          const runtimeNodes = filterPreCompletedRuntimeNodes(
+            allRuntimeNodes,
+            new Set(preCompleted.keys()),
+          );
+          await collectExplicitSourceValuesAsync(runtimeNodes, runtime);
+          // Best-effort seeding: run effectful source completions so
+          // prompted values reach phase-two contexts.  A failure (e.g.,
+          // a cancelled prompt) aborts seed extraction entirely so no
+          // further effects run; the fallback parse surfaces the cached
+          // failure.  Deferred Phase 1 results stay schedulable so a
+          // demand-only prompt can still complete once demand is
+          // discovered here.
+          const effectfulFailure = await scheduleEffectfulSourceCompletions(
+            filterPreCompletedRuntimeNodes(
+              allRuntimeNodes,
+              settledPreCompletedKeys(preCompleted),
+            ),
+            annotatedState,
+            runtime,
+            childExec,
+            preCompleted,
+          );
+          if (effectfulFailure != null) return null;
           const resolvedFieldStates = await resolveStateWithRuntimeAsync(
             annotatedState,
             runtime,
@@ -7910,13 +8210,31 @@ function createSeqComplete(
           runtime.registry,
           childExec,
         );
-        await collectExplicitSourceValuesAsync(
-          filterPreCompletedRuntimeNodes(
-            buildRuntimeNodesFromArray(parsers, stateArray, exec?.path),
-            new Set(preCompleted.keys()),
-          ),
-          runtime,
+        const allRuntimeNodes = buildRuntimeNodesFromArray(
+          parsers,
+          stateArray,
+          exec?.path,
         );
+        const runtimeNodes = filterPreCompletedRuntimeNodes(
+          allRuntimeNodes,
+          new Set(preCompleted.keys()),
+        );
+        await collectExplicitSourceValuesAsync(runtimeNodes, runtime);
+        // Phase 2b: Run effectful source completions (e.g., prompts)
+        // serially so their values register before deferred replay.
+        // Deferred Phase 1 results stay schedulable so a demand-only
+        // prompt can still complete once demand is discovered here.
+        const effectfulFailure = await scheduleEffectfulSourceCompletions(
+          filterPreCompletedRuntimeNodes(
+            allRuntimeNodes,
+            settledPreCompletedKeys(preCompleted),
+          ),
+          stateArray,
+          runtime,
+          childExec,
+          preCompleted,
+        );
+        if (effectfulFailure != null) return effectfulFailure;
         const phase3Exec: ExecutionContext = {
           ...childExec,
           preCompletedByParser: undefined,
@@ -8991,13 +9309,31 @@ export function tuple<
             runtime.registry,
             childExec,
           );
-          await collectExplicitSourceValuesAsync(
-            filterPreCompletedRuntimeNodes(
-              buildRuntimeNodesFromArray(parsers, stateArray, exec?.path),
-              new Set(preCompleted.keys()),
-            ),
-            runtime,
+          const allRuntimeNodes = buildRuntimeNodesFromArray(
+            parsers,
+            stateArray,
+            exec?.path,
           );
+          const runtimeNodes = filterPreCompletedRuntimeNodes(
+            allRuntimeNodes,
+            new Set(preCompleted.keys()),
+          );
+          await collectExplicitSourceValuesAsync(runtimeNodes, runtime);
+          // Phase 2b: Run effectful source completions (e.g., prompts)
+          // serially so their values register before deferred replay.
+          // Deferred Phase 1 results stay schedulable so a demand-only
+          // prompt can still complete once demand is discovered here.
+          const effectfulFailure = await scheduleEffectfulSourceCompletions(
+            filterPreCompletedRuntimeNodes(
+              allRuntimeNodes,
+              settledPreCompletedKeys(preCompleted),
+            ),
+            stateArray,
+            runtime,
+            childExec,
+            preCompleted,
+          );
+          if (effectfulFailure != null) return effectfulFailure;
           const phase3Exec: ExecutionContext = {
             ...childExec,
             preCompletedByParser: undefined,
@@ -9173,13 +9509,34 @@ export function tuple<
             runtime.registry,
             childExec,
           );
-          await collectExplicitSourceValuesAsync(
-            filterPreCompletedRuntimeNodes(
-              buildRuntimeNodesFromArray(parsers, stateArray, exec?.path),
-              new Set(preCompleted.keys()),
-            ),
-            runtime,
+          const allRuntimeNodes = buildRuntimeNodesFromArray(
+            parsers,
+            stateArray,
+            exec?.path,
           );
+          const runtimeNodes = filterPreCompletedRuntimeNodes(
+            allRuntimeNodes,
+            new Set(preCompleted.keys()),
+          );
+          await collectExplicitSourceValuesAsync(runtimeNodes, runtime);
+          // Best-effort seeding: run effectful source completions so
+          // prompted values reach phase-two contexts.  A failure (e.g.,
+          // a cancelled prompt) aborts seed extraction entirely so no
+          // further effects run; the fallback parse surfaces the cached
+          // failure.  Deferred Phase 1 results stay schedulable so a
+          // demand-only prompt can still complete once demand is
+          // discovered here.
+          const effectfulFailure = await scheduleEffectfulSourceCompletions(
+            filterPreCompletedRuntimeNodes(
+              allRuntimeNodes,
+              settledPreCompletedKeys(preCompleted),
+            ),
+            stateArray,
+            runtime,
+            childExec,
+            preCompleted,
+          );
+          if (effectfulFailure != null) return null;
           const phase3Exec: ExecutionContext = {
             ...childExec,
             preCompletedByParser: undefined,
@@ -9780,13 +10137,34 @@ export function seq<
             runtime.registry,
             childExec,
           );
-          await collectExplicitSourceValuesAsync(
-            filterPreCompletedRuntimeNodes(
-              buildRuntimeNodesFromArray(parsers, stateArray, exec?.path),
-              new Set(preCompleted.keys()),
-            ),
-            runtime,
+          const allRuntimeNodes = buildRuntimeNodesFromArray(
+            parsers,
+            stateArray,
+            exec?.path,
           );
+          const runtimeNodes = filterPreCompletedRuntimeNodes(
+            allRuntimeNodes,
+            new Set(preCompleted.keys()),
+          );
+          await collectExplicitSourceValuesAsync(runtimeNodes, runtime);
+          // Best-effort seeding: run effectful source completions so
+          // prompted values reach phase-two contexts.  A failure (e.g.,
+          // a cancelled prompt) aborts seed extraction entirely so no
+          // further effects run; the fallback parse surfaces the cached
+          // failure.  Deferred Phase 1 results stay schedulable so a
+          // demand-only prompt can still complete once demand is
+          // discovered here.
+          const effectfulFailure = await scheduleEffectfulSourceCompletions(
+            filterPreCompletedRuntimeNodes(
+              allRuntimeNodes,
+              settledPreCompletedKeys(preCompleted),
+            ),
+            stateArray,
+            runtime,
+            childExec,
+            preCompleted,
+          );
+          if (effectfulFailure != null) return null;
           const phase3Exec: ExecutionContext = {
             ...childExec,
             preCompletedByParser: undefined,
@@ -10311,6 +10689,89 @@ export function merge(
   const duplicateOutputFieldNames = collectDuplicateFieldNames(
     mergedFieldParsers,
   );
+  // Effectful source completions (e.g., prompts) run in declaration
+  // order, while parsing and completion iterate the priority-sorted
+  // parsers—so scheduling iterates the original declaration order but
+  // builds paths with each child's *sorted* index, matching the paths
+  // used by parse-time tracing and child completion.  Duplicate output
+  // fields stay local to their own child and are never scheduled here.
+  const sortedIndexByOriginal: number[] = [];
+  sorted.forEach(([, originalIndex], sortedIndex) => {
+    sortedIndexByOriginal[originalIndex] = sortedIndex;
+  });
+  const buildMergeSchedulingNodes = (
+    state: Record<PropertyKey, unknown>,
+    parentPath: readonly PropertyKey[] | undefined,
+  ): readonly RuntimeNode[] => {
+    // Mirrors the state routing that child completion uses: children
+    // whose state is stored under a dedicated key (`__parser_N` or a
+    // preserved local object state) receive that stored state, while
+    // flat-record children read their own fields from the merged state.
+    const extractChildSchedulingState = (
+      parser: Parser<
+        Mode,
+        Record<string | symbol, unknown>,
+        Record<string | symbol, unknown>
+      >,
+      sortedIndex: number,
+    ): unknown => {
+      if (parser.initialState === undefined) {
+        const key = parserStateKey(sortedIndex);
+        return key in state ? state[key] : undefined;
+      }
+      if (parser.initialState && typeof parser.initialState === "object") {
+        const key = localObjectStateKey(sortedIndex);
+        if (shouldPreserveLocalChildState(parser) && key in state) {
+          return state[key];
+        }
+      }
+      return state;
+    };
+    const nodes: RuntimeNode[] = [];
+    rawParsers.forEach((parser, originalIndex) => {
+      if (!(fieldParsersKey in parser)) {
+        // A child that exposes no field pairs may still carry the
+        // effectful scheduling hook through a wrapper such as
+        // nonEmpty(object(...)); expose it as a child-indexed node so
+        // its nested sources are scheduled before sibling replay.
+        if (effectfulSchedulingNodesKey in parser) {
+          const sortedIndex = sortedIndexByOriginal[originalIndex];
+          nodes.push({
+            path: [...(parentPath ?? []), sortedIndex],
+            parser,
+            state: extractChildSchedulingState(parser, sortedIndex),
+          });
+        }
+        return;
+      }
+      const pairs = (parser as {
+        readonly [fieldParsersKey]: ReadonlyArray<
+          readonly [string | symbol, Parser<Mode, unknown, unknown>]
+        >;
+      })[fieldParsersKey];
+      const unambiguousPairs = pairs.filter(
+        ([field]) => !duplicateOutputFieldNames.has(field),
+      );
+      // Annotate each field state with the merge state's annotations so
+      // source bindings (e.g., bindEnv()) can read their values when
+      // completed through the scheduling pass.
+      const annotatedState: Record<string | symbol, unknown> = {};
+      for (const [field, fieldParser] of unambiguousPairs) {
+        annotatedState[field] = getAnnotatedFieldState(
+          state,
+          field,
+          fieldParser,
+        );
+      }
+      nodes.push(
+        ...buildRuntimeNodesFromPairs(unambiguousPairs, annotatedState, [
+          ...(parentPath ?? []),
+          sortedIndexByOriginal[originalIndex],
+        ]),
+      );
+    });
+    return nodes;
+  };
   const parserStateKey = (index: number) => `__parser_${index}`;
   const localObjectStateKey = (index: number) => `__merge_local_${index}`;
   const shouldPreserveLocalChildState = (
@@ -11029,6 +11490,14 @@ export function merge(
     $valueType: [],
     $stateType: [],
     [fieldParsersKey]: mergedFieldParsers,
+    [effectfulSchedulingNodesKey]:
+      ((state, parentPath) =>
+        state != null && typeof state === "object"
+          ? buildMergeSchedulingNodes(
+            state as Record<PropertyKey, unknown>,
+            parentPath,
+          )
+          : []) satisfies EffectfulSchedulingNodesFn,
     priority: Math.max(...mergeParseLanes.map((lane) => lane.priority)),
     usage: applyHiddenToUsage(
       parsers.flatMap((p) => p.usage),
@@ -11262,18 +11731,24 @@ export function merge(
         const duplicateFieldNames = collectDuplicateFieldNames(
           mergedFieldParsers,
         );
-        const unambiguousFieldParsers = filterDuplicateFieldParsers(
-          mergedFieldParsers,
-        );
         type AsyncFieldPairs = ReadonlyArray<
           readonly [string | symbol, Parser<Mode, unknown, unknown>]
         >;
         const perChildPhase1: {
           readonly cache?: ReadonlyMap<string | symbol, unknown>;
           readonly excludedSourceFields?: ReadonlySet<string | symbol>;
-        }[] = [];
-        for (let i = 0; i < parsers.length; i++) {
-          const parser = parsers[i];
+        }[] = new Array(parsers.length);
+        // Pre-completion may be effectful (e.g., a prompt reached through
+        // a source binding wrapper), so iterate children in declaration
+        // order while storing entries at their sorted index (the index
+        // used by completion paths and tracing).
+        for (
+          let originalIndex = 0;
+          originalIndex < rawParsers.length;
+          originalIndex++
+        ) {
+          const parser = rawParsers[originalIndex];
+          const sortedIndex = sortedIndexByOriginal[originalIndex];
           if (fieldParsersKey in parser) {
             const pairs = (parser as { [fieldParsersKey]: AsyncFieldPairs })[
               fieldParsersKey
@@ -11291,29 +11766,72 @@ export function merge(
               state as Record<string | symbol, unknown>,
               phase1Pairs,
               runtime.registry,
-              withChildExecPath(childExec, i),
+              withChildExecPath(childExec, sortedIndex),
             );
-            perChildPhase1.push({
+            // A failed pre-completion (e.g., a cancelled prompt) fails
+            // this merge anyway; abort before pre-completing later
+            // children so cancellation stops later prompts immediately.
+            const failure = firstPreCompletedFailure(preCompleted);
+            if (failure != null) {
+              return { success: false as const, error: failure };
+            }
+            perChildPhase1[sortedIndex] = {
               cache: filterDuplicateKeys(preCompleted, phase1Pairs),
               excludedSourceFields: excludedSourceFields.size > 0
                 ? excludedSourceFields
                 : undefined,
-            });
+            };
           } else {
-            perChildPhase1.push({
+            perChildPhase1[sortedIndex] = {
               cache: undefined,
               excludedSourceFields: undefined,
-            });
+            };
           }
         }
-        await collectExplicitSourceValuesAsync(
-          buildRuntimeNodesFromPairs(
-            unambiguousFieldParsers,
-            state as Record<PropertyKey, unknown>,
-            exec?.path,
-          ),
-          runtime,
+        // Child-indexed paths keep scheduling, demand detection, and the
+        // run-scoped completion cache aligned with parse-time tracing
+        // and child completion paths.
+        const mergeNodes = buildMergeSchedulingNodes(
+          state as Record<PropertyKey, unknown>,
+          exec?.path,
         );
+        await collectExplicitSourceValuesAsync(mergeNodes, runtime);
+        // Phase 2b: Run effectful source completions (e.g., prompts) for
+        // unambiguous fields so their values register before deferred
+        // replay.  Duplicate-key fields are already excluded from the
+        // node list, so values discarded by duplicate-field resolution
+        // are never scheduled at the merge level.
+        const effectfulPreCompleted = new Map<string | symbol, unknown>();
+        const effectfulFailure = await scheduleEffectfulSourceCompletions(
+          mergeNodes,
+          state,
+          runtime,
+          childExec,
+          effectfulPreCompleted,
+        );
+        if (effectfulFailure != null) return effectfulFailure;
+        if (effectfulPreCompleted.size > 0) {
+          // Route each completed field into the owning child's Phase 1
+          // cache so the child's completion reuses the result instead of
+          // completing the same field twice.
+          for (let i = 0; i < parsers.length; i++) {
+            const parser = parsers[i];
+            if (!(fieldParsersKey in parser)) continue;
+            const pairs = (parser as { [fieldParsersKey]: AsyncFieldPairs })[
+              fieldParsersKey
+            ];
+            let cache: Map<string | symbol, unknown> | undefined;
+            for (const [field] of pairs) {
+              const completed = effectfulPreCompleted.get(field);
+              if (completed === undefined) continue;
+              cache ??= new Map(perChildPhase1[i].cache);
+              cache.set(field, completed);
+            }
+            if (cache != null) {
+              perChildPhase1[i] = { ...perChildPhase1[i], cache };
+            }
+          }
+        }
 
         // Phase 2: Resolve deferred parse states across the entire merged
         // state using the dependency runtime.
@@ -11571,18 +12089,25 @@ export function merge(
           const duplicateFieldNames = collectDuplicateFieldNames(
             mergedFieldParsers,
           );
-          const unambiguousFieldParsers = filterDuplicateFieldParsers(
-            mergedFieldParsers,
-          );
           type AsyncFieldPairs = ReadonlyArray<
             readonly [string | symbol, Parser<Mode, unknown, unknown>]
           >;
           const perChildPhase1: {
             readonly cache?: ReadonlyMap<string | symbol, unknown>;
             readonly excludedSourceFields?: ReadonlySet<string | symbol>;
-          }[] = [];
-          for (let i = 0; i < parsers.length; i++) {
-            const parser = parsers[i];
+          }[] = new Array(parsers.length);
+          // Pre-completion may be effectful, so iterate children in
+          // declaration order while storing entries at their sorted
+          // index.  A failed pre-completion (e.g., a cancelled prompt)
+          // must stop all subsequent effects, so seed extraction aborts
+          // entirely; the fallback parse surfaces the cached failure.
+          for (
+            let originalIndex = 0;
+            originalIndex < rawParsers.length;
+            originalIndex++
+          ) {
+            const parser = rawParsers[originalIndex];
+            const sortedIndex = sortedIndexByOriginal[originalIndex];
             if (fieldParsersKey in parser) {
               const pairs = (parser as { [fieldParsersKey]: AsyncFieldPairs })[
                 fieldParsersKey
@@ -11601,29 +12126,63 @@ export function merge(
                   state as Record<string | symbol, unknown>,
                   phase1Pairs,
                   runtime.registry,
-                  withChildExecPath(childExec, i),
+                  withChildExecPath(childExec, sortedIndex),
                 );
-              perChildPhase1.push({
+              if (firstPreCompletedFailure(preCompleted) != null) return null;
+              perChildPhase1[sortedIndex] = {
                 cache: filterDuplicateKeys(preCompleted, phase1Pairs),
                 excludedSourceFields: excludedSourceFields.size > 0
                   ? excludedSourceFields
                   : undefined,
-              });
+              };
             } else {
-              perChildPhase1.push({
+              perChildPhase1[sortedIndex] = {
                 cache: undefined,
                 excludedSourceFields: undefined,
-              });
+              };
             }
           }
-          await collectExplicitSourceValuesAsync(
-            buildRuntimeNodesFromPairs(
-              unambiguousFieldParsers,
-              state as Record<PropertyKey, unknown>,
-              exec?.path,
-            ),
-            runtime,
+          // Child-indexed paths keep scheduling, demand detection, and
+          // the run-scoped completion cache aligned with parse-time
+          // tracing and child completion paths.
+          const mergeNodes = buildMergeSchedulingNodes(
+            state as Record<PropertyKey, unknown>,
+            exec?.path,
           );
+          await collectExplicitSourceValuesAsync(mergeNodes, runtime);
+          // Best-effort seeding: run effectful source completions so
+          // prompted values reach phase-two contexts.  A failure (e.g.,
+          // a cancelled prompt) aborts seed extraction entirely so no
+          // further effects run; the fallback parse surfaces the cached
+          // failure.
+          const effectfulPreCompleted = new Map<string | symbol, unknown>();
+          const effectfulFailure = await scheduleEffectfulSourceCompletions(
+            mergeNodes,
+            state,
+            runtime,
+            childExec,
+            effectfulPreCompleted,
+          );
+          if (effectfulFailure != null) return null;
+          if (effectfulPreCompleted.size > 0) {
+            for (let i = 0; i < parsers.length; i++) {
+              const parser = parsers[i];
+              if (!(fieldParsersKey in parser)) continue;
+              const pairs = (parser as { [fieldParsersKey]: AsyncFieldPairs })[
+                fieldParsersKey
+              ];
+              let cache: Map<string | symbol, unknown> | undefined;
+              for (const [field] of pairs) {
+                const completed = effectfulPreCompleted.get(field);
+                if (completed === undefined) continue;
+                cache ??= new Map(perChildPhase1[i].cache);
+                cache.set(field, completed);
+              }
+              if (cache != null) {
+                perChildPhase1[i] = { ...perChildPhase1[i], cache };
+              }
+            }
+          }
           const resolvedState = await resolveStateWithRuntimeAsync(
             state,
             runtime,
@@ -13043,13 +13602,31 @@ export function concat(
       runtime.registry,
       childExec,
     );
-    await collectExplicitSourceValuesAsync(
-      filterPreCompletedRuntimeNodes(
-        buildRuntimeNodesFromArray(parsers, stateArray, exec?.path),
-        new Set(preCompleted.keys()),
-      ),
-      runtime,
+    const allRuntimeNodes = buildRuntimeNodesFromArray(
+      parsers,
+      stateArray,
+      exec?.path,
     );
+    const runtimeNodes = filterPreCompletedRuntimeNodes(
+      allRuntimeNodes,
+      new Set(preCompleted.keys()),
+    );
+    await collectExplicitSourceValuesAsync(runtimeNodes, runtime);
+    // Phase 2b: Run effectful source completions (e.g., prompts)
+    // serially so their values register before deferred replay.
+    // Deferred Phase 1 results stay schedulable so a demand-only
+    // prompt can still complete once demand is discovered here.
+    const effectfulFailure = await scheduleEffectfulSourceCompletions(
+      filterPreCompletedRuntimeNodes(
+        allRuntimeNodes,
+        settledPreCompletedKeys(preCompleted),
+      ),
+      stateArray,
+      runtime,
+      childExec,
+      preCompleted,
+    );
+    if (effectfulFailure != null) return effectfulFailure;
     const phase3Exec: ExecutionContext = {
       ...childExec,
       preCompletedByParser: undefined,
@@ -13136,6 +13713,16 @@ export function concat(
     usage: parsers.flatMap((p) => p.usage),
     leadingNames: sharedBufferLeadingNames(parsers),
     acceptingAnyToken: parsers.some((p) => p.acceptingAnyToken),
+    // Expose child parsers like tuple() and seq() do, so parent
+    // constructs can expand into concat() children when scheduling
+    // effectful source completions.
+    [fieldParsersKey]: parsers.map(
+      (parser, index) =>
+        [String(index), parser] as [
+          string,
+          Parser<Mode, unknown, unknown>,
+        ],
+    ),
     initialState,
     canSkip(state, exec?: ExecutionContext) {
       const stateArray = state as readonly unknown[];
@@ -13250,13 +13837,34 @@ export function concat(
             runtime.registry,
             childExec,
           );
-          await collectExplicitSourceValuesAsync(
-            filterPreCompletedRuntimeNodes(
-              buildRuntimeNodesFromArray(parsers, stateArray, exec?.path),
-              new Set(preCompleted.keys()),
-            ),
-            runtime,
+          const allRuntimeNodes = buildRuntimeNodesFromArray(
+            parsers,
+            stateArray,
+            exec?.path,
           );
+          const runtimeNodes = filterPreCompletedRuntimeNodes(
+            allRuntimeNodes,
+            new Set(preCompleted.keys()),
+          );
+          await collectExplicitSourceValuesAsync(runtimeNodes, runtime);
+          // Best-effort seeding: run effectful source completions so
+          // prompted values reach phase-two contexts.  A failure (e.g.,
+          // a cancelled prompt) aborts seed extraction entirely so no
+          // further effects run; the fallback parse surfaces the cached
+          // failure.  Deferred Phase 1 results stay schedulable so a
+          // demand-only prompt can still complete once demand is
+          // discovered here.
+          const effectfulFailure = await scheduleEffectfulSourceCompletions(
+            filterPreCompletedRuntimeNodes(
+              allRuntimeNodes,
+              settledPreCompletedKeys(preCompleted),
+            ),
+            stateArray,
+            runtime,
+            childExec,
+            preCompleted,
+          );
+          if (effectfulFailure != null) return null;
           const phase3Exec: ExecutionContext = {
             ...childExec,
             preCompletedByParser: undefined,
@@ -13488,6 +14096,17 @@ export function group<M extends Mode, TValue, TState>(
         )[fieldParsersKey],
       }
       : {}),
+    // Forward effectful scheduling nodes so that a grouped merge()
+    // expands with the same child-indexed paths and declaration order.
+    ...(effectfulSchedulingNodesKey in parser
+      ? {
+        [effectfulSchedulingNodesKey]: (
+          parser as {
+            [effectfulSchedulingNodesKey]: EffectfulSchedulingNodesFn;
+          }
+        )[effectfulSchedulingNodesKey],
+      }
+      : {}),
     // Forward completion deferral hook from inner parser so that
     // prompt(group("label", bindConfig(...))) defers correctly.
     ...(typeof parser.shouldDeferCompletion === "function"
@@ -13613,6 +14232,15 @@ export function group<M extends Mode, TValue, TState>(
     configurable: true,
     enumerable: false,
   });
+  // Forward dependency metadata unchanged—group() passes state through,
+  // so source extraction and effectful completion see the inner shape.
+  if (parser.dependencyMetadata != null) {
+    Object.defineProperty(groupParser, "dependencyMetadata", {
+      value: parser.dependencyMetadata,
+      configurable: true,
+      enumerable: false,
+    });
+  }
   // Lazily forward placeholder from inner parser to avoid eagerly
   // evaluating derived value parser factories at construction time.
   if ("placeholder" in parser) {
@@ -15068,6 +15696,48 @@ export function conditional(
     };
   };
 
+  // Builds the effectful scheduling nodes for this conditional: the
+  // discriminator (always) and the committed branch (only when the
+  // selection is not speculative, so branch sources stay hidden until
+  // the discriminator confirms the selection).  Shared by the parser's
+  // effectfulSchedulingNodesKey hook and the completion below; the
+  // "_discriminator"/"_branch" path segments match completion paths so
+  // the run-scoped completion cache lines up.
+  const buildConditionalSchedulingNodes = (
+    state: unknown,
+    parentPath: readonly PropertyKey[] | undefined,
+  ): readonly RuntimeNode[] => {
+    if (state == null || typeof state !== "object") return [];
+    const conditionalState = state as ConditionalState<string>;
+    const nodes: RuntimeNode[] = [{
+      path: [...(parentPath ?? []), "_discriminator"],
+      parser: discriminator,
+      state: getAnnotatedChildState(
+        conditionalState,
+        conditionalState.discriminatorState,
+        discriminator,
+      ),
+    }];
+    const selected = conditionalState.selectedBranch;
+    if (selected !== undefined && conditionalState.speculative !== true) {
+      const branchParser = selected.kind === "default"
+        ? defaultBranch
+        : branches[selected.key];
+      if (branchParser != null) {
+        nodes.push({
+          path: [...(parentPath ?? []), "_branch"],
+          parser: branchParser,
+          state: getAnnotatedChildState(
+            conditionalState,
+            conditionalState.branchState,
+            branchParser,
+          ),
+        });
+      }
+    }
+    return nodes;
+  };
+
   // Async complete implementation
   const completeAsync = async (
     state: ConditionalState<string>,
@@ -15312,6 +15982,32 @@ export function conditional(
       dependencyRuntime: runtime,
       dependencyRegistry: runtime.registry,
     };
+    // Complete a prompted dependency-source discriminator (and, for a
+    // confirmed selection, the committed branch) before branch replay
+    // so branch consumers resolve against the answered value even when
+    // no parent construct invoked this parser's scheduling hook.  While
+    // the selection is speculative, only the discriminator is scheduled:
+    // the guessed branch must produce no interactive side effects before
+    // the mismatch verification below confirms or rejects it.
+    {
+      const allSchedulingNodes = buildConditionalSchedulingNodes(
+        state,
+        exec?.path,
+      );
+      const schedulingNodes = wasSpeculative
+        ? allSchedulingNodes.filter((node) =>
+          node.path.at(-1) === "_discriminator"
+        )
+        : allSchedulingNodes;
+      const schedulingFailure = await scheduleEffectfulSourceCompletions(
+        schedulingNodes,
+        combinedState,
+        runtime,
+        completionExec,
+        new Map<string | symbol, unknown>(),
+      );
+      if (schedulingFailure != null) return schedulingFailure;
+    }
     // Only complete the discriminator when needed
     // (see sync counterpart for rationale).
     const needsDiscriminatorCompletion = state.selectedBranch.kind !==
@@ -16108,5 +16804,18 @@ export function conditional(
     ConditionalState<string>
   >;
   defineInheritedAnnotationParser(conditionalParser);
+  // Expose the discriminator (and the committed, non-speculative branch)
+  // to parent-level effectful scheduling so a prompted source inside a
+  // conditional completes before sibling dependency replay.  A
+  // speculatively selected branch stays hidden: its sources must not be
+  // visible while the discriminator has not confirmed the selection,
+  // mirroring the discriminator-only verification runtime above.  Node
+  // paths reuse the "_discriminator"/"_branch" segments that completion
+  // itself uses, so the run-scoped completion cache lines up.
+  Object.defineProperty(conditionalParser, effectfulSchedulingNodesKey, {
+    value: buildConditionalSchedulingNodes satisfies EffectfulSchedulingNodesFn,
+    configurable: true,
+    enumerable: false,
+  });
   return fluent(conditionalParser);
 }

--- a/packages/core/src/dependency-metadata.ts
+++ b/packages/core/src/dependency-metadata.ts
@@ -10,7 +10,7 @@
  * @since 1.0.0
  * @module
  */
-import type { Suggestion } from "./parser.ts";
+import type { ExecutionContext, Suggestion } from "./parser.ts";
 import {
   defaultValues,
   dependencyId,
@@ -72,6 +72,29 @@ export interface DependencySourceCapability {
   readonly getMissingSourceValue?: () =>
     | ValueParserResult<unknown>
     | Promise<ValueParserResult<unknown>>;
+
+  /**
+   * Runs the parser's effectful completion (e.g., an interactive prompt)
+   * to obtain the source value when it is not extractable from state.
+   *
+   * Invoked only during real completion (never probes, help, or suggest),
+   * serially in declaration order, at most once per parse operation—the
+   * result is cached in the run-scoped effectful completion session.  Only
+   * honored in asynchronous completion lanes; synchronous completion
+   * ignores this hook, in which case the owning parser still completes
+   * normally in the construct's final completion phase without early
+   * registration.
+   *
+   * May resolve to `undefined` when the state offers nothing to complete.
+   * A result marked `deferred` is treated the same way: it is skipped and
+   * never registered.
+   *
+   * @since 1.3.0
+   */
+  readonly completeSource?: (
+    state: unknown,
+    exec?: ExecutionContext,
+  ) => Promise<ValueParserResult<unknown> | undefined>;
 
   /**
    * Whether the parser's output value is the actual dependency source value.
@@ -297,6 +320,26 @@ function unwrapArrayThenExtract(innerExtract: ExtractFn): ExtractFn {
   };
 }
 
+type CompleteSourceFn = NonNullable<
+  DependencySourceCapability["completeSource"]
+>;
+
+/**
+ * Wraps an inner `completeSource` to unwrap `[innerState]` first, mirroring
+ * `unwrapArrayThenExtract` for the effectful completion operation.
+ */
+function unwrapArrayThenComplete(
+  innerComplete: CompleteSourceFn,
+): CompleteSourceFn {
+  return (state: unknown, exec?: ExecutionContext) => {
+    if (Array.isArray(state) && state.length === 1) {
+      return innerComplete(state[0], exec);
+    }
+    // Also try the bare state in case it's already unwrapped.
+    return innerComplete(state, exec);
+  };
+}
+
 // =============================================================================
 // Composition: modify metadata through modifier wrappers
 // =============================================================================
@@ -353,6 +396,11 @@ export function composeDependencyMetadata(
             extractSourceValue: unwrapArrayThenExtract(
               inner.source.extractSourceValue,
             ),
+            ...(inner.source.completeSource != null && {
+              completeSource: unwrapArrayThenComplete(
+                inner.source.completeSource,
+              ),
+            }),
           },
         };
       }
@@ -372,6 +420,11 @@ export function composeDependencyMetadata(
             ...(wrappedExtract != null && {
               extractSourceValue: wrappedExtract,
             }),
+            ...(inner.source.completeSource != null && {
+              completeSource: unwrapArrayThenComplete(
+                inner.source.completeSource,
+              ),
+            }),
             ...(preservesSourceValue && options?.defaultValue != null && {
               getMissingSourceValue: options.defaultValue,
             }),
@@ -383,7 +436,13 @@ export function composeDependencyMetadata(
 
     case "map": {
       // map() does not wrap state—it passes through the inner state
-      // unchanged.  extractSourceValue is inherited as-is from inner.
+      // unchanged.  extractSourceValue and completeSource are inherited
+      // as-is from inner: completeSource stays the *inner* effectful
+      // completion, so scheduling it yields (and registers) the
+      // pre-transform source value, while the mapped field value is
+      // produced separately by map()'s own complete().
+      // `preservesSourceValue: false` keeps the scheduler from caching
+      // the pre-transform result as the field's completion result.
       const result: ParserDependencyMetadata = {
         ...inner,
         transform: { transformsSourceValue: true },

--- a/packages/core/src/dependency-runtime.test.ts
+++ b/packages/core/src/dependency-runtime.test.ts
@@ -2121,29 +2121,82 @@ describe("completeEffectfulSourcesAsync", () => {
     );
   });
 
-  test("skips sources that already have a registered value", async () => {
-    const runtime = createDependencyRuntimeContext();
-    const id = Symbol("a");
-    runtime.registerSource(id, "cli");
-    let calls = 0;
-    const nodes: RuntimeNode[] = [
-      createEffectfulSourceNode("a", id, () => {
-        calls++;
-        return Promise.resolve({ success: true, value: "prompted" });
-      }),
-    ];
+  test(
+    "completes an occurrence despite another occurrence's registered value",
+    async () => {
+      const runtime = createDependencyRuntimeContext();
+      const id = Symbol("a");
+      // Registered by another occurrence of the shared source (e.g., a
+      // command-line value for a sibling field).  The effectful
+      // occurrence's own field still needs a value, so its completion
+      // runs and re-registers, and the last occurrence wins.
+      runtime.registerSource(id, "cli");
+      let calls = 0;
+      const nodes: RuntimeNode[] = [
+        createEffectfulSourceNode("a", id, () => {
+          calls++;
+          return Promise.resolve({ success: true, value: "prompted" });
+        }),
+      ];
 
-    const result = await completeEffectfulSourcesAsync(
-      nodes,
-      undefined,
-      runtime,
-      createCompleteExecFixture(),
-    );
+      const result = await completeEffectfulSourcesAsync(
+        nodes,
+        undefined,
+        runtime,
+        createCompleteExecFixture(),
+      );
 
-    assert.ok(result.success);
-    assert.equal(calls, 0);
-    assert.equal(runtime.getSource(id), "cli");
-  });
+      assert.ok(result.success);
+      assert.equal(calls, 1);
+      assert.equal(runtime.getSource(id), "prompted");
+    },
+  );
+
+  test(
+    "re-registers a later structural occurrence over an earlier effect",
+    async () => {
+      const runtime = createDependencyRuntimeContext();
+      const id = Symbol("shared");
+      // A structural occurrence declared after an effectful one: its
+      // extracted value must register after the effectful result so
+      // registration order follows declaration order.
+      const structuralNode: RuntimeNode = {
+        path: ["b"],
+        parser: {
+          dependencyMetadata: {
+            source: {
+              kind: "source",
+              sourceId: id,
+              extractSourceValue: () => ({
+                success: true,
+                value: "structural",
+              }),
+              preservesSourceValue: true,
+            },
+          },
+        },
+        state: undefined,
+      };
+      const nodes: RuntimeNode[] = [
+        createEffectfulSourceNode(
+          "a",
+          id,
+          () => Promise.resolve({ success: true, value: "prompted" }),
+        ),
+        structuralNode,
+      ];
+
+      const result = await completeEffectfulSourcesAsync(
+        nodes,
+        undefined,
+        runtime,
+        createCompleteExecFixture(),
+      );
+
+      assert.ok(result.success);
+      assert.equal(runtime.getSource(id), "structural");
+    },
+  );
 
   test(
     "completes every occurrence of a shared source, last one winning",

--- a/packages/core/src/dependency-runtime.test.ts
+++ b/packages/core/src/dependency-runtime.test.ts
@@ -9,9 +9,11 @@ import * as assert from "node:assert/strict";
 import {
   buildRuntimeNodesFromArray,
   buildRuntimeNodesFromPairs,
+  collectDemandedDependencyIds,
   collectExplicitSourceValues,
   collectExplicitSourceValuesAsync,
   collectSourcesFromState,
+  completeEffectfulSourcesAsync,
   createDependencyFingerprint,
   createDependencyRuntimeContext,
   createReplayKey,
@@ -24,6 +26,7 @@ import {
   resolveStateWithRuntimeAsync,
   type RuntimeNode,
 } from "#src/dependency-runtime.ts";
+import { createInputTrace } from "#src/input-trace.ts";
 import type { ParserDependencyMetadata } from "#src/dependency-metadata.ts";
 import {
   createDeferredParseState,
@@ -39,7 +42,12 @@ import {
   parseWithDependency,
 } from "#src/internal/dependency.ts";
 import { formatMessage, message } from "#src/message.ts";
-import { unmatchedNonCliDependencySourceStateMarker } from "#src/internal/parser.ts";
+import {
+  createEffectfulCompletionSession,
+  type EffectfulCompletionSession,
+  type ExecutionContext,
+  unmatchedNonCliDependencySourceStateMarker,
+} from "#src/internal/parser.ts";
 import type { DependencyRegistryLike } from "#src/registry-types.ts";
 import type { ValueParserResult } from "#src/valueparser.ts";
 
@@ -2035,5 +2043,439 @@ describe("DependencyRuntimeContext—FailedAwareRegistry clone", () => {
     assert.ok(cloned.isSourceFailed(sourceA));
     assert.ok(cloned.isSourceFailed(sourceB));
     assert.ok(!cloned.hasSource(sourceA));
+  });
+});
+
+// =============================================================================
+// Effectful source completion scheduling (issue #870)
+// =============================================================================
+
+function createCompleteExecFixture(
+  session?: EffectfulCompletionSession,
+  phase: "complete" | "parse" = "complete",
+): ExecutionContext {
+  return {
+    usage: [],
+    phase,
+    path: [],
+    ...(session != null ? { effectfulCompletionSession: session } : {}),
+  };
+}
+
+function createEffectfulSourceNode(
+  key: string,
+  sourceId: symbol,
+  completeSource: NonNullable<
+    NonNullable<ParserDependencyMetadata["source"]>["completeSource"]
+  >,
+  options: { readonly preservesSourceValue?: boolean } = {},
+): RuntimeNode {
+  return {
+    path: [key],
+    parser: {
+      dependencyMetadata: {
+        source: {
+          kind: "source",
+          sourceId,
+          extractSourceValue: () => undefined,
+          preservesSourceValue: options.preservesSourceValue ?? true,
+          completeSource,
+        },
+      },
+    },
+    state: undefined,
+  };
+}
+
+describe("completeEffectfulSourcesAsync", () => {
+  test("runs completions serially in declaration order and registers", async () => {
+    const runtime = createDependencyRuntimeContext();
+    const idA = Symbol("a");
+    const idB = Symbol("b");
+    const order: string[] = [];
+    const nodes: RuntimeNode[] = [
+      createEffectfulSourceNode("a", idA, () => {
+        order.push("a");
+        return Promise.resolve({ success: true, value: "A" });
+      }),
+      createEffectfulSourceNode("b", idB, () => {
+        order.push("b");
+        return Promise.resolve({ success: true, value: "B" });
+      }),
+    ];
+
+    const result = await completeEffectfulSourcesAsync(
+      nodes,
+      undefined,
+      runtime,
+      createCompleteExecFixture(),
+    );
+
+    assert.ok(result.success);
+    assert.deepEqual(order, ["a", "b"]);
+    assert.equal(runtime.getSource(idA), "A");
+    assert.equal(runtime.getSource(idB), "B");
+    assert.deepEqual(
+      result.completed.map((c) => c.key),
+      ["a", "b"],
+    );
+  });
+
+  test("skips sources that already have a registered value", async () => {
+    const runtime = createDependencyRuntimeContext();
+    const id = Symbol("a");
+    runtime.registerSource(id, "cli");
+    let calls = 0;
+    const nodes: RuntimeNode[] = [
+      createEffectfulSourceNode("a", id, () => {
+        calls++;
+        return Promise.resolve({ success: true, value: "prompted" });
+      }),
+    ];
+
+    const result = await completeEffectfulSourcesAsync(
+      nodes,
+      undefined,
+      runtime,
+      createCompleteExecFixture(),
+    );
+
+    assert.ok(result.success);
+    assert.equal(calls, 0);
+    assert.equal(runtime.getSource(id), "cli");
+  });
+
+  test(
+    "completes every occurrence of a shared source, last one winning",
+    async () => {
+      const runtime = createDependencyRuntimeContext();
+      const id = Symbol("shared");
+      const order: string[] = [];
+      const nodes: RuntimeNode[] = [
+        createEffectfulSourceNode("a", id, () => {
+          order.push("a");
+          return Promise.resolve({ success: true, value: "first" });
+        }),
+        createEffectfulSourceNode("b", id, () => {
+          order.push("b");
+          return Promise.resolve({ success: true, value: "second" });
+        }),
+      ];
+
+      // A value registered by an earlier effectful occurrence within the
+      // same pass must not suppress later occurrences: each occurrence
+      // completes and re-registers, matching how repeated command-line
+      // source occurrences overwrite earlier ones.
+      const result = await completeEffectfulSourcesAsync(
+        nodes,
+        undefined,
+        runtime,
+        createCompleteExecFixture(),
+      );
+
+      assert.ok(result.success);
+      assert.deepEqual(order, ["a", "b"]);
+      assert.equal(runtime.getSource(id), "second");
+    },
+  );
+
+  test("skips non-reusable sources when no session is available", async () => {
+    const runtime = createDependencyRuntimeContext();
+    const id = Symbol("a");
+    let calls = 0;
+    const nodes: RuntimeNode[] = [
+      createEffectfulSourceNode("a", id, () => {
+        calls++;
+        return Promise.resolve({ success: true, value: "prompted" });
+      }, { preservesSourceValue: false }),
+    ];
+
+    // Without a run-scoped session, a non-reusable completion cannot be
+    // deduplicated against the construct's final completion phase, so it
+    // must not run.
+    const result = await completeEffectfulSourcesAsync(
+      nodes,
+      undefined,
+      runtime,
+      createCompleteExecFixture(),
+    );
+
+    assert.ok(result.success);
+    assert.equal(calls, 0);
+    assert.ok(!runtime.hasSource(id));
+  });
+
+  test(
+    "registers pre-transform values for non-preserved sources with a session",
+    async () => {
+      const runtime = createDependencyRuntimeContext();
+      const id = Symbol("a");
+      let calls = 0;
+      const nodes: RuntimeNode[] = [
+        createEffectfulSourceNode("a", id, () => {
+          calls++;
+          return Promise.resolve({ success: true, value: "prompted" });
+        }, { preservesSourceValue: false }),
+      ];
+
+      // With a session, the completion runs and registers the source
+      // value, but the result is not cached for the owning construct
+      // because the field's final value differs from the source value.
+      const result = await completeEffectfulSourcesAsync(
+        nodes,
+        undefined,
+        runtime,
+        createCompleteExecFixture(createEffectfulCompletionSession()),
+      );
+
+      assert.ok(result.success);
+      assert.equal(calls, 1);
+      assert.equal(runtime.getSource(id), "prompted");
+      assert.deepEqual(result.completed, []);
+    },
+  );
+
+  test("treats expanded nodes as non-reusable via isReusable", async () => {
+    const runtime = createDependencyRuntimeContext();
+    const id = Symbol("a");
+    const nodes: RuntimeNode[] = [
+      createEffectfulSourceNode(
+        "a",
+        id,
+        () => Promise.resolve({ success: true, value: "prompted" }),
+      ),
+    ];
+
+    const result = await completeEffectfulSourcesAsync(
+      nodes,
+      undefined,
+      runtime,
+      createCompleteExecFixture(createEffectfulCompletionSession()),
+      { isReusable: () => false },
+    );
+
+    assert.ok(result.success);
+    assert.equal(runtime.getSource(id), "prompted");
+    assert.deepEqual(result.completed, []);
+  });
+
+  test("does not run completions during probe phases", async () => {
+    const runtime = createDependencyRuntimeContext();
+    const id = Symbol("a");
+    let calls = 0;
+    const nodes: RuntimeNode[] = [
+      createEffectfulSourceNode("a", id, () => {
+        calls++;
+        return Promise.resolve({ success: true, value: "prompted" });
+      }),
+    ];
+
+    const result = await completeEffectfulSourcesAsync(
+      nodes,
+      undefined,
+      runtime,
+      createCompleteExecFixture(undefined, "parse"),
+    );
+
+    assert.ok(result.success);
+    assert.equal(calls, 0);
+  });
+
+  test("aborts on failure without running later completions", async () => {
+    const runtime = createDependencyRuntimeContext();
+    const idA = Symbol("a");
+    const idB = Symbol("b");
+    let laterCalls = 0;
+    const nodes: RuntimeNode[] = [
+      createEffectfulSourceNode("a", idA, () =>
+        Promise.resolve({
+          success: false,
+          error: message`Prompt cancelled.`,
+        })),
+      createEffectfulSourceNode("b", idB, () => {
+        laterCalls++;
+        return Promise.resolve({ success: true, value: "B" });
+      }),
+    ];
+
+    const result = await completeEffectfulSourcesAsync(
+      nodes,
+      undefined,
+      runtime,
+      createCompleteExecFixture(),
+    );
+
+    assert.ok(!result.success);
+    assert.equal(formatMessage(result.error), "Prompt cancelled.");
+    assert.equal(laterCalls, 0);
+    assert.ok(runtime.isSourceFailed(idA));
+    assert.ok(!runtime.hasSource(idB));
+  });
+
+  test("treats undefined and deferred results as declined", async () => {
+    const runtime = createDependencyRuntimeContext();
+    const idA = Symbol("a");
+    const idB = Symbol("b");
+    const nodes: RuntimeNode[] = [
+      createEffectfulSourceNode("a", idA, () => Promise.resolve(undefined)),
+      createEffectfulSourceNode("b", idB, () =>
+        Promise.resolve({
+          success: true,
+          value: "placeholder",
+          deferred: true,
+        })),
+    ];
+
+    const result = await completeEffectfulSourcesAsync(
+      nodes,
+      undefined,
+      runtime,
+      createCompleteExecFixture(),
+    );
+
+    assert.ok(result.success);
+    assert.deepEqual(result.completed, []);
+    assert.ok(!runtime.hasSource(idA));
+    assert.ok(!runtime.hasSource(idB));
+  });
+
+  test("caches a successful undefined value without registering it", async () => {
+    const runtime = createDependencyRuntimeContext();
+    const id = Symbol("a");
+    const nodes: RuntimeNode[] = [
+      createEffectfulSourceNode(
+        "a",
+        id,
+        () => Promise.resolve({ success: true, value: undefined }),
+      ),
+    ];
+
+    const result = await completeEffectfulSourcesAsync(
+      nodes,
+      undefined,
+      runtime,
+      createCompleteExecFixture(),
+    );
+
+    assert.ok(result.success);
+    assert.equal(result.completed.length, 1);
+    assert.equal(result.completed[0].key, "a");
+    assert.ok(!runtime.hasSource(id));
+  });
+
+  test("accumulates demanded ids into a demand-only session", async () => {
+    const runtime = createDependencyRuntimeContext();
+    const sourceId = Symbol("mode");
+    const session = createEffectfulCompletionSession("demand-only");
+    const trace = createInputTrace().set(["level"], {
+      kind: "option-value",
+      rawInput: "debug",
+      consumed: ["--level", "debug"],
+    });
+    const consumerNode: RuntimeNode = {
+      path: ["level"],
+      parser: {
+        dependencyMetadata: {
+          derived: {
+            kind: "derived",
+            dependencyIds: [sourceId],
+            replayParse: () => ({ success: true, value: "debug" }),
+          },
+        },
+      },
+      state: undefined,
+    };
+    const nodes: RuntimeNode[] = [
+      createEffectfulSourceNode(
+        "mode",
+        sourceId,
+        () => Promise.resolve({ success: true, value: "prod" }),
+      ),
+      consumerNode,
+    ];
+
+    const result = await completeEffectfulSourcesAsync(
+      nodes,
+      undefined,
+      runtime,
+      { ...createCompleteExecFixture(session), trace },
+    );
+
+    assert.ok(result.success);
+    assert.ok(session.demanded.has(sourceId));
+  });
+});
+
+describe("collectDemandedDependencyIds", () => {
+  test("collects ids from derived nodes with trace raw input", () => {
+    const sourceId = Symbol("mode");
+    const trace = createInputTrace().set(["level"], {
+      kind: "option-value",
+      rawInput: "debug",
+      consumed: ["--level", "debug"],
+    });
+    const nodes: RuntimeNode[] = [{
+      path: ["level"],
+      parser: {
+        dependencyMetadata: {
+          derived: {
+            kind: "derived",
+            dependencyIds: [sourceId],
+            replayParse: () => ({ success: true, value: "debug" }),
+          },
+        },
+      },
+      state: undefined,
+    }];
+
+    const demanded = collectDemandedDependencyIds(nodes, undefined, trace);
+
+    assert.ok(demanded.has(sourceId));
+  });
+
+  test("ignores derived nodes without raw input evidence", () => {
+    const sourceId = Symbol("mode");
+    const nodes: RuntimeNode[] = [{
+      path: ["level"],
+      parser: {
+        dependencyMetadata: {
+          derived: {
+            kind: "derived",
+            dependencyIds: [sourceId],
+            replayParse: () => ({ success: true, value: "debug" }),
+          },
+        },
+      },
+      state: undefined,
+    }];
+
+    const demanded = collectDemandedDependencyIds(
+      nodes,
+      undefined,
+      createInputTrace(),
+    );
+
+    assert.ok(!demanded.has(sourceId));
+  });
+
+  test("collects ids from legacy deferred states in the state tree", () => {
+    const sourceId = Symbol("mode");
+    const derivedParser = makeDerivedValueParser(
+      sourceId,
+      (rawInput) => ({ success: true, value: rawInput }),
+    );
+    const deferred = createDeferredParseState(
+      "debug",
+      derivedParser,
+      { success: true, value: "debug" } as ValueParserResult<unknown>,
+    );
+
+    const demanded = collectDemandedDependencyIds(
+      [],
+      { level: deferred },
+      undefined,
+    );
+
+    assert.ok(demanded.has(sourceId));
   });
 });

--- a/packages/core/src/dependency-runtime.ts
+++ b/packages/core/src/dependency-runtime.ts
@@ -1186,31 +1186,31 @@ export async function completeEffectfulSourcesAsync(
   );
   if (schedulable.length === 0) return empty;
 
-  // Structural precedence applies to values present before this pass
-  // (CLI state, environment, configuration, or defaults).  A value
-  // registered by an *earlier effectful occurrence within this pass* does
-  // not suppress later occurrences of the same source: each occurrence
-  // completes and re-registers, so the last occurrence wins, matching how
-  // repeated command-line source occurrences overwrite earlier ones.
-  const preexisting = new Set<symbol>();
-  for (const node of schedulable) {
-    const source = node.parser.dependencyMetadata?.source;
-    if (
-      source != null && runtime.hasSource(source.sourceId) &&
-      // A value registered by an effectful completion (e.g., a prompt
-      // pre-completed through a source binding during Phase 1) is not a
-      // structural value: later prompted occurrences still run so the
-      // last occurrence wins, as with repeated command-line occurrences.
-      session?.effectfulSources.has(source.sourceId) !== true
-    ) {
-      preexisting.add(source.sourceId);
-    }
-  }
-
   const completed: EffectfulSourceCompletion[] = [];
-  for (const node of schedulable) {
+  for (const node of nodes) {
     const source = node.parser.dependencyMetadata?.source;
-    if (source?.completeSource == null) continue;
+    if (source == null) continue;
+    if (source.completeSource == null) {
+      // Registration order must follow declaration order across
+      // structural and effectful occurrences of a shared source, the
+      // way repeated command-line occurrences overwrite earlier ones.
+      // Structural values were registered by source collection before
+      // this pass, so a structural occurrence declared *after* an
+      // effectful one re-registers its extracted value here to restore
+      // that order.  Only the construct's own nodes re-register:
+      // expanded descendants were never part of its source collection.
+      if (
+        source.extractSourceValue == null ||
+        (options?.isReusable?.(node) ?? true) === false
+      ) {
+        continue;
+      }
+      const extracted = await source.extractSourceValue(node.state);
+      if (extracted?.success === true && extracted.value !== undefined) {
+        runtime.registerSource(source.sourceId, extracted.value);
+      }
+      continue;
+    }
 
     // A completion already performed for this exact node in this pass—
     // typically by a parent construct's expanded scheduling—is reused
@@ -1231,7 +1231,16 @@ export async function completeEffectfulSourcesAsync(
       continue;
     }
 
-    if (preexisting.has(source.sourceId)) continue;
+    // Structural precedence is enforced per occurrence by the effectful
+    // completion itself: a command-line value or a source binding for
+    // the occurrence's own field is returned without running the effect
+    // (see prompt()'s completion, which consults both before its
+    // run-scoped cache).  A value registered by *another* occurrence of
+    // the same source does not suppress this one: its field still needs
+    // a value, so the completion runs here rather than after dependency
+    // replay, and its registration overwrites earlier ones so the last
+    // occurrence wins, matching repeated command-line occurrences.
+    //
     // A source marked failed by extraction (e.g., an invalid bound
     // environment or configuration value) is not skipped: the effectful
     // completion is its recovery path—a prompt wrapper falls back after

--- a/packages/core/src/dependency-runtime.ts
+++ b/packages/core/src/dependency-runtime.ts
@@ -1273,15 +1273,7 @@ export async function completeEffectfulSourcesAsync(
  * length-prefixed segments so no separator escaping is needed.
  */
 function serializeSchedulingPath(path: readonly PropertyKey[]): string {
-  return path.map((segment) => {
-    if (typeof segment === "symbol") {
-      const key = stableSymbolKey(segment);
-      return `y${key.length}:${key}`;
-    }
-    const tag = typeof segment === "number" ? "n" : "s";
-    const text = String(segment);
-    return `${tag}${text.length}:${text}`;
-  }).join("");
+  return path.map(serializePathSegment).join("");
 }
 
 // =============================================================================

--- a/packages/core/src/dependency-runtime.ts
+++ b/packages/core/src/dependency-runtime.ts
@@ -18,8 +18,12 @@ import {
   isPendingDependencySourceState,
   parseWithDependency,
 } from "./internal/dependency.ts";
-import { message } from "./message.ts";
-import { unmatchedNonCliDependencySourceStateMarker } from "./internal/parser.ts";
+import type { InputTrace } from "./input-trace.ts";
+import { type Message, message } from "./message.ts";
+import {
+  type ExecutionContext,
+  unmatchedNonCliDependencySourceStateMarker,
+} from "./internal/parser.ts";
 import type { DependencyRegistryLike } from "./registry-types.ts";
 import type { ValueParserResult } from "./valueparser.ts";
 import type { ParserDependencyMetadata } from "./dependency-metadata.ts";
@@ -898,6 +902,386 @@ export function extractRawInputFromState(state: unknown): string | undefined {
   }
 
   return undefined;
+}
+
+// =============================================================================
+// Effectful source completion scheduling
+// =============================================================================
+
+/**
+ * Internal parser hook for constructs whose effectful scheduling nodes
+ * cannot be derived from flattened field pairs alone.
+ *
+ * `merge()` installs it so a parent's scheduling expansion uses the same
+ * child-indexed paths, declaration order, and duplicate-field exclusion
+ * as the merge's own scheduling pass; `or()`/`longestMatch()` install it
+ * to expose the committed branch; `command()` installs it to expose its
+ * inner parser once the command has matched.  The returned node paths
+ * must match the execution paths used when the same parsers complete, so
+ * the run-scoped completion cache lines up.
+ *
+ * @internal
+ * @since 1.3.0
+ */
+export const effectfulSchedulingNodesKey: unique symbol = Symbol(
+  "@optique/core/dependency-runtime/effectfulSchedulingNodes",
+);
+
+/**
+ * The shape of the {@link effectfulSchedulingNodesKey} hook.
+ *
+ * @internal
+ * @since 1.3.0
+ */
+export type EffectfulSchedulingNodesFn = (
+  state: unknown,
+  parentPath: readonly PropertyKey[] | undefined,
+) => readonly RuntimeNode[];
+
+/**
+ * Forwards effectful scheduling through a shape-preserving wrapper such
+ * as `map()`, `optional()`, `withDefault()`, or `nonEmpty()`, so the
+ * wrapped parser—a selected exclusive or command branch, or an ordinary
+ * construct with nested effectful sources—stays visible to a parent
+ * construct's scheduling expansion.
+ *
+ * The installed hook simply re-exposes the inner parser as a node with
+ * the wrapper's own state shape unwrapped (`adaptState`, e.g. the
+ * `[innerState]` array used by `optional()`/`withDefault()`); the
+ * expansion then applies its ordinary rules to the inner parser, whether
+ * it carries its own hook, flattened field pairs, or source metadata.
+ * Wrappers are path-transparent, so the node keeps the wrapper's path.
+ *
+ * @internal
+ * @since 1.3.0
+ */
+export function defineForwardedEffectfulSchedulingNodes(
+  wrapper: object,
+  inner: { readonly dependencyMetadata?: ParserDependencyMetadata },
+  adaptState?: (state: unknown) => unknown,
+): void {
+  // When the inner parser is itself a dependency source, the wrapper's
+  // own composed metadata governs scheduling—including the deliberate
+  // absence of an effectful completion (e.g., optional() suppression or
+  // a transformed source).  Re-exposing the inner parser here would
+  // bypass that decision, so the hook is only installed for wrapped
+  // non-source parsers such as constructs and exclusive branches.
+  if (inner.dependencyMetadata?.source != null) return;
+  Object.defineProperty(wrapper, effectfulSchedulingNodesKey, {
+    value: ((state, parentPath) => [{
+      path: parentPath ?? [],
+      parser: inner,
+      state: adaptState == null ? state : adaptState(state),
+    }]) satisfies EffectfulSchedulingNodesFn,
+    configurable: true,
+    enumerable: false,
+  });
+}
+
+/**
+ * A completed effectful source result to be reused by the owning
+ * construct's final completion phase, keyed by the node's last path
+ * segment (its field key or tuple index).
+ *
+ * @internal
+ * @since 1.3.0
+ */
+export interface EffectfulSourceCompletion {
+  /** The node's field key or index (its last path segment). */
+  readonly key: PropertyKey;
+
+  /** The effectful completion result. */
+  readonly result: ValueParserResult<unknown>;
+}
+
+/**
+ * The result of scheduling effectful source completions.
+ *
+ * @internal
+ * @since 1.3.0
+ */
+export type EffectfulSourceCompletionResult =
+  | {
+    readonly success: true;
+    readonly completed: readonly EffectfulSourceCompletion[];
+  }
+  | { readonly success: false; readonly error: Message };
+
+/**
+ * Collects the dependency source IDs demanded by consumers among the
+ * given nodes and state subtree.
+ *
+ * A consumer demands its sources when it has raw input evidence: either a
+ * trace entry recorded at its path during parsing, or a legacy
+ * `DeferredParseState` embedded in the state subtree.  Consumers without
+ * raw input never replay against real dependency values, so their sources
+ * are not demanded.
+ *
+ * @param nodes The direct-child runtime nodes of the owning construct.
+ * @param state The construct's state subtree (for legacy deferred states).
+ * @param trace The input trace recorded during parsing.
+ * @returns The set of demanded dependency source IDs.
+ * @internal
+ * @since 1.3.0
+ */
+export function collectDemandedDependencyIds(
+  nodes: readonly RuntimeNode[],
+  state: unknown,
+  trace: InputTrace | undefined,
+): ReadonlySet<symbol> {
+  const demanded = new Set<symbol>();
+  for (const node of nodes) {
+    const derived = node.parser.dependencyMetadata?.derived;
+    if (derived == null) continue;
+    const hasRawInput = trace?.get(node.path)?.rawInput != null ||
+      extractRawInputFromState(node.state) != null;
+    if (!hasRawInput) continue;
+    for (const id of derived.dependencyIds) demanded.add(id);
+  }
+  collectDeferredDemand(state, demanded, new WeakSet<object>());
+  return demanded;
+}
+
+function collectDeferredDemand(
+  state: unknown,
+  demanded: Set<symbol>,
+  visited: WeakSet<object>,
+): void {
+  if (state == null || typeof state !== "object") return;
+  if (visited.has(state)) return;
+  visited.add(state);
+
+  if (isDeferredParseState(state)) {
+    const ids = state.dependencyIds != null && state.dependencyIds.length > 0
+      ? state.dependencyIds
+      : [state.dependencyId];
+    for (const id of ids) demanded.add(id);
+    return;
+  }
+
+  for (const key of Reflect.ownKeys(state)) {
+    collectDeferredDemand(
+      (state as Record<string | symbol, unknown>)[key],
+      demanded,
+      visited,
+    );
+  }
+}
+
+/**
+ * Options for {@link completeEffectfulSourcesAsync}.
+ *
+ * @internal
+ * @since 1.3.0
+ */
+export interface CompleteEffectfulSourcesOptions {
+  /**
+   * Nodes used for demand detection instead of the scheduled nodes.
+   * Constructs whose parse-time trace paths differ from their scheduling
+   * node paths (e.g., `merge()`, which records child-indexed paths but
+   * schedules flattened field nodes) pass path-corrected nodes here.
+   */
+  readonly demandNodes?: readonly RuntimeNode[];
+
+  /**
+   * Whether a node's completion result may be cached by the owning
+   * construct for reuse in its final completion phase.  Defaults to
+   * treating every node as reusable.  Non-reusable completions (nodes
+   * expanded from nested children, or sources whose field value differs
+   * from the source value) rely on the run-scoped session cache to avoid
+   * running twice, and are skipped when no session is available.
+   */
+  readonly isReusable?: (node: RuntimeNode) => boolean;
+}
+
+/**
+ * Runs effectful source completions (e.g., interactive prompts) serially
+ * in declaration order for source nodes whose value is not yet registered.
+ *
+ * This is the scheduling half of the `completeSource` capability contract:
+ *
+ * - Runs only during real completion (`exec.phase === "complete"`); probe
+ *   and suggest phases return immediately without effects.
+ * - Precedence is structural: a source whose value was registered before
+ *   the pass begins (from CLI state, environment, configuration, or a
+ *   default) or that has already failed is never completed effectfully.
+ *   When several scheduled occurrences share one source, each occurrence
+ *   still completes and re-registers, so the last occurrence wins—the
+ *   same rule as repeated command-line source occurrences.
+ * - Completion results that are `undefined` or marked `deferred` are
+ *   treated as declined and neither registered nor cached.
+ * - A successful result registers its value unless the value is
+ *   `undefined`.  When the node is reusable (a direct child whose field
+ *   value is the source value), the result is also returned for reuse by
+ *   the owning construct so the node is not completed twice; otherwise the
+ *   effectful parser's own run-scoped session cache prevents a second
+ *   execution, so nodes that are not reusable are only scheduled when a
+ *   session is present.  For a source behind a transform such as `map()`
+ *   (`preservesSourceValue: false`), the `completeSource` contract still
+ *   yields the pre-transform source value, so registration stays correct
+ *   while the field's final value is produced separately.
+ * - A failed result (e.g., a cancelled prompt) marks the source as failed
+ *   and aborts immediately—later effectful completions do not run.
+ *
+ * When the run-scoped session policy is `"demand-only"` (the phase-two
+ * seed pass), the demanded source IDs from
+ * {@link collectDemandedDependencyIds} are added to the session before any
+ * completion runs, letting effectful parsers defer when no phase-one
+ * consumer demands their value.
+ *
+ * @param nodes The runtime nodes to schedule, in declaration order.
+ * @param state The construct's state subtree (for demand detection).
+ * @param runtime The dependency runtime context.
+ * @param exec The execution context of the owning construct.
+ * @param options Scheduling options.
+ * @returns The scheduling result: completed nodes for reuse, or the first
+ *   failure.
+ * @internal
+ * @since 1.3.0
+ */
+export async function completeEffectfulSourcesAsync(
+  nodes: readonly RuntimeNode[],
+  state: unknown,
+  runtime: DependencyRuntimeContext,
+  exec: ExecutionContext | undefined,
+  options?: CompleteEffectfulSourcesOptions,
+): Promise<EffectfulSourceCompletionResult> {
+  const empty: EffectfulSourceCompletionResult = {
+    success: true,
+    completed: [],
+  };
+  if (exec == null || exec.phase !== "complete") return empty;
+
+  // Demand accumulates in the session even when this construct has
+  // nothing schedulable itself: a consumer here may demand a source that
+  // an opaque descendant (e.g., a selected command branch) completes in
+  // its own, later scheduling pass.
+  const session = exec.effectfulCompletionSession;
+  if (session?.policy === "demand-only") {
+    const demandNodes = options?.demandNodes ?? nodes;
+    const demanded = collectDemandedDependencyIds(
+      demandNodes,
+      state,
+      exec.trace,
+    );
+    for (const id of demanded) {
+      session.demanded.add(id);
+    }
+  }
+
+  // A failed effectful completion cached in the run-scoped session (a
+  // cancelled prompt) stops every later effectful completion in the run,
+  // even across separate scheduling passes sharing the session—such as a
+  // seed-extraction fallback after a failed completion attempt.
+  if (session != null) {
+    for (const result of session.results.values()) {
+      if (!result.success) {
+        return { success: false, error: result.error };
+      }
+    }
+  }
+
+  const schedulable = nodes.filter((node) =>
+    node.parser.dependencyMetadata?.source?.completeSource != null
+  );
+  if (schedulable.length === 0) return empty;
+
+  // Structural precedence applies to values present before this pass
+  // (CLI state, environment, configuration, or defaults).  A value
+  // registered by an *earlier effectful occurrence within this pass* does
+  // not suppress later occurrences of the same source: each occurrence
+  // completes and re-registers, so the last occurrence wins, matching how
+  // repeated command-line source occurrences overwrite earlier ones.
+  const preexisting = new Set<symbol>();
+  for (const node of schedulable) {
+    const source = node.parser.dependencyMetadata?.source;
+    if (
+      source != null && runtime.hasSource(source.sourceId) &&
+      // A value registered by an effectful completion (e.g., a prompt
+      // pre-completed through a source binding during Phase 1) is not a
+      // structural value: later prompted occurrences still run so the
+      // last occurrence wins, as with repeated command-line occurrences.
+      session?.effectfulSources.has(source.sourceId) !== true
+    ) {
+      preexisting.add(source.sourceId);
+    }
+  }
+
+  const completed: EffectfulSourceCompletion[] = [];
+  for (const node of schedulable) {
+    const source = node.parser.dependencyMetadata?.source;
+    if (source?.completeSource == null) continue;
+
+    // A completion already performed for this exact node in this pass—
+    // typically by a parent construct's expanded scheduling—is reused
+    // instead of being performed again, keeping lazy wrapper defaults at
+    // one evaluation per pass and letting the owning construct cache the
+    // very result whose value was registered.
+    const pathKey = serializeSchedulingPath(node.path);
+    const priorResult = session?.completedByPath.get(pathKey);
+    if (priorResult != null) {
+      if (
+        source.preservesSourceValue && (options?.isReusable?.(node) ?? true)
+      ) {
+        completed.push({
+          key: node.path[node.path.length - 1],
+          result: priorResult,
+        });
+      }
+      continue;
+    }
+
+    if (preexisting.has(source.sourceId)) continue;
+    // A source marked failed by extraction (e.g., an invalid bound
+    // environment or configuration value) is not skipped: the effectful
+    // completion is its recovery path—a prompt wrapper falls back after
+    // the inner completion fails, and a successful answer re-registers
+    // the source, clearing the failed state, so consumers resolve
+    // consistently with the prompted field.  (Missing-source *defaults*
+    // still never override explicit failures; see
+    // fillMissingSourceDefaults.)
+    const reusable = source.preservesSourceValue &&
+      (options?.isReusable?.(node) ?? true);
+    // A completion that cannot be cached by the owning construct would
+    // run again during the construct's final completion phase unless it
+    // is deduplicated through the run-scoped session.
+    if (!reusable && session == null) continue;
+
+    const childExec: ExecutionContext = { ...exec, path: node.path };
+    const result = await source.completeSource(node.state, childExec);
+    if (result == null) continue;
+    if (!result.success) {
+      runtime.markSourceFailed(source.sourceId);
+      return { success: false, error: result.error };
+    }
+    // Deferred results carry placeholder values, which must never become
+    // dependency values or cached completions.
+    if (result.deferred === true) continue;
+    session?.completedByPath.set(pathKey, result);
+    if (reusable) {
+      completed.push({ key: node.path[node.path.length - 1], result });
+    }
+    if (result.value !== undefined) {
+      runtime.registerSource(source.sourceId, result.value);
+    }
+  }
+  return { success: true, completed };
+}
+
+/**
+ * Serializes a scheduling node path into a stable string key, using
+ * length-prefixed segments so no separator escaping is needed.
+ */
+function serializeSchedulingPath(path: readonly PropertyKey[]): string {
+  return path.map((segment) => {
+    if (typeof segment === "symbol") {
+      const key = stableSymbolKey(segment);
+      return `y${key.length}:${key}`;
+    }
+    const tag = typeof segment === "number" ? "n" : "s";
+    const text = String(segment);
+    return `${tag}${text.length}:${text}`;
+  }).join("");
 }
 
 // =============================================================================

--- a/packages/core/src/facade.ts
+++ b/packages/core/src/facade.ts
@@ -35,6 +35,7 @@ import { multiple, optional, withDefault } from "./modifiers.ts";
 import type { Program } from "./program.ts";
 import {
   createParserContext,
+  type EffectfulCompletionSession,
   type ExecutionContext,
   getDocPage,
   type InferMode,
@@ -46,6 +47,7 @@ import {
   type ParserResult,
   type Suggestion,
 } from "./parser.ts";
+import { createEffectfulCompletionSession } from "./internal/parser.ts";
 import { dispatchByMode } from "./internal/mode-dispatch.ts";
 import {
   collectExplicitSourceValues,
@@ -317,12 +319,35 @@ function getCommandPath(exec: ExecutionContext | undefined): readonly string[] {
   return exec?.commandPath ?? [];
 }
 
+// Module-private options key carrying the run-scoped effectful completion
+// session from runWith() into the final runParser() pass without widening
+// the public RunOptions surface.
+const effectfulSessionOptionsKey: unique symbol = Symbol(
+  "@optique/core/facade/effectfulSessionOptionsKey",
+);
+
+function getEffectfulSessionOption(
+  options: object,
+): EffectfulCompletionSession | undefined {
+  return (options as {
+    readonly [effectfulSessionOptionsKey]?: EffectfulCompletionSession;
+  })[effectfulSessionOptionsKey];
+}
+
+function withEffectfulSessionOption<T extends object>(
+  options: T,
+  session: EffectfulCompletionSession,
+): T {
+  return { ...options, [effectfulSessionOptionsKey]: session } as T;
+}
+
 function createCompleteExec(
   exec: ExecutionContext,
   context: {
     readonly exec?: ExecutionContext;
     readonly trace?: ReturnType<typeof createInputTrace>;
   },
+  session?: EffectfulCompletionSession,
 ): ExecutionContext {
   const runtime = createDependencyRuntimeContext();
   return {
@@ -332,6 +357,7 @@ function createCompleteExec(
     dependencyRegistry: runtime.registry,
     commandPath: getCommandPath(context.exec) ?? exec.commandPath,
     trace: context.exec?.trace ?? context.trace ?? exec.trace,
+    effectfulCompletionSession: session ?? createEffectfulCompletionSession(),
   };
 }
 
@@ -347,7 +373,14 @@ function attemptParseSync(
 function attemptParseSync<T>(
   parser: Parser<"sync", T, unknown>,
   args: readonly string[],
+  mode: "complete",
+  session?: EffectfulCompletionSession,
+): ParseAttempt<T>;
+function attemptParseSync<T>(
+  parser: Parser<"sync", T, unknown>,
+  args: readonly string[],
   mode: "complete" | "parse-only" = "complete",
+  session?: EffectfulCompletionSession,
 ): ParseAttempt<T | undefined> {
   const shouldUnwrapAnnotatedValue = isInjectedAnnotationWrapper(
     parser.initialState,
@@ -403,7 +436,7 @@ function attemptParseSync<T>(
 
   const endResult = parser.complete(
     context.state,
-    createCompleteExec(exec, context),
+    createCompleteExec(exec, context, session),
   );
   if (!endResult.success) {
     return {
@@ -435,7 +468,14 @@ async function attemptParseAsync(
 async function attemptParseAsync<T>(
   parser: Parser<Mode, T, unknown>,
   args: readonly string[],
+  mode: "complete",
+  session?: EffectfulCompletionSession,
+): Promise<ParseAttempt<T>>;
+async function attemptParseAsync<T>(
+  parser: Parser<Mode, T, unknown>,
+  args: readonly string[],
   mode: "complete" | "parse-only" = "complete",
+  session?: EffectfulCompletionSession,
 ): Promise<ParseAttempt<T | undefined>> {
   const shouldUnwrapAnnotatedValue = isInjectedAnnotationWrapper(
     parser.initialState,
@@ -491,7 +531,7 @@ async function attemptParseAsync<T>(
 
   const endResult = await parser.complete(
     context.state,
-    createCompleteExec(exec, context),
+    createCompleteExec(exec, context, session),
   );
   if (!endResult.success) {
     return {
@@ -517,6 +557,7 @@ function createPhase2SeedExec(
     readonly trace?: ReturnType<typeof createInputTrace>;
     readonly exec?: ExecutionContext;
   },
+  session?: EffectfulCompletionSession,
 ): ExecutionContext {
   const exec: ExecutionContext = {
     usage: parser.usage,
@@ -533,6 +574,7 @@ function createPhase2SeedExec(
     dependencyRegistry: runtime.registry,
     commandPath: getCommandPath(context.exec),
     trace: context.exec?.trace ?? context.trace ?? exec.trace,
+    effectfulCompletionSession: session ?? createEffectfulCompletionSession(),
   };
 }
 
@@ -560,6 +602,7 @@ function createPhase2SeedContext(
 function extractPhase2SeedSync(
   parser: Parser<"sync", unknown, unknown>,
   args: readonly string[],
+  session?: EffectfulCompletionSession,
 ) {
   let context = createPhase2SeedContext(parser, args);
   do {
@@ -568,7 +611,7 @@ function extractPhase2SeedSync(
       return completeOrExtractPhase2Seed(
         parser,
         context.state,
-        createPhase2SeedExec(parser, context),
+        createPhase2SeedExec(parser, context, session),
       );
     }
     const previousBuffer = context.buffer;
@@ -577,20 +620,21 @@ function extractPhase2SeedSync(
       return completeOrExtractPhase2Seed(
         parser,
         context.state,
-        createPhase2SeedExec(parser, context),
+        createPhase2SeedExec(parser, context, session),
       );
     }
   } while (context.buffer.length > 0);
   return completeOrExtractPhase2Seed(
     parser,
     context.state,
-    createPhase2SeedExec(parser, context),
+    createPhase2SeedExec(parser, context, session),
   );
 }
 
 async function extractPhase2SeedAsync(
   parser: Parser<Mode, unknown, unknown>,
   args: readonly string[],
+  session?: EffectfulCompletionSession,
 ) {
   let context = createPhase2SeedContext(parser, args);
   do {
@@ -599,7 +643,7 @@ async function extractPhase2SeedAsync(
       return await completeOrExtractPhase2Seed(
         parser,
         context.state,
-        createPhase2SeedExec(parser, context),
+        createPhase2SeedExec(parser, context, session),
       );
     }
     const previousBuffer = context.buffer;
@@ -608,14 +652,14 @@ async function extractPhase2SeedAsync(
       return await completeOrExtractPhase2Seed(
         parser,
         context.state,
-        createPhase2SeedExec(parser, context),
+        createPhase2SeedExec(parser, context, session),
       );
     }
   } while (context.buffer.length > 0);
   return await completeOrExtractPhase2Seed(
     parser,
     context.state,
-    createPhase2SeedExec(parser, context),
+    createPhase2SeedExec(parser, context, session),
   );
 }
 
@@ -3075,6 +3119,8 @@ export function runParser<
       const attempted = attemptParseSync(
         parser as Parser<"sync", unknown, unknown>,
         args,
+        "complete",
+        getEffectfulSessionOption(options),
       );
       const classified: ParsedResult = attempted.kind === "success"
         ? { type: "success", value: attempted.value }
@@ -3094,7 +3140,12 @@ export function runParser<
       return handled;
     },
     async () => {
-      const attempted = await attemptParseAsync(parser, args);
+      const attempted = await attemptParseAsync(
+        parser,
+        args,
+        "complete",
+        getEffectfulSessionOption(options),
+      );
       const classified: ParsedResult = attempted.kind === "success"
         ? { type: "success", value: attempted.value }
         : classifyParseFailure(
@@ -3858,6 +3909,24 @@ async function runWithBody<
   }
 
   // Two-phase parsing for two-pass contexts.
+  // Run-scoped effectful completion session shared by the seed pass and
+  // the final pass, so an effectful source (e.g., a prompt) runs at most
+  // once per runWith() invocation.  The seed pass uses the demand-only
+  // policy: an effectful source completes there only when a phase-one
+  // consumer demands its value; others defer to the final pass.
+  const seedSession = createEffectfulCompletionSession("demand-only");
+  // The final pass shares the run-scoped results cache and demand set,
+  // but recomputes structural precedence from scratch: phase-two
+  // annotations may introduce environment/configuration values that must
+  // win over a cached seed prompt answer, so the effectful-source
+  // markers do not carry over.
+  const finalSession: EffectfulCompletionSession = {
+    ...seedSession,
+    policy: "eager",
+    effectfulSources: new Set(),
+    completedByPath: new Map(),
+  };
+  const sessionOptions = withEffectfulSessionOption(options, finalSession);
   // First pass: parse with Phase 1 annotations to get initial result
   const firstPassSeed = await dispatchByMode(
     parser.mode,
@@ -3865,8 +3934,9 @@ async function runWithBody<
       extractPhase2SeedSync(
         augmentedParser1 as Parser<"sync", unknown, unknown>,
         args,
+        seedSession,
       ),
-    () => extractPhase2SeedAsync(augmentedParser1, args),
+    () => extractPhase2SeedAsync(augmentedParser1, args, seedSession),
   );
 
   // First pass failed - run through runParser for proper error handling.
@@ -3882,13 +3952,18 @@ async function runWithBody<
         fallbackParser,
         programName,
         args,
-        options,
+        sessionOptions,
       ) as Promise<
         InferValue<TParser>
       >;
     }
     return Promise.resolve(
-      runParser(fallbackParser, programName, args, options) as InferValue<
+      runParser(
+        fallbackParser,
+        programName,
+        args,
+        sessionOptions,
+      ) as InferValue<
         TParser
       >,
     );
@@ -3911,12 +3986,22 @@ async function runWithBody<
   );
 
   if (parser.mode === "async") {
-    return runParser(augmentedParser2, programName, args, options) as Promise<
+    return runParser(
+      augmentedParser2,
+      programName,
+      args,
+      sessionOptions,
+    ) as Promise<
       InferValue<TParser>
     >;
   }
   return Promise.resolve(
-    runParser(augmentedParser2, programName, args, options) as InferValue<
+    runParser(
+      augmentedParser2,
+      programName,
+      args,
+      sessionOptions,
+    ) as InferValue<
       TParser
     >,
   );
@@ -4094,14 +4179,33 @@ function runWithSyncBody<
   }
 
   // Two-phase parsing for two-pass contexts.
+  // Run-scoped effectful completion session shared by the seed pass and
+  // the final pass (see runWithBody for details).
+  const seedSession = createEffectfulCompletionSession("demand-only");
+  // The final pass shares the run-scoped results cache and demand set,
+  // but recomputes structural precedence from scratch: phase-two
+  // annotations may introduce environment/configuration values that must
+  // win over a cached seed prompt answer, so the effectful-source
+  // markers do not carry over.
+  const finalSession: EffectfulCompletionSession = {
+    ...seedSession,
+    policy: "eager",
+    effectfulSources: new Set(),
+    completedByPath: new Map(),
+  };
+  const sessionOptions = withEffectfulSessionOption(options, finalSession);
   // First pass: parse with Phase 1 annotations
-  const firstPassSeed = extractPhase2SeedSync(augmentedParser1, args);
+  const firstPassSeed = extractPhase2SeedSync(
+    augmentedParser1,
+    args,
+    seedSession,
+  );
   if (firstPassSeed == null) {
     const fallbackParser = injectAnnotationsIntoParser(
       parser,
       phase1Annotations,
     );
-    return runParser(fallbackParser, programName, args, options);
+    return runParser(fallbackParser, programName, args, sessionOptions);
   }
 
   // Phase 2: Collect annotations with parsed result
@@ -4120,7 +4224,7 @@ function runWithSyncBody<
     finalAnnotations,
   );
 
-  return runParser(augmentedParser2, programName, args, options);
+  return runParser(augmentedParser2, programName, args, sessionOptions);
 }
 
 /**

--- a/packages/core/src/facade.ts
+++ b/packages/core/src/facade.ts
@@ -341,6 +341,32 @@ function withEffectfulSessionOption<T extends object>(
   return { ...options, [effectfulSessionOptionsKey]: session } as T;
 }
 
+/**
+ * Creates the run-scoped effectful completion sessions shared by a
+ * `runWith()` two-phase run, so an effectful source (e.g., a prompt)
+ * runs at most once per invocation.  The seed pass uses the demand-only
+ * policy: an effectful source completes there only when a phase-one
+ * consumer demands its value; others defer to the final pass.  The
+ * final pass shares the run-scoped results cache and demand set, but
+ * recomputes structural precedence from scratch: phase-two annotations
+ * may introduce environment/configuration values that must win over a
+ * cached seed prompt answer, so the effectful-source markers do not
+ * carry over.
+ */
+function createRunWithSessions(): {
+  readonly seedSession: EffectfulCompletionSession;
+  readonly finalSession: EffectfulCompletionSession;
+} {
+  const seedSession = createEffectfulCompletionSession("demand-only");
+  const finalSession: EffectfulCompletionSession = {
+    ...seedSession,
+    policy: "eager",
+    effectfulSources: new Set(),
+    completedByPath: new Map(),
+  };
+  return { seedSession, finalSession };
+}
+
 function createCompleteExec(
   exec: ExecutionContext,
   context: {
@@ -3909,23 +3935,7 @@ async function runWithBody<
   }
 
   // Two-phase parsing for two-pass contexts.
-  // Run-scoped effectful completion session shared by the seed pass and
-  // the final pass, so an effectful source (e.g., a prompt) runs at most
-  // once per runWith() invocation.  The seed pass uses the demand-only
-  // policy: an effectful source completes there only when a phase-one
-  // consumer demands its value; others defer to the final pass.
-  const seedSession = createEffectfulCompletionSession("demand-only");
-  // The final pass shares the run-scoped results cache and demand set,
-  // but recomputes structural precedence from scratch: phase-two
-  // annotations may introduce environment/configuration values that must
-  // win over a cached seed prompt answer, so the effectful-source
-  // markers do not carry over.
-  const finalSession: EffectfulCompletionSession = {
-    ...seedSession,
-    policy: "eager",
-    effectfulSources: new Set(),
-    completedByPath: new Map(),
-  };
+  const { seedSession, finalSession } = createRunWithSessions();
   const sessionOptions = withEffectfulSessionOption(options, finalSession);
   // First pass: parse with Phase 1 annotations to get initial result
   const firstPassSeed = await dispatchByMode(
@@ -4179,20 +4189,7 @@ function runWithSyncBody<
   }
 
   // Two-phase parsing for two-pass contexts.
-  // Run-scoped effectful completion session shared by the seed pass and
-  // the final pass (see runWithBody for details).
-  const seedSession = createEffectfulCompletionSession("demand-only");
-  // The final pass shares the run-scoped results cache and demand set,
-  // but recomputes structural precedence from scratch: phase-two
-  // annotations may introduce environment/configuration values that must
-  // win over a cached seed prompt answer, so the effectful-source
-  // markers do not carry over.
-  const finalSession: EffectfulCompletionSession = {
-    ...seedSession,
-    policy: "eager",
-    effectfulSources: new Set(),
-    completedByPath: new Map(),
-  };
+  const { seedSession, finalSession } = createRunWithSessions();
   const sessionOptions = withEffectfulSessionOption(options, finalSession);
   // First pass: parse with Phase 1 annotations
   const firstPassSeed = extractPhase2SeedSync(

--- a/packages/core/src/internal/parser.ts
+++ b/packages/core/src/internal/parser.ts
@@ -500,9 +500,9 @@ export type ExecutionPhase =
  * run, shared by the phase-two seed pass and the final pass) and threaded
  * through {@link ExecutionContext}.  It guarantees that an effectful source
  * completion runs at most once per run: the completion result is cached by
- * dependency source ID, and a cache hit is returned without repeating the
- * effect.  Results never leak between runs because the session is discarded
- * when the run ends.
+ * completion occurrence (see {@link EffectfulCompletionSession.results}),
+ * and a cache hit is returned without repeating the effect.  Results never
+ * leak between runs because the session is discarded when the run ends.
  *
  * @internal
  * @since 1.3.0

--- a/packages/core/src/internal/parser.ts
+++ b/packages/core/src/internal/parser.ts
@@ -494,6 +494,88 @@ export type ExecutionPhase =
   | "suggest";
 
 /**
+ * Run-scoped state for effectful source completions such as `prompt()`.
+ *
+ * A session is created once per parse operation (or once per `runWith()`
+ * run, shared by the phase-two seed pass and the final pass) and threaded
+ * through {@link ExecutionContext}.  It guarantees that an effectful source
+ * completion runs at most once per run: the completion result is cached by
+ * dependency source ID, and a cache hit is returned without repeating the
+ * effect.  Results never leak between runs because the session is discarded
+ * when the run ends.
+ *
+ * @internal
+ * @since 1.3.0
+ */
+export interface EffectfulCompletionSession {
+  /**
+   * The scheduling policy for effectful source completions.
+   *
+   * `"demand-only"` is used during the phase-two seed pass of a two-pass
+   * source context run: an effectful source completion runs only when a
+   * phase-one consumer demands its source (see
+   * {@link EffectfulCompletionSession.demanded}); otherwise it defers to
+   * the final pass.  `"eager"` is used everywhere else.
+   */
+  readonly policy: "demand-only" | "eager";
+
+  /**
+   * Effectful completion results keyed by completion occurrence (e.g.,
+   * a per-`prompt()`-wrapper cache key), shared across the passes of a
+   * run.  Occurrence keys, rather than dependency source IDs, keep two
+   * distinct effectful wrappers around the same source—such as duplicate
+   * `merge()` fields—from observing each other's local results.
+   */
+  readonly results: Map<symbol, ValueParserResult<unknown>>;
+
+  /**
+   * Source IDs demanded by phase-one consumers.  Constructs add entries
+   * before scheduling effectful completions; the set accumulates across
+   * constructs within a run.
+   */
+  readonly demanded: Set<symbol>;
+
+  /**
+   * Source IDs whose registered value came from an effectful completion
+   * (a prompt that actually executed) rather than from a structural
+   * source such as CLI state, environment, configuration, or a default.
+   * The scheduler uses this to keep structural precedence while still
+   * letting a later prompted occurrence of the same source overwrite an
+   * earlier prompted answer, matching repeated command-line occurrences.
+   */
+  readonly effectfulSources: Set<symbol>;
+
+  /**
+   * Effectful source completion results keyed by serialized node path,
+   * scoped to a single pass like {@link effectfulSources}.  A completion
+   * scheduled for an expanded nested node is recorded here so that the
+   * owning nested construct's own scheduling pass reuses it instead of
+   * completing the same node again—keeping lazy wrapper defaults at one
+   * evaluation per pass and the registered dependency value identical to
+   * the field's final value.
+   */
+  readonly completedByPath: Map<string, ValueParserResult<unknown>>;
+}
+
+/**
+ * Creates a fresh {@link EffectfulCompletionSession}.
+ *
+ * @internal
+ * @since 1.3.0
+ */
+export function createEffectfulCompletionSession(
+  policy: "demand-only" | "eager" = "eager",
+): EffectfulCompletionSession {
+  return {
+    policy,
+    results: new Map(),
+    demanded: new Set(),
+    effectfulSources: new Set(),
+    completedByPath: new Map(),
+  };
+}
+
+/**
  * Shared execution context carrying cross-cutting runtime data.
  * This includes information that is shared across all parsers in a parse
  * tree, such as usage information, dependency registries, and the current
@@ -584,6 +666,16 @@ export interface ExecutionContext {
    * @internal
    */
   readonly excludedSourceFields?: ReadonlySet<string | symbol>;
+
+  /**
+   * Run-scoped state for effectful source completions such as `prompt()`.
+   * Created at the top-level parse entry points and shared across the
+   * passes of a `runWith()` run.
+   *
+   * @internal
+   * @since 1.3.0
+   */
+  readonly effectfulCompletionSession?: EffectfulCompletionSession;
 }
 
 /**
@@ -594,7 +686,9 @@ export interface ExecutionContext {
  * Wrappers like `bindEnv()` and `bindConfig()` opt in because their missing
  * CLI states still carry enough fallback context to pre-complete exactly
  * once. Wrappers like `prompt()` intentionally do not opt in because
- * prompted values are not yet registered as dependency sources.
+ * Phase 1 must stay effect-free; prompted values register instead through
+ * the `completeSource` capability during the serial effectful completion
+ * pass that runs before dependency replay.
  *
  * @internal
  */
@@ -969,6 +1063,7 @@ export function parseSync<T>(
     dependencyRegistry: runtime.registry,
     commandPath: context.exec?.commandPath ?? exec.commandPath,
     trace: context.exec?.trace ?? context.trace ?? exec.trace,
+    effectfulCompletionSession: createEffectfulCompletionSession(),
   };
   const endResult = parser.complete(context.state, completeExec);
   return endResult.success
@@ -1061,6 +1156,7 @@ export async function parseAsync<T>(
     dependencyRegistry: runtime.registry,
     commandPath: context.exec?.commandPath ?? exec.commandPath,
     trace: context.exec?.trace ?? context.trace ?? exec.trace,
+    effectfulCompletionSession: createEffectfulCompletionSession(),
   };
   const endResult = await parser.complete(context.state, completeExec);
   return endResult.success

--- a/packages/core/src/modifiers.ts
+++ b/packages/core/src/modifiers.ts
@@ -6,6 +6,7 @@ import {
   normalizeNestedDelegatedAnnotationState,
 } from "./annotation-state.ts";
 import { composeDependencyMetadata } from "./dependency-metadata.ts";
+import { defineForwardedEffectfulSchedulingNodes } from "./dependency-runtime.ts";
 import { formatMessage, type Message, message, text } from "./message.ts";
 import {
   annotateFreshArray,
@@ -1006,10 +1007,50 @@ export function optional<M extends Mode, TValue, TState>(
       "optional",
     );
     if (composed != null) {
+      // Rebind the inner effectful completion (e.g., optional(prompt(...)))
+      // to this wrapper's own complete() so optional()'s suppression is
+      // honored when a parent construct schedules the completion
+      // directly: an unmatched optional field resolves to `undefined`
+      // without prompting, exactly as it does for a non-source prompt.
+      // A transformed source (preservesSourceValue: false) exposes no
+      // completion at all, because this wrapper's completion lives in
+      // the transformed domain and must never register under the raw
+      // source ID.
+      const rebound = composed.source?.completeSource == null
+        ? composed
+        : composed.source.preservesSourceValue === false
+        ? {
+          ...composed,
+          source: { ...composed.source, completeSource: undefined },
+        }
+        : {
+          ...composed,
+          source: {
+            ...composed.source,
+            completeSource: (
+              state: unknown,
+              exec?: ExecutionContext,
+            ): Promise<ValueParserResult<unknown> | undefined> =>
+              Promise.resolve(
+                optionalParser.complete(
+                  state as Parameters<typeof optionalParser.complete>[0],
+                  exec,
+                ),
+              ) as Promise<ValueParserResult<unknown>>,
+          },
+        };
       (optionalParser as unknown as Record<string, unknown>)
-        .dependencyMetadata = composed;
+        .dependencyMetadata = rebound;
     }
   }
+  // Forward the inner effectful scheduling hook (e.g., a wrapped
+  // exclusive or command construct), unwrapping optional()'s
+  // `[innerState]` state shape first.
+  defineForwardedEffectfulSchedulingNodes(
+    optionalParser,
+    parser,
+    (state) => Array.isArray(state) && state.length === 1 ? state[0] : state,
+  );
   defineParseLanes(optionalParser, adaptOptionalStyleParseLanes(parser));
   defineInheritedAnnotationParser(optionalParser);
   defineSourceBindingOnlyAnnotationCompletionParser(optionalParser);
@@ -1552,10 +1593,50 @@ export function withDefault<
       },
     );
     if (composed != null) {
+      // Rebind the inner effectful completion (e.g., withDefault(prompt(...)))
+      // to this wrapper's own complete() so the wrapper's fallback
+      // precedence is honored when a parent construct schedules the
+      // completion directly, matching how Phase 1 pre-completion behaves
+      // for a top-level field.
+      // A transformed source (preservesSourceValue: false) exposes no
+      // completion at all, because this wrapper's completion lives in
+      // the transformed domain and must never register under the raw
+      // source ID.
+      const rebound = composed.source?.completeSource == null
+        ? composed
+        : composed.source.preservesSourceValue === false
+        ? {
+          ...composed,
+          source: { ...composed.source, completeSource: undefined },
+        }
+        : {
+          ...composed,
+          source: {
+            ...composed.source,
+            completeSource: (
+              state: unknown,
+              exec?: ExecutionContext,
+            ): Promise<ValueParserResult<unknown> | undefined> =>
+              Promise.resolve(
+                withDefaultParser.complete(
+                  state as Parameters<typeof withDefaultParser.complete>[0],
+                  exec,
+                ),
+              ) as Promise<ValueParserResult<unknown>>,
+          },
+        };
       (withDefaultParser as unknown as Record<string, unknown>)
-        .dependencyMetadata = composed;
+        .dependencyMetadata = rebound;
     }
   }
+  // Forward the inner effectful scheduling hook (e.g., a wrapped
+  // exclusive or command construct), unwrapping withDefault()'s
+  // `[innerState]` state shape first.
+  defineForwardedEffectfulSchedulingNodes(
+    withDefaultParser,
+    parser,
+    (state) => Array.isArray(state) && state.length === 1 ? state[0] : state,
+  );
   defineParseLanes(
     withDefaultParser,
     adaptOptionalStyleParseLanes(parser),
@@ -1811,6 +1892,10 @@ export function map<M extends Mode, T, U, TState>(
         composed;
     }
   }
+  // Forward the inner effectful scheduling hook—map() passes state
+  // through unchanged, so a wrapped exclusive or command construct stays
+  // visible to a parent's scheduling expansion.
+  defineForwardedEffectfulSchedulingNodes(mappedParser, parser);
   return fluent(mappedParser);
 }
 
@@ -3287,6 +3372,10 @@ export function multiple<M extends Mode, TValue, TState>(
         source: {
           ...innerSource,
           preservesSourceValue: false,
+          // There is no non-surprising rule for reducing several
+          // effectful completions to one dependency value, so multiple()
+          // never forwards the effectful completion capability.
+          completeSource: undefined,
           extractSourceValue: (
             state: unknown,
           ):
@@ -3471,6 +3560,16 @@ export function nonEmpty<M extends Mode, T, TState>(
       },
     })),
   );
+  // Forward dependency metadata unchanged—nonEmpty() passes state
+  // through, so source extraction and effectful completion see the inner
+  // shape, exactly like group().
+  if (parser.dependencyMetadata != null) {
+    Object.defineProperty(nonEmptyParser, "dependencyMetadata", {
+      value: parser.dependencyMetadata,
+      configurable: true,
+      enumerable: false,
+    });
+  }
   // Forward placeholder lazily from inner parser.
   if ("placeholder" in parser) {
     Object.defineProperty(nonEmptyParser, "placeholder", {
@@ -3508,6 +3607,10 @@ export function nonEmpty<M extends Mode, T, TState>(
       enumerable: false,
     });
   }
+  // Forward the inner effectful scheduling hook—nonEmpty() passes state
+  // through unchanged, so a wrapped exclusive or command construct stays
+  // visible to a parent's scheduling expansion.
+  defineForwardedEffectfulSchedulingNodes(nonEmptyParser, parser);
   return fluent(nonEmptyParser);
 }
 

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -2,6 +2,7 @@ export type { ParseOptions } from "./annotations.ts";
 export type {
   CombineModes,
   DocState,
+  EffectfulCompletionSession,
   ExecutionContext,
   ExecutionPhase,
   InferMode,

--- a/packages/core/src/primitives.ts
+++ b/packages/core/src/primitives.ts
@@ -15,6 +15,8 @@ import {
 import { annotateFreshArray, getAnnotations } from "./internal/annotations.ts";
 import { extractDependencyMetadata } from "./dependency-metadata.ts";
 import {
+  type EffectfulSchedulingNodesFn,
+  effectfulSchedulingNodesKey,
   replayDerivedParser,
   replayDerivedParserAsync,
 } from "./dependency-runtime.ts";
@@ -3596,6 +3598,37 @@ export function command<M extends Mode, T, TState>(
       enumerable: false,
     });
   }
+  // Expose the inner parser to parent-level effectful scheduling once the
+  // command's inner parsing has started, so a source nested in a selected
+  // command completes before parent-level dependency replay.  The node
+  // path appends the command name, matching the execution path used when
+  // the inner parser completes.
+  Object.defineProperty(result, effectfulSchedulingNodesKey, {
+    value: ((state, parentPath) => {
+      const normalizedState = normalizeCommandState(
+        state as CommandState<TState>,
+      );
+      if (normalizedState == null) return [];
+      // "matched" means the command name was consumed but the inner
+      // parser has not started; scheduling then works from the inner
+      // parser's initial state, mirroring the "matched" completion
+      // branch below.
+      const innerState = normalizedState[0] === "parsing"
+        ? normalizedState[1]
+        : parser.initialState;
+      return [{
+        path: [...(parentPath ?? []), name],
+        parser,
+        state: getCommandChildState(
+          state as CommandState<TState>,
+          innerState,
+          parser,
+        ),
+      }];
+    }) satisfies EffectfulSchedulingNodesFn,
+    configurable: true,
+    enumerable: false,
+  });
   // Type assertion via 'unknown' needed because TypeScript's conditional type
   // ModeValue<M, T> cannot be verified when M is a generic type parameter.
   return fluent(result as unknown as Parser<M, T, CommandState<TState>>);

--- a/packages/derived-defaults/src/index.ts
+++ b/packages/derived-defaults/src/index.ts
@@ -687,6 +687,20 @@ export function bindDerivedDefault<
           parser,
         );
       },
+      // Rebind the inner effectful completion (e.g., a prompt wrapper)
+      // to this wrapper's own complete() so the wrapper's fallback
+      // precedence (CLI → derived default → inner prompt) is honored
+      // when a parent construct schedules the completion directly.  When
+      // the wrapped parser transforms the source value, this wrapper's
+      // completion lives in the transformed domain and must never
+      // register under the raw source ID, so no completion is exposed.
+      completeSource: sourceMetadata.completeSource == null ||
+          sourceMetadata.preservesSourceValue === false
+        ? undefined
+        : (state: unknown, exec) =>
+          Promise.resolve(
+            boundParser.complete(state as TState, exec),
+          ) as Promise<ValueParserResult<unknown> | undefined>,
     }),
   );
   if (dependencyMetadata != null) {

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -965,6 +965,20 @@ export function bindEnv<
           parser,
         );
       },
+      // Rebind the inner effectful completion (e.g., bindEnv(prompt(...)))
+      // to this wrapper's own complete() so the wrapper's fallback
+      // precedence (CLI → environment → inner prompt) is honored when a
+      // parent construct schedules the completion directly.  When the
+      // wrapped parser transforms the source value, this wrapper's
+      // completion lives in the transformed domain and must never
+      // register under the raw source ID, so no completion is exposed.
+      completeSource: sourceMetadata.completeSource == null ||
+          sourceMetadata.preservesSourceValue === false
+        ? undefined
+        : (state: unknown, exec) =>
+          Promise.resolve(
+            boundParser.complete(state as TState, exec),
+          ) as Promise<ValueParserResult<unknown> | undefined>,
     }),
   );
   if (dependencyMetadata != null) {

--- a/packages/inquirer/src/index.test.ts
+++ b/packages/inquirer/src/index.test.ts
@@ -5340,12 +5340,8 @@ describe("prompt() with dependency sources", () => {
     assert.ok(!result.success);
   });
 
-  // Note: prompted values are not currently registered as dependency
-  // sources.  When the CLI omits the source option and prompt()
-  // provides the value interactively, the derived parser falls back
-  // to its defaultValue instead of using the prompted value.
-  // This gap is tracked in https://github.com/dahlia/optique/issues/750
-  it("prompted dependency source uses default for derived parser", async () => {
+  // https://github.com/dahlia/optique/issues/870
+  it("prompted dependency source resolves the derived parser", async () => {
     const parser = object({
       mode: prompt(option("--mode", mode), {
         type: "select",
@@ -5355,14 +5351,98 @@ describe("prompt() with dependency sources", () => {
       }),
       level: option("--level", level),
     });
-    // --mode not provided; prompt returns "prod" but the derived parser
-    // uses its defaultValue ("dev") since prompted values don't register
-    // as dependency sources
-    const result = await parseAsync(parser, ["--level", "debug"]);
+    // --mode not provided; the prompt returns "prod", which registers as
+    // the dependency value, so "silent" is valid for the derived parser.
+    const result = await parseAsync(parser, ["--level", "silent"]);
     assert.ok(result.success);
     assert.equal(result.value.mode, "prod");
-    assert.equal(result.value.level, "debug");
+    assert.equal(result.value.level, "silent");
   });
+
+  // https://github.com/dahlia/optique/issues/870
+  it("prompted dependency source rejects invalid derived value", async () => {
+    const parser = object({
+      mode: prompt(option("--mode", mode), {
+        type: "select",
+        message: "Select mode:",
+        choices: ["dev", "prod"],
+        prompter: () => Promise.resolve("prod"),
+      }),
+      level: option("--level", level),
+    });
+    // "debug" is only valid for "dev", but the prompt answers "prod".
+    const result = await parseAsync(parser, ["--level", "debug"]);
+    assert.ok(!result.success);
+  });
+
+  it(
+    "lets a phase-two structural value win over a seed prompt answer",
+    async () => {
+      type SharedConfig = { readonly b?: "dev" | "prod" };
+      const shared = dependency(choice(["dev", "prod"] as const));
+      const seen: string[] = [];
+      const sharedLevel = shared.derive({
+        metavar: "LEVEL",
+        mode: "sync",
+        factory: (value: "dev" | "prod") => {
+          seen.push(value);
+          return choice(
+            value === "dev"
+              ? (["debug", "common"] as const)
+              : (["silent", "common"] as const),
+          );
+        },
+        defaultValue: () => "dev" as const,
+      });
+      const context = createConfigContext<SharedConfig>({
+        schema: {
+          "~standard": {
+            version: 1,
+            vendor: "optique-test",
+            validate(input: unknown) {
+              return { value: input as SharedConfig };
+            },
+          },
+        },
+      });
+      let promptCalls = 0;
+      const parser = object({
+        a: prompt(option("--a", shared), {
+          type: "select",
+          message: "A:",
+          choices: ["dev", "prod"],
+          prompter: () => {
+            promptCalls += 1;
+            return Promise.resolve("dev");
+          },
+        }),
+        b: bindConfig(option("--b", shared), {
+          context,
+          key: "b",
+          default: "dev",
+        }),
+        level: option("--level", sharedLevel),
+      });
+
+      // The seed pass demands the source (CLI --level), so the prompt
+      // for `a` answers "dev" there.  Phase two then supplies a
+      // structural config value "prod" for the later occurrence `b`,
+      // which must win in the final pass: the final replay must see
+      // "prod".
+      const result = await runWith(parser, "test", [context], {
+        args: ["--level", "common"],
+        contextOptions: {
+          load: () => ({ config: { b: "prod" }, meta: undefined }),
+        },
+      });
+
+      assert.equal(result.a, "dev");
+      assert.equal(result.b, "prod");
+      assert.equal(result.level, "common");
+      assert.equal(promptCalls, 1);
+      assert.equal(seen.at(-1), "prod");
+    },
+  );
 
   it("preserves inner source extraction when prompt() wraps bindEnv()", async () => {
     const envContext = createEnvContext({

--- a/packages/prompt/src/index.test.ts
+++ b/packages/prompt/src/index.test.ts
@@ -1183,6 +1183,50 @@ describe("prompted values as dependency sources", () => {
   );
 
   it(
+    "prompts a later shared-source occurrence despite an earlier CLI value",
+    async () => {
+      const shared = dependency(choice(["dev", "prod"] as const));
+      const level = shared.derive({
+        metavar: "LEVEL",
+        mode: "sync",
+        factory: (value: "dev" | "prod") =>
+          choice(
+            value === "dev"
+              ? (["debug", "verbose"] as const)
+              : (["silent", "strict"] as const),
+          ),
+        defaultValue: () => "dev" as const,
+      });
+      const { prompt, calls } = createTestPrompt();
+      const parser = object({
+        a: prompt(option("--a", shared), { value: "prod" }),
+        b: prompt(option("--b", shared), { value: "prod" }),
+        level: option("--level", level),
+      });
+
+      // CLI parity with "--a dev --b prod": a command-line value for one
+      // occurrence must not suppress the other occurrence's prompt, whose
+      // answer still registers last and wins before sibling replay.
+      const result = await parseAsync(
+        parser,
+        ["--a", "dev", "--level", "silent"],
+      );
+
+      assert.ok(result.success);
+      assert.equal(result.value.a, "dev");
+      assert.equal(result.value.b, "prod");
+      assert.equal(result.value.level, "silent");
+      assert.equal(calls.length, 1);
+
+      const invalid = await parseAsync(
+        parser,
+        ["--a", "dev", "--level", "debug"],
+      );
+      assert.ok(!invalid.success);
+    },
+  );
+
+  it(
     "runs merge() source prompts in declaration order despite priorities",
     async () => {
       const srcA = dependency(string());

--- a/packages/prompt/src/index.test.ts
+++ b/packages/prompt/src/index.test.ts
@@ -2,14 +2,40 @@ import assert from "node:assert/strict";
 import * as fc from "fast-check";
 import { describe, it } from "node:test";
 import { type Annotations, getAnnotations } from "@optique/core/annotations";
-import { object } from "@optique/core/constructs";
+import {
+  concat,
+  conditional,
+  group,
+  merge,
+  object,
+  or,
+  seq,
+  tuple,
+} from "@optique/core/constructs";
+import type {
+  SourceContext,
+  SourceContextPhase2Request,
+} from "@optique/core/context";
+import { dependency } from "@optique/core/dependency";
 import { defineTraits, getTraits } from "@optique/core/extension";
-import { runParser } from "@optique/core/facade";
+import { runParser, runWith } from "@optique/core/facade";
 import { message } from "@optique/core/message";
-import { multiple, optional, withDefault } from "@optique/core/modifiers";
+import {
+  multiple,
+  nonEmpty,
+  optional,
+  withDefault,
+} from "@optique/core/modifiers";
 import { parseAsync, type Parser, suggestAsync } from "@optique/core/parser";
-import { constant, fail, option } from "@optique/core/primitives";
-import { integer, string } from "@optique/core/valueparser";
+import {
+  argument,
+  command,
+  constant,
+  fail,
+  flag,
+  option,
+} from "@optique/core/primitives";
+import { choice, integer, string } from "@optique/core/valueparser";
 import { bindEnv, createEnvContext } from "@optique/env";
 import { createPromptAdapter, type PromptCondition } from "@optique/prompt";
 
@@ -613,6 +639,1673 @@ describe("createPromptAdapter()", () => {
 
     assert.ok(result.success);
     assert.deepEqual(result.value, ["a", "b"]);
+    assert.deepEqual(calls, []);
+  });
+});
+
+function createModeFixture() {
+  const mode = dependency(choice(["dev", "prod"] as const));
+  const level = mode.derive({
+    metavar: "LEVEL",
+    mode: "sync",
+    factory: (value: "dev" | "prod") =>
+      choice(
+        value === "dev"
+          ? (["debug", "verbose"] as const)
+          : (["silent", "strict"] as const),
+      ),
+    defaultValue: () => "dev" as const,
+  });
+  return { mode, level };
+}
+
+function isPhase2ContextRequest(
+  request: unknown,
+): request is SourceContextPhase2Request {
+  return request != null &&
+    typeof request === "object" &&
+    "phase" in request &&
+    (request as { readonly phase?: unknown }).phase === "phase2" &&
+    "parsed" in request;
+}
+
+function getPhase2ContextParsed<T>(request: unknown): T | undefined {
+  return isPhase2ContextRequest(request) ? request.parsed as T : undefined;
+}
+
+// https://github.com/dahlia/optique/issues/870
+describe("prompted values as dependency sources", () => {
+  it("registers a prompted value for a derived parser", async () => {
+    const { mode, level } = createModeFixture();
+    const { prompt, calls } = createTestPrompt();
+    const parser = object({
+      mode: prompt(option("--mode", mode), { value: "prod" }),
+      level: option("--level", level),
+    });
+
+    const result = await parseAsync(parser, ["--level", "silent"]);
+
+    assert.ok(result.success);
+    assert.equal(result.value.mode, "prod");
+    assert.equal(result.value.level, "silent");
+    assert.equal(calls.length, 1);
+  });
+
+  it("rejects a derived value invalid for the prompted source", async () => {
+    const { mode, level } = createModeFixture();
+    const { prompt } = createTestPrompt();
+    const parser = object({
+      mode: prompt(option("--mode", mode), { value: "prod" }),
+      level: option("--level", level),
+    });
+
+    // "debug" is only valid when the mode is "dev", but the prompt
+    // answers "prod".
+    const result = await parseAsync(parser, ["--level", "debug"]);
+
+    assert.ok(!result.success);
+  });
+
+  it("should behave identically for CLI and prompted source values", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom("dev", "prod"),
+        fc.constantFrom("debug", "verbose", "silent", "strict"),
+        async (modeValue, levelValue) => {
+          const { mode, level } = createModeFixture();
+          const { prompt } = createTestPrompt();
+          const parser = object({
+            mode: prompt(option("--mode", mode), { value: modeValue }),
+            level: option("--level", level),
+          });
+
+          const cliResult = await parseAsync(parser, [
+            "--mode",
+            modeValue,
+            "--level",
+            levelValue,
+          ]);
+          const promptedResult = await parseAsync(parser, [
+            "--level",
+            levelValue,
+          ]);
+
+          assert.equal(promptedResult.success, cliResult.success);
+          if (cliResult.success && promptedResult.success) {
+            assert.deepEqual(promptedResult.value, cliResult.value);
+          }
+        },
+      ),
+    );
+  });
+
+  it("keeps CLI precedence over the prompt for the source", async () => {
+    const { mode, level } = createModeFixture();
+    const { prompt, calls } = createTestPrompt();
+    const parser = object({
+      mode: prompt(option("--mode", mode), { value: "prod" }),
+      level: option("--level", level),
+    });
+
+    const result = await parseAsync(parser, [
+      "--mode",
+      "dev",
+      "--level",
+      "debug",
+    ]);
+
+    assert.ok(result.success);
+    assert.equal(result.value.mode, "dev");
+    assert.equal(result.value.level, "debug");
+    assert.deepEqual(calls, []);
+  });
+
+  it("keeps env precedence over the prompt for the source", async () => {
+    const { mode, level } = createModeFixture();
+    const { prompt, calls } = createTestPrompt();
+    const envContext = createEnvContext({
+      prefix: "APP_",
+      source: (key) => ({ APP_MODE: "prod" })[key],
+    });
+    const annotations = envContext.getAnnotations();
+    if (annotations instanceof Promise) {
+      throw new TypeError("Expected synchronous annotations.");
+    }
+    const parser = object({
+      mode: prompt(
+        bindEnv(option("--mode", mode), {
+          context: envContext,
+          key: "MODE",
+          parser: choice(["dev", "prod"] as const),
+        }),
+        { value: "dev" },
+      ),
+      level: option("--level", level),
+    });
+
+    const result = await parseAsync(parser, ["--level", "silent"], {
+      annotations,
+    });
+
+    assert.ok(result.success);
+    assert.equal(result.value.mode, "prod");
+    assert.equal(result.value.level, "silent");
+    assert.deepEqual(calls, []);
+  });
+
+  it("registers a prompted value inside tuple()", async () => {
+    const { mode, level } = createModeFixture();
+    const { prompt, calls } = createTestPrompt();
+    const parser = tuple([
+      prompt(option("--mode", mode), { value: "prod" }),
+      option("--level", level),
+    ]);
+
+    const valid = await parseAsync(parser, ["--level", "silent"]);
+    assert.ok(valid.success);
+    assert.deepEqual(valid.value, ["prod", "silent"]);
+    assert.equal(calls.length, 1);
+
+    const invalid = await parseAsync(parser, ["--level", "debug"]);
+    assert.ok(!invalid.success);
+  });
+
+  it("registers a prompted value inside seq()", async () => {
+    const { mode, level } = createModeFixture();
+    const { prompt, calls } = createTestPrompt();
+    const parser = seq(
+      prompt(option("--mode", mode), { value: "prod" }),
+      option("--level", level),
+    );
+
+    const valid = await parseAsync(parser, ["--level", "silent"]);
+    assert.ok(valid.success);
+    assert.deepEqual(valid.value, ["prod", "silent"]);
+    assert.equal(calls.length, 1);
+
+    const invalid = await parseAsync(parser, ["--level", "debug"]);
+    assert.ok(!invalid.success);
+  });
+
+  it("registers a prompted value across merge() children", async () => {
+    const { mode, level } = createModeFixture();
+    const { prompt, calls } = createTestPrompt();
+    const parser = merge(
+      object({ mode: prompt(option("--mode", mode), { value: "prod" }) }),
+      object({ level: option("--level", level) }),
+    );
+
+    const result = await parseAsync(parser, ["--level", "silent"]);
+
+    assert.ok(result.success);
+    assert.equal(result.value.mode, "prod");
+    assert.equal(result.value.level, "silent");
+    assert.equal(calls.length, 1);
+  });
+
+  it("keeps a duplicated merge() field's prompted source local", async () => {
+    const { mode, level } = createModeFixture();
+    const { prompt } = createTestPrompt();
+    const parser = merge(
+      object({ mode: prompt(option("--mode", mode), { value: "prod" }) }),
+      object({
+        mode: withDefault(option("--override-mode", string()), "dev"),
+        level: option("--level", level),
+      }),
+    );
+
+    // The first child's prompted source is behind a duplicated field, so
+    // it must stay local to that child.  The sibling consumer falls back
+    // to its own default ("dev"), for which "debug" is valid.
+    const result = await parseAsync(parser, ["--level", "debug"]);
+
+    assert.ok(result.success);
+    assert.equal(result.value.level, "debug");
+  });
+
+  it("registers a prompted value behind group()", async () => {
+    const { mode, level } = createModeFixture();
+    const { prompt, calls } = createTestPrompt();
+    const parser = object({
+      mode: group("Mode", prompt(option("--mode", mode), { value: "prod" })),
+      level: option("--level", level),
+    });
+
+    const result = await parseAsync(parser, ["--level", "silent"]);
+
+    assert.ok(result.success);
+    assert.equal(result.value.mode, "prod");
+    assert.equal(result.value.level, "silent");
+    assert.equal(calls.length, 1);
+  });
+
+  it("stops later prompts when a source prompt is cancelled", async () => {
+    const first = createModeFixture();
+    const second = createModeFixture();
+    const { prompt, calls } = createTestPrompt();
+    const parser = object({
+      a: prompt(option("--a", first.mode), { value: "dev", reject: true }),
+      b: prompt(option("--b", second.mode), { value: "dev" }),
+      aLevel: option("--a-level", first.level),
+      bLevel: option("--b-level", second.level),
+    });
+
+    const result = await parseAsync(parser, [
+      "--a-level",
+      "debug",
+      "--b-level",
+      "debug",
+    ]);
+
+    assert.ok(!result.success);
+    assert.equal(calls.length, 1);
+  });
+
+  it("does not register a successful undefined prompt value", async () => {
+    const { mode, level } = createModeFixture();
+    const { prompt, calls } = createTestPrompt();
+    const parser = object({
+      mode: prompt(optional(option("--mode", mode)), { value: undefined }),
+      level: option("--level", level),
+    });
+
+    // The prompt succeeds with `undefined`, which must not register as a
+    // dependency value; the derived parser falls back to its default
+    // ("dev"), for which "debug" is valid.
+    const result = await parseAsync(parser, ["--level", "debug"]);
+
+    assert.ok(result.success);
+    assert.equal(result.value.mode, undefined);
+    assert.equal(result.value.level, "debug");
+    assert.equal(calls.length, 1);
+  });
+
+  it("does not prompt a source during shell suggestions", async () => {
+    const { mode, level } = createModeFixture();
+    const { prompt, calls } = createTestPrompt();
+    const parser = object({
+      mode: prompt(option("--mode", mode), { value: "prod" }),
+      level: option("--level", level),
+    });
+
+    const suggestions = await suggestAsync(parser, ["--level", ""]);
+
+    assert.ok(suggestions.length > 0);
+    assert.deepEqual(calls, []);
+  });
+
+  it("prompts a source once per parse operation", async () => {
+    const { mode, level } = createModeFixture();
+    const { prompt, calls } = createTestPrompt();
+    const parser = object({
+      mode: prompt(option("--mode", mode), { value: "prod" }),
+      level: option("--level", level),
+    });
+
+    const first = await parseAsync(parser, ["--level", "silent"]);
+    const second = await parseAsync(parser, ["--level", "strict"]);
+
+    assert.ok(first.success);
+    assert.equal(first.value.level, "silent");
+    assert.ok(second.success);
+    assert.equal(second.value.level, "strict");
+    assert.equal(calls.length, 2);
+  });
+
+  it(
+    "prompts a demanded source during the phase-two seed pass exactly once",
+    async () => {
+      const { mode, level } = createModeFixture();
+      const { prompt, calls } = createTestPrompt();
+      let phase2Parsed:
+        | { readonly mode?: string; readonly level?: string }
+        | undefined;
+      const dynamicContext: SourceContext = {
+        id: Symbol.for("@optique/prompt/test-demanded-phase-two"),
+        phase: "two-pass",
+        getAnnotations(request?: unknown) {
+          const parsed = getPhase2ContextParsed<
+            { readonly mode?: string; readonly level?: string }
+          >(request);
+          if (parsed !== undefined) phase2Parsed = parsed;
+          return {};
+        },
+      };
+      const parser = object({
+        mode: prompt(option("--mode", mode), { value: "prod" }),
+        level: option("--level", level),
+      });
+
+      const result = await runWith(parser, "test", [dynamicContext], {
+        args: ["--level", "silent"],
+      });
+
+      assert.deepEqual(result, { mode: "prod", level: "silent" });
+      assert.equal(phase2Parsed?.mode, "prod");
+      assert.equal(phase2Parsed?.level, "silent");
+      assert.equal(calls.length, 1);
+    },
+  );
+
+  it(
+    "defers an undemanded source prompt to the final pass",
+    async () => {
+      const { mode } = createModeFixture();
+      const { prompt, calls } = createTestPrompt();
+      let phase2Mode: string | undefined = "unset";
+      const dynamicContext: SourceContext = {
+        id: Symbol.for("@optique/prompt/test-undemanded-phase-two"),
+        phase: "two-pass",
+        getAnnotations(request?: unknown) {
+          const parsed = getPhase2ContextParsed<
+            { readonly mode?: string } | undefined
+          >(request);
+          if (isPhase2ContextRequest(request)) phase2Mode = parsed?.mode;
+          return {};
+        },
+      };
+      const parser = object({
+        mode: prompt(option("--mode", mode), { value: "prod" }),
+      });
+
+      const result = await runWith(parser, "test", [dynamicContext], {
+        args: [],
+      });
+
+      assert.deepEqual(result, { mode: "prod" });
+      assert.equal(phase2Mode, undefined);
+      assert.equal(calls.length, 1);
+    },
+  );
+
+  it(
+    "registers a prompted value nested in a concat() child tuple",
+    async () => {
+      const { mode, level } = createModeFixture();
+      const { prompt, calls } = createTestPrompt();
+      // The consumer's tuple precedes the source's tuple, so the source
+      // prompt must complete before any child tuple completes.
+      const parser = concat(
+        tuple([option("--level", level)]),
+        tuple([prompt(option("--mode", mode), { value: "prod" })]),
+      );
+
+      const valid = await parseAsync(parser, ["--level", "silent"]);
+      assert.ok(valid.success);
+      assert.deepEqual(valid.value, ["silent", "prod"]);
+      assert.equal(calls.length, 1);
+
+      const invalid = await parseAsync(parser, ["--level", "debug"]);
+      assert.ok(!invalid.success);
+    },
+  );
+
+  it("registers a prompted value inside a nested concat()", async () => {
+    const { mode, level } = createModeFixture();
+    const { prompt, calls } = createTestPrompt();
+    const parser = object({
+      combo: concat(
+        tuple([prompt(option("--mode", mode), { value: "prod" })]),
+        tuple([optional(option("--other", string()))]),
+      ),
+      level: option("--level", level),
+    });
+
+    const result = await parseAsync(parser, ["--level", "silent"]);
+
+    assert.ok(result.success);
+    assert.deepEqual(result.value.combo, ["prod", undefined]);
+    assert.equal(result.value.level, "silent");
+    assert.equal(calls.length, 1);
+  });
+
+  it(
+    "keeps a duplicate-field prompt local inside a nested merge()",
+    async () => {
+      const { mode, level } = createModeFixture();
+      const { prompt } = createTestPrompt();
+      const parser = object({
+        combo: merge(
+          object({
+            mode: prompt(option("--mode-a", mode), { value: "prod" }),
+          }),
+          object({ mode: withDefault(option("--mode-b", string()), "dev") }),
+        ),
+        level: option("--level", level),
+      });
+
+      // The first child's prompted source is behind a duplicated merge()
+      // field, so it must stay local to that child even when the merge is
+      // nested; the outer consumer falls back to its own default ("dev"),
+      // for which "debug" is valid.
+      const result = await parseAsync(parser, ["--level", "debug"]);
+
+      assert.ok(result.success);
+      assert.equal(result.value.combo.mode, "dev");
+      assert.equal(result.value.level, "debug");
+    },
+  );
+
+  it(
+    "keeps env precedence for a nested bindEnv(prompt(...)) source",
+    async () => {
+      const { mode, level } = createModeFixture();
+      const { prompt, calls } = createTestPrompt();
+      const envContext = createEnvContext({
+        prefix: "APP_",
+        source: (key) => ({ APP_MODE: "prod" })[key],
+      });
+      const annotations = envContext.getAnnotations();
+      if (annotations instanceof Promise) {
+        throw new TypeError("Expected synchronous annotations.");
+      }
+      const parser = object({
+        settings: object({
+          mode: bindEnv(prompt(option("--mode", mode), { value: "dev" }), {
+            context: envContext,
+            key: "MODE",
+            parser: choice(["dev", "prod"] as const),
+          }),
+        }),
+        level: option("--level", level),
+      });
+
+      const result = await parseAsync(parser, ["--level", "silent"], {
+        annotations,
+      });
+
+      assert.ok(result.success);
+      assert.equal(result.value.settings.mode, "prod");
+      assert.equal(result.value.level, "silent");
+      assert.deepEqual(calls, []);
+    },
+  );
+
+  it(
+    "keeps withDefault(prompt(...)) behavior identical when nested",
+    async () => {
+      const { mode, level } = createModeFixture();
+      const { prompt, calls } = createTestPrompt();
+      // At the top level, withDefault(prompt(...)) resolves to the default
+      // without prompting; nesting the field under another object() must
+      // not change that.
+      const parser = object({
+        settings: object({
+          mode: withDefault(
+            prompt(option("--mode", mode), { value: "prod" }),
+            "dev" as const,
+          ),
+        }),
+        level: option("--level", level),
+      });
+
+      const result = await parseAsync(parser, ["--level", "debug"]);
+
+      assert.ok(result.success);
+      assert.equal(result.value.settings.mode, "dev");
+      assert.equal(result.value.level, "debug");
+      assert.deepEqual(calls, []);
+    },
+  );
+
+  it(
+    "lets the later prompted occurrence of a shared source win",
+    async () => {
+      const shared = dependency(choice(["dev", "prod"] as const));
+      const level = shared.derive({
+        metavar: "LEVEL",
+        mode: "sync",
+        factory: (value: "dev" | "prod") =>
+          choice(
+            value === "dev"
+              ? (["debug", "verbose"] as const)
+              : (["silent", "strict"] as const),
+          ),
+        defaultValue: () => "dev" as const,
+      });
+      const { prompt, calls } = createTestPrompt();
+      const parser = object({
+        a: prompt(option("--a", shared), { value: "dev" }),
+        b: prompt(option("--b", shared), { value: "prod" }),
+        level: option("--level", level),
+      });
+
+      // CLI parity: with --a dev --b prod, the later source occurrence
+      // wins, so the prompted run must behave the same way.
+      const result = await parseAsync(parser, ["--level", "silent"]);
+
+      assert.ok(result.success);
+      assert.equal(result.value.a, "dev");
+      assert.equal(result.value.b, "prod");
+      assert.equal(result.value.level, "silent");
+      assert.equal(calls.length, 2);
+    },
+  );
+
+  it(
+    "runs merge() source prompts in declaration order despite priorities",
+    async () => {
+      const srcA = dependency(string());
+      const srcB = dependency(string());
+      const { prompt, calls } = createTestPrompt();
+      // The argument-based child has lower priority than the option-based
+      // child, so merge() sorts the option child first internally; the
+      // prompts must still run in declaration order (A before B).
+      const parser = merge(
+        object({ a: prompt(argument(srcA), { value: "A" }) }),
+        object({ b: prompt(option("--b", srcB), { value: "B" }) }),
+      );
+
+      const result = await parseAsync(parser, []);
+
+      assert.ok(result.success);
+      assert.deepEqual(calls, [{ value: "A" }, { value: "B" }]);
+    },
+  );
+
+  it(
+    "prompts once for a source nested below a merge() child",
+    async () => {
+      const { mode, level } = createModeFixture();
+      const { prompt, calls } = createTestPrompt();
+      const parser = merge(
+        object({
+          settings: object({
+            mode: prompt(option("--mode", mode), { value: "prod" }),
+          }),
+        }),
+        object({ level: option("--level", level) }),
+      );
+
+      const result = await parseAsync(parser, ["--level", "silent"]);
+
+      assert.ok(result.success);
+      assert.equal(result.value.settings.mode, "prod");
+      assert.equal(result.value.level, "silent");
+      assert.equal(calls.length, 1);
+    },
+  );
+
+  it(
+    "does not register a bound wrapper around a transformed source",
+    async () => {
+      const { mode, level } = createModeFixture();
+      const { prompt, calls } = createTestPrompt();
+      const envContext = createEnvContext({
+        prefix: "APP_",
+        source: () => undefined,
+      });
+      const annotations = envContext.getAnnotations();
+      if (annotations instanceof Promise) {
+        throw new TypeError("Expected synchronous annotations.");
+      }
+      // bindEnv() around a transformed prompted source completes in the
+      // transformed domain, so nothing may register under the raw source
+      // ID even when the field is nested and scheduled by expansion; the
+      // consumer falls back to its own default ("dev").
+      const parser = object({
+        settings: object({
+          mode: bindEnv(
+            prompt(option("--mode", mode), { value: "prod" })
+              .map((value) => value.toUpperCase()),
+            {
+              context: envContext,
+              key: "MODE",
+              parser: choice(["DEV", "PROD"] as const),
+            },
+          ),
+        }),
+        level: option("--level", level),
+      });
+
+      const result = await parseAsync(parser, ["--level", "debug"], {
+        annotations,
+      });
+
+      assert.ok(result.success);
+      assert.equal(result.value.settings.mode, "PROD");
+      assert.equal(result.value.level, "debug");
+      assert.equal(calls.length, 1);
+    },
+  );
+
+  it(
+    "propagates demand into a selected command branch in two-pass runs",
+    async () => {
+      const { mode, level } = createModeFixture();
+      const other = dependency(string());
+      const { prompt, calls } = createTestPrompt();
+      let phase2Parsed: unknown;
+      const dynamicContext: SourceContext = {
+        id: Symbol.for("@optique/prompt/test-command-demand-phase-two"),
+        phase: "two-pass",
+        getAnnotations(request?: unknown) {
+          if (isPhase2ContextRequest(request)) phase2Parsed = request.parsed;
+          return {};
+        },
+      };
+      // The enclosing concat() has nothing schedulable itself (the or()
+      // branches wrap different sources), but its consumer's demand must
+      // still reach the prompt scheduled inside the selected command
+      // branch during the phase-two seed pass.
+      const parser = concat(
+        or(
+          command(
+            "run",
+            tuple([prompt(option("--mode", mode), { value: "prod" })]),
+          ),
+          command(
+            "stop",
+            tuple([prompt(option("--other", other), { value: "x" })]),
+          ),
+        ),
+        tuple([option("--level", level)]),
+      );
+
+      const result = await runWith(parser, "test", [dynamicContext], {
+        args: ["run", "--level", "silent"],
+      });
+
+      assert.deepEqual(result, ["prod", "silent"]);
+      assert.deepEqual(phase2Parsed, ["prod", "silent"]);
+      assert.equal(calls.length, 1);
+    },
+  );
+
+  it(
+    "keeps env precedence for a bound source nested below a merge() child",
+    async () => {
+      const { mode, level } = createModeFixture();
+      const { prompt, calls } = createTestPrompt();
+      const envContext = createEnvContext({
+        prefix: "APP_",
+        source: (key) => ({ APP_MODE: "prod" })[key],
+      });
+      const annotations = envContext.getAnnotations();
+      if (annotations instanceof Promise) {
+        throw new TypeError("Expected synchronous annotations.");
+      }
+      const parser = merge(
+        object({
+          settings: object({
+            mode: bindEnv(prompt(option("--mode", mode), { value: "dev" }), {
+              context: envContext,
+              key: "MODE",
+              parser: choice(["dev", "prod"] as const),
+            }),
+          }),
+        }),
+        object({ level: option("--level", level) }),
+      );
+
+      const result = await parseAsync(parser, ["--level", "silent"], {
+        annotations,
+      });
+
+      assert.ok(result.success);
+      assert.equal(result.value.settings.mode, "prod");
+      assert.equal(result.value.level, "silent");
+      assert.deepEqual(calls, []);
+    },
+  );
+
+  it("registers a prompted value behind nonEmpty()", async () => {
+    const { mode, level } = createModeFixture();
+    const { prompt, calls } = createTestPrompt();
+    const parser = object({
+      mode: prompt(nonEmpty(option("--mode", mode)), { value: "prod" }),
+      level: option("--level", level),
+    });
+
+    const valid = await parseAsync(parser, ["--level", "silent"]);
+    assert.ok(valid.success);
+    assert.equal(valid.value.mode, "prod");
+    assert.equal(valid.value.level, "silent");
+    assert.equal(calls.length, 1);
+
+    const invalid = await parseAsync(parser, ["--level", "debug"]);
+    assert.ok(!invalid.success);
+  });
+
+  it(
+    "stops later prompts when a pre-completed prompt is cancelled",
+    async () => {
+      const a = dependency(choice(["dev", "prod"] as const));
+      const b = dependency(choice(["x", "y"] as const));
+      const { prompt, calls } = createTestPrompt();
+      const envContext = createEnvContext({
+        prefix: "APP_",
+        source: () => undefined,
+      });
+      const annotations = envContext.getAnnotations();
+      if (annotations instanceof Promise) {
+        throw new TypeError("Expected synchronous annotations.");
+      }
+      // Field `a` is pre-completed during Phase 1 (bindEnv() opts into
+      // pre-completion) and its prompt is cancelled there; the later
+      // source prompt `b` must not run.
+      const parser = object({
+        a: prompt(
+          bindEnv(option("--a", a), {
+            context: envContext,
+            key: "A",
+            parser: choice(["dev", "prod"] as const),
+          }),
+          { value: "dev", reject: true },
+        ),
+        b: prompt(option("--b", b), { value: "x" }),
+      });
+
+      const result = await parseAsync(parser, [], { annotations });
+
+      assert.ok(!result.success);
+      assert.equal(calls.length, 1);
+    },
+  );
+
+  it(
+    "stops later prompts when a merge() child's pre-completed prompt is cancelled",
+    async () => {
+      const a = dependency(choice(["dev", "prod"] as const));
+      const b = dependency(choice(["x", "y"] as const));
+      const { prompt, calls } = createTestPrompt();
+      const envContext = createEnvContext({
+        prefix: "APP_",
+        source: () => undefined,
+      });
+      const annotations = envContext.getAnnotations();
+      if (annotations instanceof Promise) {
+        throw new TypeError("Expected synchronous annotations.");
+      }
+      const parser = merge(
+        object({
+          a: prompt(
+            bindEnv(option("--a", a), {
+              context: envContext,
+              key: "A",
+              parser: choice(["dev", "prod"] as const),
+            }),
+            { value: "dev", reject: true },
+          ),
+        }),
+        object({ b: prompt(option("--b", b), { value: "x" }) }),
+      );
+
+      const result = await parseAsync(parser, [], { annotations });
+
+      assert.ok(!result.success);
+      assert.equal(calls.length, 1);
+    },
+  );
+
+  it("prompts once for a source inside a nested merge()", async () => {
+    const { mode, level } = createModeFixture();
+    const { prompt, calls } = createTestPrompt();
+    const parser = object({
+      combo: merge(
+        object({ mode: prompt(option("--mode", mode), { value: "prod" }) }),
+        object({ other: optional(option("--other", string())) }),
+      ),
+      level: option("--level", level),
+    });
+
+    const result = await parseAsync(parser, ["--level", "silent"]);
+
+    assert.ok(result.success);
+    assert.equal(result.value.combo.mode, "prod");
+    assert.equal(result.value.level, "silent");
+    assert.equal(calls.length, 1);
+  });
+
+  it(
+    "runs nested merge() source prompts in declaration order",
+    async () => {
+      const srcA = dependency(string());
+      const srcB = dependency(string());
+      const { prompt, calls } = createTestPrompt();
+      // The argument-based child has lower priority than the option-based
+      // child, so the nested merge() sorts the option child first
+      // internally; the prompts must still run in declaration order and
+      // exactly once each.
+      const parser = object({
+        combo: merge(
+          object({ a: prompt(argument(srcA), { value: "A" }) }),
+          object({ b: prompt(option("--b", srcB), { value: "B" }) }),
+        ),
+      });
+
+      const result = await parseAsync(parser, []);
+
+      assert.ok(result.success);
+      assert.deepEqual(calls, [{ value: "A" }, { value: "B" }]);
+    },
+  );
+
+  it(
+    "does not register prompt answers for mixed or() alternatives",
+    async () => {
+      const { mode, level } = createModeFixture();
+      const { prompt, calls } = createTestPrompt();
+      const parser = object({
+        mode: prompt(
+          or(option("--mode", mode), constant("fallback")),
+          { value: "fallback" },
+        ),
+        level: option("--level", level),
+      });
+
+      // The union completes in a mixed domain, so nothing may register
+      // under the source ID; the consumer falls back to its own default
+      // ("dev"), for which "debug" is valid.
+      const result = await parseAsync(parser, ["--level", "debug"]);
+
+      assert.ok(result.success);
+      assert.equal(result.value.mode, "fallback");
+      assert.equal(result.value.level, "debug");
+      assert.equal(calls.length, 1);
+    },
+  );
+
+  it(
+    "completes a selected command branch source before sibling replay",
+    async () => {
+      const { mode, level } = createModeFixture();
+      const other = dependency(string());
+      const { prompt, calls } = createTestPrompt();
+      const parser = object({
+        cmd: or(
+          command(
+            "run",
+            object({
+              mode: prompt(option("--mode", mode), { value: "prod" }),
+            }),
+          ),
+          command(
+            "stop",
+            object({
+              other: prompt(option("--other", other), { value: "x" }),
+            }),
+          ),
+        ),
+        level: option("--level", level),
+      });
+
+      const result = await parseAsync(parser, ["run", "--level", "silent"]);
+
+      assert.ok(result.success);
+      assert.ok("mode" in result.value.cmd);
+      assert.equal(result.value.cmd.mode, "prod");
+      assert.equal(result.value.level, "silent");
+      assert.equal(calls.length, 1);
+    },
+  );
+
+  it(
+    "stops seed extraction after a demanded prompt cancellation",
+    async () => {
+      const { mode, level } = createModeFixture();
+      const { prompt, calls } = createTestPrompt();
+      const dynamicContext: SourceContext = {
+        id: Symbol.for("@optique/prompt/test-seed-cancellation"),
+        phase: "two-pass",
+        getAnnotations() {
+          return {};
+        },
+      };
+      const parser = object({
+        mode: prompt(option("--mode", mode), { value: "prod", reject: true }),
+        level: option("--level", level),
+        name: prompt(option("--name", string()), { value: "n" }),
+      });
+
+      // The demanded source prompt is cancelled during the seed pass; no
+      // later prompt (including the ordinary `name` prompt) may run in
+      // any pass afterwards.
+      await assert.rejects(() =>
+        runWith(parser, "test", [dynamicContext], {
+          args: ["--level", "silent"],
+        })
+      );
+
+      assert.equal(calls.length, 1);
+    },
+  );
+
+  it("runs bound merge() prompts in declaration order", async () => {
+    const srcA = dependency(string());
+    const srcB = dependency(string());
+    const { prompt, calls } = createTestPrompt();
+    const envContext = createEnvContext({
+      prefix: "APP_",
+      source: () => undefined,
+    });
+    const annotations = envContext.getAnnotations();
+    if (annotations instanceof Promise) {
+      throw new TypeError("Expected synchronous annotations.");
+    }
+    // The argument-based child has lower priority than the option-based
+    // child, so merge() pre-completes the option child first internally
+    // unless Phase 1 follows declaration order; the bound prompts must
+    // run in declaration order (A before B).
+    const parser = merge(
+      object({
+        a: bindEnv(prompt(argument(srcA), { value: "A" }), {
+          context: envContext,
+          key: "A",
+          parser: string(),
+        }),
+      }),
+      object({
+        b: bindEnv(prompt(option("--b", srcB), { value: "B" }), {
+          context: envContext,
+          key: "B",
+          parser: string(),
+        }),
+      }),
+    );
+
+    const result = await parseAsync(parser, [], { annotations });
+
+    assert.ok(result.success);
+    assert.deepEqual(calls, [{ value: "A" }, { value: "B" }]);
+  });
+
+  it(
+    "schedules through map() around a selected command branch",
+    async () => {
+      const { mode, level } = createModeFixture();
+      const other = dependency(string());
+      const { prompt, calls } = createTestPrompt();
+      const parser = object({
+        cmd: or(
+          command(
+            "run",
+            object({
+              mode: prompt(option("--mode", mode), { value: "prod" }),
+            }),
+          ),
+          command(
+            "stop",
+            object({
+              other: prompt(option("--other", other), { value: "x" }),
+            }),
+          ),
+        ).map((value) => value),
+        level: option("--level", level),
+      });
+
+      const result = await parseAsync(parser, ["run", "--level", "silent"]);
+
+      assert.ok(result.success);
+      assert.equal(result.value.level, "silent");
+      assert.equal(calls.length, 1);
+    },
+  );
+
+  it(
+    "lets a later occurrence override a pre-completed prompt answer",
+    async () => {
+      const shared = dependency(choice(["dev", "prod"] as const));
+      const level = shared.derive({
+        metavar: "LEVEL",
+        mode: "sync",
+        factory: (value: "dev" | "prod") =>
+          choice(
+            value === "dev"
+              ? (["debug", "verbose"] as const)
+              : (["silent", "strict"] as const),
+          ),
+        defaultValue: () => "dev" as const,
+      });
+      const { prompt, calls } = createTestPrompt();
+      const envContext = createEnvContext({
+        prefix: "APP_",
+        source: () => undefined,
+      });
+      const annotations = envContext.getAnnotations();
+      if (annotations instanceof Promise) {
+        throw new TypeError("Expected synchronous annotations.");
+      }
+      // The first occurrence is pre-completed through its source binding
+      // (prompting "dev"); the later prompted occurrence must still run
+      // and win, matching repeated command-line source occurrences.
+      const parser = object({
+        a: prompt(
+          bindEnv(option("--a", shared), {
+            context: envContext,
+            key: "A",
+            parser: choice(["dev", "prod"] as const),
+          }),
+          { value: "dev" },
+        ),
+        b: prompt(option("--b", shared), { value: "prod" }),
+        level: option("--level", level),
+      });
+
+      const result = await parseAsync(parser, ["--level", "silent"], {
+        annotations,
+      });
+
+      assert.ok(result.success);
+      assert.equal(result.value.a, "dev");
+      assert.equal(result.value.b, "prod");
+      assert.equal(result.value.level, "silent");
+      assert.equal(calls.length, 2);
+    },
+  );
+
+  it(
+    "keeps declaration order across nested and bound shared prompts",
+    async () => {
+      const shared = dependency(choice(["dev", "prod"] as const));
+      const level = shared.derive({
+        metavar: "LEVEL",
+        mode: "sync",
+        factory: (value: "dev" | "prod") =>
+          choice(
+            value === "dev"
+              ? (["debug", "verbose"] as const)
+              : (["silent", "strict"] as const),
+          ),
+        defaultValue: () => "dev" as const,
+      });
+      const { prompt, calls } = createTestPrompt();
+      const envContext = createEnvContext({
+        prefix: "APP_",
+        source: () => undefined,
+      });
+      const annotations = envContext.getAnnotations();
+      if (annotations instanceof Promise) {
+        throw new TypeError("Expected synchronous annotations.");
+      }
+      // The nested prompt is declared first and the bound prompt second;
+      // both must run in declaration order and the later answer wins for
+      // the derived consumer.
+      const parser = object({
+        g: object({ a: prompt(option("--a", shared), { value: "dev" }) }),
+        b: prompt(
+          bindEnv(option("--b", shared), {
+            context: envContext,
+            key: "B",
+            parser: choice(["dev", "prod"] as const),
+          }),
+          { value: "prod" },
+        ),
+        level: option("--level", level),
+      });
+
+      const result = await parseAsync(parser, ["--level", "silent"], {
+        annotations,
+      });
+
+      assert.ok(result.success);
+      assert.equal(result.value.level, "silent");
+      assert.deepEqual(calls.map((c) => c.value), ["dev", "prod"]);
+    },
+  );
+
+  it(
+    "exposes nested prompts through a matched optional(object(...))",
+    async () => {
+      const { mode, level } = createModeFixture();
+      const { prompt, calls } = createTestPrompt();
+      const parser = object({
+        g: optional(object({
+          flag: option("--g", string()),
+          mode: prompt(option("--mode", mode), { value: "prod" }),
+        })),
+        level: option("--level", level),
+      });
+
+      const result = await parseAsync(parser, [
+        "--g",
+        "x",
+        "--level",
+        "silent",
+      ]);
+
+      assert.ok(result.success);
+      assert.equal(result.value.g?.mode, "prod");
+      assert.equal(result.value.level, "silent");
+      assert.equal(calls.length, 1);
+    },
+  );
+
+  it(
+    "exposes nested prompts through withDefault(object(...))",
+    async () => {
+      const { mode, level } = createModeFixture();
+      const { prompt, calls } = createTestPrompt();
+      const parser = object({
+        g: withDefault(
+          object({
+            flag: option("--g", string()),
+            mode: prompt(option("--mode", mode), { value: "prod" }),
+          }),
+          { flag: "d", mode: "dev" as const },
+        ),
+        level: option("--level", level),
+      });
+
+      const result = await parseAsync(parser, [
+        "--g",
+        "x",
+        "--level",
+        "silent",
+      ]);
+
+      assert.ok(result.success);
+      assert.equal(result.value.g.mode, "prod");
+      assert.equal(result.value.level, "silent");
+      assert.equal(calls.length, 1);
+    },
+  );
+
+  it(
+    "keeps optional() suppression for a mapped prompted source",
+    async () => {
+      const { mode, level } = createModeFixture();
+      const { prompt, calls } = createTestPrompt();
+      const parser = object({
+        mode: optional(
+          prompt(option("--mode", mode), { value: "prod" })
+            .map((value) => value.toUpperCase()),
+        ),
+        level: option("--level", level),
+      });
+
+      // An unmatched optional() resolves to undefined without prompting,
+      // even around a mapped source; the consumer falls back to its own
+      // default ("dev").
+      const result = await parseAsync(parser, ["--level", "debug"]);
+
+      assert.ok(result.success);
+      assert.equal(result.value.mode, undefined);
+      assert.equal(result.value.level, "debug");
+      assert.deepEqual(calls, []);
+    },
+  );
+
+  it(
+    "schedules prompts inside a nonEmpty(object(...)) merge child",
+    async () => {
+      const { mode, level } = createModeFixture();
+      const { prompt, calls } = createTestPrompt();
+      const parser = merge(
+        object({ level: option("--level", level) }),
+        nonEmpty(object({
+          enabled: flag("--enabled"),
+          mode: prompt(option("--mode", mode), { value: "prod" }),
+        })),
+      );
+
+      const result = await parseAsync(parser, [
+        "--enabled",
+        "--level",
+        "silent",
+      ]);
+
+      assert.ok(result.success);
+      assert.equal(result.value.mode, "prod");
+      assert.equal(result.value.level, "silent");
+      assert.equal(calls.length, 1);
+    },
+  );
+
+  it(
+    "does not prompt for an unmatched withDefault(object) merge child",
+    async () => {
+      const { mode, level } = createModeFixture();
+      const { prompt, calls } = createTestPrompt();
+      const parser = merge(
+        object({ level: option("--level", level) }),
+        withDefault(
+          object({ mode: prompt(option("--mode", mode), { value: "prod" }) }),
+          { mode: "dev" as const },
+        ),
+      );
+
+      // Nothing matches the second child, so its default applies without
+      // prompting; the consumer falls back to its own default ("dev").
+      const result = await parseAsync(parser, ["--level", "debug"]);
+
+      assert.ok(result.success);
+      assert.equal(result.value.mode, "dev");
+      assert.equal(result.value.level, "debug");
+      assert.deepEqual(calls, []);
+    },
+  );
+
+  it("recovers a failed bound source through the prompt", async () => {
+    const { mode, level } = createModeFixture();
+    const { prompt, calls } = createTestPrompt();
+    const envContext = createEnvContext({
+      prefix: "APP_",
+      source: (key) => ({ APP_MODE: "invalid" })[key],
+    });
+    const annotations = envContext.getAnnotations();
+    if (annotations instanceof Promise) {
+      throw new TypeError("Expected synchronous annotations.");
+    }
+    const parser = object({
+      mode: prompt(
+        bindEnv(option("--mode", mode), {
+          context: envContext,
+          key: "MODE",
+          parser: choice(["dev", "prod"] as const),
+        }),
+        { value: "prod" },
+      ),
+      level: option("--level", level),
+    });
+
+    // The environment value is invalid, so the prompt falls back; its
+    // answer must feed the derived consumer consistently.
+    const result = await parseAsync(parser, ["--level", "silent"], {
+      annotations,
+    });
+
+    assert.ok(result.success);
+    assert.equal(result.value.mode, "prod");
+    assert.equal(result.value.level, "silent");
+    assert.equal(calls.length, 1);
+  });
+
+  it(
+    "completes a prompted conditional() discriminator before sibling replay",
+    async () => {
+      const { mode, level } = createModeFixture();
+      const { prompt, calls } = createTestPrompt();
+      const parser = object({
+        selected: conditional(
+          prompt(option("--mode", mode), { value: "prod" }),
+          {
+            dev: object({
+              d: withDefault(option("--d", choice(["x"] as const)), "x"),
+            }),
+            prod: object({
+              p: withDefault(option("--p", choice(["y"] as const)), "y"),
+            }),
+          },
+        ),
+        level: option("--level", level),
+      });
+
+      const result = await parseAsync(parser, ["--level", "silent"]);
+
+      assert.ok(result.success);
+      assert.equal(result.value.level, "silent");
+      assert.equal(calls.length, 1);
+    },
+  );
+
+  it(
+    "schedules a prompted discriminator in a root-level conditional()",
+    async () => {
+      const { mode, level } = createModeFixture();
+      const { prompt, calls } = createTestPrompt();
+      // No parent construct invokes the scheduling hook here, so the
+      // conditional's own completion must schedule the discriminator
+      // prompt before branch replay.
+      const parser = conditional(
+        prompt(option("--mode", mode), { value: "prod" }),
+        { prod: object({ level: option("--level", level) }) },
+      );
+
+      const result = await parseAsync(parser, ["--level", "silent"]);
+
+      assert.ok(result.success);
+      assert.deepEqual(result.value, ["prod", { level: "silent" }]);
+      assert.equal(calls.length, 1);
+    },
+  );
+
+  it(
+    "does not prompt inside a mismatched speculative conditional() branch",
+    async () => {
+      const mode = dependency(choice(["dev", "prod"] as const));
+      const other = dependency(string());
+      const { prompt, calls } = createTestPrompt();
+      // "--d 1" speculatively selects the dev branch, but the prompted
+      // discriminator answers "prod": the guessed branch must produce no
+      // interactive side effects before the mismatch is verified.
+      const parser = conditional(
+        prompt(option("--mode", mode), { value: "prod" }),
+        {
+          dev: object({
+            d: option("--d", string()),
+            dp: prompt(option("--dp", other), { value: "DP" }),
+          }),
+          prod: object({ p: option("--p", string()) }),
+        },
+      );
+
+      const result = await parseAsync(parser, ["--d", "1"]);
+
+      assert.ok(!result.success);
+      assert.deepEqual(calls, [{ value: "prod" }]);
+    },
+  );
+
+  it(
+    "evaluates a nested lazy withDefault(prompt) default exactly once",
+    async () => {
+      const { mode, level } = createModeFixture();
+      const { prompt, calls } = createTestPrompt();
+      let defaultCalls = 0;
+      const parser = object({
+        settings: object({
+          mode: withDefault(
+            prompt(option("--mode", mode), { value: "prod" }),
+            () => (++defaultCalls === 1 ? "prod" : "dev") as "dev" | "prod",
+          ),
+        }),
+        level: option("--level", level),
+      });
+
+      // The registered dependency value and the returned field must come
+      // from the same single evaluation of the lazy default.
+      const result = await parseAsync(parser, ["--level", "silent"]);
+
+      assert.ok(result.success);
+      assert.equal(result.value.settings.mode, "prod");
+      assert.equal(result.value.level, "silent");
+      assert.deepEqual(calls, []);
+      assert.equal(defaultCalls, 1);
+    },
+  );
+
+  it("registers a prompted value nested in an inner object()", async () => {
+    const { mode, level } = createModeFixture();
+    const { prompt, calls } = createTestPrompt();
+    const parser = object({
+      settings: object({
+        mode: prompt(option("--mode", mode), { value: "prod" }),
+      }),
+      level: option("--level", level),
+    });
+
+    const result = await parseAsync(parser, ["--level", "silent"]);
+
+    assert.ok(result.success);
+    assert.equal(result.value.settings.mode, "prod");
+    assert.equal(result.value.level, "silent");
+    assert.equal(calls.length, 1);
+  });
+
+  it(
+    "keeps optional(prompt(...)) suppression for a wrapped source",
+    async () => {
+      const { mode, level } = createModeFixture();
+      const { prompt, calls } = createTestPrompt();
+      // An unmatched optional() field resolves to `undefined` without
+      // prompting for non-source prompts; wrapping a dependency source
+      // must behave the same way, so the consumer falls back to its own
+      // default ("dev").
+      const parser = object({
+        mode: optional(prompt(option("--mode", mode), { value: "prod" })),
+        level: option("--level", level),
+      });
+
+      const result = await parseAsync(parser, ["--level", "debug"]);
+
+      assert.ok(result.success);
+      assert.equal(result.value.mode, undefined);
+      assert.equal(result.value.level, "debug");
+      assert.deepEqual(calls, []);
+    },
+  );
+
+  it(
+    "does not register a prompt answer for a transformed inner source",
+    async () => {
+      const { mode, level } = createModeFixture();
+      const { prompt, calls } = createTestPrompt();
+      // The prompt's answer lives in the mapped domain, so the
+      // pre-transform source value is unrecoverable and nothing
+      // registers; the consumer falls back to its own default ("dev").
+      const parser = object({
+        mode: prompt(
+          option("--mode", mode).map((value) => value.toUpperCase()),
+          { value: "PROD" },
+        ),
+        level: option("--level", level),
+      });
+
+      const result = await parseAsync(parser, ["--level", "debug"]);
+
+      assert.ok(result.success);
+      assert.equal(result.value.mode, "PROD");
+      assert.equal(result.value.level, "debug");
+      assert.equal(calls.length, 1);
+    },
+  );
+
+  it(
+    "prompts once per occurrence when one instance is reused",
+    async () => {
+      const src = dependency(string());
+      const { prompt, calls } = createTestPrompt();
+      const shared = prompt(argument(src), { value: "answer" });
+      const parser = tuple([shared, shared]);
+
+      // Each position is a separate occurrence, matching how the same
+      // non-source prompt instance behaves at two positions.
+      const result = await parseAsync(parser, []);
+
+      assert.ok(result.success);
+      assert.deepEqual(result.value, ["answer", "answer"]);
+      assert.equal(calls.length, 2);
+    },
+  );
+
+  it("registers the pre-transform value of a mapped source prompt", async () => {
+    const { mode, level } = createModeFixture();
+    const { prompt, calls } = createTestPrompt();
+    const parser = object({
+      mode: prompt(option("--mode", mode), { value: "prod" })
+        .map((value) => value.toUpperCase()),
+      level: option("--level", level),
+    });
+
+    // The derived parser sees the pre-transform value ("prod"), while
+    // the field itself produces the mapped value ("PROD").
+    const valid = await parseAsync(parser, ["--level", "silent"]);
+    assert.ok(valid.success);
+    assert.equal(valid.value.mode, "PROD");
+    assert.equal(valid.value.level, "silent");
+    assert.equal(calls.length, 1);
+
+    const invalid = await parseAsync(parser, ["--level", "debug"]);
+    assert.ok(!invalid.success);
+  });
+
+  it(
+    "keeps distinct prompts on one source local to duplicate merge() fields",
+    async () => {
+      const mode = dependency(choice(["dev", "prod"] as const));
+      const { prompt, calls } = createTestPrompt();
+      const parser = merge(
+        object({ mode: prompt(option("--mode-a", mode), { value: "prod" }) }),
+        object({ mode: prompt(option("--mode-b", mode), { value: "dev" }) }),
+      );
+
+      // Both prompts run in their own children, and the later duplicate
+      // field wins; the first child's result must not leak into the
+      // second child's prompt.
+      const result = await parseAsync(parser, []);
+
+      assert.ok(result.success);
+      assert.equal(result.value.mode, "dev");
+      assert.equal(calls.length, 2);
+    },
+  );
+
+  it(
+    "detects phase-one demand across merge() children in the seed pass",
+    async () => {
+      const { mode, level } = createModeFixture();
+      const { prompt, calls } = createTestPrompt();
+      let phase2Parsed:
+        | { readonly mode?: string; readonly level?: string }
+        | undefined;
+      const dynamicContext: SourceContext = {
+        id: Symbol.for("@optique/prompt/test-merge-demand-phase-two"),
+        phase: "two-pass",
+        getAnnotations(request?: unknown) {
+          const parsed = getPhase2ContextParsed<
+            { readonly mode?: string; readonly level?: string }
+          >(request);
+          if (parsed !== undefined) phase2Parsed = parsed;
+          return {};
+        },
+      };
+      const parser = merge(
+        object({ mode: prompt(option("--mode", mode), { value: "prod" }) }),
+        object({ level: option("--level", level) }),
+      );
+
+      const result = await runWith(parser, "test", [dynamicContext], {
+        args: ["--level", "silent"],
+      });
+
+      assert.deepEqual(result, { mode: "prod", level: "silent" });
+      assert.equal(phase2Parsed?.mode, "prod");
+      assert.equal(phase2Parsed?.level, "silent");
+      assert.equal(calls.length, 1);
+    },
+  );
+
+  it(
+    "prompts a demanded bound source during the phase-two seed pass",
+    async () => {
+      const { mode, level } = createModeFixture();
+      const { prompt, calls } = createTestPrompt();
+      const envContext = createEnvContext({
+        prefix: "APP_",
+        source: () => undefined,
+      });
+      let phase2Parsed:
+        | { readonly mode?: string; readonly level?: string }
+        | undefined;
+      const dynamicContext: SourceContext = {
+        id: Symbol.for("@optique/prompt/test-bound-demanded-phase-two"),
+        phase: "two-pass",
+        getAnnotations(request?: unknown) {
+          const parsed = getPhase2ContextParsed<
+            { readonly mode?: string; readonly level?: string }
+          >(request);
+          if (parsed !== undefined) phase2Parsed = parsed;
+          return {};
+        },
+      };
+      // The source binding pre-completes the prompt during Phase 1,
+      // before consumer demand is known; the deferred result must stay
+      // schedulable so the prompt still runs during the seed pass.
+      const parser = object({
+        mode: prompt(
+          bindEnv(option("--mode", mode), {
+            context: envContext,
+            key: "MODE",
+            parser: choice(["dev", "prod"] as const),
+          }),
+          { value: "prod" },
+        ),
+        level: option("--level", level),
+      });
+
+      const result = await runWith(
+        parser,
+        "test",
+        [dynamicContext, envContext],
+        { args: ["--level", "silent"] },
+      );
+
+      assert.deepEqual(result, { mode: "prod", level: "silent" });
+      assert.equal(phase2Parsed?.mode, "prod");
+      assert.equal(phase2Parsed?.level, "silent");
+      assert.equal(calls.length, 1);
+    },
+  );
+
+  it(
+    "defers an undemanded bound source prompt to the final pass",
+    async () => {
+      const { mode } = createModeFixture();
+      const { prompt, calls } = createTestPrompt();
+      const envContext = createEnvContext({
+        prefix: "APP_",
+        source: () => undefined,
+      });
+      let phase2Mode: string | undefined = "unset";
+      const dynamicContext: SourceContext = {
+        id: Symbol.for("@optique/prompt/test-bound-undemanded-phase-two"),
+        phase: "two-pass",
+        getAnnotations(request?: unknown) {
+          if (isPhase2ContextRequest(request)) {
+            phase2Mode = (request.parsed as { readonly mode?: string })?.mode;
+          }
+          return {};
+        },
+      };
+      const parser = object({
+        mode: prompt(
+          bindEnv(option("--mode", mode), {
+            context: envContext,
+            key: "MODE",
+            parser: choice(["dev", "prod"] as const),
+          }),
+          { value: "prod" },
+        ),
+      });
+
+      const result = await runWith(
+        parser,
+        "test",
+        [dynamicContext, envContext],
+        { args: [] },
+      );
+
+      assert.deepEqual(result, { mode: "prod" });
+      assert.equal(phase2Mode, undefined);
+      assert.equal(calls.length, 1);
+    },
+  );
+
+  it("keeps env precedence over a bound source prompt in two-pass runs", async () => {
+    const { mode, level } = createModeFixture();
+    const { prompt, calls } = createTestPrompt();
+    const envContext = createEnvContext({
+      prefix: "APP_",
+      source: (key) => ({ APP_MODE: "prod" })[key],
+    });
+    const dynamicContext: SourceContext = {
+      id: Symbol.for("@optique/prompt/test-bound-env-precedence"),
+      phase: "two-pass",
+      getAnnotations() {
+        return {};
+      },
+    };
+    const parser = object({
+      mode: prompt(
+        bindEnv(option("--mode", mode), {
+          context: envContext,
+          key: "MODE",
+          parser: choice(["dev", "prod"] as const),
+        }),
+        { value: "dev" },
+      ),
+      level: option("--level", level),
+    });
+
+    const result = await runWith(
+      parser,
+      "test",
+      [dynamicContext, envContext],
+      { args: ["--level", "silent"] },
+    );
+
+    assert.deepEqual(result, { mode: "prod", level: "silent" });
     assert.deepEqual(calls, []);
   });
 });

--- a/packages/prompt/src/index.ts
+++ b/packages/prompt/src/index.ts
@@ -203,6 +203,40 @@ export function createPromptAdapter<TConfig>(
     const promptBindStateKey: unique symbol = Symbol(
       "@optique/prompt/promptState",
     );
+    // Identifies this prompt wrapper occurrence in the run-scoped
+    // effectful completion session.  The cache key combines the wrapper
+    // instance (via this closure) with the completion path so that two
+    // distinct prompts sharing one source (e.g., duplicate merge()
+    // fields) and one instance reused at several positions (e.g.,
+    // `tuple([p, p])`) each keep their own result, while the same
+    // occurrence still reuses its result across the seed and final
+    // passes of a runWith() run.
+    const completionCacheKeys = new Map<string, symbol>();
+    const completionCacheSymbolIds = new Map<symbol, number>();
+    const completionCacheKeyFor = (
+      path: readonly PropertyKey[] | undefined,
+    ): symbol => {
+      // Length-prefix each segment so no separator escaping is needed.
+      const serialized = (path ?? []).map((segment) => {
+        if (typeof segment === "symbol") {
+          let id = completionCacheSymbolIds.get(segment);
+          if (id == null) {
+            id = completionCacheSymbolIds.size;
+            completionCacheSymbolIds.set(segment, id);
+          }
+          return `y${id}:`;
+        }
+        const tag = typeof segment === "number" ? "n" : "s";
+        const text = String(segment);
+        return `${tag}${text.length}:${text}`;
+      }).join("");
+      let key = completionCacheKeys.get(serialized);
+      if (key == null) {
+        key = Symbol("@optique/prompt/completionCache");
+        completionCacheKeys.set(serialized, key);
+      }
+      return key;
+    };
 
     type PromptBindState =
       & { readonly [K in typeof promptBindStateKey]: true }
@@ -441,6 +475,45 @@ export function createPromptAdapter<TConfig>(
               value: readPlaceholder() as TValue,
             });
           }
+          // When this prompt wraps a dependency source, its execution is
+          // coordinated through the run-scoped effectful completion
+          // session: a cached result (including a cancellation) is reused
+          // so the prompt runs at most once per run, and under the
+          // demand-only policy of the phase-two seed pass the prompt
+          // defers unless a phase-one consumer demands its source.
+          const session = exec?.effectfulCompletionSession;
+          const sourceId = promptedParser.dependencyMetadata?.source?.sourceId;
+          if (session != null && sourceId != null) {
+            const cacheKey = completionCacheKeyFor(exec?.path);
+            const cached = session.results.get(cacheKey);
+            if (cached != null) {
+              // A reused answer is still effectful in origin: mark the
+              // source so a later prompted occurrence in the same pass
+              // can overwrite it (last occurrence wins).
+              session.effectfulSources.add(sourceId);
+              return Promise.resolve(cached as ValueParserResult<TValue>);
+            }
+            if (
+              session.policy === "demand-only" &&
+              !session.demanded.has(sourceId)
+            ) {
+              return Promise.resolve(
+                deferredPromptResult(readPlaceholder() as TValue),
+              );
+            }
+            return executePrompt().then((result) => {
+              session.results.set(
+                cacheKey,
+                result as ValueParserResult<unknown>,
+              );
+              // Record that this source's value now comes from an
+              // effectful completion, so a later prompted occurrence of
+              // the same source can still overwrite it (last occurrence
+              // wins) while structural values keep their precedence.
+              session.effectfulSources.add(sourceId);
+              return result;
+            });
+          }
           return executePrompt();
         };
 
@@ -604,6 +677,25 @@ export function createPromptAdapter<TConfig>(
             state.cliState ?? state,
           );
         },
+        // Originate the effectful completion so the scheduler can run
+        // the prompt before dependency replay and register its value.
+        // The wrapper's own complete() already handles CLI delegation,
+        // source-binding delegation, runtime conditions, deferral, and
+        // adapter execution, so it is the completion in its entirety.
+        //
+        // When the wrapped parser transforms the source value (e.g.,
+        // prompt() around a mapped source), the prompt's answer lives in
+        // the transformed domain and the pre-transform source value is
+        // unrecoverable, so no effectful completion is exposed: the
+        // prompt keeps running in the ordinary completion phase and
+        // never registers a transformed value under the raw source ID.
+        completeSource: source.preservesSourceValue === false ? undefined : (
+          state: unknown,
+          exec?: ExecutionContext,
+        ): Promise<ValueParserResult<unknown> | undefined> =>
+          promptedParser.complete(state as TState, exec) as Promise<
+            ValueParserResult<unknown>
+          >,
       }),
     );
     if (dependencyMetadata != null) {


### PR DESCRIPTION
When a dependency source was wrapped in `prompt()`, the prompted value never reached the dependency runtime. Source collection and derived-parser replay both run before per-field completion, where the prompt executes, so a derived parser fell back to its default whenever the value was entered interactively, even though the same value on the command line worked.

Phase one must stay effect-free, so instead of moving prompts earlier, this adds an effectful completion operation, `completeSource`, beside the pure `extractSourceValue`. A serial pass runs it between source collection and dependency replay, in declaration order, at most once per run, and never for help, suggestions, or probes. Command-line values and source bindings still take precedence and skip the prompt entirely. Cancelling a prompt fails the parse before later prompts run.

In `runWith()` two-pass contexts, the seed pass prompts only when a phase-one consumer demands the value; otherwise prompting waits until the final pass, and a run-scoped cache keeps it to one execution across passes.

`optional()`, `withDefault()`, and `map()` forward the capability, and `bindEnv()`/`bindConfig()`/`bindDerivedDefault()` rebind it to the bound parser, so wrapping or binding a source keeps prompt completion. *docs/integrations/prompt.md* now documents a pre-existing limitation: a prompt used directly as an `or()`/`longestMatch()` branch does not run unless input commits that branch.

Part of #869. Closes #870.
