### PR TITLE
Harden terminal capability detection in @optique/run

### DIFF
--- a/packages/run/src/detect.test.ts
+++ b/packages/run/src/detect.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { detectColorSupport, detectTerminalWidth } from "./run.ts";
+
+describe("detectColorSupport()", () => {
+  it("should enable colors if FORCE_COLOR is '1', '2', '3', 'true', or ''", () => {
+    assert.ok(detectColorSupport({}, { FORCE_COLOR: "1" }));
+    assert.ok(detectColorSupport({}, { FORCE_COLOR: "2" }));
+    assert.ok(detectColorSupport({}, { FORCE_COLOR: "3" }));
+    assert.ok(detectColorSupport({}, { FORCE_COLOR: "true" }));
+    assert.ok(detectColorSupport({}, { FORCE_COLOR: "" }));
+  });
+
+  it("should disable colors if FORCE_COLOR is '0' or any unsupported value", () => {
+    assert.ok(!detectColorSupport({ isTTY: true }, { FORCE_COLOR: "0" }));
+    assert.ok(!detectColorSupport({ isTTY: true }, { FORCE_COLOR: "false" }));
+    assert.ok(!detectColorSupport({ isTTY: true }, { FORCE_COLOR: "foo" }));
+  });
+
+  it("should disable colors if NO_COLOR is present", () => {
+    assert.ok(!detectColorSupport({ isTTY: true }, { NO_COLOR: "" }));
+    assert.ok(!detectColorSupport({ isTTY: true }, { NO_COLOR: "1" }));
+  });
+
+  it("should disable colors if NODE_DISABLE_COLORS is present", () => {
+    assert.ok(
+      !detectColorSupport({ isTTY: true }, { NODE_DISABLE_COLORS: "" }),
+    );
+  });
+
+  it("should prioritize FORCE_COLOR over NO_COLOR and NODE_DISABLE_COLORS", () => {
+    assert.ok(detectColorSupport({}, { FORCE_COLOR: "1", NO_COLOR: "1" }));
+    assert.ok(
+      detectColorSupport({}, { FORCE_COLOR: "1", NODE_DISABLE_COLORS: "1" }),
+    );
+  });
+
+  it("should fallback to stdout.isTTY if no environment variables are set", () => {
+    assert.ok(detectColorSupport({ isTTY: true }, {}));
+    assert.ok(!detectColorSupport({ isTTY: false }, {}));
+    assert.ok(!detectColorSupport({}, {}));
+  });
+});
+
+describe("detectTerminalWidth()", () => {
+  it("should use stdout.columns if it is a positive integer", () => {
+    assert.equal(detectTerminalWidth({ columns: 80 }, {}), 80);
+    assert.equal(detectTerminalWidth({ columns: 120 }, {}), 120);
+  });
+
+  it("should ignore stdout.columns if it is not a positive integer", () => {
+    assert.equal(detectTerminalWidth({ columns: 0 }, {}), undefined);
+    assert.equal(detectTerminalWidth({ columns: -10 }, {}), undefined);
+    assert.equal(detectTerminalWidth({ columns: 80.5 }, {}), undefined);
+  });
+
+  it("should fallback to COLUMNS environment variable if stdout.columns is invalid or missing", () => {
+    assert.equal(detectTerminalWidth({}, { COLUMNS: "100" }), 100);
+    assert.equal(detectTerminalWidth({ columns: 0 }, { COLUMNS: "100" }), 100);
+  });
+
+  it("should allow whitespace around COLUMNS environment variable", () => {
+    assert.equal(detectTerminalWidth({}, { COLUMNS: "  80  " }), 80);
+  });
+
+  it("should ignore COLUMNS if it is not a positive decimal integer", () => {
+    assert.equal(detectTerminalWidth({}, { COLUMNS: "0" }), undefined);
+    assert.equal(detectTerminalWidth({}, { COLUMNS: "-80" }), undefined);
+    assert.equal(detectTerminalWidth({}, { COLUMNS: "80.5" }), undefined);
+    assert.equal(detectTerminalWidth({}, { COLUMNS: "abc" }), undefined);
+    assert.equal(detectTerminalWidth({}, { COLUMNS: "" }), undefined);
+  });
+
+  it("should return undefined if neither provides a valid width", () => {
+    assert.equal(detectTerminalWidth({}, {}), undefined);
+  });
+});

