### PR TITLE
Keep Twoslash documentation builds within the heap limit

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -7,7 +7,7 @@ on:
     tags:
     - "*.*.*"
     branches:
-    - "*"
+    - "**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -148,7 +148,7 @@ jobs:
       pages: write
       deployments: write
     environment:
-      name: github-pages
+      name: ${{ github.ref_type == 'tag' && 'github-pages' || 'preview' }}
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
     - uses: actions/checkout@v6
@@ -157,6 +157,16 @@ jobs:
         experimental: true
         install: true
         log_level: ${{ runner.debug == '1' && 'debug' || 'info' }}
+    - uses: actions/cache@v6
+      with:
+        path: docs/.vitepress/cache/twoslash
+        key: >-
+          twoslash-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml',
+          'docs/package.json', 'docs/.vitepress/*.mts',
+          'packages/**/package.json', 'packages/**/src/**') }}-${{
+          hashFiles('docs/**/*.md') }}
+        restore-keys: |
+          twoslash-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'docs/package.json', 'docs/.vitepress/*.mts', 'packages/**/package.json', 'packages/**/src/**') }}-
     - run: |
         set -ex
         if [[ "$GITHUB_REF_TYPE" = "tag" ]]; then

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -157,17 +157,19 @@ jobs:
         experimental: true
         install: true
         log_level: ${{ runner.debug == '1' && 'debug' || 'info' }}
+    - run: pnpm build:packages
+      working-directory: docs
     - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: docs/.vitepress/cache/twoslash
         key: >-
           twoslash-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml',
           'docs/package.json', 'docs/.vitepress/*.mts',
-          'packages/**/package.json', 'packages/**/tsdown.config.*',
-          'packages/**/src/**') }}-${{
+          'packages/**/dist/**/*.d.ts', 'packages/**/dist/**/*.d.mts',
+          'packages/**/dist/**/*.d.cts') }}-${{
           hashFiles('docs/**/*.md') }}
         restore-keys: |
-          twoslash-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'docs/package.json', 'docs/.vitepress/*.mts', 'packages/**/package.json', 'packages/**/tsdown.config.*', 'packages/**/src/**') }}-
+          twoslash-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'docs/package.json', 'docs/.vitepress/*.mts', 'packages/**/dist/**/*.d.ts', 'packages/**/dist/**/*.d.mts', 'packages/**/dist/**/*.d.cts') }}-
     - run: |
         set -ex
         if [[ "$GITHUB_REF_TYPE" = "tag" ]]; then
@@ -175,13 +177,13 @@ jobs:
           EXTRA_NAV_LINK="$UNSTABLE_DOCS_URL" \
           SITEMAP_HOSTNAME="$STABLE_DOCS_URL" \
           JSR_REF_VERSION=stable \
-          pnpm build
+          pnpm build:site
         else
           EXTRA_NAV_TEXT=Stable \
           EXTRA_NAV_LINK="$STABLE_DOCS_URL" \
           SITEMAP_HOSTNAME="$UNSTABLE_DOCS_URL" \
           JSR_REF_VERSION=unstable \
-          pnpm build
+          pnpm build:site
         fi
       env:
         STABLE_DOCS_URL: ${{ vars.STABLE_DOCS_URL }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -163,10 +163,11 @@ jobs:
         key: >-
           twoslash-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml',
           'docs/package.json', 'docs/.vitepress/*.mts',
-          'packages/**/package.json', 'packages/**/src/**') }}-${{
+          'packages/**/package.json', 'packages/**/tsdown.config.*',
+          'packages/**/src/**') }}-${{
           hashFiles('docs/**/*.md') }}
         restore-keys: |
-          twoslash-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'docs/package.json', 'docs/.vitepress/*.mts', 'packages/**/package.json', 'packages/**/src/**') }}-
+          twoslash-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'docs/package.json', 'docs/.vitepress/*.mts', 'packages/**/package.json', 'packages/**/tsdown.config.*', 'packages/**/src/**') }}-
     - run: |
         set -ex
         if [[ "$GITHUB_REF_TYPE" = "tag" ]]; then

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -157,7 +157,7 @@ jobs:
         experimental: true
         install: true
         log_level: ${{ runner.debug == '1' && 'debug' || 'info' }}
