### PR TITLE
Support derived parsers as dependency sources

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,6 +53,9 @@ To be released.
     sibling parsers against the answered values.  A prompted
     discriminator that does not wrap a dependency source cannot take part
     in this early resolution.  [[#869], [#913], [#914]]
+ -  Fixed derived parsers so they can act as dependency sources for later
+    parsers, allowing multi-level parsing, defaults, and shell suggestions to
+    resolve independently of object/tuple field order. [[#869], [#871], [#915]]
  -  Removed the unused `DependencyValueOrigin` type and `registerSource()`
     origin argument from `@optique/core/dependency-runtime`.  Both APIs were
     marked `@internal`; dependency resolution behavior is unchanged.
@@ -60,6 +63,7 @@ To be released.
 
 [#869]: https://github.com/dahlia/optique/issues/869
 [#870]: https://github.com/dahlia/optique/issues/870
+[#871]: https://github.com/dahlia/optique/issues/871
 [#874]: https://github.com/dahlia/optique/issues/874
 [#879]: https://github.com/dahlia/optique/issues/879
 [#889]: https://github.com/dahlia/optique/pull/889
@@ -70,6 +74,7 @@ To be released.
 [#912]: https://github.com/dahlia/optique/pull/912
 [#913]: https://github.com/dahlia/optique/issues/913
 [#914]: https://github.com/dahlia/optique/pull/914
+[#915]: https://github.com/dahlia/optique/pull/915
 
 ### @optique/run
 

--- a/changes.d/core/derived-dependency-sources.md
+++ b/changes.d/core/derived-dependency-sources.md
@@ -1,0 +1,9 @@
+---
+links:
+  '#869': https://github.com/dahlia/optique/issues/869
+  '#871': https://github.com/dahlia/optique/issues/871
+  '#915': https://github.com/dahlia/optique/pull/915
+---
+ -  Fixed derived parsers so they can act as dependency sources for later
+    parsers, allowing multi-level parsing, defaults, and shell suggestions to
+    resolve independently of object/tuple field order. [[#869], [#871], [#915]]

--- a/changes.d/core/root-usage-line.md
+++ b/changes.d/core/root-usage-line.md
@@ -1,3 +1,7 @@
+---
+links:
+  '#879': https://github.com/dahlia/optique/issues/879
+---
  -  Added `usageLine` to the core runner `RunOptions`.  Top-level full help can
     now replace the generated root synopsis or derive one from a callback,
     while subcommand help and usage-only error output remain unchanged.

--- a/changes.d/discover/root-usage-line.md
+++ b/changes.d/discover/root-usage-line.md
@@ -1,3 +1,7 @@
+---
+links:
+  '#879': https://github.com/dahlia/optique/issues/879
+---
  -  Added `usageLine` to `runProgram()` so large discovered command trees can
     show a compact root synopsis such as `Usage: my-tool ...` while keeping
     their full command menu.  [[#879]]

--- a/changes.d/run/root-usage-line.md
+++ b/changes.d/run/root-usage-line.md
@@ -1,3 +1,7 @@
+---
+links:
+  '#879': https://github.com/dahlia/optique/issues/879
+---
  -  Added `usageLine` to `RunOptions`.  `run()`, `runSync()`, and `runAsync()`
     can now replace the root synopsis in full help without changing parsing or
     subcommand help.  [[#879]]

--- a/docs/concepts/dependencies.md
+++ b/docs/concepts/dependencies.md
@@ -594,7 +594,8 @@ their declaration order, while each source is resolved before the derived
 parsers that consume it. This applies equally to `object()` and `tuple()` and
 to sources exposed through selected `conditional()`/`command()` branches.
 
-Suggestions use only values already present in parser state and never run
+Suggestions use values already present in parser state, plus declared
+`defaultValue`/`defaultValues` fallbacks when a source is absent. They never run
 prompts or other effectful completions. During real completion, effectful
 sources run serially and at most once per parse operation. Their results and
 failures are scoped to that operation.

--- a/docs/concepts/dependencies.md
+++ b/docs/concepts/dependencies.md
@@ -375,6 +375,66 @@ const serverParser = deriveFromSync({
 ~~~~
 
 
+Chaining derived dependency sources
+-----------------------------------
+
+*This behavior is available since Optique 1.3.0.*
+
+Wrap a derived parser with `dependency()` when later parsers need to depend on
+its resolved value. The result keeps both roles: it remains derived from its
+upstream source and becomes a source for the next level:
+
+~~~~ typescript twoslash
+import { object } from "@optique/core/constructs";
+import { dependency } from "@optique/core/dependency";
+import { parseSync } from "@optique/core/parser";
+import { option } from "@optique/core/primitives";
+import { choice } from "@optique/core/valueparser";
+
+const frameworkParser = dependency(choice(["fresh", "hono"] as const));
+
+const packageManagerParser = dependency(frameworkParser.deriveSync({
+  metavar: "PACKAGE_MANAGER",
+  factory: (framework) =>
+    choice(framework === "fresh" ? ["deno"] : ["npm"]),
+  defaultValue: () => "fresh" as const,
+}));
+
+const storageParser = packageManagerParser.deriveSync({
+  metavar: "STORAGE",
+  factory: (packageManager) =>
+    choice(packageManager === "deno" ? ["kv"] : ["redis"]),
+  defaultValue: () => "deno" as const,
+});
+
+const parser = object({
+  // Field order does not determine dependency evaluation order.
+  storage: option("--storage", storageParser),
+  packageManager: option("--package-manager", packageManagerParser),
+  framework: option("--framework", frameworkParser),
+});
+
+const result = parseSync(parser, [
+  "--framework", "hono",
+  "--package-manager", "npm",
+  "--storage", "redis",
+]);
+~~~~
+
+The same composition works when the middle parser was created with
+`deriveFrom()` and therefore has several upstream sources. Synchronous and
+asynchronous modes continue to combine at each level, so one asynchronous
+source or factory makes every downstream parser asynchronous.
+
+Optique resolves a chain in dependency order rather than object/tuple field
+order. A derived source publishes only its replayed value; its preliminary
+parse result, which may have used an upstream default, is never exposed to the
+next level. If an intermediate source is absent without failing, a downstream
+parser may use its own `defaultValue`/`defaultValues`. If an upstream value was
+provided but failed validation, that failure propagates instead, and the error
+includes the affected metavar chain.
+
+
 Shell completion support
 ------------------------
 
@@ -526,18 +586,21 @@ branch resolution, so sources inside the branch it selects only complete
 during the conditional's own completion.
 
 
-Limitations
------------
+Evaluation order and failures
+-----------------------------
 
-The current dependency implementation has some limitations to be aware of:
+Dependency evaluation follows the active source graph. Independent nodes keep
+their declaration order, while each source is resolved before the derived
+parsers that consume it. This applies equally to `object()` and `tuple()` and
+to sources exposed through selected `conditional()`/`command()` branches.
 
- -  *No nested dependencies*: A derived parser cannot itself be used as a
-    dependency source. Dependencies form a single level of relationships.
-    However, you can have multiple derived parsers that depend on the same
-    source, or use `deriveFrom()` to depend on multiple sources simultaneously.
+Suggestions use only values already present in parser state and never run
+prompts or other effectful completions. During real completion, effectful
+sources run serially and at most once per parse operation. Their results and
+failures are scoped to that operation.
 
- -  *`deriveFrom()` requires dependency sources*: The `dependencies` array
-    in `deriveFrom()` must contain `DependencySource` objects created with
-    `dependency()`, not derived parsers. If you need a parser that depends
-    on both a source and a derived value, consider restructuring to have
-    multiple sources instead.
+An invalid source never falls back to its default. The failure propagates
+through every derived source that consumes it, and diagnostics show the
+metavars along that dependency path. Optique also rejects a cycle in the active
+runtime graph with the involved paths/metavars, although ordinary `derive()`
+and `deriveFrom()` composition constructs an acyclic graph by value.

--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -291,6 +291,12 @@ inner one. Derived defaults slot in wherever you wrap them in that chain.
 
 Two more points worth knowing:
 
+ -  *A derived parser needs `dependency()` before another parser can depend on
+    it.* Write `dependency(source.deriveSync(...))` for the middle level of a
+    chain, then call `.derive*()` on that new source. Do not flatten a
+    framework → package manager → storage graph into unrelated one-level
+    dependencies merely to work around field order; Optique resolves the
+    source graph independently of object/tuple declaration order.
  -  *Fallback values are re-validated.* A config or environment value still
     passes through the inner parser's constraints. A config `port` of `80` is
     rejected by `option("--port", integer({ min: 1024 }))` exactly as a

--- a/packages/core/skills/optique/SKILL.md
+++ b/packages/core/skills/optique/SKILL.md
@@ -52,6 +52,10 @@ Core rules
  -  Async value parsers make the containing parser async. If you use packages
     such as *@optique/git*, remember to `await run(...)`, `await parse(...)`, or
     `await runParser(...)` as appropriate.
+ -  Use `dependency()` when one value parser controls another's valid values.
+    For a multi-level chain, wrap the middle derivation too:
+    `dependency(source.deriveSync(...))`. Optique resolves such chains by
+    dependency order, independently of object/tuple field order.
  -  Build subcommands with `command()` combined by `or()`. Put a literal field
     such as `command: constant("serve")` in each branch when you want a
     discriminated union.
@@ -228,6 +232,9 @@ Common mistakes checklist
     `message` values.
  -  Do not forget to register source contexts when using `bindEnv()`,
     `bindConfig()`, or `bindDerivedDefault()`.
+ -  Do not flatten a multi-level dependency graph into duplicated one-level
+    factories. Wrap each derived value that becomes a later source with
+    `dependency()` and derive the next parser from it.
  -  Do not probe runtime capabilities eagerly before constructing a prompt
     parser. Put synchronous or asynchronous checks in the prompt config's
     `when` field and provide a typed `otherwise` value. The check then runs

--- a/packages/core/src/constructs.ts
+++ b/packages/core/src/constructs.ts
@@ -25,6 +25,8 @@ import {
   effectfulSchedulingNodesKey,
   fillMissingSourceDefaults,
   fillMissingSourceDefaultsAsync,
+  resolveDerivedSourceValues,
+  resolveDerivedSourceValuesAsync,
   resolveStateWithRuntime,
   resolveStateWithRuntimeAsync,
   type RuntimeNode,
@@ -5471,7 +5473,7 @@ function* suggestObjectSync<
   completeDependencySourceDefaults(
     context,
     sourceParserPairs,
-    runtime.registry,
+    runtime,
     context.exec,
   );
 
@@ -5593,7 +5595,7 @@ async function* suggestObjectAsync<
   await completeDependencySourceDefaultsAsync(
     context,
     sourceParserPairs,
-    runtime.registry,
+    runtime,
     context.exec,
   );
 
@@ -5806,20 +5808,30 @@ function completeDependencySourceDefaults(
   parserPairs: ReadonlyArray<
     readonly [string | symbol, Parser<Mode, unknown, unknown>]
   >,
-  registry: DependencyRegistryLike,
+  runtime: ReturnType<typeof createDependencyRuntimeContext>,
   exec?: ExecutionContext,
 ): void {
   for (
     const { parser, state } of pendingDependencyDefaults(
       context,
       parserPairs,
-      registry,
+      runtime.registry,
     )
   ) {
     const completed = parser.complete(state, exec);
     const depState = wrapAsDependencySourceState(completed, parser);
-    if (depState) registerCompletedDependency(depState, registry);
+    if (depState) registerCompletedDependency(depState, runtime.registry);
   }
+  const stateRecord = context.state != null && typeof context.state === "object"
+    ? context.state as Record<PropertyKey, unknown>
+    : {};
+  resolveDerivedSourceValues(
+    expandSourceCollectionNodes(
+      buildRuntimeNodesFromPairs(parserPairs, stateRecord, exec?.path),
+    ),
+    runtime,
+    { effectfulProviders: "inactive" },
+  );
 }
 
 /**
@@ -5880,20 +5892,30 @@ async function completeDependencySourceDefaultsAsync(
   parserPairs: ReadonlyArray<
     readonly [string | symbol, Parser<Mode, unknown, unknown>]
   >,
-  registry: DependencyRegistryLike,
+  runtime: ReturnType<typeof createDependencyRuntimeContext>,
   exec?: ExecutionContext,
 ): Promise<void> {
   for (
     const { parser, state } of pendingDependencyDefaults(
       context,
       parserPairs,
-      registry,
+      runtime.registry,
     )
   ) {
     const completed = await parser.complete(state, exec);
     const depState = wrapAsDependencySourceState(completed, parser);
-    if (depState) registerCompletedDependency(depState, registry);
+    if (depState) registerCompletedDependency(depState, runtime.registry);
   }
+  const stateRecord = context.state != null && typeof context.state === "object"
+    ? context.state as Record<PropertyKey, unknown>
+    : {};
+  await resolveDerivedSourceValuesAsync(
+    expandSourceCollectionNodes(
+      buildRuntimeNodesFromPairs(parserPairs, stateRecord, exec?.path),
+    ),
+    runtime,
+    { effectfulProviders: "inactive" },
+  );
 }
 
 /**
@@ -8540,7 +8562,7 @@ function suggestTupleSync(
         state: createAnnotatedArrayStateRecord(stateArray),
       },
       buildIndexedParserPairs(parsers),
-      runtime.registry,
+      runtime,
       advancedContext.exec,
     );
   }
@@ -8615,7 +8637,7 @@ async function* suggestTupleAsync(
         state: createAnnotatedArrayStateRecord(stateArray),
       },
       buildIndexedParserPairs(parsers),
-      runtime.registry,
+      runtime,
       advancedContext.exec,
     );
   }
@@ -10498,7 +10520,7 @@ export function seq<
               state: createAnnotatedArrayStateRecord(stateArray),
             },
             buildIndexedParserPairs(syncParsers),
-            runtime.registry,
+            runtime,
             advancedContext.exec,
           );
           const contextWithRegistry = {
@@ -10563,7 +10585,7 @@ export function seq<
               state: createAnnotatedArrayStateRecord(stateArray),
             },
             buildIndexedParserPairs(parsers),
-            runtime.registry,
+            runtime,
             advancedContext.exec,
           );
           const contextWithRegistry = {
@@ -12616,7 +12638,7 @@ export function merge(
           await completeDependencySourceDefaultsAsync(
             context,
             childFieldPairs,
-            runtime.registry,
+            runtime,
             context.exec,
           );
           const contextWithRegistry = {
@@ -12718,7 +12740,7 @@ export function merge(
       completeDependencySourceDefaults(
         context,
         childFieldPairs,
-        runtime.registry,
+        runtime,
         context.exec,
       );
       const contextWithRegistry = {
@@ -12952,7 +12974,7 @@ function buildSuggestRegistry(
         state: createAnnotatedArrayStateRecord(stateArray),
       },
       buildIndexedParserPairs(parsers),
-      runtime.registry,
+      runtime,
       preParsedContext.exec,
     );
     const prefix = preParsedContext.exec?.path ?? [];
@@ -13014,7 +13036,7 @@ async function buildSuggestRegistryAsync(
         state: createAnnotatedArrayStateRecord(stateArray),
       },
       buildIndexedParserPairs(parsers),
-      runtime.registry,
+      runtime,
       preParsedContext.exec,
     );
     const prefix = preParsedContext.exec?.path ?? [];
@@ -13093,7 +13115,7 @@ function seedSuggestRuntimeFromFieldParsers(
       },
     },
     pairs,
-    runtime.registry,
+    runtime,
     {
       usage: parser.usage,
       phase: "suggest",
@@ -13163,7 +13185,7 @@ async function seedSuggestRuntimeFromFieldParsersAsync(
       },
     },
     pairs,
-    runtime.registry,
+    runtime,
     {
       usage: parser.usage,
       phase: "suggest",

--- a/packages/core/src/dependency-metadata.test.ts
+++ b/packages/core/src/dependency-metadata.test.ts
@@ -10,6 +10,7 @@ import {
   dependency,
   dependencyId,
   dependencyIds,
+  dependencySourceId,
   derivedValueParserMarker,
   deriveFrom,
   isDependencySourceState,
@@ -215,6 +216,24 @@ describe("extractDependencyMetadata", () => {
     assert.equal(metadata.source, undefined);
   });
 
+  test("extracts source and derived capabilities from a derived source", () => {
+    const env = createEnvSource();
+    const level = dependency(env.deriveSync({
+      metavar: "LEVEL" as NonEmptyString,
+      factory: () => choice(["debug"] as const),
+      defaultValue: () => "dev" as const,
+    }));
+
+    const metadata = extractDependencyMetadata(level);
+
+    assert.ok(metadata?.source != null);
+    assert.ok(metadata.derived != null);
+    assert.equal(metadata.source.sourceId, level[dependencySourceId]);
+    assert.deepEqual(metadata.derived.dependencyIds, [
+      env[dependencySourceId],
+    ]);
+  });
+
   test("derived capability replayParse works", () => {
     const env = createEnvSource();
     const logLevel = createDerivedLogLevel(env);
@@ -261,7 +280,7 @@ describe("extractDependencyMetadata", () => {
     const env = createEnvSource();
     const valueParser = {
       [derivedValueParserMarker]: true,
-      [dependencyId]: env[dependencyId],
+      [dependencyId]: env[dependencySourceId],
       mode: "sync" as const,
       metavar: "LEVEL" as NonEmptyString,
       placeholder: "",
@@ -284,7 +303,10 @@ describe("extractDependencyMetadata", () => {
     const region = createEnvSource();
     const valueParser = {
       [derivedValueParserMarker]: true,
-      [dependencyIds]: [env[dependencyId], region[dependencyId]] as const,
+      [dependencyIds]: [
+        env[dependencySourceId],
+        region[dependencySourceId],
+      ] as const,
       mode: "sync" as const,
       metavar: "URL" as NonEmptyString,
       placeholder: "",

--- a/packages/core/src/dependency-metadata.ts
+++ b/packages/core/src/dependency-metadata.ts
@@ -15,6 +15,7 @@ import {
   defaultValues,
   dependencyId,
   dependencyIds,
+  dependencySourceId,
   isDependencySource,
   isDependencySourceState,
   isDerivedValueParser,
@@ -40,6 +41,9 @@ export interface DependencySourceCapability {
 
   /** The unique dependency source identifier. */
   readonly sourceId: symbol;
+
+  /** Metavariable used to identify this source in diagnostics. */
+  readonly metavar?: string;
 
   /**
    * Extracts the dependency source parse result from the parser's state.
@@ -116,6 +120,9 @@ export interface DerivedDependencyCapability {
   /** The dependency source IDs this parser depends on. */
   readonly dependencyIds: readonly symbol[];
 
+  /** Metavariable used to identify this parser in diagnostics. */
+  readonly metavar?: string;
+
   /**
    * Returns default values for each dependency, used when the
    * corresponding sources are not provided.
@@ -190,17 +197,18 @@ export interface ParserDependencyMetadata {
 export function extractDependencyMetadata<M extends Mode, T>(
   valueParser: ValueParser<M, T>,
 ): ParserDependencyMetadata | undefined {
+  let source: DependencySourceCapability | undefined;
   if (isDependencySource(valueParser)) {
-    return {
-      source: {
-        kind: "source",
-        sourceId: valueParser[dependencyId],
-        extractSourceValue: extractFromBareState,
-        preservesSourceValue: true,
-      },
+    source = {
+      kind: "source",
+      sourceId: valueParser[dependencySourceId],
+      metavar: valueParser.metavar,
+      extractSourceValue: extractFromBareState,
+      preservesSourceValue: true,
     };
   }
 
+  let derived: DerivedDependencyCapability | undefined;
   if (isDerivedValueParser(valueParser)) {
     // deriveFrom() sets [dependencyIds]; derive() only sets [dependencyId].
     // This distinction matters for parseWithDependency: derive() expects
@@ -252,18 +260,17 @@ export function extractDependencyMetadata<M extends Mode, T>(
       }
       : undefined;
 
-    return {
-      derived: {
-        kind: "derived",
-        dependencyIds: allIds,
-        getDefaultDependencyValues: defaultValuesFn,
-        replayParse,
-        replaySuggest,
-      },
+    derived = {
+      kind: "derived",
+      dependencyIds: allIds,
+      metavar: valueParser.metavar,
+      getDefaultDependencyValues: defaultValuesFn,
+      replayParse,
+      replaySuggest,
     };
   }
 
-  return undefined;
+  return source == null && derived == null ? undefined : { source, derived };
 }
 
 // =============================================================================

--- a/packages/core/src/dependency-runtime.test.ts
+++ b/packages/core/src/dependency-runtime.test.ts
@@ -1767,6 +1767,23 @@ describe("buildRuntimeNodesFromPairs", () => {
     const nodes = buildRuntimeNodesFromPairs(pairs, state);
     assert.equal(nodes[0].defaultDependencyValues, undefined);
   });
+
+  test("does not inspect plain parser state properties", () => {
+    const parser = makeParser();
+    const parserState = {
+      success: true as const,
+      value: "ok",
+      get diagnostic(): never {
+        throw new Error("diagnostic getter should not run");
+      },
+    };
+
+    assert.doesNotThrow(() =>
+      buildRuntimeNodesFromPairs([["value", parser]], {
+        value: parserState,
+      })
+    );
+  });
 });
 
 describe("buildRuntimeNodesFromArray", () => {
@@ -1807,6 +1824,21 @@ describe("buildRuntimeNodesFromArray", () => {
     const p = makeParser();
     const nodes = buildRuntimeNodesFromArray([p], ["x"], ["parent"]);
     assert.deepStrictEqual(nodes[0].path, ["parent", 0]);
+  });
+
+  test("does not inspect plain parser state properties", () => {
+    const parser = makeParser();
+    const parserState = {
+      success: true as const,
+      value: "ok",
+      get diagnostic(): never {
+        throw new Error("diagnostic getter should not run");
+      },
+    };
+
+    assert.doesNotThrow(() =>
+      buildRuntimeNodesFromArray([parser], [parserState])
+    );
   });
 });
 

--- a/packages/core/src/dependency-runtime.test.ts
+++ b/packages/core/src/dependency-runtime.test.ts
@@ -17,9 +17,11 @@ import {
   createDependencyFingerprint,
   createDependencyRuntimeContext,
   createReplayKey,
+  derivedRawInputKey,
   extractRawInputFromState,
   fillMissingSourceDefaults,
   fillMissingSourceDefaultsAsync,
+  orderDependencyNodes,
   replayDerivedParser,
   replayDerivedParserAsync,
   resolveStateWithRuntime,
@@ -229,6 +231,40 @@ describe("DependencyRuntimeContext", () => {
     assert.ok(!runtime.hasSource(sourceId));
     assert.equal(runtime.getSource(sourceId), undefined);
     assert.ok(runtime.isSourceFailed(sourceId));
+  });
+
+  test("tracks a transitive diagnostic chain for failed sources", () => {
+    const framework = Symbol("framework");
+    const packageManager = Symbol("package-manager");
+    const runtime = createDependencyRuntimeContext();
+    runtime.registerSourceMetadata(framework, "FRAMEWORK");
+    runtime.registerSourceMetadata(
+      packageManager,
+      "PACKAGE_MANAGER",
+      [framework],
+    );
+
+    runtime.markSourceFailed(framework);
+    assert.ok(runtime.propagateSourceFailure(
+      [framework],
+      "PACKAGE_MANAGER",
+      packageManager,
+    ));
+    assert.ok(runtime.propagateSourceFailure(
+      [packageManager],
+      "STORAGE",
+    ));
+
+    assert.deepEqual(runtime.getSourceFailureChain(framework), [
+      "FRAMEWORK",
+      "PACKAGE_MANAGER",
+      "STORAGE",
+    ]);
+    assert.deepEqual(runtime.getSourceFailureChain(packageManager), [
+      "FRAMEWORK",
+      "PACKAGE_MANAGER",
+      "STORAGE",
+    ]);
   });
 });
 
@@ -1301,6 +1337,30 @@ describe("extractRawInputFromState", () => {
       { success: true, value: "world" },
     );
     assert.equal(extractRawInputFromState([deferred]), "world");
+  });
+
+  test("extracts rawInput from a single-state extension wrapper", () => {
+    const inner = Object.defineProperty(
+      { success: true, value: "npm" },
+      derivedRawInputKey,
+      { value: "npm", enumerable: false },
+    );
+    assert.equal(
+      extractRawInputFromState({ hasCliValue: true, cliState: inner }),
+      "npm",
+    );
+  });
+
+  test("rejects an extension wrapper with ambiguous raw inputs", () => {
+    const first = Object.defineProperty({}, derivedRawInputKey, {
+      value: "npm",
+      enumerable: false,
+    });
+    const second = Object.defineProperty({}, derivedRawInputKey, {
+      value: "deno",
+      enumerable: false,
+    });
+    assert.equal(extractRawInputFromState({ first, second }), undefined);
   });
 
   test("returns undefined for PendingDependencySourceState", () => {
@@ -2532,3 +2592,99 @@ describe("collectDemandedDependencyIds", () => {
     assert.ok(demanded.has(sourceId));
   });
 });
+
+describe("orderDependencyNodes", () => {
+  test("orders a derived source after every in-scope provider", () => {
+    const upstreamId = Symbol("upstream");
+    const derivedId = Symbol("derived");
+    const consumer = createRuntimeSourceNode({
+      path: ["consumer"],
+      sourceId: derivedId,
+      dependencyIds: [upstreamId],
+      metavar: "CONSUMER",
+    });
+    const unrelated = createRuntimeSourceNode({
+      path: ["unrelated"],
+      sourceId: Symbol("unrelated"),
+      metavar: "UNRELATED",
+    });
+    const provider = createRuntimeSourceNode({
+      path: ["provider"],
+      sourceId: upstreamId,
+      metavar: "PROVIDER",
+    });
+
+    const ordered = orderDependencyNodes([consumer, unrelated, provider]);
+
+    assert.deepEqual(ordered, [unrelated, provider, consumer]);
+  });
+
+  test("does not treat a missing provider as a cycle", () => {
+    const consumer = createRuntimeSourceNode({
+      path: ["consumer"],
+      sourceId: Symbol("derived"),
+      dependencyIds: [Symbol("absent")],
+      metavar: "CONSUMER",
+    });
+
+    const ordered = orderDependencyNodes([consumer]);
+
+    assert.deepEqual(ordered, [consumer]);
+  });
+
+  test("reports the paths and metavars in a forged cycle", () => {
+    const firstId = Symbol("first");
+    const secondId = Symbol("second");
+    const first = createRuntimeSourceNode({
+      path: ["first"],
+      sourceId: firstId,
+      dependencyIds: [secondId],
+      metavar: "FIRST",
+    });
+    const second = createRuntimeSourceNode({
+      path: ["second"],
+      sourceId: secondId,
+      dependencyIds: [firstId],
+      metavar: "SECOND",
+    });
+
+    assert.throws(
+      () => orderDependencyNodes([first, second]),
+      /Circular dependency.*FIRST \(first\).*SECOND \(second\)/,
+    );
+  });
+});
+
+// Helpers
+
+function createRuntimeSourceNode(options: {
+  readonly path: readonly PropertyKey[];
+  readonly sourceId: symbol;
+  readonly dependencyIds?: readonly symbol[];
+  readonly metavar: string;
+}): RuntimeNode {
+  const source: NonNullable<ParserDependencyMetadata["source"]> = {
+    kind: "source",
+    sourceId: options.sourceId,
+    metavar: options.metavar,
+    extractSourceValue: () => undefined,
+    preservesSourceValue: true,
+  };
+  const derived: ParserDependencyMetadata["derived"] =
+    options.dependencyIds == null ? undefined : {
+      kind: "derived",
+      dependencyIds: options.dependencyIds,
+      metavar: options.metavar,
+      replayParse: (rawInput) => ({ success: true, value: rawInput }),
+    };
+  return {
+    path: options.path,
+    parser: {
+      dependencyMetadata: {
+        source,
+        ...(derived != null ? { derived } : {}),
+      },
+    },
+    state: undefined,
+  };
+}

--- a/packages/core/src/dependency-runtime.ts
+++ b/packages/core/src/dependency-runtime.ts
@@ -13,6 +13,7 @@
 import {
   type DeferredParseState,
   dependencyId as dependencyIdSymbol,
+  getSnapshottedDefaultDependencyValues,
   isDeferredParseState,
   isDependencySourceState,
   isPendingDependencySourceState,
@@ -27,6 +28,40 @@ import {
 import type { DependencyRegistryLike } from "./registry-types.ts";
 import type { ValueParserResult } from "./valueparser.ts";
 import type { ParserDependencyMetadata } from "./dependency-metadata.ts";
+
+/**
+ * Stores the raw token parsed by a derived value parser on structural parser
+ * states that can safely carry an in-band annotation.
+ *
+ * The execution trace remains the canonical diagnostic record.  This state
+ * marker lets construct-independent dependency resolution replay a derived
+ * source before downstream fields complete.
+ * @internal
+ * @since 1.3.0
+ */
+export const derivedRawInputKey: unique symbol = Symbol(
+  "@optique/core/dependency-runtime/derivedRawInput",
+);
+
+const derivedRawInputs = new WeakMap<object, string>();
+
+/**
+ * Records a derived parser's raw token without modifying its parse result.
+ *
+ * Parse results may be frozen or carry class private state, so primitives keep
+ * their original identity and associate replay metadata out of band.
+ *
+ * @param state The original value parser result.
+ * @param rawInput The token parsed into that result.
+ * @internal
+ * @since 1.3.0
+ */
+export function recordDerivedRawInput(
+  state: object,
+  rawInput: string,
+): void {
+  derivedRawInputs.set(state, rawInput);
+}
 
 // =============================================================================
 // Symbol serialization
@@ -153,6 +188,9 @@ export interface RuntimeNode {
   /** The parser's current state. */
   readonly state: unknown;
 
+  /** Raw input captured for a derived parser, when this node matched. */
+  readonly rawInput?: string;
+
   /**
    * Whether the parser consumed explicit input during parsing.
    * When `true`, the parser's state reflects user-provided input (which
@@ -208,6 +246,21 @@ export interface RuntimeNode {
    * @since 1.3.0
    */
   readonly requiresSourceId?: symbol;
+}
+
+/**
+ * Options for resolving matched derived source values.
+ *
+ * @internal
+ * @since 1.3.0
+ */
+export interface ResolveDerivedSourceValuesOptions {
+  /**
+   * Whether an unpopulated effectful source can still provide a value later.
+   * Suggestion generation sets this to `"inactive"` because it never runs
+   * effects and must let downstream parsers use declared dependency defaults.
+   */
+  readonly effectfulProviders?: "pending" | "inactive";
 }
 
 /**
@@ -271,6 +324,26 @@ export interface DependencyRuntimeContext {
    */
   markSourceFailed(sourceId: symbol): void;
 
+  /** Register a source's diagnostic label and upstream dependencies. */
+  registerSourceMetadata(
+    sourceId: symbol,
+    label: string,
+    dependencyIds?: readonly symbol[],
+  ): void;
+
+  /**
+   * Propagate a failed upstream source through one derived dependency edge.
+   * Returns whether any upstream source had failed.
+   */
+  propagateSourceFailure(
+    dependencyIds: readonly symbol[],
+    label: string,
+    sourceId?: symbol,
+  ): boolean;
+
+  /** Return the most informative dependency chain for a failed source. */
+  getSourceFailureChain(sourceId: symbol): readonly string[] | undefined;
+
   /**
    * Check if a source was explicitly attempted but failed validation.
    */
@@ -288,6 +361,15 @@ class DependencyRuntimeContextImpl implements DependencyRuntimeContext {
   readonly registry: DependencyRegistryLike;
   readonly #replayCache = new Map<string, ValueParserResult<unknown>>();
   readonly #failedSources = new Set<symbol>();
+  readonly #sourceMetadata = new Map<symbol, {
+    readonly label: string;
+    readonly dependencyIds: readonly symbol[];
+  }>();
+  readonly #sourceFailures = new Map<symbol, {
+    readonly chain: readonly string[];
+    readonly participants: readonly symbol[];
+    diagnosticChain: readonly string[];
+  }>();
 
   constructor(registry: DependencyRegistryLike) {
     if (registry instanceof FailedAwareRegistry) {
@@ -299,6 +381,7 @@ class DependencyRuntimeContextImpl implements DependencyRuntimeContext {
 
   registerSource(sourceId: symbol, value: unknown): void {
     this.registry.set(sourceId, value);
+    this.#sourceFailures.delete(sourceId);
   }
 
   hasSource(sourceId: symbol): boolean {
@@ -326,6 +409,60 @@ class DependencyRuntimeContextImpl implements DependencyRuntimeContext {
 
   markSourceFailed(sourceId: symbol): void {
     this.#failedSources.add(sourceId);
+    const lineage = this.#getSourceLineage(sourceId, new Set<symbol>());
+    const failure = {
+      chain: lineage.labels,
+      participants: lineage.sourceIds,
+      diagnosticChain: lineage.labels,
+    };
+    this.#sourceFailures.set(sourceId, failure);
+    this.#promoteDiagnosticChain(failure);
+  }
+
+  registerSourceMetadata(
+    sourceId: symbol,
+    label: string,
+    dependencyIds: readonly symbol[] = [],
+  ): void {
+    this.#sourceMetadata.set(sourceId, { label, dependencyIds });
+  }
+
+  propagateSourceFailure(
+    dependencyIds: readonly symbol[],
+    label: string,
+    sourceId?: symbol,
+  ): boolean {
+    const upstream = dependencyIds
+      .filter((id) => this.isSourceFailed(id))
+      .map((id) =>
+        this.#sourceFailures.get(id) ?? {
+          chain: [this.#getSourceLabel(id)],
+          participants: [id],
+          diagnosticChain: [this.#getSourceLabel(id)],
+        }
+      )
+      .sort((left, right) => right.chain.length - left.chain.length)[0];
+    if (upstream == null) return false;
+
+    const chain = upstream.chain.at(-1) === label
+      ? upstream.chain
+      : [...upstream.chain, label];
+    const participants = sourceId == null ||
+        upstream.participants.includes(sourceId)
+      ? upstream.participants
+      : [...upstream.participants, sourceId];
+    const failure = { chain, participants, diagnosticChain: chain };
+    if (sourceId != null) {
+      this.#failedSources.add(sourceId);
+      this.#sourceFailures.set(sourceId, failure);
+    }
+    this.#promoteDiagnosticChain(failure);
+    return true;
+  }
+
+  getSourceFailureChain(sourceId: symbol): readonly string[] | undefined {
+    if (!this.#failedSources.has(sourceId)) return undefined;
+    return this.#sourceFailures.get(sourceId)?.diagnosticChain;
   }
 
   isSourceFailed(sourceId: symbol): boolean {
@@ -334,6 +471,54 @@ class DependencyRuntimeContextImpl implements DependencyRuntimeContext {
 
   getSuggestionDependencies(request: DependencyRequest): DependencyResolution {
     return resolveRequest(this, request);
+  }
+
+  #getSourceLabel(sourceId: symbol): string {
+    return this.#sourceMetadata.get(sourceId)?.label ??
+      sourceId.description ?? String(sourceId);
+  }
+
+  #getSourceLineage(
+    sourceId: symbol,
+    visited: Set<symbol>,
+  ): {
+    readonly labels: readonly string[];
+    readonly sourceIds: readonly symbol[];
+  } {
+    if (visited.has(sourceId)) {
+      return {
+        labels: [this.#getSourceLabel(sourceId)],
+        sourceIds: [sourceId],
+      };
+    }
+    visited.add(sourceId);
+    const metadata = this.#sourceMetadata.get(sourceId);
+    const upstream = (metadata?.dependencyIds ?? [])
+      .map((id) => this.#getSourceLineage(id, new Set(visited)))
+      .sort((left, right) => right.labels.length - left.labels.length)[0];
+    return upstream == null
+      ? { labels: [this.#getSourceLabel(sourceId)], sourceIds: [sourceId] }
+      : {
+        labels: [...upstream.labels, this.#getSourceLabel(sourceId)],
+        sourceIds: [...upstream.sourceIds, sourceId],
+      };
+  }
+
+  #promoteDiagnosticChain(
+    failure: {
+      readonly participants: readonly symbol[];
+      readonly diagnosticChain: readonly string[];
+    },
+  ): void {
+    for (const sourceId of failure.participants) {
+      const current = this.#sourceFailures.get(sourceId);
+      if (
+        current != null &&
+        current.diagnosticChain.length < failure.diagnosticChain.length
+      ) {
+        current.diagnosticChain = failure.diagnosticChain;
+      }
+    }
   }
 }
 
@@ -612,10 +797,15 @@ export function collectExplicitSourceValues(
   nodes: readonly RuntimeNode[],
   runtime: DependencyRuntimeContext,
 ): void {
+  registerRuntimeSourceMetadata(nodes, runtime);
   for (const node of nodes) {
     const meta = node.parser.dependencyMetadata;
     if (meta?.source == null) continue;
     if (meta.source.extractSourceValue == null) continue;
+    // A matched parser that is both derived and a source contains only its
+    // preliminary result.  It was parsed against snapshotted upstream
+    // defaults and must not be published before dependency replay.
+    if (meta.derived != null && getNodeRawInput(node) != null) continue;
 
     const result = meta.source.extractSourceValue(node.state);
     if (isPromiseLike(result)) {
@@ -627,6 +817,7 @@ export function collectExplicitSourceValues(
     }
     registerExplicitSourceValue(meta.source.sourceId, result, runtime);
   }
+  resolveDerivedSourceValues(nodes, runtime);
 }
 
 function registerExplicitSourceValue(
@@ -669,14 +860,331 @@ export async function collectExplicitSourceValuesAsync(
   nodes: readonly RuntimeNode[],
   runtime: DependencyRuntimeContext,
 ): Promise<void> {
+  registerRuntimeSourceMetadata(nodes, runtime);
   for (const node of nodes) {
     const meta = node.parser.dependencyMetadata;
     if (meta?.source == null) continue;
     if (meta.source.extractSourceValue == null) continue;
+    if (meta.derived != null && getNodeRawInput(node) != null) continue;
 
     const result = await meta.source.extractSourceValue(node.state);
     registerExplicitSourceValue(meta.source.sourceId, result, runtime);
   }
+  await resolveDerivedSourceValuesAsync(nodes, runtime);
+}
+
+/**
+ * Orders runtime nodes so every in-scope provider precedes a derived source
+ * that consumes it.  Independent nodes retain declaration order.
+ *
+ * Missing providers create no edge because the consumer may use its declared
+ * default.  Scheduling barriers act as providers for the source IDs their
+ * selected subtree may expose and depend on their discriminator source.
+ *
+ * @param nodes Runtime nodes in declaration order.
+ * @returns The same nodes in stable dependency order.
+ * @throws {TypeError} If active provider edges contain a cycle.
+ * @internal
+ * @since 1.3.0
+ */
+export function orderDependencyNodes(
+  nodes: readonly RuntimeNode[],
+): readonly RuntimeNode[] {
+  const providers = new Map<symbol, RuntimeNode[]>();
+  const addProvider = (sourceId: symbol, node: RuntimeNode): void => {
+    const existing = providers.get(sourceId);
+    if (existing == null) providers.set(sourceId, [node]);
+    else existing.push(node);
+  };
+  for (const node of nodes) {
+    const source = node.parser.dependencyMetadata?.source;
+    if (source != null) addProvider(source.sourceId, node);
+    for (const sourceId of node.providesSourceIds ?? []) {
+      addProvider(sourceId, node);
+    }
+  }
+
+  const outgoing = new Map<RuntimeNode, Set<RuntimeNode>>();
+  const indegree = new Map<RuntimeNode, number>();
+  for (const node of nodes) indegree.set(node, 0);
+  const addEdge = (provider: RuntimeNode, consumer: RuntimeNode): void => {
+    const edges = outgoing.get(provider) ?? new Set<RuntimeNode>();
+    if (edges.has(consumer)) return;
+    edges.add(consumer);
+    outgoing.set(provider, edges);
+    indegree.set(consumer, (indegree.get(consumer) ?? 0) + 1);
+  };
+
+  for (const node of nodes) {
+    const derived = node.parser.dependencyMetadata?.derived;
+    if (derived != null) {
+      for (const dependencySourceId of derived.dependencyIds) {
+        for (const provider of providers.get(dependencySourceId) ?? []) {
+          addEdge(provider, node);
+        }
+      }
+    }
+    if (node.requiresSourceId != null) {
+      for (const provider of providers.get(node.requiresSourceId) ?? []) {
+        if (provider !== node) addEdge(provider, node);
+      }
+    }
+  }
+
+  const declarationOrder = new Map(
+    nodes.map((node, index) => [node, index] as const),
+  );
+  const ready = nodes.filter((node) => indegree.get(node) === 0);
+  const ordered: RuntimeNode[] = [];
+  while (ready.length > 0) {
+    ready.sort((left, right) =>
+      declarationOrder.get(left)! - declarationOrder.get(right)!
+    );
+    const node = ready.shift()!;
+    ordered.push(node);
+    for (const consumer of outgoing.get(node) ?? []) {
+      const next = (indegree.get(consumer) ?? 0) - 1;
+      indegree.set(consumer, next);
+      if (next === 0) ready.push(consumer);
+    }
+  }
+
+  if (ordered.length !== nodes.length) {
+    const cycle = nodes.filter((node) => (indegree.get(node) ?? 0) > 0);
+    const labels = cycle.map(formatDependencyNodeLabel).join(" -> ");
+    throw new TypeError(
+      `Circular dependency detected among derived sources: ${labels}.`,
+    );
+  }
+  return ordered;
+}
+
+/** Resolves and publishes matched derived sources in stable dependency order. */
+export function resolveDerivedSourceValues(
+  nodes: readonly RuntimeNode[],
+  runtime: DependencyRuntimeContext,
+  options?: ResolveDerivedSourceValuesOptions,
+): void {
+  resolveDerivedSourceValuesInOrder(
+    orderDependencyNodes(nodes),
+    nodes,
+    runtime,
+    (node, rawInput) => replayDerivedParser(node, rawInput, runtime),
+    options,
+  );
+}
+
+/** Async version of {@link resolveDerivedSourceValues}. */
+export async function resolveDerivedSourceValuesAsync(
+  nodes: readonly RuntimeNode[],
+  runtime: DependencyRuntimeContext,
+  options?: ResolveDerivedSourceValuesOptions,
+): Promise<void> {
+  await resolveDerivedSourceValuesInOrderAsync(
+    orderDependencyNodes(nodes),
+    nodes,
+    runtime,
+    options,
+  );
+}
+
+function resolveDerivedSourceValuesInOrder(
+  ordered: readonly RuntimeNode[],
+  allNodes: readonly RuntimeNode[],
+  runtime: DependencyRuntimeContext,
+  replay: (
+    node: RuntimeNode,
+    rawInput: string,
+  ) => ValueParserResult<unknown> | undefined,
+  options?: ResolveDerivedSourceValuesOptions,
+): void {
+  const providers = collectSourceProviders(allNodes);
+  const settled = new Set<RuntimeNode>();
+  for (const node of ordered) {
+    const metadata = node.parser.dependencyMetadata;
+    const rawInput = getNodeRawInput(node);
+    if (metadata?.derived == null) {
+      continue;
+    }
+    const label = formatDependencyNodeMetavar(node);
+    if (
+      runtime.propagateSourceFailure(
+        metadata.derived.dependencyIds,
+        label,
+        metadata.source?.sourceId,
+      )
+    ) {
+      if (metadata.source != null) settled.add(node);
+      continue;
+    }
+    if (metadata.source == null || rawInput == null) continue;
+    if (hasPendingProvider(node, providers, settled, runtime, options)) {
+      continue;
+    }
+    settleDerivedSource(node, rawInput, runtime, replay);
+    settled.add(node);
+  }
+}
+
+async function resolveDerivedSourceValuesInOrderAsync(
+  ordered: readonly RuntimeNode[],
+  allNodes: readonly RuntimeNode[],
+  runtime: DependencyRuntimeContext,
+  options?: ResolveDerivedSourceValuesOptions,
+): Promise<void> {
+  const providers = collectSourceProviders(allNodes);
+  const settled = new Set<RuntimeNode>();
+  for (const node of ordered) {
+    const metadata = node.parser.dependencyMetadata;
+    const rawInput = getNodeRawInput(node);
+    if (metadata?.derived == null) {
+      continue;
+    }
+    const label = formatDependencyNodeMetavar(node);
+    if (
+      runtime.propagateSourceFailure(
+        metadata.derived.dependencyIds,
+        label,
+        metadata.source?.sourceId,
+      )
+    ) {
+      if (metadata.source != null) settled.add(node);
+      continue;
+    }
+    if (metadata.source == null || rawInput == null) continue;
+    if (hasPendingProvider(node, providers, settled, runtime, options)) {
+      continue;
+    }
+    const result = await replayDerivedParserAsync(node, rawInput, runtime);
+    publishDerivedSourceResult(metadata.source.sourceId, result, runtime);
+    settled.add(node);
+  }
+}
+
+function settleDerivedSource(
+  node: RuntimeNode,
+  rawInput: string,
+  runtime: DependencyRuntimeContext,
+  replay: (
+    node: RuntimeNode,
+    rawInput: string,
+  ) => ValueParserResult<unknown> | undefined,
+): void {
+  const metadata = node.parser.dependencyMetadata!;
+  publishDerivedSourceResult(
+    metadata.source!.sourceId,
+    replay(node, rawInput),
+    runtime,
+  );
+}
+
+function publishDerivedSourceResult(
+  sourceId: symbol,
+  result: ValueParserResult<unknown> | undefined,
+  runtime: DependencyRuntimeContext,
+): void {
+  if (result == null || (result.success && result.deferred === true)) return;
+  if (!result.success) {
+    runtime.markSourceFailed(sourceId);
+  } else {
+    runtime.registerSource(sourceId, result.value);
+  }
+}
+
+function collectSourceProviders(
+  nodes: readonly RuntimeNode[],
+): ReadonlyMap<symbol, readonly RuntimeNode[]> {
+  const providers = new Map<symbol, RuntimeNode[]>();
+  for (const node of nodes) {
+    const sourceId = node.parser.dependencyMetadata?.source?.sourceId;
+    if (sourceId == null) continue;
+    const existing = providers.get(sourceId);
+    if (existing == null) providers.set(sourceId, [node]);
+    else existing.push(node);
+  }
+  return providers;
+}
+
+function hasPendingProvider(
+  node: RuntimeNode,
+  providers: ReadonlyMap<symbol, readonly RuntimeNode[]>,
+  settled: ReadonlySet<RuntimeNode>,
+  runtime: DependencyRuntimeContext,
+  options?: ResolveDerivedSourceValuesOptions,
+): boolean {
+  const derived = node.parser.dependencyMetadata!.derived!;
+  return derived.dependencyIds.some((sourceId) =>
+    (providers.get(sourceId) ?? []).some((provider) => {
+      if (
+        provider === node || runtime.hasSource(sourceId) ||
+        runtime.isSourceFailed(sourceId)
+      ) return false;
+      const metadata = provider.parser.dependencyMetadata;
+      if (metadata?.derived != null && getNodeRawInput(provider) != null) {
+        return !settled.has(provider);
+      }
+      return options?.effectfulProviders !== "inactive" &&
+        metadata?.source?.completeSource != null;
+    })
+  );
+}
+
+function getNodeRawInput(node: RuntimeNode): string | undefined {
+  return node.rawInput ?? extractRawInputFromState(node.state);
+}
+
+function registerRuntimeSourceMetadata(
+  nodes: readonly RuntimeNode[],
+  runtime: DependencyRuntimeContext,
+): void {
+  for (const node of nodes) {
+    const metadata = node.parser.dependencyMetadata;
+    if (metadata?.source == null) continue;
+    runtime.registerSourceMetadata(
+      metadata.source.sourceId,
+      formatDependencyNodeMetavar(node),
+      metadata.derived?.dependencyIds,
+    );
+  }
+}
+
+function propagateRuntimeSourceFailures(
+  nodes: readonly RuntimeNode[],
+  runtime: DependencyRuntimeContext,
+): void {
+  for (const node of orderDependencyNodes(nodes)) {
+    const metadata = node.parser.dependencyMetadata;
+    if (metadata?.derived == null) continue;
+    runtime.propagateSourceFailure(
+      metadata.derived.dependencyIds,
+      formatDependencyNodeMetavar(node),
+      metadata.source?.sourceId,
+    );
+  }
+}
+
+function includeSourceFailureChain(
+  error: Message,
+  sourceId: symbol,
+  runtime: DependencyRuntimeContext,
+): Message {
+  const chain = runtime.getSourceFailureChain(sourceId);
+  return chain == null || chain.length < 2
+    ? error
+    : message`${error} Dependency chain: ${chain.join(" -> ")}.`;
+}
+
+function formatDependencyNodeMetavar(node: RuntimeNode): string {
+  return node.parser.dependencyMetadata?.derived?.metavar ??
+    node.parser.dependencyMetadata?.source?.metavar ??
+    (node.path.map(String).join(".") || "<root>");
+}
+
+function formatDependencyNodeLabel(node: RuntimeNode): string {
+  const metavar = node.parser.dependencyMetadata?.derived?.metavar ??
+    node.parser.dependencyMetadata?.source?.metavar;
+  const path = node.path.map(String).join(".") || "<root>";
+  return metavar == null ? path : `${metavar} (${path})`;
 }
 
 /**
@@ -753,6 +1261,7 @@ export function fillMissingSourceDefaults(
       });
     }
   }
+  resolveDerivedSourceValues(nodes, runtime);
   return failures;
 }
 
@@ -805,6 +1314,7 @@ export async function fillMissingSourceDefaultsAsync(
       });
     }
   }
+  await resolveDerivedSourceValuesAsync(nodes, runtime);
   return failures;
 }
 
@@ -850,6 +1360,11 @@ export function replayDerivedParser(
 
   if (resolution.kind === "missing") return undefined;
   if (resolution.kind === "partial") return undefined;
+
+  if (resolution.usedDefaults.every((usedDefault) => usedDefault)) {
+    const preliminary = extractPreliminaryResultFromState(node.state);
+    if (preliminary != null) return preliminary;
+  }
 
   // Check replay cache
   const key = createReplayKey(
@@ -912,6 +1427,11 @@ export async function replayDerivedParserAsync(
   if (resolution.kind === "missing") return undefined;
   if (resolution.kind === "partial") return undefined;
 
+  if (resolution.usedDefaults.every((usedDefault) => usedDefault)) {
+    const preliminary = extractPreliminaryResultFromState(node.state);
+    if (preliminary != null) return preliminary;
+  }
+
   // Check replay cache
   const key = createReplayKey(
     node.path,
@@ -947,21 +1467,106 @@ export async function replayDerivedParserAsync(
  * @since 1.0.0
  */
 export function extractRawInputFromState(state: unknown): string | undefined {
+  return extractRawInputFromStateInner(state, new Set<object>());
+}
+
+function extractRawInputFromStateInner(
+  state: unknown,
+  visited: Set<object>,
+): string | undefined {
   if (state == null) return undefined;
   if (typeof state !== "object") return undefined;
+  if (visited.has(state)) return undefined;
+  visited.add(state);
+
+  const recordedRawInput = getRecordedDerivedRawInput(state);
+  if (recordedRawInput != null) return recordedRawInput;
 
   // Direct DeferredParseState
   if (isDeferredParseState(state)) return state.rawInput;
 
-  // Array-wrapped: [DeferredParseState] from optional/withDefault
-  if (
-    Array.isArray(state) &&
-    state.length === 1 &&
-    isDeferredParseState(state[0])
-  ) {
-    return state[0].rawInput;
+  // Wrapper arrays preserve occurrence order.  For multiple(), the last
+  // occurrence is the dependency source value; single-element wrappers such
+  // as optional()/withDefault() follow the same rule.
+  if (Array.isArray(state)) {
+    for (let index = state.length - 1; index >= 0; index--) {
+      const rawInput = extractRawInputFromStateInner(state[index], visited);
+      if (rawInput != null) return rawInput;
+    }
+    return undefined;
   }
 
+  // Extension wrappers can store a primitive's parse state inside a plain
+  // object (for example, prompt() uses `cliState`).  Walk single-state wrapper
+  // objects so the outer node can replay a parser that is both derived and a
+  // dependency source.  If several children expose different raw inputs, the
+  // wrapper is ambiguous and must not claim any of them as its own.
+  const nested = new Set<string>();
+  for (const value of Object.values(state)) {
+    const rawInput = extractRawInputFromStateInner(value, visited);
+    if (rawInput != null) nested.add(rawInput);
+  }
+  return nested.size === 1 ? nested.values().next().value : undefined;
+}
+
+function extractPreliminaryResultFromState(
+  state: unknown,
+): ValueParserResult<unknown> | undefined {
+  return extractPreliminaryResultFromStateInner(state, new Set<object>());
+}
+
+function extractPreliminaryResultFromStateInner(
+  state: unknown,
+  visited: Set<object>,
+): ValueParserResult<unknown> | undefined {
+  if (state == null || typeof state !== "object") return undefined;
+  if (visited.has(state)) return undefined;
+  visited.add(state);
+
+  if (isDeferredParseState(state)) return state.preliminaryResult;
+  if (
+    getRecordedDerivedRawInput(state) != null && "success" in state &&
+    typeof state.success === "boolean"
+  ) {
+    if (state.success === true && "value" in state) {
+      return state as { readonly success: true; readonly value: unknown };
+    }
+    if (state.success === false && "error" in state) {
+      return state as { readonly success: false; readonly error: Message };
+    }
+  }
+  if (Array.isArray(state)) {
+    for (let index = state.length - 1; index >= 0; index--) {
+      const result = extractPreliminaryResultFromStateInner(
+        state[index],
+        visited,
+      );
+      if (result != null) return result;
+    }
+    return undefined;
+  }
+
+  const nested = new Set<ValueParserResult<unknown>>();
+  for (const value of Object.values(state)) {
+    const result = extractPreliminaryResultFromStateInner(value, visited);
+    if (result != null) nested.add(result);
+  }
+  return nested.size === 1 ? nested.values().next().value : undefined;
+}
+
+function getRecordedDerivedRawInput(state: object): string | undefined {
+  const recorded = derivedRawInputs.get(state);
+  if (recorded != null) return recorded;
+  if (
+    derivedRawInputKey in state &&
+    typeof (state as { readonly [derivedRawInputKey]?: unknown })[
+        derivedRawInputKey
+      ] === "string"
+  ) {
+    return (state as { readonly [derivedRawInputKey]: string })[
+      derivedRawInputKey
+    ];
+  }
   return undefined;
 }
 
@@ -1294,6 +1899,7 @@ export async function completeEffectfulSourcesAsync(
     completed: [],
   };
   if (exec == null || exec.phase !== "complete") return empty;
+  registerRuntimeSourceMetadata(nodes, runtime);
 
   // Demand accumulates in the session even when this construct has
   // nothing schedulable itself: a consumer here may demand a source that
@@ -1322,6 +1928,17 @@ export async function completeEffectfulSourcesAsync(
     while (demandAdded) {
       demandAdded = false;
       for (const node of nodes) {
+        const metadata = node.parser.dependencyMetadata;
+        if (
+          metadata?.source != null && metadata.derived != null &&
+          session.demanded.has(metadata.source.sourceId)
+        ) {
+          for (const dependencySourceId of metadata.derived.dependencyIds) {
+            if (session.demanded.has(dependencySourceId)) continue;
+            session.demanded.add(dependencySourceId);
+            demandAdded = true;
+          }
+        }
         if (node.requiresSourceId == null || node.providesSourceIds == null) {
           continue;
         }
@@ -1358,7 +1975,7 @@ export async function completeEffectfulSourcesAsync(
   }
 
   const completed: EffectfulSourceCompletion[] = [];
-  for (const node of nodes) {
+  for (const node of orderDependencyNodes(nodes)) {
     // A scheduling barrier runs at its declaration position; its
     // preparation may schedule further nodes through the nested call,
     // which shares this pass's runtime, session, and exec.
@@ -1384,6 +2001,49 @@ export async function completeEffectfulSourcesAsync(
     const source = node.parser.dependencyMetadata?.source;
     if (source == null) continue;
     if (source.completeSource == null) {
+      const derived = node.parser.dependencyMetadata?.derived;
+      const rawInput = getNodeRawInput(node);
+      if (derived != null && rawInput != null) {
+        if (
+          runtime.propagateSourceFailure(
+            derived.dependencyIds,
+            formatDependencyNodeMetavar(node),
+            source.sourceId,
+          )
+        ) {
+          continue;
+        }
+        const replayed = await replayDerivedParserAsync(
+          node,
+          rawInput,
+          runtime,
+        );
+        if (replayed == null) continue;
+        if (!replayed.success) {
+          runtime.markSourceFailed(source.sourceId);
+          propagateRuntimeSourceFailures(nodes, runtime);
+          return {
+            success: false,
+            error: includeSourceFailureChain(
+              replayed.error,
+              source.sourceId,
+              runtime,
+            ),
+          };
+        }
+        if (replayed.deferred === true) continue;
+        runtime.registerSource(source.sourceId, replayed.value);
+        if (
+          source.preservesSourceValue &&
+          (options?.isReusable?.(node) ?? true)
+        ) {
+          completed.push({
+            key: node.path[node.path.length - 1],
+            result: replayed,
+          });
+        }
+        continue;
+      }
       // Registration order must follow declaration order across
       // structural and effectful occurrences of a shared source, the
       // way repeated command-line occurrences overwrite earlier ones.
@@ -1454,7 +2114,15 @@ export async function completeEffectfulSourcesAsync(
     if (result == null) continue;
     if (!result.success) {
       runtime.markSourceFailed(source.sourceId);
-      return { success: false, error: result.error };
+      propagateRuntimeSourceFailures(nodes, runtime);
+      return {
+        success: false,
+        error: includeSourceFailureChain(
+          result.error,
+          source.sourceId,
+          runtime,
+        ),
+      };
     }
     // Deferred results carry placeholder values, which must never become
     // dependency values or cached completions.
@@ -1869,11 +2537,15 @@ export function buildRuntimeNodesFromPairs(
     const fieldState = Object.hasOwn(state, field)
       ? state[field as string | symbol]
       : undefined;
+    const rawInput = extractRawInputFromState(fieldState);
+    const defaultDependencyValues = getDefaultDependencySnapshot(fieldState);
     nodes.push({
       path: [...prefix, field],
       parser,
       state: fieldState,
       matched: isMatchedState(fieldState, parser),
+      ...(rawInput != null ? { rawInput } : {}),
+      ...(defaultDependencyValues != null ? { defaultDependencyValues } : {}),
     });
   }
   return nodes;
@@ -1906,12 +2578,54 @@ export function buildRuntimeNodesFromArray(
   for (let i = 0; i < parsers.length; i++) {
     const parser = parsers[i];
     const elemState = i < stateArray.length ? stateArray[i] : undefined;
+    const rawInput = extractRawInputFromState(elemState);
+    const defaultDependencyValues = getDefaultDependencySnapshot(elemState);
     nodes.push({
       path: [...prefix, i],
       parser,
       state: elemState,
       matched: isMatchedState(elemState, parser),
+      ...(rawInput != null ? { rawInput } : {}),
+      ...(defaultDependencyValues != null ? { defaultDependencyValues } : {}),
     });
   }
   return nodes;
+}
+
+function getDefaultDependencySnapshot(
+  state: unknown,
+): readonly unknown[] | undefined {
+  return getDefaultDependencySnapshotInner(state, new Set<object>());
+}
+
+function getDefaultDependencySnapshotInner(
+  state: unknown,
+  visited: Set<object>,
+): readonly unknown[] | undefined {
+  if (state == null || typeof state !== "object") return undefined;
+  if (visited.has(state)) return undefined;
+  visited.add(state);
+
+  const direct = getSnapshottedDefaultDependencyValues(
+    state as ValueParserResult<unknown>,
+  );
+  if (direct != null) return direct;
+
+  if (Array.isArray(state)) {
+    for (let index = state.length - 1; index >= 0; index--) {
+      const snapshot = getDefaultDependencySnapshotInner(
+        state[index],
+        visited,
+      );
+      if (snapshot != null) return snapshot;
+    }
+    return undefined;
+  }
+
+  const nested: (readonly unknown[])[] = [];
+  for (const value of Object.values(state)) {
+    const snapshot = getDefaultDependencySnapshotInner(value, visited);
+    if (snapshot != null) nested.push(snapshot);
+  }
+  return nested.length === 1 ? nested[0] : undefined;
 }

--- a/packages/core/src/dependency-runtime.ts
+++ b/packages/core/src/dependency-runtime.ts
@@ -2547,8 +2547,13 @@ export function buildRuntimeNodesFromPairs(
     const fieldState = Object.hasOwn(state, field)
       ? state[field as string | symbol]
       : undefined;
-    const rawInput = extractRawInputFromState(fieldState);
-    const defaultDependencyValues = getDefaultDependencySnapshot(fieldState);
+    const isDerived = parser.dependencyMetadata?.derived != null;
+    const rawInput = isDerived
+      ? extractRawInputFromState(fieldState)
+      : undefined;
+    const defaultDependencyValues = isDerived
+      ? getDefaultDependencySnapshot(fieldState)
+      : undefined;
     nodes.push({
       path: [...prefix, field],
       parser,
@@ -2588,8 +2593,13 @@ export function buildRuntimeNodesFromArray(
   for (let i = 0; i < parsers.length; i++) {
     const parser = parsers[i];
     const elemState = i < stateArray.length ? stateArray[i] : undefined;
-    const rawInput = extractRawInputFromState(elemState);
-    const defaultDependencyValues = getDefaultDependencySnapshot(elemState);
+    const isDerived = parser.dependencyMetadata?.derived != null;
+    const rawInput = isDerived
+      ? extractRawInputFromState(elemState)
+      : undefined;
+    const defaultDependencyValues = isDerived
+      ? getDefaultDependencySnapshot(elemState)
+      : undefined;
     nodes.push({
       path: [...prefix, i],
       parser,

--- a/packages/core/src/dependency-runtime.ts
+++ b/packages/core/src/dependency-runtime.ts
@@ -1163,7 +1163,17 @@ function propagateRuntimeSourceFailures(
   }
 }
 
-function includeSourceFailureChain(
+/**
+ * Appends the recorded dependency chain to a source failure.
+ *
+ * @param error The source failure to annotate.
+ * @param sourceId The identifier of the failed source.
+ * @param runtime The dependency runtime that recorded the failure chain.
+ * @returns The annotated failure, or the original failure when no chain exists.
+ * @internal
+ * @since 1.3.0
+ */
+export function includeSourceFailureChain(
   error: Message,
   sourceId: symbol,
   runtime: DependencyRuntimeContext,

--- a/packages/core/src/dependency-semantics.test.ts
+++ b/packages/core/src/dependency-semantics.test.ts
@@ -8,8 +8,9 @@
  *
  * Part of https://github.com/dahlia/optique/issues/751
  */
-import { describe, test } from "node:test";
+import { describe, it, test } from "node:test";
 import * as assert from "node:assert/strict";
+import * as fc from "fast-check";
 import { dependency, deriveFrom } from "#src/internal/dependency.ts";
 import {
   parseAsync,
@@ -18,11 +19,11 @@ import {
   type Suggestion,
   suggestSync,
 } from "#src/parser.ts";
-import { choice } from "#src/valueparser.ts";
+import { choice, type ValueParser } from "#src/valueparser.ts";
 import { concat, merge, object, or, tuple } from "#src/constructs.ts";
 import { argument, option } from "#src/primitives.ts";
 import { map, multiple, optional, withDefault } from "#src/modifiers.ts";
-import { message } from "#src/message.ts";
+import { formatMessage, message } from "#src/message.ts";
 import type { NonEmptyString } from "#src/nonempty.ts";
 // =============================================================================
 // Shared test fixtures
@@ -131,6 +132,556 @@ function literalTexts(suggestions: readonly Suggestion[]): string[] {
     .filter((s): s is Suggestion & { kind: "literal" } => s.kind === "literal")
     .map((s) => s.text);
 }
+
+describe("derived dependency sources", () => {
+  it("should validate a multi-level chain against resolved upstream values", () => {
+    // Arrange
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const packageManager = dependency(framework.deriveSync({
+      metavar: "PACKAGE_MANAGER" as NonEmptyString,
+      factory: (value) =>
+        choice(value === "fresh" ? (["deno"] as const) : (["npm"] as const)),
+      defaultValue: () => "fresh" as const,
+    }));
+    const storage = packageManager.deriveSync({
+      metavar: "STORAGE" as NonEmptyString,
+      factory: (value) =>
+        choice(value === "deno" ? (["kv"] as const) : (["redis"] as const)),
+      defaultValue: () => "deno" as const,
+    });
+    const parser = object({
+      storage: option("--storage", storage),
+      packageManager: option("--package-manager", packageManager),
+      framework: option("--framework", framework),
+    });
+
+    // Act
+    const result = parseSync(parser, [
+      "--framework",
+      "hono",
+      "--package-manager",
+      "npm",
+      "--storage",
+      "redis",
+    ]);
+
+    // Assert
+    assert.deepEqual(result, {
+      success: true,
+      value: {
+        storage: "redis",
+        packageManager: "npm",
+        framework: "hono",
+      },
+    });
+  });
+
+  it("should reject a stale preliminary value in a multi-level chain", () => {
+    // Arrange
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const packageManager = dependency(framework.deriveSync({
+      metavar: "PACKAGE_MANAGER" as NonEmptyString,
+      factory: (value) =>
+        choice(value === "fresh" ? (["deno"] as const) : (["npm"] as const)),
+      defaultValue: () => "fresh" as const,
+    }));
+    const storage = packageManager.deriveSync({
+      metavar: "STORAGE" as NonEmptyString,
+      factory: (value) =>
+        choice(value === "deno" ? (["kv"] as const) : (["redis"] as const)),
+      defaultValue: () => "deno" as const,
+    });
+    const parser = object({
+      framework: option("--framework", framework),
+      packageManager: option("--package-manager", packageManager),
+      storage: option("--storage", storage),
+    });
+
+    // Act
+    const result = parseSync(parser, [
+      "--framework",
+      "hono",
+      "--package-manager",
+      "deno",
+      "--storage",
+      "kv",
+    ]);
+
+    // Assert
+    assert.ok(!result.success);
+  });
+
+  it("should resolve downstream suggestions through a derived source", () => {
+    // Arrange
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const packageManager = dependency(framework.deriveSync({
+      metavar: "PACKAGE_MANAGER" as NonEmptyString,
+      factory: (value) =>
+        choice(value === "fresh" ? (["deno"] as const) : (["npm"] as const)),
+      defaultValue: () => "fresh" as const,
+    }));
+    const storage = packageManager.deriveSync({
+      metavar: "STORAGE" as NonEmptyString,
+      factory: (value) =>
+        choice(value === "deno" ? (["kv"] as const) : (["redis"] as const)),
+      defaultValue: () => "deno" as const,
+    });
+    const parser = object({
+      framework: option("--framework", framework),
+      packageManager: option("--package-manager", packageManager),
+      storage: option("--storage", storage),
+    });
+
+    // Act
+    const suggestions = suggestSync(parser, [
+      "--framework",
+      "hono",
+      "--package-manager",
+      "npm",
+      "--storage",
+      "",
+    ]);
+
+    // Assert
+    assert.deepEqual(literalTexts(suggestions), ["redis"]);
+  });
+
+  it("should resolve downstream suggestions after an upstream source default", () => {
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const packageManager = dependency(framework.deriveSync({
+      metavar: "PACKAGE_MANAGER" as NonEmptyString,
+      factory: (value) =>
+        choice(value === "fresh" ? (["deno"] as const) : (["npm"] as const)),
+      defaultValue: () => "fresh" as const,
+    }));
+    const storage = packageManager.deriveSync({
+      metavar: "STORAGE" as NonEmptyString,
+      factory: (value) =>
+        choice(value === "deno" ? (["kv"] as const) : (["redis"] as const)),
+      defaultValue: () => "deno" as const,
+    });
+    const parser = object({
+      framework: withDefault(option("--framework", framework), "hono"),
+      packageManager: option("--package-manager", packageManager),
+      storage: option("--storage", storage),
+    });
+
+    const suggestions = suggestSync(parser, [
+      "--package-manager",
+      "npm",
+      "--storage",
+      "",
+    ]);
+
+    assert.deepEqual(literalTexts(suggestions), ["redis"]);
+  });
+
+  it("should preserve a derived source snapshot through wrappers", () => {
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    let defaultCalls = 0;
+    const packageManager = dependency(framework.deriveSync({
+      metavar: "PACKAGE_MANAGER" as NonEmptyString,
+      factory: (value) =>
+        choice(value === "fresh" ? (["deno"] as const) : (["npm"] as const)),
+      defaultValue: () => {
+        defaultCalls++;
+        if (defaultCalls > 1) throw new TypeError("Default evaluated twice.");
+        return "fresh" as const;
+      },
+    }));
+    const storage = packageManager.deriveSync({
+      metavar: "STORAGE" as NonEmptyString,
+      factory: (value) =>
+        choice(value === "deno" ? (["kv"] as const) : (["redis"] as const)),
+      defaultValue: () => "deno" as const,
+    });
+    const parser = object({
+      framework: option("--framework", framework),
+      packageManager: optional(option("--package-manager", packageManager)),
+      storage: option("--storage", storage),
+    });
+
+    const result = parseSync(parser, [
+      "--framework",
+      "hono",
+      "--package-manager",
+      "npm",
+      "--storage",
+      "redis",
+    ]);
+
+    assert.ok(result.success);
+    assert.equal(result.value.storage, "redis");
+    assert.equal(defaultCalls, 1);
+  });
+
+  it("should reuse a preliminary source result when all inputs default", () => {
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    let factoryCalls = 0;
+    const packageManager = dependency(framework.deriveSync({
+      metavar: "PACKAGE_MANAGER" as NonEmptyString,
+      factory: () => {
+        factoryCalls++;
+        if (factoryCalls > 1) throw new TypeError("Factory evaluated twice.");
+        return choice(["npm"] as const);
+      },
+      defaultValue: () => "fresh" as const,
+    }));
+    const storage = packageManager.deriveSync({
+      metavar: "STORAGE" as NonEmptyString,
+      factory: (value) =>
+        choice(value === "npm" ? (["registry"] as const) : (["none"] as const)),
+      defaultValue: () => "npm" as const,
+    });
+    const parser = object({
+      packageManager: option("--package-manager", packageManager),
+      storage: option("--storage", storage),
+    });
+
+    const result = parseSync(parser, [
+      "--package-manager",
+      "npm",
+      "--storage",
+      "registry",
+    ]);
+
+    assert.ok(result.success);
+    assert.equal(result.value.storage, "registry");
+    assert.equal(factoryCalls, 1);
+  });
+
+  it("should replay the last occurrence of a repeated derived source", () => {
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const packageManager = dependency(framework.deriveSync({
+      metavar: "PACKAGE_MANAGER" as NonEmptyString,
+      factory: (value) =>
+        choice(
+          value === "fresh"
+            ? (["deno", "bun"] as const)
+            : (["npm", "pnpm"] as const),
+        ),
+      defaultValue: () => "fresh" as const,
+    }));
+    const storage = packageManager.deriveSync({
+      metavar: "STORAGE" as NonEmptyString,
+      factory: (value) =>
+        choice(
+          value === "pnpm" ? (["workspace"] as const) : (["registry"] as const),
+        ),
+      defaultValue: () => "deno" as const,
+    });
+    const parser = object({
+      framework: option("--framework", framework),
+      packageManagers: multiple(option("--package-manager", packageManager)),
+      storage: option("--storage", storage),
+    });
+
+    const result = parseSync(parser, [
+      "--framework",
+      "hono",
+      "--package-manager",
+      "npm",
+      "--package-manager",
+      "pnpm",
+      "--storage",
+      "workspace",
+    ]);
+
+    assert.ok(result.success);
+    assert.deepEqual(result.value.packageManagers, ["npm", "pnpm"]);
+    assert.equal(result.value.storage, "workspace");
+  });
+
+  it("should publish a successful undefined derived source value", () => {
+    const upstream = dependency(choice(["enabled"] as const));
+    const maybeValueParser: ValueParser<"sync", string | undefined> = {
+      mode: "sync",
+      metavar: "MAYBE" as NonEmptyString,
+      placeholder: undefined,
+      parse: () => ({ success: true, value: undefined }),
+      format: () => "none",
+    };
+    const maybe = dependency(upstream.deriveSync({
+      metavar: "MAYBE" as NonEmptyString,
+      factory: () => maybeValueParser,
+      defaultValue: () => "enabled" as const,
+    }));
+    const downstream = maybe.deriveSync({
+      metavar: "DOWNSTREAM" as NonEmptyString,
+      factory: (value) =>
+        choice(
+          value === undefined
+            ? (["undefined"] as const)
+            : (["fallback"] as const),
+        ),
+      defaultValue: () => "fallback" as const,
+    });
+    const parser = object({
+      upstream: option("--upstream", upstream),
+      maybe: option("--maybe", maybe),
+      downstream: option("--downstream", downstream),
+    });
+
+    const result = parseSync(parser, [
+      "--upstream",
+      "enabled",
+      "--maybe",
+      "none",
+      "--downstream",
+      "undefined",
+    ]);
+
+    assert.ok(result.success);
+    assert.equal(result.value.downstream, "undefined");
+  });
+
+  it("should combine async modes through every level", async () => {
+    // Arrange
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const packageManager = dependency(framework.derive({
+      metavar: "PACKAGE_MANAGER" as NonEmptyString,
+      mode: "async",
+      factory: (value) =>
+        asyncChoice(
+          value === "fresh" ? (["deno"] as const) : (["npm"] as const),
+        ),
+      defaultValue: () => "fresh" as const,
+    }));
+    const storage = packageManager.deriveSync({
+      metavar: "STORAGE" as NonEmptyString,
+      factory: (value) =>
+        choice(value === "deno" ? (["kv"] as const) : (["redis"] as const)),
+      defaultValue: () => "deno" as const,
+    });
+    const parser = object({
+      storage: option("--storage", storage),
+      packageManager: option("--package-manager", packageManager),
+      framework: option("--framework", framework),
+    });
+
+    // Act
+    const result = await parseAsync(parser, [
+      "--framework",
+      "hono",
+      "--package-manager",
+      "npm",
+      "--storage",
+      "redis",
+    ]);
+
+    // Assert
+    assert.ok(result.success);
+    assert.equal(result.value.storage, "redis");
+  });
+
+  it("should support a multi-source deriveFrom parser as a source", () => {
+    // Arrange
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const runtime = dependency(choice(["deno", "node"] as const));
+    const packageManager = dependency(deriveFrom({
+      metavar: "PACKAGE_MANAGER" as NonEmptyString,
+      mode: "sync",
+      dependencies: [framework, runtime] as const,
+      factory: (frameworkValue, runtimeValue) =>
+        choice(
+          frameworkValue === "fresh" && runtimeValue === "deno"
+            ? (["jsr"] as const)
+            : (["npm"] as const),
+        ),
+      defaultValues: () => ["fresh", "deno"] as const,
+    }));
+    const registry = packageManager.deriveSync({
+      metavar: "REGISTRY" as NonEmptyString,
+      factory: (value) =>
+        choice(value === "jsr" ? (["jsr.io"] as const) : (["npmjs"] as const)),
+      defaultValue: () => "jsr" as const,
+    });
+    const parser = object({
+      registry: option("--registry", registry),
+      packageManager: option("--package-manager", packageManager),
+      runtime: option("--runtime", runtime),
+      framework: option("--framework", framework),
+    });
+
+    // Act
+    const result = parseSync(parser, [
+      "--framework",
+      "hono",
+      "--runtime",
+      "node",
+      "--package-manager",
+      "npm",
+      "--registry",
+      "npmjs",
+    ]);
+
+    // Assert
+    assert.ok(result.success);
+    assert.equal(result.value.registry, "npmjs");
+  });
+
+  it("should use downstream defaults when a derived source is absent", () => {
+    // Arrange
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const packageManager = dependency(framework.deriveSync({
+      metavar: "PACKAGE_MANAGER" as NonEmptyString,
+      factory: (value) =>
+        choice(value === "fresh" ? (["deno"] as const) : (["npm"] as const)),
+      defaultValue: () => "fresh" as const,
+    }));
+    const storage = packageManager.deriveSync({
+      metavar: "STORAGE" as NonEmptyString,
+      factory: (value) =>
+        choice(value === "deno" ? (["kv"] as const) : (["redis"] as const)),
+      defaultValue: () => "deno" as const,
+    });
+    const parser = option("--storage", storage);
+
+    // Act
+    const result = parseSync(parser, ["--storage", "kv"]);
+
+    // Assert
+    assert.deepEqual(result, { success: true, value: "kv" });
+  });
+
+  it("should propagate an upstream failure through the dependency chain", () => {
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const packageManager = dependency(framework.deriveSync({
+      metavar: "PACKAGE_MANAGER" as NonEmptyString,
+      factory: (value) =>
+        choice(value === "fresh" ? (["deno"] as const) : (["npm"] as const)),
+      defaultValue: () => "fresh" as const,
+    }));
+    const storage = packageManager.deriveSync({
+      metavar: "STORAGE" as NonEmptyString,
+      factory: (value) =>
+        choice(value === "deno" ? (["kv"] as const) : (["redis"] as const)),
+      defaultValue: () => "deno" as const,
+    });
+    const parser = object({
+      storage: option("--storage", storage),
+      packageManager: option("--package-manager", packageManager),
+      framework: option("--framework", framework),
+    });
+
+    const result = parseSync(parser, [
+      "--framework",
+      "invalid",
+      "--package-manager",
+      "deno",
+      "--storage",
+      "kv",
+    ]);
+
+    assert.ok(!result.success);
+    assert.match(
+      formatMessage(result.error, { quotes: false }),
+      /TYPE -> PACKAGE_MANAGER -> STORAGE/u,
+    );
+    assert.deepEqual(
+      literalTexts(suggestSync(parser, [
+        "--framework",
+        "invalid",
+        "--package-manager",
+        "deno",
+        "--storage",
+        "",
+      ])),
+      [],
+    );
+  });
+
+  it("should resolve a tuple independently of element order", () => {
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const packageManager = dependency(framework.deriveSync({
+      metavar: "PACKAGE_MANAGER" as NonEmptyString,
+      factory: (value) =>
+        choice(value === "fresh" ? (["deno"] as const) : (["npm"] as const)),
+      defaultValue: () => "fresh" as const,
+    }));
+    const storage = packageManager.deriveSync({
+      metavar: "STORAGE" as NonEmptyString,
+      factory: (value) =>
+        choice(value === "deno" ? (["kv"] as const) : (["redis"] as const)),
+      defaultValue: () => "deno" as const,
+    });
+    const parser = tuple([
+      option("--storage", storage),
+      option("--package-manager", packageManager),
+      option("--framework", framework),
+    ]);
+
+    const result = parseSync(parser, [
+      "--framework",
+      "hono",
+      "--package-manager",
+      "npm",
+      "--storage",
+      "redis",
+    ]);
+
+    assert.deepEqual(result, {
+      success: true,
+      value: ["redis", "npm", "hono"],
+    });
+  });
+
+  it("should preserve results for every object field permutation", () => {
+    fc.assert(
+      fc.property(
+        fc.constantFrom(
+          ["framework", "packageManager", "storage"] as const,
+          ["framework", "storage", "packageManager"] as const,
+          ["packageManager", "framework", "storage"] as const,
+          ["packageManager", "storage", "framework"] as const,
+          ["storage", "framework", "packageManager"] as const,
+          ["storage", "packageManager", "framework"] as const,
+        ),
+        (order) => {
+          // Arrange
+          const framework = dependency(choice(["fresh", "hono"] as const));
+          const packageManager = dependency(framework.deriveSync({
+            metavar: "PACKAGE_MANAGER" as NonEmptyString,
+            factory: (value) =>
+              choice(
+                value === "fresh" ? (["deno"] as const) : (["npm"] as const),
+              ),
+            defaultValue: () => "fresh" as const,
+          }));
+          const storage = packageManager.deriveSync({
+            metavar: "STORAGE" as NonEmptyString,
+            factory: (value) =>
+              choice(
+                value === "deno" ? (["kv"] as const) : (["redis"] as const),
+              ),
+            defaultValue: () => "deno" as const,
+          });
+          const fields = {
+            framework: option("--framework", framework),
+            packageManager: option("--package-manager", packageManager),
+            storage: option("--storage", storage),
+          };
+          const parser = object(Object.fromEntries(
+            order.map((field) => [field, fields[field]] as const),
+          ));
+
+          // Act
+          const result = parseSync(parser, [
+            "--framework",
+            "hono",
+            "--package-manager",
+            "npm",
+            "--storage",
+            "redis",
+          ]);
+
+          // Assert
+          assert.ok(result.success);
+        },
+      ),
+    );
+  });
+});
 
 // =============================================================================
 // Section A: Core dependency shapes × execution contexts (parse path)

--- a/packages/core/src/dependency.test.ts
+++ b/packages/core/src/dependency.test.ts
@@ -6,6 +6,7 @@ import {
   dependency,
   dependencyId,
   DependencyRegistry,
+  dependencySourceId,
   dependencySourceMarker,
   derivedValueParserMarker,
   deriveFrom,
@@ -200,7 +201,7 @@ describe("dependency()", () => {
 
     assert.ok(isDependencySource(source));
     assert.equal(source[dependencySourceMarker], true);
-    assert.equal(typeof source[dependencyId], "symbol");
+    assert.equal(typeof source[dependencySourceId], "symbol");
   });
 
   test("preserves the original parser's properties", () => {
@@ -232,7 +233,10 @@ describe("dependency()", () => {
     const source1 = dependency(parser);
     const source2 = dependency(parser);
 
-    assert.notEqual(source1[dependencyId], source2[dependencyId]);
+    assert.notEqual(
+      source1[dependencySourceId],
+      source2[dependencySourceId],
+    );
   });
 });
 
@@ -317,7 +321,7 @@ describe("derive()", () => {
       defaultValue: () => "/default",
     });
 
-    assert.equal(derived[dependencyId], cwdParser[dependencyId]);
+    assert.equal(derived[dependencyId], cwdParser[dependencySourceId]);
   });
 
   test("derived parser has sync mode when source is sync", () => {
@@ -513,8 +517,8 @@ describe("deriveFrom()", () => {
   });
 });
 
-describe("nested dependency prevention", () => {
-  test("DerivedValueParser does not have derive method", () => {
+describe("derived dependency source composition", () => {
+  test("a derived parser must be wrapped before it can source another parser", () => {
     const source = dependency(string({ metavar: "DIR" }));
     const derived = source.derive<string>({
       metavar: "FILE",
@@ -523,9 +527,32 @@ describe("nested dependency prevention", () => {
       defaultValue: () => "/default",
     });
 
-    // TypeScript should prevent this at compile time, but we also verify at runtime
-    // that DerivedValueParser does not have the derive method
     assert.ok(!("derive" in derived));
+
+    const derivedSource = dependency(derived);
+    assert.ok("derive" in derivedSource);
+    assert.equal(derived[dependencyId], source[dependencySourceId]);
+    assert.notEqual(
+      derivedSource[dependencySourceId],
+      source[dependencySourceId],
+    );
+  });
+
+  test("wrapping a derived parser does not evaluate its lazy placeholder", () => {
+    const source = dependency(string({ metavar: "DIR" }));
+    let defaultCalls = 0;
+    const derived = source.deriveSync({
+      metavar: "FILE",
+      factory: () => string({ metavar: "FILE" }),
+      defaultValue: () => {
+        defaultCalls++;
+        return "/default";
+      },
+    });
+
+    dependency(derived);
+
+    assert.equal(defaultCalls, 0);
   });
 });
 
@@ -550,7 +577,7 @@ describe("DeferredParseState", () => {
     assert.equal(deferred[deferredParseMarker], true);
     assert.equal(deferred.rawInput, "test-input");
     assert.equal(deferred.parser, derived);
-    assert.equal(deferred.dependencyId, source[dependencyId]);
+    assert.equal(deferred.dependencyId, source[dependencySourceId]);
     assert.deepEqual(deferred.preliminaryResult, preliminaryResult);
   });
 
@@ -596,7 +623,7 @@ describe("DeferredParseState", () => {
       derived,
       preliminaryResult,
     );
-    assert.equal(deferred.dependencyId, source[dependencyId]);
+    assert.equal(deferred.dependencyId, source[dependencySourceId]);
   });
 
   test("deferred state stores preliminary result", () => {

--- a/packages/core/src/internal/dependency.ts
+++ b/packages/core/src/internal/dependency.ts
@@ -15,6 +15,19 @@ export const dependencySourceMarker: unique symbol = Symbol.for(
 );
 
 /**
+ * A unique symbol used to store a dependency source's own identity.
+ *
+ * This is distinct from {@link dependencyId}, which stores an upstream
+ * reference on a derived parser.  A parser wrapped with `dependency()` after
+ * derivation carries both values.
+ * @internal
+ * @since 1.3.0
+ */
+export const dependencySourceId: unique symbol = Symbol.for(
+  "@optique/core/dependency/dependencySourceId",
+);
+
+/**
  * A unique symbol used to identify derived value parsers at compile time.
  * This marker is used to distinguish {@link DerivedValueParser} from regular
  * {@link ValueParser} instances.
@@ -217,7 +230,7 @@ export interface DependencySource<M extends Mode = "sync", T = unknown>
    * Unique identifier for this dependency source.
    * @internal
    */
-  readonly [dependencyId]: symbol;
+  readonly [dependencySourceId]: symbol;
 
   /**
    * Creates a derived value parser whose behavior depends on this
@@ -326,7 +339,7 @@ export type CombinedDependencyMode<T extends readonly unknown[]> =
  */
 export interface AnyDependencySource<M extends Mode = Mode> {
   readonly [dependencySourceMarker]: true;
-  readonly [dependencyId]: symbol;
+  readonly [dependencySourceId]: symbol;
   readonly mode: M;
 }
 
@@ -456,9 +469,6 @@ export interface DeriveFromAsyncOptions<
 /**
  * A value parser that depends on another parser's value.
  *
- * A derived value parser cannot be nested (i.e., you cannot call
- * {@link DependencySource.derive} on a {@link DerivedValueParser}).
- *
  * @template M The execution mode of the parser (`"sync"` or `"async"`).
  * @template T The type of value this parser produces.
  * @template S The type of the source dependency value.
@@ -542,6 +552,8 @@ export interface DerivedValueParser<
  * A dependency source wraps an existing value parser and enables creating
  * derived parsers that depend on the parsed value. This is useful for
  * scenarios where one option's valid values depend on another option's value.
+ * A derived parser can itself become a source by wrapping it with
+ * `dependency()`, allowing dependency chains of any depth.
  *
  * @template M The execution mode of the value parser.
  * @template T The type of value the parser produces.
@@ -563,6 +575,14 @@ export interface DerivedValueParser<
  *   factory: (dir) => gitBranch({ dir }),
  *   defaultValue: () => process.cwd(),
  * });
+ *
+ * // A derived parser can provide the next dependency level.
+ * const branchSource = dependency(branchParser);
+ * const commitParser = branchSource.deriveSync({
+ *   metavar: "COMMIT",
+ *   factory: (branch) => gitCommit({ branch }),
+ *   defaultValue: () => "main",
+ * });
  * ```
  * @since 0.10.0
  */
@@ -570,42 +590,48 @@ export function dependency<M extends Mode, T>(
   parser: ValueParser<M, T>,
 ): DependencySource<M, T> {
   const id = Symbol();
-  const result: DependencySource<M, T> = {
-    ...parser,
-    [dependencySourceMarker]: true,
-    [dependencyId]: id,
-    derive<U, FM extends Mode = "sync">(
-      options: DeriveOptions<T, U, FM>,
-    ): DerivedValueParser<CombineMode<M, FM>, U, T> {
-      if (options.mode !== "sync" && options.mode !== "async") {
-        throw new TypeError(
-          'derive() requires an explicit mode field ("sync" or "async").',
-        );
-      }
-      return createDerivedValueParser(id, parser, options, options.mode);
-    },
-    deriveSync<U>(
-      options: DeriveSyncOptions<T, U>,
-    ): DerivedValueParser<M, U, T> {
-      // For sync factories, the mode is determined solely by the source mode
-      if (parser.mode === "async") {
-        return createAsyncDerivedParserFromSyncFactory(
+  const result = Object.create(
+    Object.getPrototypeOf(parser),
+    Object.getOwnPropertyDescriptors(parser),
+  ) as DependencySource<M, T>;
+  Object.defineProperties(
+    result,
+    Object.getOwnPropertyDescriptors({
+      [dependencySourceMarker]: true,
+      [dependencySourceId]: id,
+      derive<U, FM extends Mode = "sync">(
+        options: DeriveOptions<T, U, FM>,
+      ): DerivedValueParser<CombineMode<M, FM>, U, T> {
+        if (options.mode !== "sync" && options.mode !== "async") {
+          throw new TypeError(
+            'derive() requires an explicit mode field ("sync" or "async").',
+          );
+        }
+        return createDerivedValueParser(id, parser, options, options.mode);
+      },
+      deriveSync<U>(
+        options: DeriveSyncOptions<T, U>,
+      ): DerivedValueParser<M, U, T> {
+        // For sync factories, the mode is determined solely by the source mode
+        if (parser.mode === "async") {
+          return createAsyncDerivedParserFromSyncFactory(
+            id,
+            options,
+          ) as unknown as DerivedValueParser<M, U, T>;
+        }
+        return createSyncDerivedParser(
           id,
           options,
         ) as unknown as DerivedValueParser<M, U, T>;
-      }
-      return createSyncDerivedParser(
-        id,
-        options,
-      ) as unknown as DerivedValueParser<M, U, T>;
-    },
-    deriveAsync<U>(
-      options: DeriveAsyncOptions<T, U>,
-    ): DerivedValueParser<"async", U, T> {
-      // Skip mode detection—the type guarantees the factory returns async.
-      return createAsyncDerivedParserFromAsyncFactory(id, options);
-    },
-  };
+      },
+      deriveAsync<U>(
+        options: DeriveAsyncOptions<T, U>,
+      ): DerivedValueParser<"async", U, T> {
+        // Skip mode detection—the type guarantees the factory returns async.
+        return createAsyncDerivedParserFromAsyncFactory(id, options);
+      },
+    }),
+  );
   return result;
 }
 
@@ -690,7 +716,7 @@ export function deriveFrom<
   const depsAsync = options.dependencies.some((dep) => dep.mode === "async");
 
   const sourceId = options.dependencies.length > 0
-    ? options.dependencies[0][dependencyId]
+    ? options.dependencies[0][dependencySourceId]
     : Symbol();
 
   // Use the explicit mode to avoid calling the factory during
@@ -748,7 +774,7 @@ export function deriveFromSync<
   const depsAsync = options.dependencies.some((dep) => dep.mode === "async");
 
   const sourceId = options.dependencies.length > 0
-    ? options.dependencies[0][dependencyId]
+    ? options.dependencies[0][dependencySourceId]
     : Symbol();
 
   if (depsAsync) {
@@ -793,7 +819,7 @@ export function deriveFromAsync<
   options: DeriveFromAsyncOptions<Deps, T>,
 ): DerivedValueParser<"async", T, DependencyValues<Deps>> {
   const sourceId = options.dependencies.length > 0
-    ? options.dependencies[0][dependencyId]
+    ? options.dependencies[0][dependencySourceId]
     : Symbol();
 
   return createAsyncDerivedFromParserFromAsyncFactory(sourceId, options);
@@ -924,7 +950,9 @@ function createSyncDerivedFromParser<
   options: DeriveFromSyncOptions<Deps, T>,
 ): DerivedValueParser<"sync", T, DependencyValues<Deps>> {
   // Collect all dependency IDs for multi-dependency resolution
-  const alldependencyIds = options.dependencies.map((dep) => dep[dependencyId]);
+  const alldependencyIds = options.dependencies.map((dep) =>
+    dep[dependencySourceId]
+  );
 
   return {
     mode: "sync",
@@ -1087,7 +1115,9 @@ function createAsyncDerivedFromParserFromAsyncFactory<
   options: DeriveFromAsyncOptions<Deps, T>,
 ): DerivedValueParser<"async", T, DependencyValues<Deps>> {
   // Collect all dependency IDs for multi-dependency resolution
-  const alldependencyIds = options.dependencies.map((dep) => dep[dependencyId]);
+  const alldependencyIds = options.dependencies.map((dep) =>
+    dep[dependencySourceId]
+  );
 
   return {
     mode: "async",
@@ -1231,7 +1261,9 @@ function createAsyncDerivedFromParserFromSyncFactory<
   options: DeriveFromSyncOptions<Deps, T>,
 ): DerivedValueParser<"async", T, DependencyValues<Deps>> {
   // Collect all dependency IDs for multi-dependency resolution
-  const alldependencyIds = options.dependencies.map((dep) => dep[dependencyId]);
+  const alldependencyIds = options.dependencies.map((dep) =>
+    dep[dependencySourceId]
+  );
 
   return {
     mode: "async",

--- a/packages/core/src/primitives.test.ts
+++ b/packages/core/src/primitives.test.ts
@@ -43,6 +43,7 @@ import {
 } from "#src/internal/dependency.ts";
 import { annotationKey } from "#src/internal/annotations.ts";
 import { extractDependencyMetadata } from "#src/dependency-metadata.ts";
+import { extractRawInputFromState } from "#src/dependency-runtime.ts";
 import {
   type InferValue,
   parse,
@@ -533,6 +534,23 @@ describe("option", () => {
         }
         assert.deepEqual(result.next.buffer, []);
         assert.deepEqual(result.consumed, ["--port", "8080"]);
+      }
+    });
+
+    it("should not record raw input for a plain value parser", () => {
+      const parser = option("--value", string());
+      const context = {
+        buffer: ["--value", "plain"] as readonly string[],
+        state: parser.initialState,
+        optionsTerminated: false,
+        usage: parser.usage,
+      };
+
+      const result = parser.parse(context);
+
+      assert.ok(result.success);
+      if (result.success) {
+        assert.equal(extractRawInputFromState(result.next.state), undefined);
       }
     });
 

--- a/packages/core/src/primitives.test.ts
+++ b/packages/core/src/primitives.test.ts
@@ -36,8 +36,8 @@ import {
 } from "@optique/core/valueparser";
 import {
   dependency,
-  dependencyId,
   DependencyRegistry,
+  dependencySourceId,
   deriveFromAsync,
   deriveFromSync,
 } from "#src/internal/dependency.ts";
@@ -534,6 +534,60 @@ describe("option", () => {
         assert.deepEqual(result.next.buffer, []);
         assert.deepEqual(result.consumed, ["--port", "8080"]);
       }
+    });
+
+    it("should preserve a value parser result prototype", () => {
+      const valueParser: ValueParser<"sync", string> = {
+        mode: "sync",
+        metavar: "VALUE",
+        placeholder: "",
+        parse(input) {
+          const prototype: ValueParserResult<string> = {
+            success: true,
+            value: input,
+          };
+          return Object.create(prototype) as ValueParserResult<string>;
+        },
+        format(value) {
+          return value;
+        },
+      };
+      const parser = option("--value", valueParser);
+
+      const result = parseSync(parser, ["--value", "inherited"]);
+
+      assert.deepEqual(result, { success: true, value: "inherited" });
+    });
+
+    it("should preserve private state in a value parser result", () => {
+      class PrivateResult {
+        readonly success = true as const;
+        readonly #value: string;
+
+        constructor(value: string) {
+          this.#value = value;
+        }
+
+        get value(): string {
+          return this.#value;
+        }
+      }
+      const valueParser: ValueParser<"sync", string> = {
+        mode: "sync",
+        metavar: "VALUE",
+        placeholder: "",
+        parse(input) {
+          return new PrivateResult(input);
+        },
+        format(value) {
+          return value;
+        },
+      };
+      const parser = option("--value", valueParser);
+
+      const result = parseSync(parser, ["--value", "private"]);
+
+      assert.deepEqual(result, { success: true, value: "private" });
     });
 
     it("should parse option with equals-separated value", () => {
@@ -7178,7 +7232,7 @@ describe("branch coverage: primitives edge cases", () => {
     });
     const parser = option("--target", asyncDerived);
     const registry = new DependencyRegistry();
-    registry.set(modeDep[dependencyId], "prod");
+    registry.set(modeDep[dependencySourceId], "prod");
     const ctx = {
       buffer: ["--target"] as readonly string[],
       state: undefined,
@@ -7228,7 +7282,7 @@ describe("branch coverage: primitives edge cases", () => {
       usage: parser.usage,
       dependencyRegistry: (() => {
         const r = new DependencyRegistry();
-        r.set(modeDep[dependencyId], "prod");
+        r.set(modeDep[dependencySourceId], "prod");
         return r;
       })(),
     };

--- a/packages/core/src/primitives.ts
+++ b/packages/core/src/primitives.ts
@@ -17,6 +17,7 @@ import { extractDependencyMetadata } from "./dependency-metadata.ts";
 import {
   type EffectfulSchedulingNodesFn,
   effectfulSchedulingNodesKey,
+  recordDerivedRawInput,
   replayDerivedParser,
   replayDerivedParserAsync,
   sourceCollectionExpansionKey,
@@ -90,7 +91,9 @@ function isTerminalValueState<T>(
  */
 function createOptionParseState<M extends Mode, T>(
   parseResult: ValueParserResult<T>,
+  rawInput: string,
 ): ValueParserResult<T> {
+  recordDerivedRawInput(parseResult, rawInput);
   return parseResult;
 }
 
@@ -175,6 +178,18 @@ function resolveDerivedCompletionSync<T>(
   return replayed as ValueParserResult<T> ??
     traceEntry.preliminaryResult as ValueParserResult<T> ??
     state;
+}
+
+function includeDependencyFailureChain(
+  error: Message,
+  dependencyMetadata: ReturnType<typeof extractDependencyMetadata> | undefined,
+  exec: ExecutionContext | undefined,
+): Message {
+  const sourceId = dependencyMetadata?.source?.sourceId;
+  if (sourceId == null || exec?.dependencyRuntime == null) return error;
+  const chain = exec.dependencyRuntime.getSourceFailureChain(sourceId);
+  if (chain == null || chain.length < 2) return error;
+  return message`${error} Dependency chain: ${chain.join(" -> ")}.`;
 }
 
 async function resolveDerivedCompletionAsync<T>(
@@ -1087,7 +1102,7 @@ export function option<M extends Mode, T>(
               success: true as const,
               next: {
                 ...next,
-                state: createOptionParseState(parseResult),
+                state: createOptionParseState(parseResult, rawInput),
                 buffer: context.buffer.slice(2),
               },
               consumed: context.buffer.slice(0, 2),
@@ -1110,7 +1125,7 @@ export function option<M extends Mode, T>(
               success: true as const,
               next: {
                 ...next,
-                state: createOptionParseState(parseResult),
+                state: createOptionParseState(parseResult, rawInput),
                 buffer: context.buffer.slice(2),
               },
               consumed: context.buffer.slice(0, 2),
@@ -1177,7 +1192,7 @@ export function option<M extends Mode, T>(
               success: true as const,
               next: {
                 ...next,
-                state: createOptionParseState(parseResult),
+                state: createOptionParseState(parseResult, rawInput),
                 buffer: context.buffer.slice(1),
               },
               consumed: context.buffer.slice(0, 1),
@@ -1200,7 +1215,7 @@ export function option<M extends Mode, T>(
               success: true as const,
               next: {
                 ...next,
-                state: createOptionParseState(parseResult),
+                state: createOptionParseState(parseResult, rawInput),
                 buffer: context.buffer.slice(1),
               },
               consumed: context.buffer.slice(0, 1),
@@ -1311,7 +1326,11 @@ export function option<M extends Mode, T>(
           : state;
         return resolvedState.success ? resolvedState : {
           success: false,
-          error: formatInvalidValueError(resolvedState.error),
+          error: formatInvalidValueError(includeDependencyFailureChain(
+            resolvedState.error,
+            dependencyMetadata,
+            exec,
+          )),
         };
       };
       const completeAsync = async (): Promise<
@@ -1328,7 +1347,11 @@ export function option<M extends Mode, T>(
         );
         return resolved.success ? resolved : {
           success: false,
-          error: formatInvalidValueError(resolved.error),
+          error: formatInvalidValueError(includeDependencyFailureChain(
+            resolved.error,
+            dependencyMetadata,
+            exec,
+          )),
         };
       };
       return dispatchByMode(
@@ -2560,7 +2583,7 @@ export function argument<M extends Mode, T>(
             next: {
               ...next,
               buffer: context.buffer.slice(i + 1),
-              state: createOptionParseState(parseResult),
+              state: createOptionParseState(parseResult, rawInput),
               optionsTerminated,
             },
             consumed: context.buffer.slice(0, i + 1),
@@ -2583,7 +2606,7 @@ export function argument<M extends Mode, T>(
             next: {
               ...next,
               buffer: context.buffer.slice(i + 1),
-              state: createOptionParseState(parseResult),
+              state: createOptionParseState(parseResult, rawInput),
               optionsTerminated,
             },
             consumed: context.buffer.slice(0, i + 1),
@@ -2609,7 +2632,11 @@ export function argument<M extends Mode, T>(
           : state;
         return resolvedState.success ? resolvedState : {
           success: false,
-          error: formatInvalidValueError(resolvedState.error),
+          error: formatInvalidValueError(includeDependencyFailureChain(
+            resolvedState.error,
+            dependencyMetadata,
+            exec,
+          )),
         };
       };
       const completeAsync = async (): Promise<ValueParserResult<T>> => {
@@ -2622,7 +2649,11 @@ export function argument<M extends Mode, T>(
         );
         return resolved.success ? resolved : {
           success: false,
-          error: formatInvalidValueError(resolved.error),
+          error: formatInvalidValueError(includeDependencyFailureChain(
+            resolved.error,
+            dependencyMetadata,
+            exec,
+          )),
         };
       };
       return dispatchByMode(

--- a/packages/core/src/primitives.ts
+++ b/packages/core/src/primitives.ts
@@ -17,6 +17,7 @@ import { extractDependencyMetadata } from "./dependency-metadata.ts";
 import {
   type EffectfulSchedulingNodesFn,
   effectfulSchedulingNodesKey,
+  includeSourceFailureChain,
   recordDerivedRawInput,
   replayDerivedParser,
   replayDerivedParserAsync,
@@ -190,9 +191,7 @@ function includeDependencyFailureChain(
 ): Message {
   const sourceId = dependencyMetadata?.source?.sourceId;
   if (sourceId == null || exec?.dependencyRuntime == null) return error;
-  const chain = exec.dependencyRuntime.getSourceFailureChain(sourceId);
-  if (chain == null || chain.length < 2) return error;
-  return message`${error} Dependency chain: ${chain.join(" -> ")}.`;
+  return includeSourceFailureChain(error, sourceId, exec.dependencyRuntime);
 }
 
 async function resolveDerivedCompletionAsync<T>(

--- a/packages/core/src/primitives.ts
+++ b/packages/core/src/primitives.ts
@@ -92,8 +92,11 @@ function isTerminalValueState<T>(
 function createOptionParseState<M extends Mode, T>(
   parseResult: ValueParserResult<T>,
   rawInput: string,
+  valueParser: ValueParser<M, T>,
 ): ValueParserResult<T> {
-  recordDerivedRawInput(parseResult, rawInput);
+  if (isDerivedValueParser(valueParser)) {
+    recordDerivedRawInput(parseResult, rawInput);
+  }
   return parseResult;
 }
 
@@ -1102,7 +1105,11 @@ export function option<M extends Mode, T>(
               success: true as const,
               next: {
                 ...next,
-                state: createOptionParseState(parseResult, rawInput),
+                state: createOptionParseState(
+                  parseResult,
+                  rawInput,
+                  syncValueParser!,
+                ),
                 buffer: context.buffer.slice(2),
               },
               consumed: context.buffer.slice(0, 2),
@@ -1125,7 +1132,11 @@ export function option<M extends Mode, T>(
               success: true as const,
               next: {
                 ...next,
-                state: createOptionParseState(parseResult, rawInput),
+                state: createOptionParseState(
+                  parseResult,
+                  rawInput,
+                  valueParser!,
+                ),
                 buffer: context.buffer.slice(2),
               },
               consumed: context.buffer.slice(0, 2),
@@ -1192,7 +1203,11 @@ export function option<M extends Mode, T>(
               success: true as const,
               next: {
                 ...next,
-                state: createOptionParseState(parseResult, rawInput),
+                state: createOptionParseState(
+                  parseResult,
+                  rawInput,
+                  syncValueParser!,
+                ),
                 buffer: context.buffer.slice(1),
               },
               consumed: context.buffer.slice(0, 1),
@@ -1215,7 +1230,11 @@ export function option<M extends Mode, T>(
               success: true as const,
               next: {
                 ...next,
-                state: createOptionParseState(parseResult, rawInput),
+                state: createOptionParseState(
+                  parseResult,
+                  rawInput,
+                  valueParser,
+                ),
                 buffer: context.buffer.slice(1),
               },
               consumed: context.buffer.slice(0, 1),
@@ -2583,7 +2602,11 @@ export function argument<M extends Mode, T>(
             next: {
               ...next,
               buffer: context.buffer.slice(i + 1),
-              state: createOptionParseState(parseResult, rawInput),
+              state: createOptionParseState(
+                parseResult,
+                rawInput,
+                syncValueParser,
+              ),
               optionsTerminated,
             },
             consumed: context.buffer.slice(0, i + 1),
@@ -2606,7 +2629,7 @@ export function argument<M extends Mode, T>(
             next: {
               ...next,
               buffer: context.buffer.slice(i + 1),
-              state: createOptionParseState(parseResult, rawInput),
+              state: createOptionParseState(parseResult, rawInput, valueParser),
               optionsTerminated,
             },
             consumed: context.buffer.slice(0, i + 1),

--- a/packages/prompt/src/index.test.ts
+++ b/packages/prompt/src/index.test.ts
@@ -675,6 +675,157 @@ function getPhase2ContextParsed<T>(request: unknown): T | undefined {
 
 // https://github.com/dahlia/optique/issues/870
 describe("prompted values as dependency sources", () => {
+  it("resolves a prompted source before a derived source chain", async () => {
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const packageManager = dependency(framework.deriveSync({
+      metavar: "PACKAGE_MANAGER",
+      factory: (value) =>
+        choice(value === "fresh" ? (["deno"] as const) : (["npm"] as const)),
+      defaultValue: () => "fresh" as const,
+    }));
+    const storage = packageManager.deriveSync({
+      metavar: "STORAGE",
+      factory: (value) =>
+        choice(value === "deno" ? (["kv"] as const) : (["redis"] as const)),
+      defaultValue: () => "deno" as const,
+    });
+    const { prompt, calls } = createTestPrompt();
+    const parser = object({
+      storage: option("--storage", storage),
+      packageManager: option("--package-manager", packageManager),
+      framework: prompt(option("--framework", framework), { value: "hono" }),
+    });
+
+    const result = await parseAsync(parser, [
+      "--package-manager",
+      "npm",
+      "--storage",
+      "redis",
+    ]);
+
+    assert.ok(result.success);
+    assert.deepEqual(result.value, {
+      storage: "redis",
+      packageManager: "npm",
+      framework: "hono",
+    });
+    assert.equal(calls.length, 1);
+  });
+
+  it("publishes a prompted value from a derived source", async () => {
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const packageManager = dependency(framework.deriveSync({
+      metavar: "PACKAGE_MANAGER",
+      factory: (value) =>
+        choice(value === "fresh" ? (["deno"] as const) : (["npm"] as const)),
+      defaultValue: () => "fresh" as const,
+    }));
+    const storage = packageManager.deriveSync({
+      metavar: "STORAGE",
+      factory: (value) =>
+        choice(value === "deno" ? (["kv"] as const) : (["redis"] as const)),
+      defaultValue: () => "deno" as const,
+    });
+    const { prompt, calls } = createTestPrompt();
+    const parser = object({
+      storage: option("--storage", storage),
+      packageManager: prompt(
+        option("--package-manager", packageManager),
+        { value: "npm" },
+      ),
+      framework: prompt(option("--framework", framework), { value: "hono" }),
+    });
+
+    const result = await parseAsync(parser, ["--storage", "redis"]);
+
+    assert.ok(result.success);
+    assert.deepEqual(result.value, {
+      storage: "redis",
+      packageManager: "npm",
+      framework: "hono",
+    });
+    assert.equal(calls.length, 2);
+  });
+
+  it("resolves derived-source suggestions without prompting", async () => {
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const packageManager = dependency(framework.deriveSync({
+      metavar: "PACKAGE_MANAGER",
+      factory: (value) =>
+        choice(value === "fresh" ? (["deno"] as const) : (["npm"] as const)),
+      defaultValue: () => "fresh" as const,
+    }));
+    const storage = packageManager.deriveSync({
+      metavar: "STORAGE",
+      factory: (value) =>
+        choice(value === "deno" ? (["kv"] as const) : (["redis"] as const)),
+      defaultValue: () => "deno" as const,
+    });
+    const { prompt, calls } = createTestPrompt();
+    const parser = object({
+      framework: prompt(option("--framework", framework), { value: "fresh" }),
+      packageManager: prompt(
+        option("--package-manager", packageManager),
+        { value: "deno" },
+      ),
+      storage: option("--storage", storage),
+    });
+
+    const suggestions = await suggestAsync(parser, [
+      "--framework",
+      "hono",
+      "--package-manager",
+      "npm",
+      "--storage",
+      "",
+    ]);
+
+    assert.deepEqual(
+      suggestions.flatMap((suggestion) =>
+        suggestion.kind === "literal" ? [suggestion.text] : []
+      ),
+      ["redis"],
+    );
+    assert.deepEqual(calls, []);
+  });
+
+  it("uses an inactive prompted source's default for derived suggestions", async () => {
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const packageManager = dependency(framework.deriveSync({
+      metavar: "PACKAGE_MANAGER",
+      factory: (value) =>
+        choice(value === "fresh" ? (["deno"] as const) : (["npm"] as const)),
+      defaultValue: () => "fresh" as const,
+    }));
+    const storage = packageManager.deriveSync({
+      metavar: "STORAGE",
+      factory: (value) =>
+        choice(value === "deno" ? (["kv"] as const) : (["redis"] as const)),
+      defaultValue: () => "npm" as const,
+    });
+    const { prompt, calls } = createTestPrompt();
+    const parser = object({
+      framework: prompt(option("--framework", framework), { value: "hono" }),
+      packageManager: option("--package-manager", packageManager),
+      storage: option("--storage", storage),
+    });
+
+    const suggestions = await suggestAsync(parser, [
+      "--package-manager",
+      "deno",
+      "--storage",
+      "",
+    ]);
+
+    assert.deepEqual(
+      suggestions.flatMap((suggestion) =>
+        suggestion.kind === "literal" ? [suggestion.text] : []
+      ),
+      ["kv"],
+    );
+    assert.deepEqual(calls, []);
+  });
+
   it("registers a prompted value for a derived parser", async () => {
     const { mode, level } = createModeFixture();
     const { prompt, calls } = createTestPrompt();
@@ -1263,6 +1414,31 @@ describe("prompted values as dependency sources", () => {
       assert.ok(result.success);
       assert.equal(result.value.a, "dev");
       assert.equal(result.value.level, "silent");
+      assert.equal(calls.length, 1);
+    },
+  );
+
+  it(
+    "does not treat a conditional source barrier as its own provider",
+    async () => {
+      const shared = dependency(choice(["dev", "prod"] as const));
+      const { prompt, calls } = createTestPrompt();
+      const parser = conditional(
+        prompt(option("--mode", shared), { value: "prod" }),
+        {
+          dev: object({
+            again: withDefault(option("--again", shared), "dev"),
+          }),
+          prod: object({
+            again: withDefault(option("--again", shared), "prod"),
+          }),
+        },
+      );
+
+      const result = await parseAsync(parser, []);
+
+      assert.ok(result.success);
+      assert.deepEqual(result.value, ["prod", { again: "prod" }]);
       assert.equal(calls.length, 1);
     },
   );


### PR DESCRIPTION
`dependency()` used one internal marker for both a source's identity and its upstream dependency, so wrapping a derived parser erased the information needed to continue the chain. Its preliminary result could then be published before replay, exposing a value computed from defaults.

This separates those identities and preserves both capabilities on the wrapped parser. Matched derived sources are replayed in stable dependency order and published only after their upstream values resolve. Raw input and default snapshots are retained without cloning parser results, which preserves lazy defaults and custom result objects.

The same resolution path serves sync/async parsing, suggestions, and prompt-backed sources. Effects remain completion-only, while suggestions treat inactive effectful providers as absent and continue through declared defaults.

Closes #871. Part of #869.
