### PR TITLE
Align `conditional()` and `command()` source delivery

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,6 +38,21 @@ To be released.
     consumer demands its value and otherwise defers to the final pass, so
     an undemanded source prompt no longer exposes its value to phase-two
     contexts.  [[#869], [#870], [#912]]
+ -  Fixed dependency sources inside `conditional()` and `command()` to
+    reach derived parsers declared next to those constructs when their
+    value comes from the command line, matching how a prompted value
+    already reached them.  The `conditional()` discriminator, the fields
+    of the selected branch, and a selected command's subtree now register
+    their command-line values for sibling consumers, and a value behaves
+    identically whether it was typed or answered interactively.  When
+    nothing on the command line selects a branch, the branch chosen by
+    the discriminator's completion—including a prompted discriminator's
+    answer, and the default branch when no named branch applies—is now
+    resolved once before derived parsers re-evaluate and reused by the
+    conditional's completion, so purely interactive sessions validate
+    sibling parsers against the answered values.  A prompted
+    discriminator that does not wrap a dependency source cannot take part
+    in this early resolution.  [[#869], [#913], [#914]]
  -  Removed the unused `DependencyValueOrigin` type and `registerSource()`
     origin argument from `@optique/core/dependency-runtime`.  Both APIs were
     marked `@internal`; dependency resolution behavior is unchanged.
@@ -53,6 +68,8 @@ To be released.
 [#909]: https://github.com/dahlia/optique/pull/909
 [#911]: https://github.com/dahlia/optique/pull/911
 [#912]: https://github.com/dahlia/optique/pull/912
+[#913]: https://github.com/dahlia/optique/issues/913
+[#914]: https://github.com/dahlia/optique/pull/914
 
 ### @optique/run
 

--- a/changes.d/core/conditional-command-source-scope.md
+++ b/changes.d/core/conditional-command-source-scope.md
@@ -1,0 +1,21 @@
+---
+links:
+  '#869': https://github.com/dahlia/optique/issues/869
+  '#913': https://github.com/dahlia/optique/issues/913
+  '#914': https://github.com/dahlia/optique/pull/914
+---
+ -  Fixed dependency sources inside `conditional()` and `command()` to
+    reach derived parsers declared next to those constructs when their
+    value comes from the command line, matching how a prompted value
+    already reached them.  The `conditional()` discriminator, the fields
+    of the selected branch, and a selected command's subtree now register
+    their command-line values for sibling consumers, and a value behaves
+    identically whether it was typed or answered interactively.  When
+    nothing on the command line selects a branch, the branch chosen by
+    the discriminator's completion—including a prompted discriminator's
+    answer, and the default branch when no named branch applies—is now
+    resolved once before derived parsers re-evaluate and reused by the
+    conditional's completion, so purely interactive sessions validate
+    sibling parsers against the answered values.  A prompted
+    discriminator that does not wrap a dependency source cannot take part
+    in this early resolution.  [[#869], [#913], [#914]]

--- a/docs/concepts/dependencies.md
+++ b/docs/concepts/dependencies.md
@@ -511,6 +511,20 @@ displayed before a non-source prompt declared earlier in the same object.
 When the user cancels a source prompt, the parse fails immediately and
 later prompts do not run.
 
+A source inside a `conditional()` or a `command()` also reaches consumers
+declared next to that construct, and it does so whether the value was
+typed on the command line or answered interactively: the `conditional()`
+discriminator, the fields of the selected branch, and the subtree of a
+selected command all register into the enclosing runtime.  When nothing
+on the command line selects a branch, the branch chosen by the
+discriminator's completion—including a prompted discriminator's answer,
+and the default branch when no named branch applies—is resolved once
+before derived parsers re-evaluate, and the same selection is reused by
+the final completion.  One limitation: a prompted discriminator that
+does not wrap a dependency source cannot participate in this early
+branch resolution, so sources inside the branch it selects only complete
+during the conditional's own completion.
+
 
 Limitations
 -----------

--- a/docs/integrations/prompt.md
+++ b/docs/integrations/prompt.md
@@ -593,6 +593,15 @@ once per run.  During the phase-two seed pass it runs only when another
 parser's command-line input demands the source value; otherwise it defers to
 the final pass, and phase-two contexts see the field as deferred.
 
+Inside a `conditional()`, a prompted source discriminator and the
+prompted sources of the selected branch both run before sibling derived
+parsers re-evaluate, even when nothing on the command line selects a
+branch: the discriminator's answer resolves the branch once, and the
+same selection is reused when the conditional completes.  A prompted
+discriminator that does not wrap a dependency source cannot take part in
+this early resolution, so the branch it selects prompts only during the
+conditional's own completion.
+
 One pre-existing limitation carries over: a prompt used directly as an
 `or()`/`longestMatch()` branch never executes when no command-line input
 matches, because the parse fails before any branch is chosen.  Prompts

--- a/packages/core/src/constructs.ts
+++ b/packages/core/src/constructs.ts
@@ -256,18 +256,38 @@ function expandEffectfulRuntimeNodes(
   const expanded: RuntimeNode[] = [];
   const visit = (node: RuntimeNode): void => {
     const meta = node.parser.dependencyMetadata;
-    if (meta?.source?.completeSource != null || meta?.derived != null) {
+    const schedulingNodes = (node.parser as {
+      readonly [effectfulSchedulingNodesKey]?: EffectfulSchedulingNodesFn;
+    })[effectfulSchedulingNodesKey];
+    // A marked exclusive parser (an or() whose alternative is a
+    // command() or conditional()) can carry composed source metadata
+    // that merely delegates to its committed branch.  The branch is
+    // what must be expanded, so the scheduling hook takes precedence
+    // over that metadata; a hook yielding no nodes (no committed
+    // branch) falls back to the node itself.  Derived metadata still
+    // pins the node: consumers must stay visible to demand detection.
+    const expandsThroughHook = schedulingNodes != null &&
+      meta?.derived == null &&
+      (node.parser as {
+          readonly [sourceCollectionExpansionKey]?: boolean;
+        })[sourceCollectionExpansionKey] === true;
+    if (
+      !expandsThroughHook &&
+      (meta?.source?.completeSource != null || meta?.derived != null)
+    ) {
       expanded.push(node);
       return;
     }
     // A nested merge() supplies its own scheduling nodes so that the
     // expansion uses the same child-indexed paths, declaration order,
     // and duplicate-field exclusion as the merge's direct scheduling.
-    const schedulingNodes = (node.parser as {
-      readonly [effectfulSchedulingNodesKey]?: EffectfulSchedulingNodesFn;
-    })[effectfulSchedulingNodesKey];
     if (schedulingNodes != null) {
-      for (const child of schedulingNodes(node.state, node.path)) {
+      const children = schedulingNodes(node.state, node.path);
+      if (children.length === 0 && meta?.source != null) {
+        expanded.push(node);
+        return;
+      }
+      for (const child of children) {
         visit(child);
       }
       return;

--- a/packages/core/src/constructs.ts
+++ b/packages/core/src/constructs.ts
@@ -412,8 +412,11 @@ function collectStaticSourceIds(
   seen.add(parser as object);
   const source = parser.dependencyMetadata?.source;
   if (source != null) {
+    // A composed source (e.g., a mixed or() delegating to its committed
+    // branch) can sit on a parser whose alternatives provide further
+    // sources, so record it and keep walking the field and static
+    // scopes rather than stopping here.
     out.add(source.sourceId);
-    return;
   }
   const pairs = (parser as {
     readonly [fieldParsersKey]?: ReadonlyArray<

--- a/packages/core/src/constructs.ts
+++ b/packages/core/src/constructs.ts
@@ -28,6 +28,7 @@ import {
   resolveStateWithRuntime,
   resolveStateWithRuntimeAsync,
   type RuntimeNode,
+  sourceCollectionExpansionKey,
 } from "./dependency-runtime.ts";
 import {
   annotateFreshArray,
@@ -311,6 +312,38 @@ function expandEffectfulRuntimeNodes(
   return expanded;
 }
 
+/**
+ * Expands a construct's direct-child nodes for explicit source
+ * collection.
+ *
+ * A direct child that opted in through {@link sourceCollectionExpansionKey}
+ * (a `conditional()` or a `command()`, possibly behind transparent
+ * wrappers) is replaced in place by its scheduling-hook expansion, so
+ * its command-line source values—the discriminator, a committed branch,
+ * a selected command subtree—register into the parent's runtime in the
+ * child's declaration position.  Every other node passes through
+ * unchanged, keeping the existing collection scope for plain nested
+ * constructs and uncommitted exclusive branches.
+ */
+function expandSourceCollectionNodes(
+  nodes: readonly RuntimeNode[],
+): readonly RuntimeNode[] {
+  let expanded: RuntimeNode[] | undefined;
+  for (let i = 0; i < nodes.length; i++) {
+    const node = nodes[i];
+    const optedIn = (node.parser as {
+      readonly [sourceCollectionExpansionKey]?: boolean;
+    })[sourceCollectionExpansionKey] === true;
+    if (!optedIn) {
+      expanded?.push(node);
+      continue;
+    }
+    if (expanded == null) expanded = nodes.slice(0, i);
+    expanded.push(...expandEffectfulRuntimeNodes([node]));
+  }
+  return expanded ?? nodes;
+}
+
 function isDeferredCompletionResult(result: unknown): boolean {
   return typeof result === "object" && result !== null &&
     "success" in result &&
@@ -388,10 +421,24 @@ async function scheduleEffectfulSourceCompletions(
   }
   // Only direct children can feed the construct's own pre-completed
   // cache; expanded descendants are deduplicated through the run-scoped
-  // session instead.
+  // session instead.  Nodes expanded from a collection-opted-in child
+  // (a conditional()/command()) did participate in the construct's
+  // explicit source collection, so they re-register structurally in
+  // declaration order even though their results are not reusable.
   const direct = new Set<RuntimeNode>(nodes);
+  const collected = new Set<RuntimeNode>();
+  const expandedNodes: RuntimeNode[] = [];
+  for (const node of nodes) {
+    const optedIn = (node.parser as {
+      readonly [sourceCollectionExpansionKey]?: boolean;
+    })[sourceCollectionExpansionKey] === true;
+    for (const expandedNode of expandEffectfulRuntimeNodes([node])) {
+      expandedNodes.push(expandedNode);
+      if (optedIn || expandedNode === node) collected.add(expandedNode);
+    }
+  }
   const effectful = await completeEffectfulSourcesAsync(
-    expandEffectfulRuntimeNodes(nodes),
+    expandedNodes,
     state,
     runtime,
     exec,
@@ -400,6 +447,7 @@ async function scheduleEffectfulSourceCompletions(
         ? { demandNodes: expandEffectfulRuntimeNodes(demandNodes) }
         : {}),
       isReusable: (node) => direct.has(node),
+      isCollected: (node) => collected.has(node),
     },
   );
   if (!effectful.success) {
@@ -5287,7 +5335,7 @@ function* suggestObjectSync<
       : {}) as Record<PropertyKey, unknown>,
     context.exec?.path,
   );
-  collectExplicitSourceValues(nodes, runtime);
+  collectExplicitSourceValues(expandSourceCollectionNodes(nodes), runtime);
 
   // Collect dependency sources from the state tree (handles nested
   // DependencySourceState inside arrays, e.g., multiple()).
@@ -5411,7 +5459,10 @@ async function* suggestObjectAsync<
       : {}) as Record<PropertyKey, unknown>,
     context.exec?.path,
   );
-  await collectExplicitSourceValuesAsync(nodes, runtime);
+  await collectExplicitSourceValuesAsync(
+    expandSourceCollectionNodes(nodes),
+    runtime,
+  );
 
   // Collect dependency sources from state tree.
   if (context.state && typeof context.state === "object") {
@@ -6944,13 +6995,15 @@ export function object<
             annotatedState[fieldKey] = getFieldState(field, fieldParser);
           }
           collectExplicitSourceValues(
-            filterPreCompletedRuntimeNodes(
-              buildRuntimeNodesFromPairs(
-                typedParserPairs,
-                annotatedState,
-                exec?.path,
+            expandSourceCollectionNodes(
+              filterPreCompletedRuntimeNodes(
+                buildRuntimeNodesFromPairs(
+                  typedParserPairs,
+                  annotatedState,
+                  exec?.path,
+                ),
+                new Set(preCompleted.keys()),
               ),
-              new Set(preCompleted.keys()),
             ),
             runtime,
           );
@@ -7071,7 +7124,10 @@ export function object<
             allRuntimeNodes,
             new Set(preCompleted.keys()),
           );
-          await collectExplicitSourceValuesAsync(runtimeNodes, runtime);
+          await collectExplicitSourceValuesAsync(
+            expandSourceCollectionNodes(runtimeNodes),
+            runtime,
+          );
           // Phase 2b: Run effectful source completions (e.g., prompts)
           // serially so their values register before deferred replay.
           // Deferred Phase 1 results stay schedulable so a demand-only
@@ -7239,13 +7295,15 @@ export function object<
             annotatedState[fieldKey] = getFieldState(field, fieldParser);
           }
           collectExplicitSourceValues(
-            filterPreCompletedRuntimeNodes(
-              buildRuntimeNodesFromPairs(
-                typedParserPairs,
-                annotatedState,
-                exec?.path,
+            expandSourceCollectionNodes(
+              filterPreCompletedRuntimeNodes(
+                buildRuntimeNodesFromPairs(
+                  typedParserPairs,
+                  annotatedState,
+                  exec?.path,
+                ),
+                new Set(preCompleted.keys()),
               ),
-              new Set(preCompleted.keys()),
             ),
             runtime,
           );
@@ -7353,7 +7411,10 @@ export function object<
             allRuntimeNodes,
             new Set(preCompleted.keys()),
           );
-          await collectExplicitSourceValuesAsync(runtimeNodes, runtime);
+          await collectExplicitSourceValuesAsync(
+            expandSourceCollectionNodes(runtimeNodes),
+            runtime,
+          );
           // Best-effort seeding: run effectful source completions so
           // prompted values reach phase-two contexts.  A failure (e.g.,
           // a cancelled prompt) aborts seed extraction entirely so no
@@ -8163,9 +8224,11 @@ function createSeqComplete(
           childExec,
         );
         collectExplicitSourceValues(
-          filterPreCompletedRuntimeNodes(
-            buildRuntimeNodesFromArray(syncParsers, stateArray, exec?.path),
-            new Set(preCompleted.keys()),
+          expandSourceCollectionNodes(
+            filterPreCompletedRuntimeNodes(
+              buildRuntimeNodesFromArray(syncParsers, stateArray, exec?.path),
+              new Set(preCompleted.keys()),
+            ),
           ),
           runtime,
         );
@@ -8253,7 +8316,10 @@ function createSeqComplete(
           allRuntimeNodes,
           new Set(preCompleted.keys()),
         );
-        await collectExplicitSourceValuesAsync(runtimeNodes, runtime);
+        await collectExplicitSourceValuesAsync(
+          expandSourceCollectionNodes(runtimeNodes),
+          runtime,
+        );
         // Phase 2b: Run effectful source completions (e.g., prompts)
         // serially so their values register before deferred replay.
         // Deferred Phase 1 results stay schedulable so a demand-only
@@ -8349,7 +8415,7 @@ function suggestTupleSync(
       stateArray,
       advancedContext.exec?.path,
     );
-    collectExplicitSourceValues(nodes, runtime);
+    collectExplicitSourceValues(expandSourceCollectionNodes(nodes), runtime);
     fillMissingSourceDefaults(nodes, runtime);
     collectSourcesFromState(stateArray, runtime);
     completeDependencySourceDefaults(
@@ -8421,7 +8487,10 @@ async function* suggestTupleAsync(
       stateArray,
       advancedContext.exec?.path,
     );
-    await collectExplicitSourceValuesAsync(nodes, runtime);
+    await collectExplicitSourceValuesAsync(
+      expandSourceCollectionNodes(nodes),
+      runtime,
+    );
     await fillMissingSourceDefaultsAsync(nodes, runtime);
     collectSourcesFromState(stateArray, runtime);
     await completeDependencySourceDefaultsAsync(
@@ -8760,7 +8829,10 @@ function markFailedTupleSuggestSources(
     if (nodes.length < 1) continue;
 
     const failedRuntime = createDependencyRuntimeContext();
-    collectExplicitSourceValues(nodes, failedRuntime);
+    collectExplicitSourceValues(
+      expandSourceCollectionNodes(nodes),
+      failedRuntime,
+    );
     for (const node of nodes) {
       const sourceId = node.parser.dependencyMetadata?.source?.sourceId;
       if (sourceId != null && failedRuntime.isSourceFailed(sourceId)) {
@@ -8795,7 +8867,10 @@ async function markFailedTupleSuggestSourcesAsync(
     if (nodes.length < 1) continue;
 
     const failedRuntime = createDependencyRuntimeContext();
-    await collectExplicitSourceValuesAsync(nodes, failedRuntime);
+    await collectExplicitSourceValuesAsync(
+      expandSourceCollectionNodes(nodes),
+      failedRuntime,
+    );
     for (const node of nodes) {
       const sourceId = node.parser.dependencyMetadata?.source?.sourceId;
       if (sourceId != null && failedRuntime.isSourceFailed(sourceId)) {
@@ -9248,9 +9323,11 @@ export function tuple<
             childExec,
           );
           collectExplicitSourceValues(
-            filterPreCompletedRuntimeNodes(
-              buildRuntimeNodesFromArray(syncParsers, stateArray, exec?.path),
-              new Set(preCompleted.keys()),
+            expandSourceCollectionNodes(
+              filterPreCompletedRuntimeNodes(
+                buildRuntimeNodesFromArray(syncParsers, stateArray, exec?.path),
+                new Set(preCompleted.keys()),
+              ),
             ),
             runtime,
           );
@@ -9352,7 +9429,10 @@ export function tuple<
             allRuntimeNodes,
             new Set(preCompleted.keys()),
           );
-          await collectExplicitSourceValuesAsync(runtimeNodes, runtime);
+          await collectExplicitSourceValuesAsync(
+            expandSourceCollectionNodes(runtimeNodes),
+            runtime,
+          );
           // Phase 2b: Run effectful source completions (e.g., prompts)
           // serially so their values register before deferred replay.
           // Deferred Phase 1 results stay schedulable so a demand-only
@@ -9461,9 +9541,11 @@ export function tuple<
             childExec,
           );
           collectExplicitSourceValues(
-            filterPreCompletedRuntimeNodes(
-              buildRuntimeNodesFromArray(syncParsers, stateArray, exec?.path),
-              new Set(preCompleted.keys()),
+            expandSourceCollectionNodes(
+              filterPreCompletedRuntimeNodes(
+                buildRuntimeNodesFromArray(syncParsers, stateArray, exec?.path),
+                new Set(preCompleted.keys()),
+              ),
             ),
             runtime,
           );
@@ -9552,7 +9634,10 @@ export function tuple<
             allRuntimeNodes,
             new Set(preCompleted.keys()),
           );
-          await collectExplicitSourceValuesAsync(runtimeNodes, runtime);
+          await collectExplicitSourceValuesAsync(
+            expandSourceCollectionNodes(runtimeNodes),
+            runtime,
+          );
           // Best-effort seeding: run effectful source completions so
           // prompted values reach phase-two contexts.  A failure (e.g.,
           // a cancelled prompt) aborts seed extraction entirely so no
@@ -10089,9 +10174,11 @@ export function seq<
             childExec,
           );
           collectExplicitSourceValues(
-            filterPreCompletedRuntimeNodes(
-              buildRuntimeNodesFromArray(syncParsers, stateArray, exec?.path),
-              new Set(preCompleted.keys()),
+            expandSourceCollectionNodes(
+              filterPreCompletedRuntimeNodes(
+                buildRuntimeNodesFromArray(syncParsers, stateArray, exec?.path),
+                new Set(preCompleted.keys()),
+              ),
             ),
             runtime,
           );
@@ -10180,7 +10267,10 @@ export function seq<
             allRuntimeNodes,
             new Set(preCompleted.keys()),
           );
-          await collectExplicitSourceValuesAsync(runtimeNodes, runtime);
+          await collectExplicitSourceValuesAsync(
+            expandSourceCollectionNodes(runtimeNodes),
+            runtime,
+          );
           // Best-effort seeding: run effectful source completions so
           // prompted values reach phase-two contexts.  A failure (e.g.,
           // a cancelled prompt) aborts seed extraction entirely so no
@@ -10280,7 +10370,10 @@ export function seq<
             stateArray,
             advancedContext.exec?.path,
           );
-          collectExplicitSourceValues(nodes, runtime);
+          collectExplicitSourceValues(
+            expandSourceCollectionNodes(nodes),
+            runtime,
+          );
           fillMissingSourceDefaults(nodes, runtime);
           collectSourcesFromState(stateArray, runtime);
           completeDependencySourceDefaults(
@@ -10342,7 +10435,10 @@ export function seq<
             stateArray,
             advancedContext.exec?.path,
           );
-          await collectExplicitSourceValuesAsync(nodes, runtime);
+          await collectExplicitSourceValuesAsync(
+            expandSourceCollectionNodes(nodes),
+            runtime,
+          );
           await fillMissingSourceDefaultsAsync(nodes, runtime);
           collectSourcesFromState(stateArray, runtime);
           await completeDependencySourceDefaultsAsync(
@@ -11663,10 +11759,12 @@ export function merge(
           return { cache: undefined, excludedSourceFields: undefined };
         });
         collectExplicitSourceValues(
-          buildRuntimeNodesFromPairs(
-            unambiguousFieldParsers,
-            state as Record<PropertyKey, unknown>,
-            exec?.path,
+          expandSourceCollectionNodes(
+            buildRuntimeNodesFromPairs(
+              unambiguousFieldParsers,
+              state as Record<PropertyKey, unknown>,
+              exec?.path,
+            ),
           ),
           runtime,
         );
@@ -11829,7 +11927,10 @@ export function merge(
           state as Record<PropertyKey, unknown>,
           exec?.path,
         );
-        await collectExplicitSourceValuesAsync(mergeNodes, runtime);
+        await collectExplicitSourceValuesAsync(
+          expandSourceCollectionNodes(mergeNodes),
+          runtime,
+        );
         // Phase 2b: Run effectful source completions (e.g., prompts) for
         // unambiguous fields so their values register before deferred
         // replay.  Duplicate-key fields are already excluded from the
@@ -12032,10 +12133,12 @@ export function merge(
             return { cache: undefined, excludedSourceFields: undefined };
           });
           collectExplicitSourceValues(
-            buildRuntimeNodesFromPairs(
-              unambiguousFieldParsers,
-              state as Record<PropertyKey, unknown>,
-              exec?.path,
+            expandSourceCollectionNodes(
+              buildRuntimeNodesFromPairs(
+                unambiguousFieldParsers,
+                state as Record<PropertyKey, unknown>,
+                exec?.path,
+              ),
             ),
             runtime,
           );
@@ -12183,7 +12286,10 @@ export function merge(
             state as Record<PropertyKey, unknown>,
             exec?.path,
           );
-          await collectExplicitSourceValuesAsync(mergeNodes, runtime);
+          await collectExplicitSourceValuesAsync(
+            expandSourceCollectionNodes(mergeNodes),
+            runtime,
+          );
           // Best-effort seeding: run effectful source completions so
           // prompted values reach phase-two contexts.  A failure (e.g.,
           // a cancelled prompt) aborts seed extraction entirely so no
@@ -12373,10 +12479,12 @@ export function merge(
           });
           if (context.state && typeof context.state === "object") {
             await collectExplicitSourceValuesAsync(
-              buildRuntimeNodesFromPairs(
-                childFieldPairs,
-                context.state as Record<PropertyKey, unknown>,
-                context.exec?.path,
+              expandSourceCollectionNodes(
+                buildRuntimeNodesFromPairs(
+                  childFieldPairs,
+                  context.state as Record<PropertyKey, unknown>,
+                  context.exec?.path,
+                ),
               ),
               runtime,
             );
@@ -12473,10 +12581,12 @@ export function merge(
       });
       if (context.state && typeof context.state === "object") {
         collectExplicitSourceValues(
-          buildRuntimeNodesFromPairs(
-            childFieldPairs,
-            context.state as Record<PropertyKey, unknown>,
-            context.exec?.path,
+          expandSourceCollectionNodes(
+            buildRuntimeNodesFromPairs(
+              childFieldPairs,
+              context.state as Record<PropertyKey, unknown>,
+              context.exec?.path,
+            ),
           ),
           runtime,
         );
@@ -12713,7 +12823,9 @@ function buildSuggestRegistry(
       preParsedContext.exec?.path,
     );
     collectExplicitSourceValues(
-      nodes,
+      expandSourceCollectionNodes(
+        nodes,
+      ),
       runtime,
     );
     fillMissingSourceDefaults(nodes, runtime);
@@ -12773,7 +12885,9 @@ async function buildSuggestRegistryAsync(
       preParsedContext.exec?.path,
     );
     await collectExplicitSourceValuesAsync(
-      nodes,
+      expandSourceCollectionNodes(
+        nodes,
+      ),
       runtime,
     );
     await fillMissingSourceDefaultsAsync(nodes, runtime);
@@ -12839,7 +12953,7 @@ function seedSuggestRuntimeFromFieldParsers(
     stateRecord,
     parentPath,
   );
-  collectExplicitSourceValues(nodes, runtime);
+  collectExplicitSourceValues(expandSourceCollectionNodes(nodes), runtime);
   fillMissingSourceDefaults(nodes, runtime);
   collectSourcesFromState(
     state,
@@ -12906,7 +13020,10 @@ async function seedSuggestRuntimeFromFieldParsersAsync(
     stateRecord,
     parentPath,
   );
-  await collectExplicitSourceValuesAsync(nodes, runtime);
+  await collectExplicitSourceValuesAsync(
+    expandSourceCollectionNodes(nodes),
+    runtime,
+  );
   await fillMissingSourceDefaultsAsync(nodes, runtime);
   collectSourcesFromState(
     state,
@@ -13527,9 +13644,11 @@ export function concat(
       childExec,
     );
     collectExplicitSourceValues(
-      filterPreCompletedRuntimeNodes(
-        buildRuntimeNodesFromArray(syncParsers, stateArray, exec?.path),
-        new Set(preCompleted.keys()),
+      expandSourceCollectionNodes(
+        filterPreCompletedRuntimeNodes(
+          buildRuntimeNodesFromArray(syncParsers, stateArray, exec?.path),
+          new Set(preCompleted.keys()),
+        ),
       ),
       runtime,
     );
@@ -13645,7 +13764,10 @@ export function concat(
       allRuntimeNodes,
       new Set(preCompleted.keys()),
     );
-    await collectExplicitSourceValuesAsync(runtimeNodes, runtime);
+    await collectExplicitSourceValuesAsync(
+      expandSourceCollectionNodes(runtimeNodes),
+      runtime,
+    );
     // Phase 2b: Run effectful source completions (e.g., prompts)
     // serially so their values register before deferred replay.
     // Deferred Phase 1 results stay schedulable so a demand-only
@@ -13800,9 +13922,11 @@ export function concat(
             childExec,
           );
           collectExplicitSourceValues(
-            filterPreCompletedRuntimeNodes(
-              buildRuntimeNodesFromArray(syncParsers, stateArray, exec?.path),
-              new Set(preCompleted.keys()),
+            expandSourceCollectionNodes(
+              filterPreCompletedRuntimeNodes(
+                buildRuntimeNodesFromArray(syncParsers, stateArray, exec?.path),
+                new Set(preCompleted.keys()),
+              ),
             ),
             runtime,
           );
@@ -13880,7 +14004,10 @@ export function concat(
             allRuntimeNodes,
             new Set(preCompleted.keys()),
           );
-          await collectExplicitSourceValuesAsync(runtimeNodes, runtime);
+          await collectExplicitSourceValuesAsync(
+            expandSourceCollectionNodes(runtimeNodes),
+            runtime,
+          );
           // Best-effort seeding: run effectful source completions so
           // prompted values reach phase-two contexts.  A failure (e.g.,
           // a cancelled prompt) aborts seed extraction entirely so no
@@ -14139,6 +14266,15 @@ export function group<M extends Mode, TValue, TState>(
             [effectfulSchedulingNodesKey]: EffectfulSchedulingNodesFn;
           }
         )[effectfulSchedulingNodesKey],
+      }
+      : {}),
+    // Forward the source-collection opt-in so a grouped conditional()
+    // or command() keeps its collection scope.
+    ...(sourceCollectionExpansionKey in parser
+      ? {
+        [sourceCollectionExpansionKey]: (
+          parser as { [sourceCollectionExpansionKey]: boolean }
+        )[sourceCollectionExpansionKey],
       }
       : {}),
     // Forward completion deferral hook from inner parser so that
@@ -15626,13 +15762,15 @@ export function conditional(
       exec?.dependencyRegistry?.clone(),
     );
     collectExplicitSourceValues(
-      buildRuntimeNodesFromPairs(
-        [
-          ["_discriminator", discriminator],
-          ["_branch", branchParser],
-        ],
-        combinedState,
-        exec?.path,
+      expandSourceCollectionNodes(
+        buildRuntimeNodesFromPairs(
+          [
+            ["_discriminator", discriminator],
+            ["_branch", branchParser],
+          ],
+          combinedState,
+          exec?.path,
+        ),
       ),
       runtime,
     );
@@ -15988,13 +16126,15 @@ export function conditional(
       exec?.dependencyRegistry?.clone(),
     );
     await collectExplicitSourceValuesAsync(
-      buildRuntimeNodesFromPairs(
-        [
-          ["_discriminator", discriminator],
-          ["_branch", branchParser],
-        ],
-        combinedState,
-        exec?.path,
+      expandSourceCollectionNodes(
+        buildRuntimeNodesFromPairs(
+          [
+            ["_discriminator", discriminator],
+            ["_branch", branchParser],
+          ],
+          combinedState,
+          exec?.path,
+        ),
       ),
       runtime,
     );
@@ -16065,10 +16205,12 @@ export function conditional(
         exec?.dependencyRegistry?.clone(),
       );
       await collectExplicitSourceValuesAsync(
-        buildRuntimeNodesFromPairs(
-          [["_discriminator", discriminator]] as const,
-          discOnlyState,
-          exec?.path,
+        expandSourceCollectionNodes(
+          buildRuntimeNodesFromPairs(
+            [["_discriminator", discriminator]] as const,
+            discOnlyState,
+            exec?.path,
+          ),
         ),
         discOnlyRuntime,
       );
@@ -16273,15 +16415,17 @@ export function conditional(
           ),
       };
       collectExplicitSourceValues(
-        buildRuntimeNodesFromPairs(
-          syncDefaultBranch == null
-            ? [["\u005fdiscriminator", discriminator]] as const
-            : [
-              ["\u005fdiscriminator", discriminator],
-              ["\u005fbranch", syncDefaultBranch],
-            ] as const,
-          defaultCombinedState,
-          context.exec?.path,
+        expandSourceCollectionNodes(
+          buildRuntimeNodesFromPairs(
+            syncDefaultBranch == null
+              ? [["\u005fdiscriminator", discriminator]] as const
+              : [
+                ["\u005fdiscriminator", discriminator],
+                ["\u005fbranch", syncDefaultBranch],
+              ] as const,
+            defaultCombinedState,
+            context.exec?.path,
+          ),
         ),
         runtime,
       );
@@ -16374,13 +16518,15 @@ export function conditional(
         ),
       };
       collectExplicitSourceValues(
-        buildRuntimeNodesFromPairs(
-          [
-            ["_discriminator", discriminator],
-            ["_branch", branchParser],
-          ],
-          combinedState,
-          context.exec?.path,
+        expandSourceCollectionNodes(
+          buildRuntimeNodesFromPairs(
+            [
+              ["_discriminator", discriminator],
+              ["_branch", branchParser],
+            ],
+            combinedState,
+            context.exec?.path,
+          ),
         ),
         runtime,
       );
@@ -16439,15 +16585,17 @@ export function conditional(
           ),
       };
       await collectExplicitSourceValuesAsync(
-        buildRuntimeNodesFromPairs(
-          defaultBranch == null
-            ? [["\u005fdiscriminator", discriminator]] as const
-            : [
-              ["\u005fdiscriminator", discriminator],
-              ["\u005fbranch", defaultBranch],
-            ] as const,
-          defaultCombinedState,
-          context.exec?.path,
+        expandSourceCollectionNodes(
+          buildRuntimeNodesFromPairs(
+            defaultBranch == null
+              ? [["\u005fdiscriminator", discriminator]] as const
+              : [
+                ["\u005fdiscriminator", discriminator],
+                ["\u005fbranch", defaultBranch],
+              ] as const,
+            defaultCombinedState,
+            context.exec?.path,
+          ),
         ),
         runtime,
       );
@@ -16548,13 +16696,15 @@ export function conditional(
         ),
       };
       await collectExplicitSourceValuesAsync(
-        buildRuntimeNodesFromPairs(
-          [
-            ["_discriminator", discriminator],
-            ["_branch", branchParser],
-          ],
-          combinedState,
-          context.exec?.path,
+        expandSourceCollectionNodes(
+          buildRuntimeNodesFromPairs(
+            [
+              ["_discriminator", discriminator],
+              ["_branch", branchParser],
+            ],
+            combinedState,
+            context.exec?.path,
+          ),
         ),
         runtime,
       );
@@ -16848,6 +16998,15 @@ export function conditional(
   // itself uses, so the run-scoped completion cache lines up.
   Object.defineProperty(conditionalParser, effectfulSchedulingNodesKey, {
     value: buildConditionalSchedulingNodes satisfies EffectfulSchedulingNodesFn,
+    configurable: true,
+    enumerable: false,
+  });
+  // Command-line source values behind the discriminator and the
+  // committed branch register into the parent's runtime through the
+  // same node expansion the scheduling pass uses, so a value behaves
+  // identically whether it was typed or prompted.
+  Object.defineProperty(conditionalParser, sourceCollectionExpansionKey, {
+    value: true,
     configurable: true,
     enumerable: false,
   });

--- a/packages/core/src/constructs.ts
+++ b/packages/core/src/constructs.ts
@@ -15994,31 +15994,22 @@ export function conditional(
       }
       return nodes;
     }
-    if (selected !== undefined || conditionalState.speculative === true) {
-      return nodes;
-    }
 
     const discriminatorSource = discriminator.dependencyMetadata?.source;
-    // A prompted discriminator that is not a dependency source has no
-    // run-scoped occurrence cache, so completing it during preparation
-    // would run its effect a second time in final completion.  Dynamic
-    // branch preparation is unsupported for it (documented limitation).
-    if (
-      discriminatorSource == null &&
-      typeof discriminator.shouldDeferCompletion === "function"
-    ) {
-      return nodes;
-    }
-
-    // Tee the discriminator's effectful completion result so the
-    // barrier below can resolve the branch without re-running the
-    // effect.  The wrapped metadata lives only on this pass's node;
-    // the discriminator parser itself is never mutated.
+    const innerCompleteSource = discriminatorSource?.completeSource;
+    const discriminatorPathKey = serializeSchedulingPath([
+      ...(parentPath ?? []),
+      "_discriminator",
+    ]);
+    // Tee the discriminator's effectful completion result so a barrier
+    // can resolve the branch without re-running the effect.  The
+    // wrapped metadata lives only on this pass's node; the
+    // discriminator parser itself is never mutated.
     const cell: {
       result?: import("./valueparser.ts").ValueParserResult<unknown>;
     } = {};
-    const innerCompleteSource = discriminatorSource?.completeSource;
-    if (discriminatorSource != null && innerCompleteSource != null) {
+    const teeDiscriminatorNode = (): void => {
+      if (discriminatorSource == null || innerCompleteSource == null) return;
       nodes[0] = {
         ...nodes[0],
         parser: {
@@ -16035,11 +16026,71 @@ export function conditional(
           },
         },
       };
+    };
+
+    if (conditionalState.speculative === true) {
+      // A speculative selection is a parse-time guess: the guessed
+      // branch stays effect-free until the discriminator's own
+      // completion confirms its key, so the barrier schedules the
+      // branch only on a confirmed match; a mismatch schedules nothing
+      // and the verification in completion fails the parse.  Only an
+      // effectful source discriminator can confirm here—its completion
+      // is deduplicated through the run-scoped session, so it runs at
+      // most once per pass.
+      if (selected?.kind !== "branch" || innerCompleteSource == null) {
+        return nodes;
+      }
+      teeDiscriminatorNode();
+      const speculativeKey = selected.key;
+      nodes.push({
+        path: [...(parentPath ?? []), "_branch"],
+        parser: {},
+        state: conditionalState,
+        ...(discriminatorSource != null
+          ? { requiresSourceId: discriminatorSource.sourceId }
+          : {}),
+        providesSourceIds: branchProvidedSourceIds,
+        prepare: async (ctx) => {
+          const session = ctx.exec?.effectfulCompletionSession;
+          if (session == null) return undefined;
+          const result = cell.result ??
+            session.completedByPath.get(discriminatorPathKey);
+          if (
+            result == null || isDeferredCompletionResult(result) ||
+            result.success !== true
+          ) {
+            return undefined;
+          }
+          if (String(result.value) !== speculativeKey) return undefined;
+          const branchParser = branches[speculativeKey];
+          if (branchParser == null) return undefined;
+          return await ctx.schedule(expandEffectfulRuntimeNodes([{
+            path: [...(parentPath ?? []), "_branch"],
+            parser: branchParser,
+            state: getAnnotatedChildState(
+              conditionalState,
+              conditionalState.branchState,
+              branchParser,
+            ),
+          }]));
+        },
+      });
+      return nodes;
     }
-    const discriminatorPathKey = serializeSchedulingPath([
-      ...(parentPath ?? []),
-      "_discriminator",
-    ]);
+    if (selected !== undefined) return nodes;
+
+    // A prompted discriminator that is not a dependency source has no
+    // run-scoped occurrence cache, so completing it during preparation
+    // would run its effect a second time in final completion.  Dynamic
+    // branch preparation is unsupported for it (documented limitation).
+    if (
+      discriminatorSource == null &&
+      typeof discriminator.shouldDeferCompletion === "function"
+    ) {
+      return nodes;
+    }
+
+    teeDiscriminatorNode();
     nodes.push({
       path: [...(parentPath ?? []), "_branch"],
       parser: {},

--- a/packages/core/src/constructs.ts
+++ b/packages/core/src/constructs.ts
@@ -30,6 +30,7 @@ import {
   type RuntimeNode,
   serializeSchedulingPath,
   sourceCollectionExpansionKey,
+  staticSourceScopeKey,
 } from "./dependency-runtime.ts";
 import {
   annotateFreshArray,
@@ -399,8 +400,17 @@ function collectStaticSourceIds(
       readonly [string | symbol, Parser<Mode, unknown, unknown>]
     >;
   })[fieldParsersKey];
-  if (pairs == null) return;
-  for (const [, child] of pairs) collectStaticSourceIds(child, out, seen);
+  if (pairs != null) {
+    for (const [, child] of pairs) collectStaticSourceIds(child, out, seen);
+  }
+  const scope = (parser as {
+    readonly [staticSourceScopeKey]?: ReadonlyArray<
+      Parser<Mode, unknown, unknown>
+    >;
+  })[staticSourceScopeKey];
+  if (scope != null) {
+    for (const child of scope) collectStaticSourceIds(child, out, seen);
+  }
 }
 
 function isDeferredCompletionResult(result: unknown): boolean {
@@ -2034,6 +2044,11 @@ function defineExclusiveSchedulingNodes(
   exclusiveParser: object,
   parsers: readonly Parser<Mode, unknown, unknown>[],
 ): void {
+  Object.defineProperty(exclusiveParser, staticSourceScopeKey, {
+    value: parsers,
+    configurable: true,
+    enumerable: false,
+  });
   Object.defineProperty(exclusiveParser, effectfulSchedulingNodesKey, {
     value: ((state, parentPath) => {
       const active = normalizeExclusiveState(state);
@@ -14454,6 +14469,12 @@ export function group<M extends Mode, TValue, TState>(
     },
   };
   defineParseLanes(groupParser, getOwnParseLanes(parser));
+  // Forward static source estimation through the group.
+  Object.defineProperty(groupParser, staticSourceScopeKey, {
+    value: [parser],
+    configurable: true,
+    enumerable: false,
+  });
   Object.defineProperty(groupParser, extractPhase2SeedKey, {
     value(state: TState, exec?: ExecutionContext) {
       return extractPhase2Seed(parser, state, exec);
@@ -17330,6 +17351,17 @@ export function conditional(
   // identically whether it was typed or prompted.
   Object.defineProperty(conditionalParser, sourceCollectionExpansionKey, {
     value: true,
+    configurable: true,
+    enumerable: false,
+  });
+  // Static source estimation reaches the discriminator and every branch
+  // (see staticSourceScopeKey); an overcount is harmless.
+  Object.defineProperty(conditionalParser, staticSourceScopeKey, {
+    value: [
+      discriminator,
+      ...Object.values(branches),
+      ...(defaultBranch != null ? [defaultBranch] : []),
+    ],
     configurable: true,
     enumerable: false,
   });

--- a/packages/core/src/constructs.ts
+++ b/packages/core/src/constructs.ts
@@ -2044,6 +2044,25 @@ function defineExclusiveSchedulingNodes(
   exclusiveParser: object,
   parsers: readonly Parser<Mode, unknown, unknown>[],
 ): void {
+  // When an alternative opts into source-collection expansion (a
+  // command() or a conditional()), the exclusive parser forwards the
+  // opt-in so its committed branch stays visible during explicit
+  // collection, matching what the scheduling hook already exposes for
+  // prompted values.  Alternatives without the marker keep the
+  // exclusive parser's existing collection scope.
+  if (
+    parsers.some((parser) =>
+      (parser as {
+        readonly [sourceCollectionExpansionKey]?: boolean;
+      })[sourceCollectionExpansionKey] === true
+    )
+  ) {
+    Object.defineProperty(exclusiveParser, sourceCollectionExpansionKey, {
+      value: true,
+      configurable: true,
+      enumerable: false,
+    });
+  }
   Object.defineProperty(exclusiveParser, staticSourceScopeKey, {
     value: parsers,
     configurable: true,

--- a/packages/core/src/constructs.ts
+++ b/packages/core/src/constructs.ts
@@ -28,6 +28,7 @@ import {
   resolveStateWithRuntime,
   resolveStateWithRuntimeAsync,
   type RuntimeNode,
+  serializeSchedulingPath,
   sourceCollectionExpansionKey,
 } from "./dependency-runtime.ts";
 import {
@@ -342,6 +343,64 @@ function expandSourceCollectionNodes(
     expanded.push(...expandEffectfulRuntimeNodes([node]));
   }
   return expanded ?? nodes;
+}
+
+/**
+ * A branch selection resolved during the effectful scheduling pass by a
+ * `conditional()` whose branch was not committed at parse time.  Cached
+ * in the run-scoped session (per pass) so final completion consumes the
+ * same decision instead of re-completing the discriminator or
+ * re-selecting a branch.
+ */
+interface PreparedConditionalSelection {
+  /** The discriminator's completion result. */
+  readonly discriminatorResult: import("./valueparser.ts").ValueParserResult<
+    unknown
+  >;
+
+  /** The selected branch parser, if any branch applies. */
+  readonly branchParser: Parser<Mode, unknown, unknown> | undefined;
+
+  /**
+   * The named branch key, or `undefined` when the default branch was
+   * selected.
+   */
+  readonly branchKey: string | undefined;
+
+  /** The branch state from the preparation's empty-input replay parse. */
+  readonly branchState: unknown;
+}
+
+// Per-instance identity for prepared-selection cache keys, so two
+// conditional() parsers at the same path never share an entry.
+let conditionalInstanceCounter = 0;
+
+/**
+ * Statically collects the dependency source IDs reachable through a
+ * parser's composed metadata and flattened field pairs.  Used as the
+ * `providesSourceIds` estimate for a conditional()'s branches: an
+ * undercount only delays an effectful completion from the seed pass to
+ * the final pass of a `runWith()` run.
+ */
+function collectStaticSourceIds(
+  parser: Parser<Mode, unknown, unknown>,
+  out: Set<symbol>,
+  seen: Set<object>,
+): void {
+  if (seen.has(parser as object)) return;
+  seen.add(parser as object);
+  const source = parser.dependencyMetadata?.source;
+  if (source != null) {
+    out.add(source.sourceId);
+    return;
+  }
+  const pairs = (parser as {
+    readonly [fieldParsersKey]?: ReadonlyArray<
+      readonly [string | symbol, Parser<Mode, unknown, unknown>]
+    >;
+  })[fieldParsersKey];
+  if (pairs == null) return;
+  for (const [, child] of pairs) collectStaticSourceIds(child, out, seen);
 }
 
 function isDeferredCompletionResult(result: unknown): boolean {
@@ -15868,6 +15927,25 @@ export function conditional(
     };
   };
 
+  // Per-instance prefix for prepared-selection cache keys.
+  const preparedKeyPrefix = `c${++conditionalInstanceCounter}|`;
+  const preparedKeyFor = (
+    parentPath: readonly PropertyKey[] | undefined,
+  ): string => preparedKeyPrefix + serializeSchedulingPath(parentPath ?? []);
+  // Source IDs the branches can provide, for demand-only control
+  // dependency detection (see RuntimeNode.providesSourceIds).
+  const branchProvidedSourceIds = (() => {
+    const out = new Set<symbol>();
+    const seen = new Set<object>();
+    for (const key of Object.keys(branches)) {
+      collectStaticSourceIds(branches[key], out, seen);
+    }
+    if (defaultBranch != null) {
+      collectStaticSourceIds(defaultBranch, out, seen);
+    }
+    return out;
+  })();
+
   // Builds the effectful scheduling nodes for this conditional: the
   // discriminator (always) and the committed branch (only when the
   // selection is not speculative, so branch sources stay hidden until
@@ -15875,20 +15953,28 @@ export function conditional(
   // effectfulSchedulingNodesKey hook and the completion below; the
   // "_discriminator"/"_branch" path segments match completion paths so
   // the run-scoped completion cache lines up.
+  //
+  // When no branch was committed at parse time, a scheduling barrier
+  // follows the discriminator node: it resolves the branch from the
+  // discriminator's completion, caches the decision in the run-scoped
+  // session (final completion consumes the same decision), and
+  // schedules the chosen branch's nodes within the same pass, so branch
+  // sources still complete before a parent sibling's dependency replay.
   const buildConditionalSchedulingNodes = (
     state: unknown,
     parentPath: readonly PropertyKey[] | undefined,
   ): readonly RuntimeNode[] => {
     if (state == null || typeof state !== "object") return [];
     const conditionalState = state as ConditionalState<string>;
+    const annotatedDiscriminatorState = getAnnotatedChildState(
+      conditionalState,
+      conditionalState.discriminatorState,
+      discriminator,
+    );
     const nodes: RuntimeNode[] = [{
       path: [...(parentPath ?? []), "_discriminator"],
       parser: discriminator,
-      state: getAnnotatedChildState(
-        conditionalState,
-        conditionalState.discriminatorState,
-        discriminator,
-      ),
+      state: annotatedDiscriminatorState,
     }];
     const selected = conditionalState.selectedBranch;
     if (selected !== undefined && conditionalState.speculative !== true) {
@@ -15906,7 +15992,148 @@ export function conditional(
           ),
         });
       }
+      return nodes;
     }
+    if (selected !== undefined || conditionalState.speculative === true) {
+      return nodes;
+    }
+
+    const discriminatorSource = discriminator.dependencyMetadata?.source;
+    // A prompted discriminator that is not a dependency source has no
+    // run-scoped occurrence cache, so completing it during preparation
+    // would run its effect a second time in final completion.  Dynamic
+    // branch preparation is unsupported for it (documented limitation).
+    if (
+      discriminatorSource == null &&
+      typeof discriminator.shouldDeferCompletion === "function"
+    ) {
+      return nodes;
+    }
+
+    // Tee the discriminator's effectful completion result so the
+    // barrier below can resolve the branch without re-running the
+    // effect.  The wrapped metadata lives only on this pass's node;
+    // the discriminator parser itself is never mutated.
+    const cell: {
+      result?: import("./valueparser.ts").ValueParserResult<unknown>;
+    } = {};
+    const innerCompleteSource = discriminatorSource?.completeSource;
+    if (discriminatorSource != null && innerCompleteSource != null) {
+      nodes[0] = {
+        ...nodes[0],
+        parser: {
+          dependencyMetadata: {
+            ...discriminator.dependencyMetadata,
+            source: {
+              ...discriminatorSource,
+              completeSource: async (s, e) => {
+                const result = await innerCompleteSource(s, e);
+                if (result != null) cell.result = result;
+                return result;
+              },
+            },
+          },
+        },
+      };
+    }
+    const discriminatorPathKey = serializeSchedulingPath([
+      ...(parentPath ?? []),
+      "_discriminator",
+    ]);
+    nodes.push({
+      path: [...(parentPath ?? []), "_branch"],
+      parser: {},
+      state: conditionalState,
+      ...(discriminatorSource != null
+        ? { requiresSourceId: discriminatorSource.sourceId }
+        : {}),
+      providesSourceIds: branchProvidedSourceIds,
+      prepare: async (ctx) => {
+        const session = ctx.exec?.effectfulCompletionSession;
+        if (session == null) return undefined;
+        const key = preparedKeyFor(parentPath);
+        let prepared = session.preparedByPath.get(key) as
+          | PreparedConditionalSelection
+          | undefined;
+        if (prepared == null) {
+          let discriminatorResult = cell.result ??
+            session.completedByPath.get(discriminatorPathKey);
+          if (
+            discriminatorResult == null && innerCompleteSource == null
+          ) {
+            // Effect-free discriminator: complete it once here; final
+            // completion reuses the prepared result, so non-idempotent
+            // completions (e.g., lazy defaults) still evaluate once.
+            const discriminatorExec = ctx.exec == null ? undefined : {
+              ...ctx.exec,
+              path: [...(parentPath ?? []), "_discriminator"],
+            };
+            discriminatorResult = unwrapCompleteResult(
+              await discriminator.complete(
+                annotatedDiscriminatorState,
+                discriminatorExec,
+              ),
+            );
+          }
+          if (
+            discriminatorResult == null ||
+            isDeferredCompletionResult(discriminatorResult)
+          ) {
+            return undefined;
+          }
+          const namedBranch = discriminatorResult.success
+            ? branches[String(discriminatorResult.value)]
+            : undefined;
+          const branchParser = namedBranch ?? defaultBranch;
+          let branchState: unknown;
+          if (branchParser != null) {
+            // Mirror final completion's empty-input replay parse so the
+            // prepared branch state matches what completion would build.
+            const branchExec = ctx.exec == null ? undefined : {
+              ...ctx.exec,
+              path: [...(parentPath ?? []), "_branch"],
+            };
+            const annotatedInitial = getAnnotatedChildState(
+              conditionalState,
+              branchParser.initialState,
+              branchParser,
+            );
+            const replayResult = await branchParser.parse({
+              buffer: [] as string[],
+              optionsTerminated: false,
+              usage: [] as never[],
+              exec: branchExec,
+              dependencyRegistry: ctx.exec?.dependencyRegistry,
+              state: annotatedInitial,
+            } as ParserContext<unknown>);
+            branchState = replayResult.success
+              ? replayResult.next.state
+              : annotatedInitial;
+          }
+          prepared = {
+            discriminatorResult,
+            branchParser,
+            branchKey: namedBranch != null
+              ? String(
+                (discriminatorResult as { readonly value: unknown }).value,
+              )
+              : undefined,
+            branchState,
+          };
+          session.preparedByPath.set(key, prepared);
+        }
+        if (prepared.branchParser == null) return undefined;
+        return await ctx.schedule(expandEffectfulRuntimeNodes([{
+          path: [...(parentPath ?? []), "_branch"],
+          parser: prepared.branchParser,
+          state: getAnnotatedChildState(
+            conditionalState,
+            prepared.branchState,
+            prepared.branchParser,
+          ),
+        }]));
+      },
+    });
     return nodes;
   };
 
@@ -15946,42 +16173,83 @@ export function conditional(
 
     // No branch selected yet (see sync counterpart for rationale).
     if (state.selectedBranch === undefined) {
+      let prepared: PreparedConditionalSelection | undefined;
       if (exec?.phase !== "parse" && exec?.phase !== "suggest") {
+        // Resolve the branch through the scheduling pass first: the
+        // barrier completes a prompted discriminator, prepares the
+        // branch selection in the run-scoped session, and completes
+        // the chosen branch's effectful sources.  When a parent
+        // construct already ran this pass, the run-scoped caches make
+        // it a no-op; without a session there is no cache to prevent
+        // double effects, so the pass is skipped and completion below
+        // behaves as before.
+        if (exec?.effectfulCompletionSession != null) {
+          const schedulingRuntime = createDependencyRuntimeContext(
+            exec.dependencyRegistry?.clone(),
+          );
+          const schedulingExec: ExecutionContext = {
+            ...exec,
+            phase: "complete",
+            dependencyRuntime: schedulingRuntime,
+            dependencyRegistry: schedulingRuntime.registry,
+          };
+          const schedulingFailure = await scheduleEffectfulSourceCompletions(
+            buildConditionalSchedulingNodes(state, exec.path),
+            state,
+            schedulingRuntime,
+            schedulingExec,
+            new Map<string | symbol, unknown>(),
+          );
+          if (schedulingFailure != null) return schedulingFailure;
+          prepared = exec.effectfulCompletionSession.preparedByPath.get(
+            preparedKeyFor(exec.path),
+          ) as PreparedConditionalSelection | undefined;
+        }
         const annotatedDiscriminatorStateForDeferred = getAnnotatedChildState(
           state,
           state.discriminatorState,
           discriminator,
         );
-        const deferredDiscriminatorResult = unwrapCompleteResult(
-          await discriminator.complete(
-            annotatedDiscriminatorStateForDeferred,
-            withChildExecPath(exec, "_discriminator"),
-          ),
-        );
+        // Consume the prepared decision instead of re-completing the
+        // discriminator, so a non-idempotent completion cannot select
+        // a different branch than the one whose sources were scheduled.
+        const deferredDiscriminatorResult = prepared != null
+          ? prepared.discriminatorResult
+          : unwrapCompleteResult(
+            await discriminator.complete(
+              annotatedDiscriminatorStateForDeferred,
+              withChildExecPath(exec, "_discriminator"),
+            ),
+          );
         if (deferredDiscriminatorResult.success) {
           const deferredValue = deferredDiscriminatorResult.value as string;
           const deferredBranch = branches[deferredValue];
           if (deferredBranch) {
             const branchExec = withChildExecPath(exec, "_branch");
-            const emptyCtx = {
-              buffer: [] as string[],
-              optionsTerminated: false,
-              usage: [] as never[],
-              exec: branchExec,
-              dependencyRegistry: exec?.dependencyRegistry,
-            };
-            const annotatedInitial = getAnnotatedChildState(
-              state,
-              deferredBranch.initialState,
-              deferredBranch,
-            );
-            const replayResult = await deferredBranch.parse({
-              ...emptyCtx,
-              state: annotatedInitial,
-            });
-            const branchState = replayResult.success
-              ? replayResult.next.state
-              : annotatedInitial;
+            let branchState: unknown;
+            if (prepared != null && prepared.branchKey === deferredValue) {
+              branchState = prepared.branchState;
+            } else {
+              const emptyCtx = {
+                buffer: [] as string[],
+                optionsTerminated: false,
+                usage: [] as never[],
+                exec: branchExec,
+                dependencyRegistry: exec?.dependencyRegistry,
+              };
+              const annotatedInitial = getAnnotatedChildState(
+                state,
+                deferredBranch.initialState,
+                deferredBranch,
+              );
+              const replayResult = await deferredBranch.parse({
+                ...emptyCtx,
+                state: annotatedInitial,
+              });
+              branchState = replayResult.success
+                ? replayResult.next.state
+                : annotatedInitial;
+            }
             // Re-inject parent annotations for the complete phase
             // (see sync counterpart for rationale).
             const annotatedBranchState = getAnnotatedChildState(
@@ -16063,11 +16331,15 @@ export function conditional(
         };
       }
 
-      // Default branch (real complete only).
+      // Default branch (real complete only).  A prepared selection for
+      // the default branch carries the branch state the scheduling
+      // pass's preparation built, so completion reuses it.
       if (defaultBranch !== undefined) {
         const branchState = getAnnotatedChildState(
           state,
-          state.branchState ?? defaultBranch.initialState,
+          (prepared != null && prepared.branchKey == null
+            ? prepared.branchState
+            : undefined) ?? state.branchState ?? defaultBranch.initialState,
           defaultBranch,
         );
         const defaultResult = unwrapCompleteResult(

--- a/packages/core/src/dependency-extra.test.ts
+++ b/packages/core/src/dependency-extra.test.ts
@@ -10156,6 +10156,48 @@ describe("source delivery from conditional()/command() to siblings", () => {
   );
 
   test(
+    "delivers a command() selected through or() to a sibling",
+    async () => {
+      const { mode, level } = createModeLevel();
+      // or() forwards the collection opt-in when an alternative carries
+      // it, so the committed command's typed value reaches the
+      // earlier-declared consumer just like a prompted one would.
+      const parser = object({
+        level: option("--level", level),
+        cmd: or(
+          command("deploy", object({ mode: option("--mode", mode) })),
+          command(
+            "status",
+            object({ s: option("--s", choice(["1"] as const)) }),
+          ),
+        ),
+      });
+
+      const valid = await parseAsync(parser, [
+        "deploy",
+        "--mode",
+        "prod",
+        "--level",
+        "silent",
+      ]);
+      assert.ok(
+        valid.success,
+        `Expected success but got: ${JSON.stringify(valid)}`,
+      );
+      assert.equal(valid.value.level, "silent");
+
+      const invalid = await parseAsync(parser, [
+        "deploy",
+        "--mode",
+        "prod",
+        "--level",
+        "debug",
+      ]);
+      assert.ok(!invalid.success);
+    },
+  );
+
+  test(
     "does not deliver a plain nested object() CLI source to an earlier consumer",
     async () => {
       const { mode, level } = createModeLevel();

--- a/packages/core/src/dependency-extra.test.ts
+++ b/packages/core/src/dependency-extra.test.ts
@@ -10198,6 +10198,58 @@ describe("source delivery from conditional()/command() to siblings", () => {
   );
 
   test(
+    "delivers through or() mixing a command() and a direct source",
+    async () => {
+      const { mode, level } = createModeLevel();
+      // Mixing a marked command() with a direct source alternative
+      // gives the or() composed source metadata; the committed branch
+      // must still expand through the scheduling hook, whichever
+      // alternative wins.
+      const parser = object({
+        level: option("--level", level),
+        cmd: or(
+          command("deploy", object({ mode: option("--mode", mode) })),
+          option("--fallback", mode),
+        ),
+      });
+
+      const viaCommand = await parseAsync(parser, [
+        "deploy",
+        "--mode",
+        "prod",
+        "--level",
+        "silent",
+      ]);
+      assert.ok(
+        viaCommand.success,
+        `Expected success but got: ${JSON.stringify(viaCommand)}`,
+      );
+      assert.equal(viaCommand.value.level, "silent");
+
+      const viaSource = await parseAsync(parser, [
+        "--fallback",
+        "prod",
+        "--level",
+        "silent",
+      ]);
+      assert.ok(
+        viaSource.success,
+        `Expected success but got: ${JSON.stringify(viaSource)}`,
+      );
+      assert.equal(viaSource.value.level, "silent");
+
+      const invalid = await parseAsync(parser, [
+        "deploy",
+        "--mode",
+        "prod",
+        "--level",
+        "debug",
+      ]);
+      assert.ok(!invalid.success);
+    },
+  );
+
+  test(
     "does not deliver a plain nested object() CLI source to an earlier consumer",
     async () => {
       const { mode, level } = createModeLevel();

--- a/packages/core/src/dependency-extra.test.ts
+++ b/packages/core/src/dependency-extra.test.ts
@@ -9892,3 +9892,372 @@ describe("Real-world scenario: Mutually dependent option groups", () => {
     assert.ok(!invalidFormat.success);
   });
 });
+
+// https://github.com/dahlia/optique/issues/913
+describe("source delivery from conditional()/command() to siblings", () => {
+  function createModeLevel() {
+    const mode = dependency(choice(["dev", "prod"] as const));
+    const level = mode.derive({
+      metavar: "LEVEL",
+      mode: "sync",
+      factory: (value: "dev" | "prod") =>
+        choice(
+          value === "dev"
+            ? (["debug", "verbose"] as const)
+            : (["silent", "strict"] as const),
+        ),
+      defaultValue: () => "dev" as const,
+    });
+    return { mode, level };
+  }
+
+  test("delivers a CLI discriminator value to an outer sibling", async () => {
+    const { mode, level } = createModeLevel();
+    const parser = object({
+      cond: conditional(
+        option("--mode", mode),
+        {
+          dev: object({
+            d: withDefault(option("--d", choice(["x"] as const)), "x" as const),
+          }),
+          prod: object({
+            p: withDefault(option("--p", choice(["y"] as const)), "y" as const),
+          }),
+        },
+      ),
+      level: option("--level", level),
+    });
+
+    const valid = await parseAsync(parser, [
+      "--mode",
+      "prod",
+      "--level",
+      "silent",
+    ]);
+    assert.ok(
+      valid.success,
+      `Expected success but got: ${JSON.stringify(valid)}`,
+    );
+    assert.equal(valid.value.level, "silent");
+
+    const invalid = await parseAsync(parser, [
+      "--mode",
+      "prod",
+      "--level",
+      "debug",
+    ]);
+    assert.ok(!invalid.success);
+  });
+
+  test("delivers a CLI discriminator value synchronously", () => {
+    const { mode, level } = createModeLevel();
+    const parser = object({
+      cond: conditional(
+        option("--mode", mode),
+        {
+          dev: object({
+            d: withDefault(option("--d", choice(["x"] as const)), "x" as const),
+          }),
+          prod: object({
+            p: withDefault(option("--p", choice(["y"] as const)), "y" as const),
+          }),
+        },
+      ),
+      level: option("--level", level),
+    });
+
+    const valid = parseSync(parser, ["--mode", "prod", "--level", "silent"]);
+    assert.ok(
+      valid.success,
+      `Expected success but got: ${JSON.stringify(valid)}`,
+    );
+    assert.equal(valid.value.level, "silent");
+
+    const invalid = parseSync(parser, ["--mode", "prod", "--level", "debug"]);
+    assert.ok(!invalid.success);
+  });
+
+  test("delivers a committed named-branch CLI source to a sibling", async () => {
+    const { mode, level } = createModeLevel();
+    const parser = object({
+      cond: conditional(
+        option("--kind", choice(["a", "b"] as const)),
+        {
+          a: object({ mode: option("--mode", mode) }),
+          b: object({ y: option("--y", choice(["2"] as const)) }),
+        },
+      ),
+      level: option("--level", level),
+    });
+
+    const valid = await parseAsync(parser, [
+      "--kind",
+      "a",
+      "--mode",
+      "prod",
+      "--level",
+      "silent",
+    ]);
+    assert.ok(
+      valid.success,
+      `Expected success but got: ${JSON.stringify(valid)}`,
+    );
+    assert.equal(valid.value.level, "silent");
+
+    const invalid = await parseAsync(parser, [
+      "--kind",
+      "a",
+      "--mode",
+      "prod",
+      "--level",
+      "debug",
+    ]);
+    assert.ok(!invalid.success);
+  });
+
+  test("delivers a consumed default-branch CLI source to a sibling", async () => {
+    const { mode, level } = createModeLevel();
+    const parser = object({
+      cond: conditional(
+        option("--kind", choice(["a", "b"] as const)),
+        {
+          a: object({ x: option("--x", choice(["1"] as const)) }),
+          b: object({ y: option("--y", choice(["2"] as const)) }),
+        },
+        object({ mode: option("--mode", mode) }),
+      ),
+      level: option("--level", level),
+    });
+
+    const valid = await parseAsync(parser, [
+      "--mode",
+      "prod",
+      "--level",
+      "silent",
+    ]);
+    assert.ok(
+      valid.success,
+      `Expected success but got: ${JSON.stringify(valid)}`,
+    );
+    assert.equal(valid.value.level, "silent");
+
+    const invalid = await parseAsync(parser, [
+      "--mode",
+      "prod",
+      "--level",
+      "debug",
+    ]);
+    assert.ok(!invalid.success);
+  });
+
+  test("delivers a selected command()'s CLI source to a sibling", async () => {
+    const { mode, level } = createModeLevel();
+    const parser = object({
+      cmd: command(
+        "deploy",
+        object({ mode: option("--mode", mode) }),
+      ),
+      level: option("--level", level),
+    });
+
+    const valid = await parseAsync(parser, [
+      "deploy",
+      "--mode",
+      "prod",
+      "--level",
+      "silent",
+    ]);
+    assert.ok(
+      valid.success,
+      `Expected success but got: ${JSON.stringify(valid)}`,
+    );
+    assert.equal(valid.value.level, "silent");
+
+    const invalid = await parseAsync(parser, [
+      "deploy",
+      "--mode",
+      "prod",
+      "--level",
+      "debug",
+    ]);
+    assert.ok(!invalid.success);
+  });
+
+  test("delivers through a group()-wrapped conditional()", async () => {
+    const { mode, level } = createModeLevel();
+    const parser = object({
+      cond: group(
+        "Mode",
+        conditional(
+          option("--kind", choice(["a"] as const)),
+          { a: object({ mode: option("--mode", mode) }) },
+        ),
+      ),
+      level: option("--level", level),
+    });
+
+    const valid = await parseAsync(parser, [
+      "--kind",
+      "a",
+      "--mode",
+      "prod",
+      "--level",
+      "silent",
+    ]);
+    assert.ok(
+      valid.success,
+      `Expected success but got: ${JSON.stringify(valid)}`,
+    );
+    assert.equal(valid.value.level, "silent");
+  });
+
+  test(
+    "does not deliver a plain nested object() CLI source to an earlier consumer",
+    async () => {
+      const { mode, level } = createModeLevel();
+      // A source nested in a plain object() only leaks to consumers
+      // completed after it (declaration order); a consumer declared
+      // first keeps seeing the source default.  This pins the existing
+      // scope so the conditional()/command() expansion does not widen it.
+      const parser = object({
+        level: option("--level", level),
+        inner: object({ mode: option("--mode", mode) }),
+      });
+
+      const result = await parseAsync(parser, [
+        "--mode",
+        "prod",
+        "--level",
+        "debug",
+      ]);
+      assert.ok(
+        result.success,
+        `Expected success but got: ${JSON.stringify(result)}`,
+      );
+      assert.equal(result.value.level, "debug");
+    },
+  );
+
+  test(
+    "delivers a CLI discriminator value to an earlier-declared sibling",
+    async () => {
+      const { mode, level } = createModeLevel();
+      const parser = object({
+        level: option("--level", level),
+        cond: conditional(
+          option("--mode", mode),
+          {
+            dev: object({
+              d: withDefault(
+                option("--d", choice(["x"] as const)),
+                "x" as const,
+              ),
+            }),
+            prod: object({
+              p: withDefault(
+                option("--p", choice(["y"] as const)),
+                "y" as const,
+              ),
+            }),
+          },
+        ),
+      });
+
+      const valid = await parseAsync(parser, [
+        "--level",
+        "silent",
+        "--mode",
+        "prod",
+      ]);
+      assert.ok(
+        valid.success,
+        `Expected success but got: ${JSON.stringify(valid)}`,
+      );
+      assert.equal(valid.value.level, "silent");
+    },
+  );
+
+  test(
+    "delivers a selected command()'s CLI source to an earlier-declared sibling",
+    async () => {
+      const { mode, level } = createModeLevel();
+      const parser = object({
+        level: option("--level", level),
+        cmd: command(
+          "deploy",
+          object({ mode: option("--mode", mode) }),
+        ),
+      });
+
+      const valid = await parseAsync(parser, [
+        "deploy",
+        "--mode",
+        "prod",
+        "--level",
+        "silent",
+      ]);
+      assert.ok(
+        valid.success,
+        `Expected success but got: ${JSON.stringify(valid)}`,
+      );
+      assert.equal(valid.value.level, "silent");
+    },
+  );
+
+  test("keeps declaration order across the conditional() boundary", async () => {
+    const { mode, level } = createModeLevel();
+    // The conditional's branch occurrence is declared after the sibling
+    // occurrence of the same source, so the branch value must win.
+    const parser = object({
+      a: withDefault(option("--a", mode), "dev" as const),
+      cond: conditional(
+        option("--kind", choice(["k"] as const)),
+        { k: object({ b: option("--b", mode) }) },
+      ),
+      level: option("--level", level),
+    });
+
+    const later = await parseAsync(parser, [
+      "--a",
+      "dev",
+      "--kind",
+      "k",
+      "--b",
+      "prod",
+      "--level",
+      "silent",
+    ]);
+    assert.ok(
+      later.success,
+      `Expected success but got: ${JSON.stringify(later)}`,
+    );
+    assert.equal(later.value.level, "silent");
+
+    // Reversed declaration: the sibling is declared after the
+    // conditional, so the sibling value wins.
+    const reversed = object({
+      cond: conditional(
+        option("--kind", choice(["k"] as const)),
+        { k: object({ b: option("--b", mode) }) },
+      ),
+      a: withDefault(option("--a", mode), "dev" as const),
+      level: option("--level", level),
+    });
+
+    const earlier = await parseAsync(reversed, [
+      "--kind",
+      "k",
+      "--b",
+      "prod",
+      "--a",
+      "dev",
+      "--level",
+      "debug",
+    ]);
+    assert.ok(
+      earlier.success,
+      `Expected success but got: ${JSON.stringify(earlier)}`,
+    );
+    assert.equal(earlier.value.level, "debug");
+  });
+});

--- a/packages/core/src/dependency-extra.test.ts
+++ b/packages/core/src/dependency-extra.test.ts
@@ -10278,7 +10278,9 @@ describe("source delivery from conditional()/command() to siblings", () => {
     assert.equal(later.value.level, "silent");
 
     // Reversed declaration: the sibling is declared after the
-    // conditional, so the sibling value wins.
+    // conditional, so the sibling value wins.  The winner must differ
+    // from the derived default ("dev"), or an undelivered value would
+    // pass the same assertion.
     const reversed = object({
       cond: conditional(
         option("--kind", choice(["k"] as const)),
@@ -10292,16 +10294,16 @@ describe("source delivery from conditional()/command() to siblings", () => {
       "--kind",
       "k",
       "--b",
-      "prod",
-      "--a",
       "dev",
+      "--a",
+      "prod",
       "--level",
-      "debug",
+      "silent",
     ]);
     assert.ok(
       earlier.success,
       `Expected success but got: ${JSON.stringify(earlier)}`,
     );
-    assert.equal(earlier.value.level, "debug");
+    assert.equal(earlier.value.level, "silent");
   });
 });

--- a/packages/core/src/dependency-extra.test.ts
+++ b/packages/core/src/dependency-extra.test.ts
@@ -10112,6 +10112,50 @@ describe("source delivery from conditional()/command() to siblings", () => {
   });
 
   test(
+    "delivers through an optional()-wrapped conditional()",
+    async () => {
+      const { mode, level } = createModeLevel();
+      // The consumer is declared first on purpose: a later-declared one
+      // could be rescued by declaration-order completion leakage, which
+      // would mask a broken wrapper forwarding of the collection opt-in.
+      const parser = object({
+        level: option("--level", level),
+        cond: optional(
+          conditional(
+            option("--mode", mode),
+            {
+              dev: object({
+                d: withDefault(
+                  option("--d", choice(["x"] as const)),
+                  "x" as const,
+                ),
+              }),
+              prod: object({
+                p: withDefault(
+                  option("--p", choice(["y"] as const)),
+                  "y" as const,
+                ),
+              }),
+            },
+          ),
+        ),
+      });
+
+      const valid = await parseAsync(parser, [
+        "--level",
+        "silent",
+        "--mode",
+        "prod",
+      ]);
+      assert.ok(
+        valid.success,
+        `Expected success but got: ${JSON.stringify(valid)}`,
+      );
+      assert.equal(valid.value.level, "silent");
+    },
+  );
+
+  test(
     "does not deliver a plain nested object() CLI source to an earlier consumer",
     async () => {
       const { mode, level } = createModeLevel();

--- a/packages/core/src/dependency-runtime.ts
+++ b/packages/core/src/dependency-runtime.ts
@@ -1313,15 +1313,25 @@ export async function completeEffectfulSourcesAsync(
     // A barrier's discriminator is a control dependency: when a source
     // it can provide is demanded, resolving the branch requires the
     // discriminator even though no consumer demands it directly.
-    for (const node of nodes) {
-      if (node.requiresSourceId == null || node.providesSourceIds == null) {
-        continue;
-      }
-      if (session.demanded.has(node.requiresSourceId)) continue;
-      for (const provided of node.providesSourceIds) {
-        if (session.demanded.has(provided)) {
-          session.demanded.add(node.requiresSourceId);
-          break;
+    // Iterate to a fixed point: one barrier's branches can provide
+    // another barrier's discriminator source, and the chain must
+    // propagate regardless of declaration order.  Each iteration adds
+    // at least one demanded ID, so the loop is bounded by the number
+    // of barriers.
+    let demandAdded = true;
+    while (demandAdded) {
+      demandAdded = false;
+      for (const node of nodes) {
+        if (node.requiresSourceId == null || node.providesSourceIds == null) {
+          continue;
+        }
+        if (session.demanded.has(node.requiresSourceId)) continue;
+        for (const provided of node.providesSourceIds) {
+          if (session.demanded.has(provided)) {
+            session.demanded.add(node.requiresSourceId);
+            demandAdded = true;
+            break;
+          }
         }
       }
     }

--- a/packages/core/src/dependency-runtime.ts
+++ b/packages/core/src/dependency-runtime.ts
@@ -939,6 +939,27 @@ export type EffectfulSchedulingNodesFn = (
 ) => readonly RuntimeNode[];
 
 /**
+ * Opt-in marker for parsers whose {@link effectfulSchedulingNodesKey}
+ * hook also defines their explicit-source *collection* scope.
+ *
+ * A parent construct normally collects explicit source values from its
+ * direct children only.  A parser carrying this marker (with value
+ * `true`) asks the parent to expand it through its scheduling hook
+ * before collecting, so command-line source values inside it—such as a
+ * `conditional()` discriminator, a committed conditional branch, or a
+ * selected `command()` subtree—register into the parent's dependency
+ * runtime exactly like a prompt-completed value would.  Constructs
+ * without the marker (plain nested `object()`, uncommitted exclusive
+ * branches) keep their existing scope.
+ *
+ * @internal
+ * @since 1.3.0
+ */
+export const sourceCollectionExpansionKey: unique symbol = Symbol(
+  "@optique/core/dependency-runtime/sourceCollectionExpansion",
+);
+
+/**
  * Forwards effectful scheduling through a shape-preserving wrapper such
  * as `map()`, `optional()`, `withDefault()`, or `nonEmpty()`, so the
  * wrapped parser—a selected exclusive or command branch, or an ordinary
@@ -976,6 +997,19 @@ export function defineForwardedEffectfulSchedulingNodes(
     configurable: true,
     enumerable: false,
   });
+  // Wrappers are transparent for source-collection expansion too: a
+  // wrapped conditional()/command() keeps its collection opt-in.
+  if (
+    (inner as { readonly [sourceCollectionExpansionKey]?: boolean })[
+      sourceCollectionExpansionKey
+    ] === true
+  ) {
+    Object.defineProperty(wrapper, sourceCollectionExpansionKey, {
+      value: true,
+      configurable: true,
+      enumerable: false,
+    });
+  }
 }
 
 /**
@@ -1092,6 +1126,17 @@ export interface CompleteEffectfulSourcesOptions {
    * running twice, and are skipped when no session is available.
    */
   readonly isReusable?: (node: RuntimeNode) => boolean;
+
+  /**
+   * Whether a node participated in the owning construct's explicit
+   * source collection, and therefore must have its structural value
+   * re-registered at its declaration position so registration order
+   * follows declaration order across structural and effectful
+   * occurrences.  This is wider than {@link isReusable}: nodes expanded
+   * from an opted-in child (see `sourceCollectionExpansionKey`) are
+   * collected but not reusable.  Defaults to {@link isReusable}.
+   */
+  readonly isCollected?: (node: RuntimeNode) => boolean;
 }
 
 /**
@@ -1102,12 +1147,12 @@ export interface CompleteEffectfulSourcesOptions {
  *
  * - Runs only during real completion (`exec.phase === "complete"`); probe
  *   and suggest phases return immediately without effects.
- * - Precedence is structural: a source whose value was registered before
- *   the pass begins (from CLI state, environment, configuration, or a
- *   default) or that has already failed is never completed effectfully.
- *   When several scheduled occurrences share one source, each occurrence
- *   still completes and re-registers, so the last occurrence wins—the
- *   same rule as repeated command-line source occurrences.
+ * - Precedence is structural per occurrence: an effectful completion
+ *   returns its own field's command-line or bound value without running
+ *   the effect, and structural occurrences re-register their extracted
+ *   values in declaration order.  When several scheduled occurrences
+ *   share one source, the last occurrence wins—the same rule as repeated
+ *   command-line source occurrences.
  * - Completion results that are `undefined` or marked `deferred` are
  *   treated as declined and neither registered nor cached.
  * - A successful result registers its value unless the value is
@@ -1197,12 +1242,12 @@ export async function completeEffectfulSourcesAsync(
       // Structural values were registered by source collection before
       // this pass, so a structural occurrence declared *after* an
       // effectful one re-registers its extracted value here to restore
-      // that order.  Only the construct's own nodes re-register:
-      // expanded descendants were never part of its source collection.
-      if (
-        source.extractSourceValue == null ||
-        (options?.isReusable?.(node) ?? true) === false
-      ) {
+      // that order.  Only nodes that participated in the construct's
+      // source collection re-register; other expanded descendants were
+      // never part of it.
+      const collected = options?.isCollected?.(node) ??
+        options?.isReusable?.(node) ?? true;
+      if (source.extractSourceValue == null || collected === false) {
         continue;
       }
       const extracted = await source.extractSourceValue(node.state);

--- a/packages/core/src/dependency-runtime.ts
+++ b/packages/core/src/dependency-runtime.ts
@@ -1198,6 +1198,16 @@ export interface CompleteEffectfulSourcesOptions {
    * collected but not reusable.  Defaults to {@link isReusable}.
    */
   readonly isCollected?: (node: RuntimeNode) => boolean;
+
+  /**
+   * Processes structural source nodes even when no node carries an
+   * effectful completion or a barrier.  A barrier's nested scheduling
+   * call sets this: the branch it schedules may hold only structural
+   * (command-line) values, which still must register into the pass's
+   * runtime, while ordinary construct passes keep the cheap early
+   * return.
+   */
+  readonly includeStructural?: boolean;
 }
 
 /**
@@ -1306,7 +1316,9 @@ export async function completeEffectfulSourcesAsync(
     node.parser.dependencyMetadata?.source?.completeSource != null ||
     node.prepare != null
   );
-  if (schedulable.length === 0) return empty;
+  if (schedulable.length === 0 && options?.includeStructural !== true) {
+    return empty;
+  }
 
   const completed: EffectfulSourceCompletion[] = [];
   for (const node of nodes) {
@@ -1317,10 +1329,16 @@ export async function completeEffectfulSourcesAsync(
       const barrierFailure = await node.prepare({
         runtime,
         exec,
+        // The barrier's subtree is part of the construct's delivery
+        // scope: its structural values re-register at the barrier's
+        // declaration position (isCollected), while its completion
+        // results stay out of the owning construct's pre-completed
+        // cache (isReusable) and deduplicate through the session.
         schedule: (barrierNodes) =>
           completeEffectfulSourcesAsync(barrierNodes, state, runtime, exec, {
             isReusable: () => false,
-            isCollected: () => false,
+            isCollected: () => true,
+            includeStructural: true,
           }).then((result) => result.success ? undefined : result),
       });
       if (barrierFailure != null) return barrierFailure;

--- a/packages/core/src/dependency-runtime.ts
+++ b/packages/core/src/dependency-runtime.ts
@@ -170,6 +170,67 @@ export interface RuntimeNode {
    * @since 1.0.0
    */
   readonly defaultDependencyValues?: readonly unknown[];
+
+  /**
+   * A scheduling barrier: a preparation step executed serially at this
+   * node's declaration position during the effectful completion pass.
+   *
+   * A `conditional()` whose branch selection is still unknown installs
+   * one after its discriminator node: the preparation resolves the
+   * branch from the discriminator's completion, caches the decision in
+   * the run-scoped session so final completion reuses it, and schedules
+   * the chosen branch's nodes through `ctx.schedule` within the same
+   * pass.  A failure aborts the pass like a failed effectful
+   * completion; `undefined` declines without effect.
+   *
+   * @since 1.3.0
+   */
+  readonly prepare?: (ctx: SchedulingBarrierContext) => Promise<
+    { readonly success: false; readonly error: Message } | undefined
+  >;
+
+  /**
+   * Source IDs that the subtree guarded by this barrier can provide.
+   * Used by the demand-only pass: when any of them is demanded, the
+   * barrier's {@link RuntimeNode.requiresSourceId} becomes demanded as
+   * a control dependency, so the guarding discriminator completes in
+   * the seed pass even though no consumer demands it directly.
+   *
+   * @since 1.3.0
+   */
+  readonly providesSourceIds?: ReadonlySet<symbol>;
+
+  /**
+   * The source ID whose completion this barrier's preparation depends
+   * on (a `conditional()` discriminator).  See
+   * {@link RuntimeNode.providesSourceIds}.
+   *
+   * @since 1.3.0
+   */
+  readonly requiresSourceId?: symbol;
+}
+
+/**
+ * The context handed to a {@link RuntimeNode.prepare} barrier.
+ *
+ * @internal
+ * @since 1.3.0
+ */
+export interface SchedulingBarrierContext {
+  /** The runtime the current pass registers source values into. */
+  readonly runtime: DependencyRuntimeContext;
+
+  /** The execution context of the current pass. */
+  readonly exec: ExecutionContext | undefined;
+
+  /**
+   * Schedules further (already expanded) nodes within the current pass,
+   * at the barrier's position.  Results are deduplicated through the
+   * run-scoped session and are not cached by the owning construct.
+   */
+  readonly schedule: (nodes: readonly RuntimeNode[]) => Promise<
+    { readonly success: false; readonly error: Message } | undefined
+  >;
 }
 
 /**
@@ -1212,6 +1273,21 @@ export async function completeEffectfulSourcesAsync(
     for (const id of demanded) {
       session.demanded.add(id);
     }
+    // A barrier's discriminator is a control dependency: when a source
+    // it can provide is demanded, resolving the branch requires the
+    // discriminator even though no consumer demands it directly.
+    for (const node of nodes) {
+      if (node.requiresSourceId == null || node.providesSourceIds == null) {
+        continue;
+      }
+      if (session.demanded.has(node.requiresSourceId)) continue;
+      for (const provided of node.providesSourceIds) {
+        if (session.demanded.has(provided)) {
+          session.demanded.add(node.requiresSourceId);
+          break;
+        }
+      }
+    }
   }
 
   // A failed effectful completion cached in the run-scoped session (a
@@ -1227,12 +1303,29 @@ export async function completeEffectfulSourcesAsync(
   }
 
   const schedulable = nodes.filter((node) =>
-    node.parser.dependencyMetadata?.source?.completeSource != null
+    node.parser.dependencyMetadata?.source?.completeSource != null ||
+    node.prepare != null
   );
   if (schedulable.length === 0) return empty;
 
   const completed: EffectfulSourceCompletion[] = [];
   for (const node of nodes) {
+    // A scheduling barrier runs at its declaration position; its
+    // preparation may schedule further nodes through the nested call,
+    // which shares this pass's runtime, session, and exec.
+    if (node.prepare != null) {
+      const barrierFailure = await node.prepare({
+        runtime,
+        exec,
+        schedule: (barrierNodes) =>
+          completeEffectfulSourcesAsync(barrierNodes, state, runtime, exec, {
+            isReusable: () => false,
+            isCollected: () => false,
+          }).then((result) => result.success ? undefined : result),
+      });
+      if (barrierFailure != null) return barrierFailure;
+      continue;
+    }
     const source = node.parser.dependencyMetadata?.source;
     if (source == null) continue;
     if (source.completeSource == null) {
@@ -1324,9 +1417,16 @@ export async function completeEffectfulSourcesAsync(
 
 /**
  * Serializes a scheduling node path into a stable string key, using
- * length-prefixed segments so no separator escaping is needed.
+ * length-prefixed segments so no separator escaping is needed.  Shared
+ * with constructs that key run-scoped session entries by path (e.g.,
+ * `conditional()`'s prepared branch selections).
+ *
+ * @internal
+ * @since 1.3.0
  */
-function serializeSchedulingPath(path: readonly PropertyKey[]): string {
+export function serializeSchedulingPath(
+  path: readonly PropertyKey[],
+): string {
   return path.map(serializePathSegment).join("");
 }
 

--- a/packages/core/src/dependency-runtime.ts
+++ b/packages/core/src/dependency-runtime.ts
@@ -1021,6 +1021,26 @@ export const sourceCollectionExpansionKey: unique symbol = Symbol(
 );
 
 /**
+ * Static child parsers reachable for dependency-source estimation.
+ *
+ * `collectStaticSourceIds()` walks flattened field pairs, which stops at
+ * parsers whose children are not field-shaped—a `command()`'s inner
+ * parser, a nested `conditional()`'s branches, exclusive alternatives,
+ * or a transparent wrapper's inner construct.  Such parsers expose their
+ * children here so the walk can estimate every source a subtree may
+ * provide.  The estimate feeds demand-only control dependencies, where
+ * an overcount merely completes a discriminator earlier than strictly
+ * needed, while an undercount delays an effectful completion to the
+ * final pass and starves phase-two contexts of seed values.
+ *
+ * @internal
+ * @since 1.3.0
+ */
+export const staticSourceScopeKey: unique symbol = Symbol(
+  "@optique/core/dependency-runtime/staticSourceScope",
+);
+
+/**
  * Forwards effectful scheduling through a shape-preserving wrapper such
  * as `map()`, `optional()`, `withDefault()`, or `nonEmpty()`, so the
  * wrapped parser—a selected exclusive or command branch, or an ordinary
@@ -1048,6 +1068,13 @@ export function defineForwardedEffectfulSchedulingNodes(
   // a transformed source).  Re-exposing the inner parser here would
   // bypass that decision, so the hook is only installed for wrapped
   // non-source parsers such as constructs and exclusive branches.
+  // Static source estimation must see through the wrapper even when the
+  // scheduling hook below is not installed.
+  Object.defineProperty(wrapper, staticSourceScopeKey, {
+    value: [inner],
+    configurable: true,
+    enumerable: false,
+  });
   if (inner.dependencyMetadata?.source != null) return;
   Object.defineProperty(wrapper, effectfulSchedulingNodesKey, {
     value: ((state, parentPath) => [{

--- a/packages/core/src/facade.ts
+++ b/packages/core/src/facade.ts
@@ -363,6 +363,7 @@ function createRunWithSessions(): {
     policy: "eager",
     effectfulSources: new Set(),
     completedByPath: new Map(),
+    preparedByPath: new Map(),
   };
   return { seedSession, finalSession };
 }

--- a/packages/core/src/internal/parser.ts
+++ b/packages/core/src/internal/parser.ts
@@ -555,6 +555,17 @@ export interface EffectfulCompletionSession {
    * the field's final value.
    */
   readonly completedByPath: Map<string, ValueParserResult<unknown>>;
+
+  /**
+   * Prepared branch selections for `conditional()` parsers whose branch
+   * was resolved during the scheduling pass, keyed by parser occurrence
+   * and serialized path.  Scoped to a single pass like
+   * {@link completedByPath}: phase-two bindings may change the
+   * selection, so the final pass of a `runWith()` run re-prepares.
+   * Final completion consumes the prepared decision instead of
+   * re-completing the discriminator or re-selecting a branch.
+   */
+  readonly preparedByPath: Map<string, unknown>;
 }
 
 /**
@@ -572,6 +583,7 @@ export function createEffectfulCompletionSession(
     demanded: new Set(),
     effectfulSources: new Set(),
     completedByPath: new Map(),
+    preparedByPath: new Map(),
   };
 }
 

--- a/packages/core/src/primitives.ts
+++ b/packages/core/src/primitives.ts
@@ -19,6 +19,7 @@ import {
   effectfulSchedulingNodesKey,
   replayDerivedParser,
   replayDerivedParserAsync,
+  sourceCollectionExpansionKey,
 } from "./dependency-runtime.ts";
 import {
   mergeChildExec,
@@ -3626,6 +3627,14 @@ export function command<M extends Mode, T, TState>(
         ),
       }];
     }) satisfies EffectfulSchedulingNodesFn,
+    configurable: true,
+    enumerable: false,
+  });
+  // Command-line source values in a selected command register into the
+  // parent's runtime through the same expansion the scheduling pass
+  // uses, so a value behaves identically whether typed or prompted.
+  Object.defineProperty(result, sourceCollectionExpansionKey, {
+    value: true,
     configurable: true,
     enumerable: false,
   });

--- a/packages/core/src/primitives.ts
+++ b/packages/core/src/primitives.ts
@@ -20,6 +20,7 @@ import {
   replayDerivedParser,
   replayDerivedParserAsync,
   sourceCollectionExpansionKey,
+  staticSourceScopeKey,
 } from "./dependency-runtime.ts";
 import {
   mergeChildExec,
@@ -3635,6 +3636,13 @@ export function command<M extends Mode, T, TState>(
   // uses, so a value behaves identically whether typed or prompted.
   Object.defineProperty(result, sourceCollectionExpansionKey, {
     value: true,
+    configurable: true,
+    enumerable: false,
+  });
+  // Static source estimation reaches the inner parser even while the
+  // command is unmatched (see staticSourceScopeKey).
+  Object.defineProperty(result, staticSourceScopeKey, {
+    value: [parser],
     configurable: true,
     enumerable: false,
   });

--- a/packages/prompt/src/index.test.ts
+++ b/packages/prompt/src/index.test.ts
@@ -2319,6 +2319,54 @@ describe("prompted values as dependency sources", () => {
   );
 
   it(
+    "demands a branch source hidden behind a command() in two-pass runs",
+    async () => {
+      const kind = dependency(choice(["a", "b"] as const));
+      const { mode, level } = createModeFixture();
+      const { prompt, calls } = createTestPrompt();
+      let phase2Level: string | undefined = "unset";
+      const dynamicContext: SourceContext = {
+        id: Symbol.for("@optique/prompt/test-command-branch-demand"),
+        phase: "two-pass",
+        getAnnotations(request?: unknown) {
+          if (isPhase2ContextRequest(request)) {
+            phase2Level = (request.parsed as { readonly level?: string })
+              ?.level;
+          }
+          return {};
+        },
+      };
+      // The branch's mode source sits behind a command(), which exposes
+      // no field pairs; the static estimate must still see it so the
+      // seed pass demands the discriminator as a control dependency and
+      // phase-two contexts observe the sibling's value.
+      const parser = object({
+        cond: conditional(
+          prompt(option("--kind", kind), { value: "a" }),
+          {
+            a: command(
+              "deploy",
+              object({
+                mode: prompt(option("--mode", mode), { value: "prod" }),
+              }),
+            ),
+            b: object({ y: option("--y", choice(["2"] as const)) }),
+          },
+        ),
+        level: option("--level", level),
+      });
+
+      const result = await runWith(parser, "test", [dynamicContext], {
+        args: ["deploy", "--level", "silent"],
+      });
+
+      assert.equal((result as { readonly level: string }).level, "silent");
+      assert.equal(phase2Level, "silent");
+      assert.equal(calls.length, 2);
+    },
+  );
+
+  it(
     "prepares a nested conditional() inside a prepared branch",
     async () => {
       const kind = dependency(choice(["x", "z"] as const));

--- a/packages/prompt/src/index.test.ts
+++ b/packages/prompt/src/index.test.ts
@@ -1227,6 +1227,47 @@ describe("prompted values as dependency sources", () => {
   );
 
   it(
+    "lets a later conditional() CLI occurrence win over an earlier prompt",
+    async () => {
+      const shared = dependency(choice(["dev", "prod"] as const));
+      const level = shared.derive({
+        metavar: "LEVEL",
+        mode: "sync",
+        factory: (value: "dev" | "prod") =>
+          choice(
+            value === "dev"
+              ? (["debug", "verbose"] as const)
+              : (["silent", "strict"] as const),
+          ),
+        defaultValue: () => "dev" as const,
+      });
+      const { prompt, calls } = createTestPrompt();
+      // The conditional's branch occurrence of the shared source is
+      // declared after the prompted sibling, so its command-line value
+      // must win over the prompt's answer, exactly as a repeated
+      // command-line occurrence would.
+      const parser = object({
+        a: prompt(option("--a", shared), { value: "dev" }),
+        cond: conditional(
+          option("--kind", choice(["k"] as const)),
+          { k: object({ b: option("--b", shared) }) },
+        ),
+        level: option("--level", level),
+      });
+
+      const result = await parseAsync(
+        parser,
+        ["--kind", "k", "--b", "prod", "--level", "silent"],
+      );
+
+      assert.ok(result.success);
+      assert.equal(result.value.a, "dev");
+      assert.equal(result.value.level, "silent");
+      assert.equal(calls.length, 1);
+    },
+  );
+
+  it(
     "runs merge() source prompts in declaration order despite priorities",
     async () => {
       const srcA = dependency(string());

--- a/packages/prompt/src/index.test.ts
+++ b/packages/prompt/src/index.test.ts
@@ -2468,6 +2468,59 @@ describe("prompted values as dependency sources", () => {
   );
 
   it(
+    "demands a branch source inside a mixed or() in two-pass runs",
+    async () => {
+      const kind = dependency(choice(["a", "b"] as const));
+      const other = dependency(choice(["x"] as const));
+      const { mode, level } = createModeFixture();
+      const { prompt, calls } = createTestPrompt();
+      let phase2Level: string | undefined = "unset";
+      const dynamicContext: SourceContext = {
+        id: Symbol.for("@optique/prompt/test-mixed-or-branch-demand"),
+        phase: "two-pass",
+        getAnnotations(request?: unknown) {
+          if (isPhase2ContextRequest(request)) {
+            phase2Level = (request.parsed as { readonly level?: string })
+              ?.level;
+          }
+          return {};
+        },
+      };
+      // The branch is a mixed or(): the exclusive parser carries
+      // composed metadata for the direct source alternative, but the
+      // static estimate must still see mode inside the command
+      // alternative so the discriminator becomes a control dependency
+      // in the seed pass.
+      const parser = object({
+        cond: conditional(
+          prompt(option("--kind", kind), { value: "a" }),
+          {
+            a: or(
+              command(
+                "deploy",
+                object({
+                  mode: prompt(option("--mode", mode), { value: "prod" }),
+                }),
+              ),
+              option("--fallback", other),
+            ),
+            b: object({ y: option("--y", choice(["2"] as const)) }),
+          },
+        ),
+        level: option("--level", level),
+      });
+
+      const result = await runWith(parser, "test", [dynamicContext], {
+        args: ["deploy", "--level", "silent"],
+      });
+
+      assert.equal((result as { readonly level: string }).level, "silent");
+      assert.equal(phase2Level, "silent");
+      assert.equal(calls.length, 2);
+    },
+  );
+
+  it(
     "prepares a nested conditional() inside a prepared branch",
     async () => {
       const kind = dependency(choice(["x", "z"] as const));

--- a/packages/prompt/src/index.test.ts
+++ b/packages/prompt/src/index.test.ts
@@ -2240,6 +2240,107 @@ describe("prompted values as dependency sources", () => {
   );
 
   it(
+    "does not prompt a rejected speculative branch through a parent",
+    async () => {
+      const kind = dependency(choice(["a", "b"] as const));
+      const { mode, level } = createModeFixture();
+      const { prompt, calls } = createTestPrompt();
+      // "--a x" speculatively selects branch a while the prompted
+      // discriminator defers; the answer "b" rejects the guess, so the
+      // parent's scheduling pass must not run the guessed branch's
+      // prompt before the mismatch is detected.
+      const parser = object({
+        cond: conditional(
+          prompt(option("--kind", kind), { value: "b" }),
+          {
+            a: object({
+              ax: option("--a", choice(["x"] as const)),
+              mode: prompt(option("--mode", mode), { value: "prod" }),
+            }),
+            b: object({ y: option("--y", choice(["2"] as const)) }),
+          },
+        ),
+        level: option("--level", level),
+      });
+
+      const result = await parseAsync(
+        parser,
+        ["--a", "x", "--level", "silent"],
+      );
+
+      assert.ok(!result.success);
+      // Only the discriminator prompt ran.
+      assert.equal(calls.length, 1);
+    },
+  );
+
+  it(
+    "propagates chained barrier demand across declaration order",
+    async () => {
+      const kindA = dependency(choice(["a", "z"] as const));
+      const kindB = dependency(choice(["b", "z"] as const));
+      const { mode, level } = createModeFixture();
+      const { prompt, calls } = createTestPrompt();
+      let phase2CondA: unknown;
+      const dynamicContext: SourceContext = {
+        id: Symbol.for("@optique/prompt/test-chained-barrier-demand"),
+        phase: "two-pass",
+        getAnnotations(request?: unknown) {
+          if (isPhase2ContextRequest(request)) {
+            phase2CondA = (request.parsed as { readonly condA?: unknown })
+              ?.condA;
+          }
+          return {};
+        },
+      };
+      // Demand flows through a chain of barriers declared in the
+      // failing order: --level demands mode, which condB provides, so
+      // condB's discriminator becomes demanded; condA's branch provides
+      // that discriminator's source, so condA's discriminator must
+      // become demanded too even though condA precedes condB.
+      const parser = object({
+        condA: conditional(
+          prompt(option("--kind-a", kindA), { value: "a" }),
+          {
+            a: object({
+              kb: prompt(option("--kb", kindB), { value: "b" }),
+            }),
+            z: object({ za: option("--za", choice(["1"] as const)) }),
+          },
+        ),
+        condB: conditional(
+          prompt(option("--kind-b", kindB), { value: "b" }),
+          {
+            b: object({
+              mode: prompt(option("--mode", mode), { value: "prod" }),
+            }),
+            z: object({ zb: option("--zb", choice(["2"] as const)) }),
+          },
+        ),
+        level: option("--level", level),
+      });
+
+      const result = await runWith(parser, "test", [dynamicContext], {
+        args: ["--level", "silent"],
+      });
+
+      assert.equal((result as { readonly level: string }).level, "silent");
+      assert.ok(phase2CondA != null);
+      // Chained demand must resolve before the seed pass runs any
+      // effect, so the prompts keep declaration order (condA's
+      // discriminator and branch before condB's); a single demand scan
+      // would run condB's prompts first and only reach condA's in its
+      // own later completion.
+      assert.deepEqual(calls, [
+        { value: "a" },
+        { value: "b" },
+        { value: "b" },
+        { value: "prod" },
+      ]);
+    },
+  );
+
+  it(
     "delivers a confirmed speculative branch's CLI source",
     async () => {
       const kind = dependency(choice(["a", "b"] as const));

--- a/packages/prompt/src/index.test.ts
+++ b/packages/prompt/src/index.test.ts
@@ -2073,6 +2073,221 @@ describe("prompted values as dependency sources", () => {
   );
 
   it(
+    "schedules the branch chosen by a prompted discriminator",
+    async () => {
+      const kind = dependency(choice(["a", "b"] as const));
+      const { mode, level } = createModeFixture();
+      const { prompt, calls } = createTestPrompt();
+      // Nothing on the command line selects the branch; the prompted
+      // discriminator answers "a", whose branch prompts a mode source
+      // consumed by an outer sibling.  Both prompts must run before
+      // the sibling's replay, once each.
+      const parser = object({
+        cond: conditional(
+          prompt(option("--kind", kind), { value: "a" }),
+          {
+            a: object({
+              mode: prompt(option("--mode", mode), { value: "prod" }),
+            }),
+            b: object({ y: option("--y", choice(["2"] as const)) }),
+          },
+        ),
+        level: option("--level", level),
+      });
+
+      const valid = await parseAsync(parser, ["--level", "silent"]);
+      assert.ok(valid.success);
+      assert.equal(valid.value.level, "silent");
+      assert.equal(calls.length, 2);
+
+      const invalid = await parseAsync(parser, ["--level", "debug"]);
+      assert.ok(!invalid.success);
+    },
+  );
+
+  it(
+    "schedules a nothing-parsed default branch's prompted source",
+    async () => {
+      const { mode, level } = createModeFixture();
+      const { prompt, calls } = createTestPrompt();
+      // No input at all commits a branch and the discriminator option
+      // cannot complete, so the default branch is selected; its
+      // prompted source must be scheduled before the sibling's replay.
+      const parser = object({
+        cond: conditional(
+          option("--kind", choice(["a", "b"] as const)),
+          {
+            a: object({ x: option("--x", choice(["1"] as const)) }),
+            b: object({ y: option("--y", choice(["2"] as const)) }),
+          },
+          object({
+            mode: prompt(option("--mode", mode), { value: "prod" }),
+          }),
+        ),
+        level: option("--level", level),
+      });
+
+      const valid = await parseAsync(parser, ["--level", "silent"]);
+      assert.ok(valid.success);
+      assert.equal(valid.value.level, "silent");
+      assert.equal(calls.length, 1);
+
+      const invalid = await parseAsync(parser, ["--level", "debug"]);
+      assert.ok(!invalid.success);
+    },
+  );
+
+  it(
+    "reuses the prepared selection for a non-idempotent discriminator",
+    async () => {
+      const { mode, level } = createModeFixture();
+      const { prompt, calls } = createTestPrompt();
+      let defaultCalls = 0;
+      // The discriminator's lazy default yields "a" on its first two
+      // evaluations (parse-time branch probing consumes one, the
+      // scheduling pass's preparation the other) and "b" afterwards.
+      // Final completion must consume the prepared selection instead of
+      // evaluating the default a third time: a third evaluation would
+      // select branch "b", whose required --y is missing.
+      const parser = object({
+        cond: conditional(
+          withDefault(
+            option("--kind", choice(["a", "b"] as const)),
+            () => (++defaultCalls <= 2 ? "a" : "b") as "a" | "b",
+          ),
+          {
+            a: object({
+              mode: prompt(option("--mode", mode), { value: "prod" }),
+            }),
+            b: object({ y: option("--y", choice(["2"] as const)) }),
+          },
+        ),
+        level: option("--level", level),
+      });
+
+      const result = await parseAsync(parser, ["--level", "silent"]);
+      assert.ok(result.success);
+      assert.equal(result.value.level, "silent");
+      assert.equal(defaultCalls, 2);
+      assert.equal(calls.length, 1);
+    },
+  );
+
+  it(
+    "stops after a cancelled prompted discriminator",
+    async () => {
+      const kind = dependency(choice(["a", "b"] as const));
+      const { mode, level } = createModeFixture();
+      const { prompt, calls } = createTestPrompt();
+      const parser = object({
+        cond: conditional(
+          prompt(option("--kind", kind), { value: "a", reject: true }),
+          {
+            a: object({
+              mode: prompt(option("--mode", mode), { value: "prod" }),
+            }),
+            b: object({ y: option("--y", choice(["2"] as const)) }),
+          },
+        ),
+        level: option("--level", level),
+      });
+
+      const result = await parseAsync(parser, ["--level", "silent"]);
+      assert.ok(!result.success);
+      // Only the discriminator prompt ran; the branch prompt never did.
+      assert.equal(calls.length, 1);
+    },
+  );
+
+  it(
+    "prepares a demanded conditional() branch across two-pass runs",
+    async () => {
+      const kind = dependency(choice(["a", "b"] as const));
+      const { mode, level } = createModeFixture();
+      const { prompt, calls } = createTestPrompt();
+      let phase2Level: string | undefined;
+      const dynamicContext: SourceContext = {
+        id: Symbol.for("@optique/prompt/test-conditional-branch-demand"),
+        phase: "two-pass",
+        getAnnotations(request?: unknown) {
+          if (isPhase2ContextRequest(request)) {
+            phase2Level = (request.parsed as { readonly level?: string })
+              ?.level;
+          }
+          return {};
+        },
+      };
+      // --level demands the branch's mode source; the discriminator is
+      // its control dependency, so both prompts already run in the seed
+      // pass and their answers are reused in the final pass: one
+      // execution each across the whole run.
+      const parser = object({
+        cond: conditional(
+          prompt(option("--kind", kind), { value: "a" }),
+          {
+            a: object({
+              mode: prompt(option("--mode", mode), { value: "prod" }),
+            }),
+            b: object({ y: option("--y", choice(["2"] as const)) }),
+          },
+        ),
+        level: option("--level", level),
+      });
+
+      const result = await runWith(parser, "test", [dynamicContext], {
+        args: ["--level", "silent"],
+      });
+
+      assert.equal(result.level, "silent");
+      assert.equal(calls.length, 2);
+      assert.equal(phase2Level, "silent");
+    },
+  );
+
+  it(
+    "prepares a nested conditional() inside a prepared branch",
+    async () => {
+      const kind = dependency(choice(["x", "z"] as const));
+      const { mode, level } = createModeFixture();
+      const { prompt, calls } = createTestPrompt();
+      const parser = object({
+        outer: conditional(
+          prompt(option("--kind", kind), { value: "x" }),
+          {
+            x: object({
+              inner: conditional(
+                prompt(option("--mode", mode), { value: "prod" }),
+                {
+                  dev: object({
+                    d: withDefault(
+                      option("--d", choice(["1"] as const)),
+                      "1" as const,
+                    ),
+                  }),
+                  prod: object({
+                    p: withDefault(
+                      option("--p", choice(["2"] as const)),
+                      "2" as const,
+                    ),
+                  }),
+                },
+              ),
+            }),
+            z: object({ y: option("--y", choice(["3"] as const)) }),
+          },
+        ),
+        level: option("--level", level),
+      });
+
+      const result = await parseAsync(parser, ["--level", "silent"]);
+
+      assert.ok(result.success);
+      assert.equal(result.value.level, "silent");
+      assert.equal(calls.length, 2);
+    },
+  );
+
+  it(
     "evaluates a nested lazy withDefault(prompt) default exactly once",
     async () => {
       const { mode, level } = createModeFixture();

--- a/packages/prompt/src/index.test.ts
+++ b/packages/prompt/src/index.test.ts
@@ -2200,6 +2200,80 @@ describe("prompted values as dependency sources", () => {
   );
 
   it(
+    "schedules a confirmed speculative branch's prompted source",
+    async () => {
+      const kind = dependency(choice(["a", "b"] as const));
+      const { mode, level } = createModeFixture();
+      const { prompt, calls } = createTestPrompt();
+      // "--a x" speculatively selects branch a while the prompted
+      // discriminator defers; the answer "a" confirms the guess, so the
+      // branch's prompted source must still complete before the outer
+      // sibling's replay.
+      const parser = object({
+        cond: conditional(
+          prompt(option("--kind", kind), { value: "a" }),
+          {
+            a: object({
+              ax: option("--a", choice(["x"] as const)),
+              mode: prompt(option("--mode", mode), { value: "prod" }),
+            }),
+            b: object({ y: option("--y", choice(["2"] as const)) }),
+          },
+        ),
+        level: option("--level", level),
+      });
+
+      const valid = await parseAsync(
+        parser,
+        ["--a", "x", "--level", "silent"],
+      );
+      assert.ok(valid.success);
+      assert.equal(valid.value.level, "silent");
+      assert.equal(calls.length, 2);
+
+      const invalid = await parseAsync(
+        parser,
+        ["--a", "x", "--level", "debug"],
+      );
+      assert.ok(!invalid.success);
+    },
+  );
+
+  it(
+    "delivers a confirmed speculative branch's CLI source",
+    async () => {
+      const kind = dependency(choice(["a", "b"] as const));
+      const { mode, level } = createModeFixture();
+      const { prompt, calls } = createTestPrompt();
+      // The speculative branch's mode value is typed, not prompted; it
+      // must reach the sibling once the discriminator's answer confirms
+      // the branch.
+      const parser = object({
+        cond: conditional(
+          prompt(option("--kind", kind), { value: "a" }),
+          {
+            a: object({
+              ax: option("--a", choice(["x"] as const)),
+              mode: option("--mode", mode),
+            }),
+            b: object({ y: option("--y", choice(["2"] as const)) }),
+          },
+        ),
+        level: option("--level", level),
+      });
+
+      const result = await parseAsync(
+        parser,
+        ["--a", "x", "--mode", "prod", "--level", "silent"],
+      );
+
+      assert.ok(result.success);
+      assert.equal(result.value.level, "silent");
+      assert.equal(calls.length, 1);
+    },
+  );
+
+  it(
     "prepares a demanded conditional() branch across two-pass runs",
     async () => {
       const kind = dependency(choice(["a", "b"] as const));


### PR DESCRIPTION
A dependency source inside `conditional()` or `command()` reached a sibling derived parser only when a prompt supplied its value: the effectful scheduling pass expands through those constructs, while explicit source collection visited direct children only. A typed value worked only when declaration order happened to let the construct complete before the consumer.

`conditional()` and `command()` now mark themselves for expansion during explicit source collection, and transparent wrappers and `group()` forward the marker. A parent expands a marked child at its declaration position through the same scheduling hook the effectful pass uses, so typed and prompted values register through the same nodes. Collection participation is tracked separately from reusable direct results, which preserves last-occurrence-wins for shared sources across the boundary.

For a branch nothing on the command line committed, a scheduling barrier follows the discriminator node. It resolves the branch from the discriminator's completion, caches the prepared selection in the run-scoped session, and schedules that branch within the same pass; final completion consumes the cached decision, so a non-idempotent discriminator cannot schedule one branch and complete another. Branch scheduling stays demand-aware: seed passes treat the discriminator as a control dependency of every source its branches can provide, discovered through `command()`, nested conditionals, and wrappers, and a speculative selection schedules the guessed branch only after the answer confirms its key.

A prompted discriminator that does not wrap a dependency source has no run-scoped occurrence cache and stays outside early branch resolution; *docs/concepts/dependencies.md* and *docs/integrations/prompt.md* document that limit.

Part of #869. Closes #913.