-    - uses: actions/cache@v6
+    - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: docs/.vitepress/cache/twoslash
         key: >-

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -2,7 +2,6 @@ import { transformerTwoslash } from "@shikijs/vitepress-twoslash";
 import deflist from "markdown-it-deflist";
 import footnote from "markdown-it-footnote";
 import process from "node:process";
-import { ModuleKind, ModuleResolutionKind, ScriptTarget } from "typescript";
 import { defineConfig } from "vitepress";
 import {
   groupIconMdPlugin,
@@ -10,6 +9,12 @@ import {
 } from "vitepress-plugin-group-icons";
 import llmstxt from "vitepress-plugin-llms";
 import { withMermaid } from "vitepress-plugin-mermaid";
+import {
+  createOptiqueTwoslashCaches,
+  twoslashCompilerOptions,
+} from "./twoslash-cache.mts";
+
+const twoslashCaches = createOptiqueTwoslashCaches(twoslashCompilerOptions);
 
 let extraNav: { text: string; link: string }[] = [];
 if (process.env.EXTRA_NAV_TEXT && process.env.EXTRA_NAV_LINK) {
@@ -240,15 +245,11 @@ export default withMermaid(defineConfig({
     ],
     codeTransformers: [
       transformerTwoslash({
+        typesCache: twoslashCaches.typesCache,
         twoslashOptions: {
-          compilerOptions: {
-            moduleResolution: ModuleResolutionKind.Bundler,
-            module: ModuleKind.ESNext,
-            target: ScriptTarget.ESNext,
-            lib: ["dom", "dom.iterable", "esnext"],
-            types: ["dom", "dom.iterable", "esnext", "node"],
-          },
-          // Reuse language service instance across files to reduce memory usage
+          cache: twoslashCaches.environmentCache,
+          compilerOptions: twoslashCompilerOptions,
+          // Generate hover information for every identifier in the examples.
           shouldGetHoverInfo: () => true,
         },
       }),
@@ -286,6 +287,24 @@ export default withMermaid(defineConfig({
           "changelog.md",
         ],
       }),
+      {
+        name: "optique:release-written-bundle-memory",
+        apply: "build",
+        writeBundle: {
+          order: "post",
+          handler(_options, bundle) {
+            for (const output of Object.values(bundle)) {
+              if (output.type === "chunk") {
+                output.code = "";
+                output.map = null;
+                output.modules = {};
+              } else {
+                output.source = "";
+              }
+            }
+          },
+        },
+      },
     ],
   },
 

--- a/docs/.vitepress/twoslash-cache.mts
+++ b/docs/.vitepress/twoslash-cache.mts
@@ -1,0 +1,206 @@
+import type { VitePressPluginTwoslashOptions } from "@shikijs/vitepress-twoslash";
+import { createFileSystemTypesCache } from "@shikijs/vitepress-twoslash/cache-fs";
+import { createHash } from "node:crypto";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import { ModuleKind, ModuleResolutionKind, ScriptTarget } from "typescript";
+
+const cacheFormatVersion = 2;
+const docsDirectory = fileURLToPath(new URL("../", import.meta.url));
+const repositoryDirectory = fileURLToPath(new URL("../../", import.meta.url));
+
+type TwoslashOptions = NonNullable<
+  VitePressPluginTwoslashOptions["twoslashOptions"]
+>;
+type TwoslashEnvironmentCache = Exclude<
+  TwoslashOptions["cache"],
+  boolean | undefined
+>;
+type TwoslashTypesCache = NonNullable<
+  VitePressPluginTwoslashOptions["typesCache"]
+>;
+
+export const twoslashCompilerOptions = {
+  moduleResolution: ModuleResolutionKind.Bundler,
+  module: ModuleKind.ESNext,
+  target: ScriptTarget.ESNext,
+  lib: ["dom", "dom.iterable", "esnext"],
+  types: ["dom", "dom.iterable", "esnext", "node"],
+};
+
+export interface TwoslashBlock {
+  readonly code: string;
+  readonly lang: string;
+  readonly meta: string;
+}
+
+const languageAliases: Readonly<Record<string, string>> = {
+  javascript: "js",
+  typescript: "ts",
+};
+
+export function extractTwoslashBlocks(markdown: string): TwoslashBlock[] {
+  const blocks: TwoslashBlock[] = [];
+  const lines = markdown.split(/\r?\n/);
+
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+    const opening = lines[lineIndex].match(
+      /^((?:[ \t]|> ?)*)~~~~\s+(\S+)\s+(.+)$/,
+    );
+    if (opening == null || !opening[3].split(/\s+/).includes("twoslash")) {
+      continue;
+    }
+
+    const prefix = opening[1];
+    const code: string[] = [];
+    for (
+      lineIndex++;
+      lineIndex < lines.length && lines[lineIndex] !== `${prefix}~~~~`;
+      lineIndex++
+    ) {
+      const line = lines[lineIndex];
+      if (line.startsWith(prefix)) {
+        code.push(line.slice(prefix.length));
+      } else if (prefix.endsWith(" ") && line === prefix.trimEnd()) {
+        code.push("");
+      } else {
+        code.push(line);
+      }
+    }
+
+    blocks.push({
+      code: code.join("\n").replace(/\n+$/, ""),
+      lang: languageAliases[opening[2]] ?? opening[2],
+      meta: opening[3],
+    });
+  }
+
+  return blocks;
+}
+
+function normalizeForCacheKey(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(normalizeForCacheKey);
+  if (value != null && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, item]) => [key, normalizeForCacheKey(item)]),
+    );
+  }
+  return value;
+}
+
+export function computeTwoslashCacheNamespace(
+  formatVersion: number,
+  compilerOptions: Readonly<Record<string, unknown>>,
+  typeEnvironmentFiles: ReadonlyMap<string, string>,
+): string {
+  const hash = createHash("sha256");
+  hash.update(`optique-twoslash-cache:${formatVersion}\0`);
+  hash.update(JSON.stringify(normalizeForCacheKey(compilerOptions)));
+  hash.update("\0");
+
+  const files = Array.from(typeEnvironmentFiles).sort(([left], [right]) =>
+    left.localeCompare(right)
+  );
+  for (const [path, contents] of files) {
+    hash.update(path);
+    hash.update("\0");
+    hash.update(contents);
+    hash.update("\0");
+  }
+
+  return hash.digest("hex");
+}
+
+export function createLanguageAwareTypesCache(
+  cache: TwoslashTypesCache,
+): TwoslashTypesCache {
+  const getKey = (code: string, lang: string | undefined): string =>
+    `${JSON.stringify(lang ?? null)}\0${code}`;
+
+  return {
+    init: cache.init,
+    preprocess: cache.preprocess,
+    read(code, lang, options, meta) {
+      try {
+        return cache.read(getKey(code, lang), lang, options, meta);
+      } catch (error) {
+        if (error instanceof SyntaxError) return null;
+        throw error;
+      }
+    },
+    write(code, data, lang, options, meta) {
+      cache.write(getKey(code, lang), data, lang, options, meta);
+    },
+  };
+}
+
+function isDeclarationFile(path: string): boolean {
+  return path.endsWith(".d.ts") ||
+    path.endsWith(".d.mts") ||
+    path.endsWith(".d.cts");
+}
+
+function collectDeclarationFiles(directory: string): string[] {
+  if (!existsSync(directory)) return [];
+
+  const files: string[] = [];
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectDeclarationFiles(path));
+    } else if (entry.isFile() && isDeclarationFile(path)) {
+      files.push(path);
+    }
+  }
+  return files;
+}
+
+function getTypeEnvironmentFiles(): ReadonlyMap<string, string> {
+  const files = [join(repositoryDirectory, "pnpm-lock.yaml")];
+  const packagesDirectory = join(repositoryDirectory, "packages");
+
+  for (
+    const entry of readdirSync(packagesDirectory, { withFileTypes: true })
+  ) {
+    if (!entry.isDirectory()) continue;
+    files.push(
+      ...collectDeclarationFiles(join(packagesDirectory, entry.name, "dist")),
+    );
+  }
+
+  return new Map(
+    files.sort().map((path) => [
+      relative(repositoryDirectory, path),
+      readFileSync(path, "utf8"),
+    ]),
+  );
+}
+
+export function createOptiqueTwoslashCaches(
+  compilerOptions: Readonly<Record<string, unknown>>,
+): {
+  readonly environmentCache: TwoslashEnvironmentCache;
+  readonly typesCache: TwoslashTypesCache;
+} {
+  const namespace = computeTwoslashCacheNamespace(
+    cacheFormatVersion,
+    compilerOptions,
+    getTypeEnvironmentFiles(),
+  );
+  const typesCache = createLanguageAwareTypesCache(
+    createFileSystemTypesCache({
+      dir: join(
+        docsDirectory,
+        ".vitepress",
+        "cache",
+        "twoslash",
+        namespace,
+      ),
+    }),
+  );
+
+  return { environmentCache: new Map(), typesCache };
+}