--- a/packages/run/src/detect.test.ts
+++ b/packages/run/src/detect.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { detectColorSupport, detectTerminalWidth } from "./run.ts";
+import { detectColorSupport, detectTerminalWidth } from "./detect.ts";
 
 describe("detectColorSupport()", () => {
   it("should enable colors if FORCE_COLOR is '1', '2', '3', 'true', or ''", () => {

--- a/packages/run/src/detect.ts
+++ b/packages/run/src/detect.ts
@@ -1,0 +1,79 @@
+/**
+ * A minimal abstraction of a writable stream (like `process.stdout`) to allow
+ * for dependency injection during testing without mutating global state.
+ *
+ * @internal
+ */
+export interface StdoutLike {
+  isTTY?: boolean;
+  columns?: number;
+  hasColors?: (depth?: number) => boolean;
+}
+
+/**
+ * A minimal abstraction of a process environment (like `process.env`).
+ *
+ * @internal
+ */
+export type EnvLike = Record<string, string | undefined>;
+
+/**
+ * Detects whether the terminal supports color output based on environment
+ * variables and TTY status.
+ *
+ * @param stdout - The standard output stream to check for TTY status.
+ * @param env - The environment variables to check for color overrides.
+ * @returns `true` if colors should be enabled, `false` otherwise.
+ *
+ * @internal
+ */
+export function detectColorSupport(stdout: StdoutLike, env: EnvLike): boolean {
+  if (env.FORCE_COLOR !== undefined) {
+    switch (env.FORCE_COLOR) {
+      case "1":
+      case "2":
+      case "3":
+      case "true":
+      case "":
+        return true;
+      default:
+        return false;
+    }
+  }
+  if (env.NO_COLOR !== undefined || env.NODE_DISABLE_COLORS !== undefined) {
+    return false;
+  }
+  return stdout.isTTY ?? false;
+}
+
+/**
+ * Detects the terminal width in columns, falling back to the `COLUMNS`
+ * environment variable if the stream does not provide a valid width.
+ *
+ * @param stdout - The standard output stream to check for column width.
+ * @param env - The environment variables to check for fallback column width.
+ * @returns The detected terminal width as a positive integer, or `undefined` if undetected.
+ *
+ * @internal
+ */
+export function detectTerminalWidth(
+  stdout: StdoutLike,
+  env: EnvLike,
+): number | undefined {
+  if (
+    typeof stdout.columns === "number" &&
+    Number.isInteger(stdout.columns) &&
+    stdout.columns > 0
+  ) {
+    return stdout.columns;
+  }
+  if (typeof env.COLUMNS === "string") {
+    if (/^\s*\d+\s*$/.test(env.COLUMNS)) {
+      const parsed = Number(env.COLUMNS);
+      if (Number.isSafeInteger(parsed) && parsed > 0) {
+        return parsed;
+      }
+    }
+  }
+  return undefined;
+}

--- a/packages/run/src/run.ts
+++ b/packages/run/src/run.ts
@@ -1,6 +1,10 @@
 import type { ShellCompletion } from "@optique/core/completion";
 import type { SourceContext } from "@optique/core/context";
-import { runParser, runWith, runWithSync } from "@optique/core/facade";
+import type {
+  DocSection,
+  ShowChoicesOptions,
+  ShowDefaultOptions,
+} from "@optique/core/doc";
 import type {
   CommandListMode,
   CommandSubConfig,
@@ -8,6 +12,8 @@ import type {
   OptionSubConfig,
   RunOptions as CoreRunOptions,
 } from "@optique/core/facade";
+import { runParser, runWith, runWithSync } from "@optique/core/facade";
+import type { Message } from "@optique/core/message";
 import type {
   InferMode,
   InferValue,
@@ -16,12 +22,6 @@ import type {
   Parser,
 } from "@optique/core/parser";
 import type { Program } from "@optique/core/program";
-import type {
-  DocSection,
-  ShowChoicesOptions,
-  ShowDefaultOptions,
-} from "@optique/core/doc";
-import type { Message } from "@optique/core/message";
 import type { Usage } from "@optique/core/usage";
 import path from "node:path";
 import process from "node:process";
@@ -850,6 +850,87 @@ export function runAsync<T extends Parser<Mode, unknown, unknown>>(
  *
  * @internal
  */
+
+/**
+ * A minimal abstraction of a writable stream (like `process.stdout`) to allow
+ * for dependency injection during testing without mutating global state.
+ *
+ * @internal
+ */
+export interface StdoutLike {
+  isTTY?: boolean;
+  columns?: number;
+  hasColors?: (depth?: number) => boolean;
+}
+
+/**
+ * A minimal abstraction of a process environment (like `process.env`).
+ *
+ * @internal
+ */
+export type EnvLike = Record<string, string | undefined>;
+
+/**
+ * Detects whether the terminal supports color output based on environment
+ * variables and TTY status.
+ *
+ * @param stdout - The standard output stream to check for TTY status.
+ * @param env - The environment variables to check for color overrides.
+ * @returns `true` if colors should be enabled, `false` otherwise.
+ *
+ * @internal
+ */
+export function detectColorSupport(stdout: StdoutLike, env: EnvLike): boolean {
+  if (env.FORCE_COLOR !== undefined) {
+    switch (env.FORCE_COLOR) {
+      case "1":
+      case "2":
+      case "3":
+      case "true":
+      case "":
+        return true;
+      default:
+        return false;
+    }
+  }
+  if (env.NO_COLOR !== undefined || env.NODE_DISABLE_COLORS !== undefined) {
+    return false;
+  }
+  return stdout.isTTY ?? false;
+}
+
+/**
+ * Detects the terminal width in columns, falling back to the `COLUMNS`
+ * environment variable if the stream does not provide a valid width.
+ *
+ * @param stdout - The standard output stream to check for column width.
+ * @param env - The environment variables to check for fallback column width.
+ * @returns The detected terminal width as a positive integer, or `undefined` if undetected.
+ *
+ * @internal
+ */
+export function detectTerminalWidth(
+  stdout: StdoutLike,
+  env: EnvLike,
+): number | undefined {
+  if (
+    typeof stdout.columns === "number" &&
+    Number.isInteger(stdout.columns) &&
+    stdout.columns > 0
+  ) {
+    return stdout.columns;
+  }
+  if (typeof env.COLUMNS === "string") {
+    if (/^\s*\d+\s*$/.test(env.COLUMNS)) {
+      const parsed = Number(env.COLUMNS);
+      if (parsed > 0) {
+        return parsed;
+      }
+    }
+  }
+  return undefined;
+}
+
 function buildCoreOptions(
   options: RunOptions,
   programMetadata?: ProgramHelpMetadata,
@@ -869,8 +950,10 @@ function buildCoreOptions(
   });
   const onExit = options.onExit ??
     ((exitCode: number) => process.exit(exitCode) as never);
-  const colors = options.colors ?? process.stdout.isTTY;
-  const maxWidth = options.maxWidth ?? process.stdout.columns;
+  const colors = options.colors ??
+    detectColorSupport(process.stdout, process.env);
+  const maxWidth = options.maxWidth ??
+    detectTerminalWidth(process.stdout, process.env);
   const termWidth = options.termWidth;
   const showDefault = options.showDefault;
   const showChoices = options.showChoices;

--- a/packages/run/src/run.ts
+++ b/packages/run/src/run.ts
@@ -25,6 +25,7 @@ import type { Program } from "@optique/core/program";
 import type { Usage } from "@optique/core/usage";
 import path from "node:path";
 import process from "node:process";
+import { detectColorSupport, detectTerminalWidth } from "./detect.ts";
 
 /**
  * Configuration options for the {@link run} function.
@@ -70,7 +71,7 @@ export interface RunOptions {
   /**
    * Whether to enable colored output in help and error messages.
    *
-   * @default `process.stdout.isTTY` (auto-detect based on terminal)
+   * @default Auto-detected. Uses `FORCE_COLOR`, `NO_COLOR`, and `NODE_DISABLE_COLORS` environment variables, falling back to `process.stdout.isTTY`.
    */
   readonly colors?: boolean;
 
@@ -78,7 +79,7 @@ export interface RunOptions {
    * Maximum width for output formatting. Text will be wrapped to fit within
    * this width. If not specified, uses the terminal width.
    *
-   * @default `process.stdout.columns` (auto-detect terminal width)
+   * @default Auto-detected. Uses `process.stdout.columns`, falling back to valid `COLUMNS` environment variable values.
    */
   readonly maxWidth?: number;
 
@@ -850,86 +851,6 @@ export function runAsync<T extends Parser<Mode, unknown, unknown>>(
  *
  * @internal
  */
-
-/**
- * A minimal abstraction of a writable stream (like `process.stdout`) to allow
- * for dependency injection during testing without mutating global state.
- *
- * @internal
- */
-export interface StdoutLike {
-  isTTY?: boolean;
-  columns?: number;
-  hasColors?: (depth?: number) => boolean;
-}
-
-/**
- * A minimal abstraction of a process environment (like `process.env`).
- *
- * @internal
- */
-export type EnvLike = Record<string, string | undefined>;
-
-/**
- * Detects whether the terminal supports color output based on environment
- * variables and TTY status.
- *
- * @param stdout - The standard output stream to check for TTY status.
- * @param env - The environment variables to check for color overrides.
- * @returns `true` if colors should be enabled, `false` otherwise.
- *
- * @internal
- */
-export function detectColorSupport(stdout: StdoutLike, env: EnvLike): boolean {
-  if (env.FORCE_COLOR !== undefined) {
-    switch (env.FORCE_COLOR) {
-      case "1":
-      case "2":
-      case "3":
-      case "true":
-      case "":
-        return true;
-      default:
-        return false;
-    }
-  }
-  if (env.NO_COLOR !== undefined || env.NODE_DISABLE_COLORS !== undefined) {
-    return false;
-  }
-  return stdout.isTTY ?? false;
-}
-
-/**
- * Detects the terminal width in columns, falling back to the `COLUMNS`
- * environment variable if the stream does not provide a valid width.
- *
- * @param stdout - The standard output stream to check for column width.
- * @param env - The environment variables to check for fallback column width.
- * @returns The detected terminal width as a positive integer, or `undefined` if undetected.
- *
- * @internal
- */
-export function detectTerminalWidth(
-  stdout: StdoutLike,
-  env: EnvLike,
-): number | undefined {
-  if (
-    typeof stdout.columns === "number" &&
-    Number.isInteger(stdout.columns) &&
-    stdout.columns > 0
-  ) {
-    return stdout.columns;
-  }
-  if (typeof env.COLUMNS === "string") {
-    if (/^\s*\d+\s*$/.test(env.COLUMNS)) {
-      const parsed = Number(env.COLUMNS);
-      if (parsed > 0) {
-        return parsed;
-      }
-    }
-  }
-  return undefined;
-}
 
 function buildCoreOptions(
   options: RunOptions,


### PR DESCRIPTION
# Summary
This PR updates run() to safely handle terminal capability detection when output is piped or redirected, resolving an issue where help text formatting would silently degrade.

# Changes
Color support: Now respects `FORCE_COLOR`, `NO_COLOR`, and `NODE_DISABLE_COLORS` standard environment variables before falling back to `process.stdout.isTTY`.
Terminal width: Safely parses the `COLUMNS` environment variable as a fallback when `process.stdout.columns` is missing or invalid.
Abstracted the detection logic using EnvLike and StdoutLike interfaces to avoid global process state mutations.
Note on pre-existing test failures

## Important 
While working on this PR, I noticed some test cases failing locally on my machine before I even wrote any code. Specifically, the test:bun runner was crashing my environment, which caused mise to forcefully terminate the Node.js test suite mid-run. This caused packages/man/src/cli.test.ts to hang and throw a confusing Promise resolution is still pending error.

I just wanted to note this for the maintainers, as those test failures are environmentally flaky and completely unrelated to the code in this PR.

Resolves https://github.com/dahlia/optique/issues/903 Assisted-by: Gemini 3.1 Pro