--- a/docs/.vitepress/twoslash-cache.mts
+++ b/docs/.vitepress/twoslash-cache.mts
@@ -46,17 +46,25 @@ export function extractTwoslashBlocks(markdown: string): TwoslashBlock[] {
 
   for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
     const opening = lines[lineIndex].match(
-      /^((?:[ \t]|> ?)*)~~~~\s+(\S+)\s+(.+)$/,
+      /^((?:[ \t]|> ?)*)(`{3,}|~{3,})[ \t]*(\S+)[ \t]+(.+)$/,
     );
-    if (opening == null || !opening[3].split(/\s+/).includes("twoslash")) {
+    if (opening == null || !opening[4].split(/\s+/).includes("twoslash")) {
       continue;
     }
 
     const prefix = opening[1];
+    const fence = opening[2];
+    const isClosingFence = (line: string): boolean => {
+      if (!line.startsWith(prefix)) return false;
+      const closing = line.slice(prefix.length).match(/^(`+|~+)[ \t]*$/);
+      return closing != null &&
+        closing[1][0] === fence[0] &&
+        closing[1].length >= fence.length;
+    };
     const code: string[] = [];
     for (
       lineIndex++;
-      lineIndex < lines.length && lines[lineIndex] !== `${prefix}~~~~`;
+      lineIndex < lines.length && !isClosingFence(lines[lineIndex]);
       lineIndex++
     ) {
       const line = lines[lineIndex];
@@ -71,8 +79,8 @@ export function extractTwoslashBlocks(markdown: string): TwoslashBlock[] {
 
     blocks.push({
       code: code.join("\n").replace(/\n+$/, ""),
-      lang: languageAliases[opening[2]] ?? opening[2],
-      meta: opening[3],
+      lang: languageAliases[opening[3]] ?? opening[3],
+      meta: opening[4],
     });
   }
 

--- a/docs/.vitepress/twoslash-cache.test.mts
+++ b/docs/.vitepress/twoslash-cache.test.mts
@@ -159,6 +159,38 @@ describe("extractTwoslashBlocks", () => {
     ]);
   });
 
+  it("should support VitePress fence characters and lengths", () => {
+    // Arrange
+    const markdown = [
+      "```typescript twoslash",
+      "const first: number = 1;",
+      "```",
+      "",
+      "~~~~~ ts twoslash",
+      "const second: number = 2;",
+      "`````",
+      "~~~~",
+      "~~~~~~",
+    ].join("\n");
+
+    // Act
+    const blocks = extractTwoslashBlocks(markdown);
+
+    // Assert
+    assert.deepEqual(blocks, [
+      {
+        code: "const first: number = 1;",
+        lang: "ts",
+        meta: "twoslash",
+      },
+      {
+        code: "const second: number = 2;\n`````\n~~~~",
+        lang: "ts",
+        meta: "twoslash",
+      },
+    ]);
+  });
+
   it("should remove trailing blank lines like VitePress", () => {
     // Arrange
     const markdown = [

--- a/docs/.vitepress/twoslash-cache.test.mts
+++ b/docs/.vitepress/twoslash-cache.test.mts
@@ -1,0 +1,293 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  computeTwoslashCacheNamespace,
+  createLanguageAwareTypesCache,
+  extractTwoslashBlocks,
+} from "./twoslash-cache.mts";
+
+const compilerOptions = {
+  module: 99,
+  moduleResolution: 100,
+  target: 99,
+  lib: ["dom", "esnext"],
+};
+
+const typeEnvironmentFiles = new Map([
+  ["pnpm-lock.yaml", "lockfileVersion: '9.0'"],
+  ["packages/core/dist/index.d.ts", "export type Parser = unknown;"],
+]);
+
+describe("computeTwoslashCacheNamespace", () => {
+  it("should ignore the input file order", () => {
+    // Arrange
+    const reversedFiles = new Map(Array.from(typeEnvironmentFiles).reverse());
+
+    // Act
+    const first = computeTwoslashCacheNamespace(
+      1,
+      compilerOptions,
+      typeEnvironmentFiles,
+    );
+    const second = computeTwoslashCacheNamespace(
+      1,
+      compilerOptions,
+      reversedFiles,
+    );
+
+    // Assert
+    assert.equal(first, second);
+  });
+
+  it("should change when the cache format changes", () => {
+    // Act
+    const first = computeTwoslashCacheNamespace(
+      1,
+      compilerOptions,
+      typeEnvironmentFiles,
+    );
+    const second = computeTwoslashCacheNamespace(
+      2,
+      compilerOptions,
+      typeEnvironmentFiles,
+    );
+
+    // Assert
+    assert.notEqual(first, second);
+  });
+
+  it("should change when the compiler options change", () => {
+    // Arrange
+    const changedOptions = { ...compilerOptions, strict: true };
+
+    // Act
+    const first = computeTwoslashCacheNamespace(
+      1,
+      compilerOptions,
+      typeEnvironmentFiles,
+    );
+    const second = computeTwoslashCacheNamespace(
+      1,
+      changedOptions,
+      typeEnvironmentFiles,
+    );
+
+    // Assert
+    assert.notEqual(first, second);
+  });
+
+  it("should change when the lockfile changes", () => {
+    // Arrange
+    const changedFiles = new Map(typeEnvironmentFiles);
+    changedFiles.set("pnpm-lock.yaml", "lockfileVersion: '10.0'");
+
+    // Act
+    const first = computeTwoslashCacheNamespace(
+      1,
+      compilerOptions,
+      typeEnvironmentFiles,
+    );
+    const second = computeTwoslashCacheNamespace(
+      1,
+      compilerOptions,
+      changedFiles,
+    );
+
+    // Assert
+    assert.notEqual(first, second);
+  });
+
+  it("should change when a declaration changes", () => {
+    // Arrange
+    const changedFiles = new Map(typeEnvironmentFiles);
+    changedFiles.set(
+      "packages/core/dist/index.d.ts",
+      "export interface Parser {}",
+    );
+
+    // Act
+    const first = computeTwoslashCacheNamespace(
+      1,
+      compilerOptions,
+      typeEnvironmentFiles,
+    );
+    const second = computeTwoslashCacheNamespace(
+      1,
+      compilerOptions,
+      changedFiles,
+    );
+
+    // Assert
+    assert.notEqual(first, second);
+  });
+});
+
+describe("extractTwoslashBlocks", () => {
+  it("should extract Twoslash fences with normalized languages", () => {
+    // Arrange
+    const markdown = [
+      "Before.",
+      "",
+      "~~~~ typescript twoslash",
+      'const greeting = "Hello";',
+      "~~~~",
+      "",
+      "~~~~ javascript",
+      'console.log("Not checked");',
+      "~~~~",
+      "",
+      "~~~~ ts twoslash",
+      "const answer: number = 42;",
+      "~~~~",
+    ].join("\n");
+
+    // Act
+    const blocks = extractTwoslashBlocks(markdown);
+
+    // Assert
+    assert.deepEqual(blocks, [
+      {
+        code: 'const greeting = "Hello";',
+        lang: "ts",
+        meta: "twoslash",
+      },
+      {
+        code: "const answer: number = 42;",
+        lang: "ts",
+        meta: "twoslash",
+      },
+    ]);
+  });
+
+  it("should remove trailing blank lines like VitePress", () => {
+    // Arrange
+    const markdown = [
+      "~~~~ typescript twoslash",
+      "const answer = 42;",
+      "",
+      "",
+      "~~~~",
+    ].join("\n");
+
+    // Act
+    const [block] = extractTwoslashBlocks(markdown);
+
+    // Assert
+    assert.equal(block.code, "const answer = 42;");
+  });
+
+  it("should extract fences from CRLF Markdown", () => {
+    // Arrange
+    const markdown = [
+      "~~~~ typescript twoslash",
+      "const answer = 42;",
+      "~~~~",
+    ].join("\r\n");
+
+    // Act
+    const [block] = extractTwoslashBlocks(markdown);
+
+    // Assert
+    assert.equal(block.code, "const answer = 42;");
+  });
+
+  it("should extract Twoslash fences indented under definition lists", () => {
+    // Arrange
+    const markdown = [
+      "`example`",
+      ":   A nested example.",
+      "",
+      "    ~~~~ typescript twoslash",
+      "    const answer: number = 42;",
+      "    ~~~~",
+    ].join("\n");
+
+    // Act
+    const [block] = extractTwoslashBlocks(markdown);
+
+    // Assert
+    assert.deepEqual(block, {
+      code: "const answer: number = 42;",
+      lang: "ts",
+      meta: "twoslash",
+    });
+  });
+
+  it("should extract Twoslash fences nested in GitHub alerts", () => {
+    // Arrange
+    const markdown = [
+      "> [!NOTE]",
+      "> A nested example.",
+      ">",
+      "> ~~~~ typescript twoslash",
+      "> const answer: number = 42;",
+      ">",
+      '> const label = "answer";',
+      "> ~~~~",
+    ].join("\n");
+
+    // Act
+    const [block] = extractTwoslashBlocks(markdown);
+
+    // Assert
+    assert.deepEqual(block, {
+      code: 'const answer: number = 42;\n\nconst label = "answer";',
+      lang: "ts",
+      meta: "twoslash",
+    });
+  });
+});
+
+describe("createLanguageAwareTypesCache", () => {
+  it("should separate identical source across languages", () => {
+    // Arrange
+    const keys: string[] = [];
+    const cache = createLanguageAwareTypesCache({
+      read(code) {
+        keys.push(code);
+        return null;
+      },
+      write() {},
+    });
+
+    // Act
+    cache.read("const answer = 42;", "ts");
+    cache.read("const answer = 42;", "js");
+
+    // Assert
+    assert.notEqual(keys[0], keys[1]);
+  });
+
+  it("should treat malformed cache entries as misses", () => {
+    // Arrange
+    const cache = createLanguageAwareTypesCache({
+      read() {
+        throw new SyntaxError("Unterminated string in JSON.");
+      },
+      write() {},
+    });
+
+    // Act
+    const result = cache.read("const answer = 42;", "ts");
+
+    // Assert
+    assert.equal(result, null);
+  });
+
+  it("should preserve non-syntax cache read failures", () => {
+    // Arrange
+    const failure = new Error("Permission denied.");
+    const cache = createLanguageAwareTypesCache({
+      read() {
+        throw failure;
+      },
+      write() {},
+    });
+
+    // Act and assert
+    assert.throws(
+      () => cache.read("const answer = 42;", "ts"),
+      (error) => error === failure,
+    );
+  });
+});

--- a/docs/.vitepress/warm-twoslash-cache.mts
+++ b/docs/.vitepress/warm-twoslash-cache.mts
@@ -1,0 +1,173 @@
+import { transformerTwoslash } from "@shikijs/vitepress-twoslash";
+import { spawnSync } from "node:child_process";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+import { createHighlighter } from "shiki";
+import {
+  createOptiqueTwoslashCaches,
+  extractTwoslashBlocks,
+  type TwoslashBlock,
+  twoslashCompilerOptions,
+} from "./twoslash-cache.mts";
+
+const batchSize = 48;
+const docsDirectory = fileURLToPath(new URL("../", import.meta.url));
+const languages = [
+  "js",
+  "jsx",
+  "ts",
+  "tsx",
+  "zsh",
+  "bash",
+  "fish",
+  "powershell",
+  "json",
+  "vue",
+];
+
+const twoslashOptions = {
+  compilerOptions: twoslashCompilerOptions,
+  shouldGetHoverInfo: () => true,
+};
+
+function collectMarkdownFiles(directory: string): string[] {
+  const files: string[] = [];
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    if (entry.name === ".vitepress" || entry.name === "node_modules") {
+      continue;
+    }
+
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectMarkdownFiles(path));
+    } else if (entry.isFile() && entry.name.endsWith(".md")) {
+      files.push(path);
+    }
+  }
+  return files;
+}
+
+function getDocumentationBlocks(): TwoslashBlock[] {
+  const blocks: TwoslashBlock[] = [];
+  const files = collectMarkdownFiles(docsDirectory).sort();
+
+  for (const file of files) {
+    blocks.push(
+      ...extractTwoslashBlocks(readFileSync(file, "utf8")),
+    );
+  }
+  return blocks;
+}
+
+function getMissingBlockIndices(blocks: readonly TwoslashBlock[]): number[] {
+  const { typesCache } = createOptiqueTwoslashCaches(
+    twoslashCompilerOptions,
+  );
+  typesCache.init?.();
+
+  const missing: number[] = [];
+  for (const [index, block] of blocks.entries()) {
+    if (typesCache.read(block.code, block.lang, twoslashOptions, {}) == null) {
+      missing.push(index);
+    }
+  }
+  return missing;
+}
+
+async function warmBlocks(
+  blocks: readonly TwoslashBlock[],
+  indices: readonly number[],
+): Promise<void> {
+  const caches = createOptiqueTwoslashCaches(twoslashCompilerOptions);
+  const transformer = transformerTwoslash({
+    typesCache: caches.typesCache,
+    twoslashOptions: {
+      ...twoslashOptions,
+      cache: caches.environmentCache,
+    },
+  });
+  const highlighter = await createHighlighter({
+    langs: languages,
+    themes: ["github-dark"],
+  });
+
+  try {
+    for (const index of indices) {
+      const block = blocks[index];
+      await highlighter.codeToHtml(block.code, {
+        lang: block.lang,
+        meta: { __raw: block.meta },
+        theme: "github-dark",
+        transformers: [transformer],
+      });
+    }
+  } finally {
+    highlighter.dispose();
+  }
+}
+
+function parseWorkerIndices(value: string | undefined): number[] {
+  if (value == null || value.length < 1) {
+    throw new TypeError("The Twoslash cache worker requires block indices.");
+  }
+
+  return value.split(",").map((part) => {
+    const index = Number(part);
+    if (!Number.isSafeInteger(index) || index < 0) {
+      throw new TypeError(`Invalid Twoslash block index: ${part}`);
+    }
+    return index;
+  });
+}
+
+function runWorkers(indices: readonly number[]): void {
+  const script = fileURLToPath(import.meta.url);
+  const batchCount = Math.ceil(indices.length / batchSize);
+  for (let offset = 0; offset < indices.length; offset += batchSize) {
+    const batch = indices.slice(offset, offset + batchSize);
+    console.log(
+      `Warming Twoslash cache batch ${offset / batchSize + 1}/${batchCount}.`,
+    );
+    const result = spawnSync(
+      process.execPath,
+      [script, "--worker", batch.join(",")],
+      {
+        cwd: docsDirectory,
+        env: process.env,
+        stdio: "inherit",
+      },
+    );
+    if (result.error != null) throw result.error;
+    if (result.status !== 0) {
+      throw new Error(
+        `Twoslash cache worker exited with status ${result.status}.`,
+      );
+    }
+  }
+}
+
+async function main(): Promise<void> {
+  const blocks = getDocumentationBlocks();
+  if (process.argv[2] === "--worker") {
+    await warmBlocks(blocks, parseWorkerIndices(process.argv[3]));
+    return;
+  }
+
+  const missing = getMissingBlockIndices(blocks);
+  if (missing.length < 1) {
+    console.log(`Twoslash cache contains all ${blocks.length} results.`);
+    return;
+  }
+
+  console.log(
+    `Warming ${missing.length} of ${blocks.length} Twoslash cache results.`,
+  );
+  runWorkers(missing);
+  console.log("Twoslash cache is warm.");
+}
+
+if (fileURLToPath(import.meta.url) === process.argv[1]) {
+  await main();
+}

--- a/docs/package.json
+++ b/docs/package.json
@@ -25,6 +25,7 @@
     "markdown-it-deflist": "^3.0.0",
     "markdown-it-footnote": "^4.0.0",
     "mermaid": "^11.16.0",
+    "shiki": "3.20.0",
     "typescript": "catalog:",
     "valibot": "catalog:",
     "vitepress": "^2.0.0-alpha.17",
@@ -35,8 +36,9 @@
   },
   "scripts": {
     "dev": "cd ../ && pnpm run --filter '!{docs}' -r build && cd docs/ && vitepress dev",
-    "build": "cd ../ && pnpm run --filter '!{docs}' -r build && cd docs/ && NODE_OPTIONS=--max-old-space-size=12288 vitepress build",
-    "preview": "vitepress preview"
+    "build": "cd ../ && pnpm run --filter '!{docs}' -r build && cd docs/ && node .vitepress/warm-twoslash-cache.mts && NODE_OPTIONS=--max-old-space-size=12288 vitepress build",
+    "preview": "vitepress preview",
+    "test": "tsc --noEmit --allowImportingTsExtensions --module nodenext --moduleResolution nodenext --target esnext --types node --skipLibCheck .vitepress/twoslash-cache.mts .vitepress/twoslash-cache.test.mts .vitepress/warm-twoslash-cache.mts && node --test .vitepress/*.test.mts"
   },
   "dependencies": {
     "wrangler": "^4",

--- a/docs/package.json
+++ b/docs/package.json
@@ -35,8 +35,10 @@
     "zod": "catalog:"
   },
   "scripts": {
-    "dev": "cd ../ && pnpm run --filter '!{docs}' -r build && cd docs/ && vitepress dev",
-    "build": "cd ../ && pnpm run --filter '!{docs}' -r build && cd docs/ && node .vitepress/warm-twoslash-cache.mts && NODE_OPTIONS=--max-old-space-size=12288 vitepress build",
+    "dev": "pnpm build:packages && vitepress dev",
+    "build": "pnpm build:packages && pnpm build:site",
+    "build:packages": "cd ../ && pnpm run --filter '!{docs}' -r build",
+    "build:site": "node .vitepress/warm-twoslash-cache.mts && NODE_OPTIONS=--max-old-space-size=12288 vitepress build",
     "preview": "vitepress preview",
     "test": "tsc --noEmit --allowImportingTsExtensions --module nodenext --moduleResolution nodenext --target esnext --types node --skipLibCheck .vitepress/twoslash-cache.mts .vitepress/twoslash-cache.test.mts .vitepress/warm-twoslash-cache.mts && node --test .vitepress/*.test.mts"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,6 +135,9 @@ importers:
       mermaid:
         specifier: ^11.16.0
         version: 11.16.0
+      shiki:
+        specifier: 3.20.0
+        version: 3.20.0
       typescript:
         specifier: 'catalog:'
         version: 5.8.3


### PR DESCRIPTION
Fixes #916.


Why this change
---------------

Twoslash analysis was repeated across the client/SSR passes, leaving the documentation build close to its 12 GiB V8 heap limit. This keeps full type checking and hover information while making that work reusable.


How it works
------------

*docs/.vitepress/twoslash-cache.mts* namespaces persistent results by compiler options, *pnpm-lock.yaml*, and built declarations. It also includes the language in each entry key because the upstream file cache keys results by source text alone.

*docs/.vitepress/warm-twoslash-cache.mts* finds every Twoslash fence and fills missing entries in bounded child processes. The normal VitePress build reads the warm cache, then releases completed client bundle payloads before SSR instead of retaining both bundles in memory.

The `public-docs` job restores and saves the cache around the build. Branch previews use the existing `preview` environment, while tagged releases keep the protected `github-pages` environment.