### PR TITLE
Propagate branch completion dependencies through scheduling barriers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,9 +16,13 @@ To be released.
     dependency values, such as prompts with derived configurations.  The
     dependency scheduler now orders such a parser after the sources its
     completion reads, propagates demand to them when the parser's own value
-    is demanded, and includes them in failure-chain diagnostics.  Cycles
+    is demanded, and includes them in failure-chain diagnostics.  The same
+    ordering and demand rules apply inside a `conditional()` whose branch is
+    selected only during completion: the branches' completion dependencies
+    propagate through the conditional's scheduling barrier, so a branch
+    configuration can read a source declared after the conditional.  Cycles
     introduced this way are rejected with the existing circular-dependency
-    error.  [[#869], [#872]]
+    error.  [[#869], [#872], [#919], [#923]]
  -  Added `termWidth: "auto"` to `formatDocPage()` for aligning descriptions
     after the widest visible term using terminal display width while reserving
     description space under `maxWidth`.  The existing default and explicit
@@ -83,6 +87,8 @@ To be released.
 [#913]: https://github.com/dahlia/optique/issues/913
 [#914]: https://github.com/dahlia/optique/pull/914
 [#915]: https://github.com/dahlia/optique/pull/915
+[#919]: https://github.com/dahlia/optique/issues/919
+[#923]: https://github.com/dahlia/optique/pull/923
 
 ### @optique/run
 

--- a/changes.d/core/completion-dependency-scheduling.md
+++ b/changes.d/core/completion-dependency-scheduling.md
@@ -2,11 +2,17 @@
 links:
   '#869': https://github.com/dahlia/optique/issues/869
   '#872': https://github.com/dahlia/optique/issues/872
+  '#919': https://github.com/dahlia/optique/issues/919
+  '#923': https://github.com/dahlia/optique/pull/923
 ---
  -  Added scheduling support for effectful completions that consume
     dependency values, such as prompts with derived configurations.  The
     dependency scheduler now orders such a parser after the sources its
     completion reads, propagates demand to them when the parser's own value
-    is demanded, and includes them in failure-chain diagnostics.  Cycles
+    is demanded, and includes them in failure-chain diagnostics.  The same
+    ordering and demand rules apply inside a `conditional()` whose branch is
+    selected only during completion: the branches' completion dependencies
+    propagate through the conditional's scheduling barrier, so a branch
+    configuration can read a source declared after the conditional.  Cycles
     introduced this way are rejected with the existing circular-dependency
-    error.  [[#869], [#872]]
+    error.  [[#869], [#872], [#919], [#923]]

--- a/docs/concepts/dependencies.md
+++ b/docs/concepts/dependencies.md
@@ -654,7 +654,10 @@ operation. Their results and failures are scoped to that operation.
 A prompt whose configuration is derived with `derivePromptConfig()` is a
 consumer node in the same graph: the sources its resolver reads count as its
 providers, so they resolve first, and the prompt runs after them regardless of
-field order.
+field order.  A branch that a `conditional()` selects only during completion
+contributes its completion dependencies to the enclosing graph as well: the
+conditional waits for the providers its selectable branches read, even when
+they are declared after it.
 
 An invalid source never falls back to its default. The failure propagates
 through every derived source that consumes it—including prompts whose

--- a/docs/integrations/prompt.md
+++ b/docs/integrations/prompt.md
@@ -711,16 +711,20 @@ completion dependencies of every selectable branch, so the conditional
 waits for the sources a branch configuration reads even when they are
 declared *after* the conditional, and the demand-only seed pass of a
 `runWith()` run reaches a prerequisite only through the branch consumer
-that actually reads it.  Two caveats follow from the branch estimates
+that actually reads it.  Three caveats follow from the branch estimates
 being static.  A dependency on a source that another sibling might
 publish, such as a completion consumer next to a conditional whose
 branch consumes the sibling's own source, can be rejected as a circular
-dependency even though only one of them would run.  And a branch that
+dependency even though only one of them would run.  A branch that
 *could* provide a source itself—through an unselected nested
 alternative, or an `optional()` occurrence that ends up parsing
 nothing—resolves that source inside the branch, so a matching provider
 declared after the conditional is not waited for and the configuration
-falls back to its declared default.
+falls back to its declared default.  And a speculative selection that
+the discriminator ultimately rejects may already have demanded its
+configuration prerequisites, so a prerequisite prompt can run before
+the branch-mismatch error surfaces, although the rejected branch's own
+resolver never runs.
 
 
 Testing adapters

--- a/docs/integrations/prompt.md
+++ b/docs/integrations/prompt.md
@@ -705,13 +705,22 @@ during the phase-two seed pass and resolves in the final pass, after
 every source has published.  If phase-two contexts need its value, make
 the wrapped parser a source with `dependency()`.
 
-One ordering limitation applies inside a `conditional()` whose branch is
-selected only during completion: the branch's prompts run at the
-conditional's declaration position, so a derived configuration inside
-such a branch cannot see a source prompt declared *after* the
-conditional—the resolver falls back to its declared default or fails as
-missing.  Declare the sources a branch configuration reads in the
-surrounding scope before the conditional, so they publish first.
+Derived configurations also work inside a `conditional()` whose branch
+is selected only during completion.  The scheduler aggregates the
+completion dependencies of every selectable branch, so the conditional
+waits for the sources a branch configuration reads even when they are
+declared *after* the conditional, and the demand-only seed pass of a
+`runWith()` run reaches a prerequisite only through the branch consumer
+that actually reads it.  Two caveats follow from the branch estimates
+being static.  A dependency on a source that another sibling might
+publish, such as a completion consumer next to a conditional whose
+branch consumes the sibling's own source, can be rejected as a circular
+dependency even though only one of them would run.  And a branch that
+*could* provide a source itself—through an unselected nested
+alternative, or an `optional()` occurrence that ends up parsing
+nothing—resolves that source inside the branch, so a matching provider
+declared after the conditional is not waited for and the configuration
+falls back to its declared default.
 
 
 Testing adapters

--- a/packages/core/src/constructs.ts
+++ b/packages/core/src/constructs.ts
@@ -14,6 +14,8 @@ import {
   wrappedDependencySourceMarker,
 } from "./internal/dependency.ts";
 import {
+  type BarrierCompletionDemandEdge,
+  type BarrierCompletionDependencies,
   buildRuntimeNodesFromArray,
   buildRuntimeNodesFromPairs,
   collectExplicitSourceValues,
@@ -25,6 +27,7 @@ import {
   effectfulSchedulingNodesKey,
   fillMissingSourceDefaults,
   fillMissingSourceDefaultsAsync,
+  hasInactiveCompletion,
   resolveDerivedSourceValues,
   resolveDerivedSourceValuesAsync,
   resolveStateWithRuntime,
@@ -436,6 +439,107 @@ function collectStaticSourceIds(
   if (scope != null) {
     for (const child of scope) collectStaticSourceIds(child, out, seen);
   }
+}
+
+/**
+ * Statically collects the completion dependencies reachable through a
+ * parser's composed metadata and flattened field pairs, mirroring
+ * {@link collectStaticSourceIds}.  Every completion consumer joins the
+ * ordering union, while demand edges record only parsers that are both
+ * a source and a completion consumer—the flat demand rule never
+ * demands a consumer-only completion's prerequisites, because such a
+ * completion defers itself out of the seed pass.
+ */
+function collectStaticCompletionDependencies(
+  parser: Parser<Mode, unknown, unknown>,
+  orderingDependencyIds: Set<symbol>,
+  demandEdges: BarrierCompletionDemandEdge[],
+  seen: Set<object>,
+): void {
+  if (seen.has(parser as object)) return;
+  seen.add(parser as object);
+  const metadata = parser.dependencyMetadata;
+  const completion = metadata?.completion;
+  if (completion != null) {
+    for (const id of completion.dependencyIds) orderingDependencyIds.add(id);
+    const consumerSourceId = metadata?.source?.sourceId;
+    if (consumerSourceId != null) {
+      demandEdges.push({
+        consumerSourceId,
+        dependencyIds: completion.dependencyIds,
+      });
+    }
+  }
+  const pairs = (parser as {
+    readonly [fieldParsersKey]?: ReadonlyArray<
+      readonly [string | symbol, Parser<Mode, unknown, unknown>]
+    >;
+  })[fieldParsersKey];
+  if (pairs != null) {
+    for (const [, child] of pairs) {
+      collectStaticCompletionDependencies(
+        child,
+        orderingDependencyIds,
+        demandEdges,
+        seen,
+      );
+    }
+  }
+  const scope = (parser as {
+    readonly [staticSourceScopeKey]?: ReadonlyArray<
+      Parser<Mode, unknown, unknown>
+    >;
+  })[staticSourceScopeKey];
+  if (scope != null) {
+    for (const child of scope) {
+      collectStaticCompletionDependencies(
+        child,
+        orderingDependencyIds,
+        demandEdges,
+        seen,
+      );
+    }
+  }
+}
+
+/**
+ * Recomputes a speculative barrier's completion dependencies from the
+ * guessed branch's expanded runtime nodes, so an occurrence already
+ * satisfied by the command line or a binding contributes neither
+ * ordering edges nor demand, mirroring the flat inactive-completion
+ * rule.  Nested barriers contribute their own aggregates, which remain
+ * static estimates.
+ */
+function computeBarrierDependenciesFromNodes(
+  nodes: readonly RuntimeNode[],
+  provides: ReadonlySet<symbol>,
+): BarrierCompletionDependencies | undefined {
+  const ordering = new Set<symbol>();
+  const demandEdges: BarrierCompletionDemandEdge[] = [];
+  for (const node of nodes) {
+    const metadata = node.parser.dependencyMetadata;
+    const completion = metadata?.completion;
+    if (completion != null && !hasInactiveCompletion(node)) {
+      for (const id of completion.dependencyIds) ordering.add(id);
+      const consumerSourceId = metadata?.source?.sourceId;
+      if (consumerSourceId != null) {
+        demandEdges.push({
+          consumerSourceId,
+          dependencyIds: completion.dependencyIds,
+        });
+      }
+    }
+    const nested = node.barrierCompletionDependencies;
+    if (nested != null) {
+      for (const id of nested.orderingDependencyIds) ordering.add(id);
+      demandEdges.push(...nested.demandEdges);
+    }
+  }
+  const orderingDependencyIds = [...ordering].filter((id) => !provides.has(id));
+  if (orderingDependencyIds.length < 1 && demandEdges.length < 1) {
+    return undefined;
+  }
+  return { orderingDependencyIds, demandEdges };
 }
 
 function isDeferredCompletionResult(result: unknown): boolean {
@@ -16032,17 +16136,82 @@ export function conditional(
     parentPath: readonly PropertyKey[] | undefined,
   ): string => preparedKeyPrefix + serializeSchedulingPath(parentPath ?? []);
   // Source IDs the branches can provide, for demand-only control
-  // dependency detection (see RuntimeNode.providesSourceIds).
-  const branchProvidedSourceIds = (() => {
-    const out = new Set<symbol>();
-    const seen = new Set<object>();
+  // dependency detection (see RuntimeNode.providesSourceIds), and the
+  // branches' aggregated completion dependencies, so a scheduling
+  // barrier can wait for outer providers a branch's effectful
+  // completion reads (see RuntimeNode.barrierCompletionDependencies).
+  // Each branch walks with its own `seen` set: a parser shared across
+  // branches must contribute to every branch's estimate.
+  const {
+    branchProvidedSourceIds,
+    mergedBarrierDependencies,
+    barrierDependenciesByKey,
+  } = (() => {
+    const provided = new Set<symbol>();
+    interface BranchDependencyEstimate {
+      readonly provides: ReadonlySet<symbol>;
+      readonly dependencies?: BarrierCompletionDependencies;
+    }
+    const byParser = new Map<object, BranchDependencyEstimate>();
+    const computeBranch = (
+      branch: Parser<Mode, unknown, unknown>,
+    ): BranchDependencyEstimate => {
+      const memoized = byParser.get(branch as object);
+      if (memoized != null) return memoized;
+      const provides = new Set<symbol>();
+      collectStaticSourceIds(branch, provides, new Set());
+      for (const id of provides) provided.add(id);
+      const ordering = new Set<symbol>();
+      const demandEdges: BarrierCompletionDemandEdge[] = [];
+      collectStaticCompletionDependencies(
+        branch,
+        ordering,
+        demandEdges,
+        new Set(),
+      );
+      // The ordering union subtracts the branch's own statically
+      // providable IDs: those prerequisites resolve inside the
+      // barrier's nested pass.  Demand edges keep them—a demanded
+      // consumer must still demand a branch-internal source prompt so
+      // it does not defer out of the seed pass.
+      const orderingDependencyIds = [...ordering].filter(
+        (id) => !provides.has(id),
+      );
+      const estimate: BranchDependencyEstimate = {
+        provides,
+        ...(orderingDependencyIds.length < 1 && demandEdges.length < 1
+          ? {}
+          : { dependencies: { orderingDependencyIds, demandEdges } }),
+      };
+      byParser.set(branch as object, estimate);
+      return estimate;
+    };
+    const byKey = new Map<string, BranchDependencyEstimate>();
     for (const key of Object.keys(branches)) {
-      collectStaticSourceIds(branches[key], out, seen);
+      const estimate = computeBranch(branches[key]);
+      if (estimate.dependencies != null) byKey.set(key, estimate);
     }
-    if (defaultBranch != null) {
-      collectStaticSourceIds(defaultBranch, out, seen);
+    if (defaultBranch != null) computeBranch(defaultBranch);
+    const orderingUnion = new Set<symbol>();
+    const mergedEdges: BarrierCompletionDemandEdge[] = [];
+    for (const estimate of new Set(byParser.values())) {
+      if (estimate.dependencies == null) continue;
+      for (const id of estimate.dependencies.orderingDependencyIds) {
+        orderingUnion.add(id);
+      }
+      mergedEdges.push(...estimate.dependencies.demandEdges);
     }
-    return out;
+    const merged = orderingUnion.size < 1 && mergedEdges.length < 1
+      ? undefined
+      : {
+        orderingDependencyIds: [...orderingUnion],
+        demandEdges: mergedEdges,
+      };
+    return {
+      branchProvidedSourceIds: provided,
+      mergedBarrierDependencies: merged,
+      barrierDependenciesByKey: byKey,
+    };
   })();
 
   // Builds the effectful scheduling nodes for this conditional: the
@@ -16141,6 +16310,29 @@ export function conditional(
       }
       teeDiscriminatorNode();
       const speculativeKey = selected.key;
+      // The guessed branch was parsed, so its occurrence states can
+      // refine the static estimate: a consumer already satisfied by the
+      // command line or a binding bypasses its completion, and its
+      // prerequisites must contribute neither ordering edges nor
+      // demand, mirroring the flat inactive-completion rule.
+      const speculativeBarrierDependencies = (() => {
+        const estimate = barrierDependenciesByKey.get(speculativeKey);
+        if (estimate?.dependencies == null) return undefined;
+        const branchParser = branches[speculativeKey];
+        if (branchParser == null) return estimate.dependencies;
+        return computeBarrierDependenciesFromNodes(
+          expandEffectfulRuntimeNodes([{
+            path: [...(parentPath ?? []), "_branch"],
+            parser: branchParser,
+            state: getAnnotatedChildState(
+              conditionalState,
+              conditionalState.branchState,
+              branchParser,
+            ),
+          }]),
+          estimate.provides,
+        );
+      })();
       nodes.push({
         path: [...(parentPath ?? []), "_branch"],
         parser: {},
@@ -16149,6 +16341,9 @@ export function conditional(
           ? { requiresSourceId: discriminatorSource.sourceId }
           : {}),
         providesSourceIds: branchProvidedSourceIds,
+        ...(speculativeBarrierDependencies != null
+          ? { barrierCompletionDependencies: speculativeBarrierDependencies }
+          : {}),
         prepare: async (ctx) => {
           const session = ctx.exec?.effectfulCompletionSession;
           if (session == null) return undefined;
@@ -16198,6 +16393,9 @@ export function conditional(
         ? { requiresSourceId: discriminatorSource.sourceId }
         : {}),
       providesSourceIds: branchProvidedSourceIds,
+      ...(mergedBarrierDependencies != null
+        ? { barrierCompletionDependencies: mergedBarrierDependencies }
+        : {}),
       prepare: async (ctx) => {
         const session = ctx.exec?.effectfulCompletionSession;
         if (session == null) return undefined;

--- a/packages/core/src/dependency-runtime.test.ts
+++ b/packages/core/src/dependency-runtime.test.ts
@@ -7,6 +7,7 @@
 import { describe, test } from "node:test";
 import * as assert from "node:assert/strict";
 import {
+  type BarrierCompletionDependencies,
   buildRuntimeNodesFromArray,
   buildRuntimeNodesFromPairs,
   collectDemandedDependencyIds,
@@ -2669,6 +2670,98 @@ describe("completeEffectfulSourcesAsync", () => {
     assert.ok(result.success);
     assert.ok(session.demanded.has(sourceId));
   });
+
+  // https://github.com/dahlia/optique/issues/919
+  test("demands a barrier edge's prerequisites for a demanded consumer", async () => {
+    const runtime = createDependencyRuntimeContext();
+    const session = createEffectfulCompletionSession("demand-only");
+    const consumerId = Symbol("consumer");
+    const prerequisiteId = Symbol("prerequisite");
+    const chainedId = Symbol("chained");
+    const trace = createInputTrace().set(["level"], {
+      kind: "option-value",
+      rawInput: "debug",
+      consumed: ["--level", "debug"],
+    });
+    const derivedConsumer: RuntimeNode = {
+      path: ["level"],
+      parser: {
+        dependencyMetadata: {
+          derived: {
+            kind: "derived",
+            dependencyIds: [consumerId],
+            replayParse: () => ({ success: true, value: "debug" }),
+          },
+        },
+      },
+      state: undefined,
+    };
+    const barrier = createBarrierNode({
+      path: ["barrier"],
+      providesSourceIds: new Set([consumerId]),
+      barrierCompletionDependencies: {
+        orderingDependencyIds: [prerequisiteId],
+        demandEdges: [{
+          consumerSourceId: consumerId,
+          dependencyIds: [prerequisiteId],
+        }],
+      },
+    });
+    // The flat rule chains onward: the demanded prerequisite's own
+    // completion consumes another source.
+    const prerequisite = createRuntimeSourceNode({
+      path: ["prerequisite"],
+      sourceId: prerequisiteId,
+      completionDependencyIds: [chainedId],
+      metavar: "PREREQ",
+    });
+
+    const result = await completeEffectfulSourcesAsync(
+      [barrier, derivedConsumer, prerequisite],
+      undefined,
+      runtime,
+      { ...createCompleteExecFixture(session), trace },
+    );
+
+    assert.ok(result.success);
+    assert.ok(session.demanded.has(prerequisiteId));
+    assert.ok(session.demanded.has(chainedId));
+  });
+
+  test("keeps an undemanded barrier edge's prerequisites undemanded", async () => {
+    const runtime = createDependencyRuntimeContext();
+    const session = createEffectfulCompletionSession("demand-only");
+    const consumerId = Symbol("consumer");
+    const otherBranchId = Symbol("otherBranch");
+    const prerequisiteId = Symbol("prerequisite");
+    const discriminatorId = Symbol("discriminator");
+    // An unrelated branch source and the discriminator control
+    // dependency are demanded, but not the edge's consumer.
+    session.demanded.add(otherBranchId);
+    session.demanded.add(discriminatorId);
+    const barrier = createBarrierNode({
+      path: ["barrier"],
+      requiresSourceId: discriminatorId,
+      providesSourceIds: new Set([consumerId, otherBranchId]),
+      barrierCompletionDependencies: {
+        orderingDependencyIds: [prerequisiteId],
+        demandEdges: [{
+          consumerSourceId: consumerId,
+          dependencyIds: [prerequisiteId],
+        }],
+      },
+    });
+
+    const result = await completeEffectfulSourcesAsync(
+      [barrier],
+      undefined,
+      runtime,
+      createCompleteExecFixture(session),
+    );
+
+    assert.ok(result.success);
+    assert.ok(!session.demanded.has(prerequisiteId));
+  });
 });
 
 describe("collectDemandedDependencyIds", () => {
@@ -2860,6 +2953,72 @@ describe("orderDependencyNodes", () => {
     );
   });
 
+  // https://github.com/dahlia/optique/issues/919
+  test("orders a barrier after providers of its branch completion deps", () => {
+    const upstreamId = Symbol("upstream");
+    const barrier = createBarrierNode({
+      path: ["barrier"],
+      barrierCompletionDependencies: {
+        orderingDependencyIds: [upstreamId],
+        demandEdges: [],
+      },
+    });
+    const unrelated = createRuntimeSourceNode({
+      path: ["unrelated"],
+      sourceId: Symbol("unrelated"),
+      metavar: "UNRELATED",
+    });
+    const provider = createRuntimeSourceNode({
+      path: ["provider"],
+      sourceId: upstreamId,
+      metavar: "PROVIDER",
+    });
+
+    const ordered = orderDependencyNodes([barrier, unrelated, provider]);
+
+    assert.deepEqual(ordered, [unrelated, provider, barrier]);
+  });
+
+  test("skips a barrier completion dependency the barrier provides", () => {
+    const sharedId = Symbol("shared");
+    const barrier = createBarrierNode({
+      path: ["barrier"],
+      providesSourceIds: new Set([sharedId]),
+      barrierCompletionDependencies: {
+        orderingDependencyIds: [sharedId],
+        demandEdges: [],
+      },
+    });
+
+    const ordered = orderDependencyNodes([barrier]);
+
+    assert.deepEqual(ordered, [barrier]);
+  });
+
+  test("detects a cycle between a barrier and a sibling consumer", () => {
+    const branchId = Symbol("branch");
+    const siblingId = Symbol("sibling");
+    const barrier = createBarrierNode({
+      path: ["barrier"],
+      providesSourceIds: new Set([branchId]),
+      barrierCompletionDependencies: {
+        orderingDependencyIds: [siblingId],
+        demandEdges: [],
+      },
+    });
+    const sibling = createRuntimeSourceNode({
+      path: ["sibling"],
+      sourceId: siblingId,
+      completionDependencyIds: [branchId],
+      metavar: "SIBLING",
+    });
+
+    assert.throws(
+      () => orderDependencyNodes([barrier, sibling]),
+      /Circular dependency/,
+    );
+  });
+
   test("reports the paths and metavars in a forged cycle", () => {
     const firstId = Symbol("first");
     const secondId = Symbol("second");
@@ -2884,6 +3043,31 @@ describe("orderDependencyNodes", () => {
 });
 
 // Helpers
+
+function createBarrierNode(options: {
+  readonly path: readonly PropertyKey[];
+  readonly requiresSourceId?: symbol;
+  readonly providesSourceIds?: ReadonlySet<symbol>;
+  readonly barrierCompletionDependencies?: BarrierCompletionDependencies;
+}): RuntimeNode {
+  return {
+    path: options.path,
+    parser: {},
+    state: undefined,
+    ...(options.requiresSourceId != null
+      ? { requiresSourceId: options.requiresSourceId }
+      : {}),
+    ...(options.providesSourceIds != null
+      ? { providesSourceIds: options.providesSourceIds }
+      : {}),
+    ...(options.barrierCompletionDependencies != null
+      ? {
+        barrierCompletionDependencies: options.barrierCompletionDependencies,
+      }
+      : {}),
+    prepare: () => Promise.resolve(undefined),
+  };
+}
 
 function createRuntimeSourceNode(options: {
   readonly path: readonly PropertyKey[];

--- a/packages/core/src/dependency-runtime.ts
+++ b/packages/core/src/dependency-runtime.ts
@@ -246,6 +246,68 @@ export interface RuntimeNode {
    * @since 1.3.0
    */
   readonly requiresSourceId?: symbol;
+
+  /**
+   * Completion dependencies aggregated from the selectable subtrees
+   * guarded by this barrier, so the outer pass can order the barrier
+   * after the providers those subtrees' effectful completions read and
+   * propagate demand to them.
+   *
+   * The sets are static estimates: they describe every selectable
+   * branch, not the one preparation will eventually choose.  They are
+   * advisory for ordering and demand only and never join failure
+   * lineage—a failed prerequisite used only by an unselected branch
+   * must not fail the barrier.
+   *
+   * @since 1.3.0
+   */
+  readonly barrierCompletionDependencies?: BarrierCompletionDependencies;
+}
+
+/**
+ * An exact demand edge inside a scheduling barrier's subtree: when the
+ * consumer's own source is demanded, the completion dependencies its
+ * effectful completion reads become demanded as well, mirroring the
+ * flat demand rule for parsers whose completion consumes dependency
+ * values.
+ *
+ * @internal
+ * @since 1.3.0
+ */
+export interface BarrierCompletionDemandEdge {
+  /** The branch consumer's own source ID (the demand trigger). */
+  readonly consumerSourceId: symbol;
+
+  /** The completion dependency IDs that consumer reads. */
+  readonly dependencyIds: readonly symbol[];
+}
+
+/**
+ * Completion dependencies a scheduling barrier aggregates from its
+ * selectable subtrees.  See
+ * {@link RuntimeNode.barrierCompletionDependencies}.
+ *
+ * @internal
+ * @since 1.3.0
+ */
+export interface BarrierCompletionDependencies {
+  /**
+   * Union of the branches' completion dependency IDs, with each
+   * branch's own statically providable IDs subtracted.  Used only to
+   * order the barrier after outer providers; a missing provider
+   * creates no edge.
+   */
+  readonly orderingDependencyIds: readonly symbol[];
+
+  /**
+   * Exact demand edges collected from branch parsers that are both a
+   * source and a completion consumer.  Unlike
+   * {@link BarrierCompletionDependencies.orderingDependencyIds}, these
+   * keep branch-internal prerequisites: a demanded consumer must also
+   * demand an internal source prompt so it does not defer out of the
+   * seed pass.
+   */
+  readonly demandEdges: readonly BarrierCompletionDemandEdge[];
 }
 
 /**
@@ -879,7 +941,9 @@ export async function collectExplicitSourceValuesAsync(
  *
  * Missing providers create no edge because the consumer may use its declared
  * default.  Scheduling barriers act as providers for the source IDs their
- * selected subtree may expose and depend on their discriminator source.
+ * selected subtree may expose and depend on their discriminator source as
+ * well as on outer providers of the completion dependencies their
+ * selectable subtrees aggregate.
  *
  * @param nodes Runtime nodes in declaration order.
  * @returns The same nodes in stable dependency order.
@@ -951,6 +1015,19 @@ export function orderDependencyNodes(
     if (node.requiresSourceId != null) {
       for (const provider of providers.get(node.requiresSourceId) ?? []) {
         if (provider !== node) addEdge(provider, node);
+      }
+    }
+    // A scheduling barrier aggregates the completion dependencies its
+    // selectable subtrees declare, so the barrier waits for outer
+    // providers a branch's effectful completion reads.  The barrier
+    // itself provides its branches' source IDs, so skipping self edges
+    // keeps a dependency on a sibling branch's source internal.
+    const barrierDeps = node.barrierCompletionDependencies;
+    if (barrierDeps != null) {
+      for (const dependencySourceId of barrierDeps.orderingDependencyIds) {
+        for (const provider of providers.get(dependencySourceId) ?? []) {
+          if (provider !== node) addEdge(provider, node);
+        }
       }
     }
   }
@@ -1176,8 +1253,11 @@ const inactiveCompletionCache = new WeakMap<RuntimeNode, boolean>();
  * the completion active (the effectful completion is its recovery
  * path), and an asynchronous extraction is conservatively treated as
  * active because it cannot be decided synchronously.
+ *
+ * @internal
+ * @since 1.3.0
  */
-function hasInactiveCompletion(node: RuntimeNode): boolean {
+export function hasInactiveCompletion(node: RuntimeNode): boolean {
   const cached = inactiveCompletionCache.get(node);
   if (cached != null) return cached;
   const inactive = computeInactiveCompletion(node);
@@ -2053,6 +2133,21 @@ export async function completeEffectfulSourcesAsync(
             if (session.demanded.has(dependencySourceId)) continue;
             session.demanded.add(dependencySourceId);
             demandAdded = true;
+          }
+        }
+        // A barrier's demand edges mirror the flat completion rule for
+        // the consumers hidden behind it: only when a branch consumer's
+        // own source is demanded do its completion prerequisites become
+        // demanded, so a demanded discriminator or an unrelated branch
+        // source never forces another consumer's prerequisites.
+        if (node.barrierCompletionDependencies != null) {
+          for (const edge of node.barrierCompletionDependencies.demandEdges) {
+            if (!session.demanded.has(edge.consumerSourceId)) continue;
+            for (const dependencySourceId of edge.dependencyIds) {
+              if (session.demanded.has(dependencySourceId)) continue;
+              session.demanded.add(dependencySourceId);
+              demandAdded = true;
+            }
           }
         }
         if (node.requiresSourceId == null || node.providesSourceIds == null) {

--- a/packages/prompt/src/index.test.ts
+++ b/packages/prompt/src/index.test.ts
@@ -4087,3 +4087,756 @@ describe("derived prompt configuration failures and edge cases", () => {
     assert.ok(true);
   });
 });
+
+// https://github.com/dahlia/optique/issues/919
+describe("branch completion dependencies across scheduling barriers", () => {
+  it("resolves a branch derived configuration against a later provider", async () => {
+    const kind = dependency(choice(["a", "b"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const { prompt, calls } = createTestPrompt();
+    // The prompted discriminator selects the branch only during
+    // completion, and the branch's derived configuration reads a
+    // source prompt declared after the conditional: the provider must
+    // still publish before the branch prepares.
+    const parser = object({
+      cond: conditional(
+        prompt(option("--kind", kind), { value: "a" }),
+        {
+          a: object({
+            pm: prompt(
+              option("--pm", dependency(choice(["deno", "npm"] as const))),
+              derivePromptConfig(framework, (value) => ({
+                value: value === "hono" ? "npm" : "deno",
+              })),
+            ),
+          }),
+          b: object({ y: option("--y", choice(["2"] as const)) }),
+        },
+      ),
+      framework: prompt(option("--framework", framework), { value: "hono" }),
+    });
+
+    const result = await parseAsync(parser, []);
+
+    assert.ok(result.success);
+    assert.deepEqual(result.value, {
+      cond: ["a", { pm: "npm" }],
+      framework: "hono",
+    });
+    assert.deepEqual(calls, [
+      { value: "a" },
+      { value: "hono" },
+      { value: "npm" },
+    ]);
+  });
+
+  it("resolves a default branch's derived configuration against a later provider", async () => {
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const { prompt, calls } = createTestPrompt();
+    // Nothing selects a named branch, so the default branch prepares
+    // during completion; its derived configuration must wait for the
+    // later provider all the same.
+    const parser = object({
+      cond: conditional(
+        option("--kind", choice(["a", "b"] as const)),
+        {
+          a: object({ x: option("--x", choice(["1"] as const)) }),
+          b: object({ y: option("--y", choice(["2"] as const)) }),
+        },
+        object({
+          pm: prompt(
+            option("--pm", dependency(choice(["deno", "npm"] as const))),
+            derivePromptConfig(framework, (value) => ({
+              value: value === "hono" ? "npm" : "deno",
+            })),
+          ),
+        }),
+      ),
+      framework: prompt(option("--framework", framework), { value: "hono" }),
+    });
+
+    const result = await parseAsync(parser, []);
+
+    assert.ok(result.success);
+    assert.deepEqual(calls, [{ value: "hono" }, { value: "npm" }]);
+  });
+
+  it("resolves a confirmed speculative branch's derived configuration against a later provider", async () => {
+    const kind = dependency(choice(["a", "b"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const { prompt, calls } = createTestPrompt();
+    // "--a x" selects the branch speculatively; the prompted
+    // discriminator confirms it, and only then may the branch's
+    // derived configuration resolve—against the later provider.
+    const parser = object({
+      cond: conditional(
+        prompt(option("--kind", kind), { value: "a" }),
+        {
+          a: object({
+            ax: option("--a", choice(["x"] as const)),
+            pm: prompt(
+              option("--pm", dependency(choice(["deno", "npm"] as const))),
+              derivePromptConfig(framework, (value) => ({
+                value: value === "hono" ? "npm" : "deno",
+              })),
+            ),
+          }),
+          b: object({ y: option("--y", choice(["2"] as const)) }),
+        },
+      ),
+      framework: prompt(option("--framework", framework), { value: "hono" }),
+    });
+
+    const result = await parseAsync(parser, ["--a", "x"]);
+
+    assert.ok(result.success);
+    assert.deepEqual(calls, [
+      { value: "a" },
+      { value: "hono" },
+      { value: "npm" },
+    ]);
+  });
+
+  it("suppresses demand for a CLI-satisfied speculative branch consumer", async () => {
+    const kind = dependency(choice(["a", "b"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const { mode, level } = createModeFixture();
+    const { prompt, calls } = createTestPrompt();
+    let phase2Parsed:
+      | { readonly framework?: unknown; readonly cond?: unknown }
+      | undefined;
+    const dynamicContext: SourceContext = {
+      id: Symbol.for("@optique/prompt/test-satisfied-branch-demand"),
+      phase: "two-pass",
+      getAnnotations(request?: unknown) {
+        if (isPhase2ContextRequest(request)) {
+          phase2Parsed = request.parsed as typeof phase2Parsed;
+        }
+        return {};
+      },
+    };
+    // "--a x" guesses the branch and "--mode prod" satisfies its
+    // consumer, so the consumer's completion is bypassed: its framework
+    // prerequisite must not be demanded into the seed pass.
+    const parser = object({
+      cond: conditional(
+        prompt(option("--kind", kind), { value: "a" }),
+        {
+          a: object({
+            ax: option("--a", choice(["x"] as const)),
+            mode: prompt(
+              option("--mode", mode),
+              derivePromptConfig(framework, (value) => ({
+                value: value === "hono" ? "prod" : "dev",
+              })),
+            ),
+          }),
+          b: object({ y: option("--y", choice(["2"] as const)) }),
+        },
+      ),
+      framework: prompt(option("--framework", framework), { value: "hono" }),
+      level: option("--level", level),
+    });
+
+    const result = await runWith(parser, "test", [dynamicContext], {
+      args: ["--a", "x", "--mode", "prod", "--level", "silent"],
+    });
+
+    assert.equal((result as { readonly level: string }).level, "silent");
+    assert.equal(
+      (result as { readonly framework: string }).framework,
+      "hono",
+    );
+    // The CLI-satisfied branch value reaches the phase-two exchange,
+    // but the bypassed consumer's prerequisite does not prompt early.
+    assert.ok(phase2Parsed?.cond != null);
+    assert.equal(phase2Parsed?.framework, undefined);
+    assert.deepEqual(calls, [{ value: "a" }, { value: "hono" }]);
+  });
+
+  it("demands a branch configuration's prerequisites in the seed pass", async () => {
+    const kind = dependency(choice(["a", "z"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const { mode, level } = createModeFixture();
+    const { prompt, calls } = createTestPrompt();
+    let phase2Cond: unknown;
+    const dynamicContext: SourceContext = {
+      id: Symbol.for("@optique/prompt/test-branch-config-demand"),
+      phase: "two-pass",
+      getAnnotations(request?: unknown) {
+        if (isPhase2ContextRequest(request)) {
+          phase2Cond = (request.parsed as { readonly cond?: unknown })?.cond;
+        }
+        return {};
+      },
+    };
+    // --level demands mode, provided inside the branch; the barrier's
+    // demand edge must pull the configuration's framework prerequisite
+    // into the seed pass too, mirroring the flat rule.
+    const parser = object({
+      cond: conditional(
+        prompt(option("--kind", kind), { value: "a" }),
+        {
+          a: object({
+            mode: prompt(
+              option("--mode", mode),
+              derivePromptConfig(framework, (value) => ({
+                value: value === "hono" ? "prod" : "dev",
+              })),
+            ),
+          }),
+          z: object({ za: option("--za", choice(["1"] as const)) }),
+        },
+      ),
+      framework: prompt(option("--framework", framework), { value: "hono" }),
+      level: option("--level", level),
+    });
+
+    const result = await runWith(parser, "test", [dynamicContext], {
+      args: ["--level", "silent"],
+    });
+
+    assert.equal((result as { readonly level: string }).level, "silent");
+    // The branch value reached the phase-two exchange, so the whole
+    // chain completed in the seed pass, provider first.
+    assert.ok(phase2Cond != null);
+    assert.deepEqual(calls, [
+      { value: "a" },
+      { value: "hono" },
+      { value: "prod" },
+    ]);
+  });
+
+  it("demands a guessed speculative branch consumer's prerequisites", async () => {
+    const kind = dependency(choice(["a", "b"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const { mode, level } = createModeFixture();
+    const { prompt, calls } = createTestPrompt();
+    let phase2Cond: unknown;
+    const dynamicContext: SourceContext = {
+      id: Symbol.for("@optique/prompt/test-speculative-branch-demand"),
+      phase: "two-pass",
+      getAnnotations(request?: unknown) {
+        if (isPhase2ContextRequest(request)) {
+          phase2Cond = (request.parsed as { readonly cond?: unknown })?.cond;
+        }
+        return {};
+      },
+    };
+    // "--a x" guesses the branch but leaves its mode consumer
+    // unsatisfied, so the speculative barrier's recomputed demand edge
+    // must still pull the framework prerequisite into the seed pass.
+    const parser = object({
+      cond: conditional(
+        prompt(option("--kind", kind), { value: "a" }),
+        {
+          a: object({
+            ax: option("--a", choice(["x"] as const)),
+            mode: prompt(
+              option("--mode", mode),
+              derivePromptConfig(framework, (value) => ({
+                value: value === "hono" ? "prod" : "dev",
+              })),
+            ),
+          }),
+          b: object({ y: option("--y", choice(["2"] as const)) }),
+        },
+      ),
+      framework: prompt(option("--framework", framework), { value: "hono" }),
+      level: option("--level", level),
+    });
+
+    const result = await runWith(parser, "test", [dynamicContext], {
+      args: ["--a", "x", "--level", "silent"],
+    });
+
+    assert.equal((result as { readonly level: string }).level, "silent");
+    assert.ok(phase2Cond != null);
+    assert.deepEqual(calls, [
+      { value: "a" },
+      { value: "hono" },
+      { value: "prod" },
+    ]);
+  });
+
+  it("chains demand through a speculative barrier's recomputed edges", async () => {
+    const kindA = dependency(choice(["a", "z"] as const));
+    const kindB = dependency(choice(["b", "z"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const { mode, level } = createModeFixture();
+    const { prompt, calls } = createTestPrompt();
+    const dynamicContext: SourceContext = {
+      id: Symbol.for("@optique/prompt/test-speculative-demand-chain"),
+      phase: "two-pass",
+      getAnnotations() {
+        return {};
+      },
+    };
+    // "--bx x" guesses condB's branch; its recomputed demand edge must
+    // chain the framework prerequisite into the seed pass so condA's
+    // discriminator becomes demanded and every prompt keeps declaration
+    // order.  Without the edge, condA's discriminator defers and the
+    // prompts run out of order.
+    const parser = object({
+      condA: conditional(
+        prompt(option("--kind-a", kindA), { value: "a" }),
+        {
+          a: object({
+            fw: prompt(option("--fw", framework), { value: "hono" }),
+          }),
+          z: object({ za: option("--za", choice(["1"] as const)) }),
+        },
+      ),
+      condB: conditional(
+        prompt(option("--kind-b", kindB), { value: "b" }),
+        {
+          b: object({
+            bx: option("--bx", choice(["x"] as const)),
+            mode: prompt(
+              option("--mode", mode),
+              derivePromptConfig(framework, (value) => ({
+                value: value === "hono" ? "prod" : "dev",
+              })),
+            ),
+          }),
+          z: object({ zb: option("--zb", choice(["2"] as const)) }),
+        },
+      ),
+      level: option("--level", level),
+    });
+
+    const result = await runWith(parser, "test", [dynamicContext], {
+      args: ["--bx", "x", "--level", "silent"],
+    });
+
+    assert.equal((result as { readonly level: string }).level, "silent");
+    assert.deepEqual(calls, [
+      { value: "a" },
+      { value: "hono" },
+      { value: "b" },
+      { value: "prod" },
+    ]);
+  });
+
+  it("forwards a nested barrier's dependencies through a guessed branch", async () => {
+    const kindOuter = dependency(choice(["a", "b"] as const));
+    const kindInner = dependency(choice(["i1", "i2"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const { prompt, calls } = createTestPrompt();
+    // The guessed outer branch contains a nested uncommitted
+    // conditional whose branch configuration reads a provider declared
+    // after the outer conditional: the speculative recompute must
+    // forward the nested barrier's aggregates.
+    const parser = object({
+      cond: conditional(
+        prompt(option("--kind", kindOuter), { value: "a" }),
+        {
+          a: object({
+            ax: option("--a", choice(["x"] as const)),
+            inner: conditional(
+              prompt(option("--inner", kindInner), { value: "i1" }),
+              {
+                i1: object({
+                  pm: prompt(
+                    option(
+                      "--pm",
+                      dependency(choice(["deno", "npm"] as const)),
+                    ),
+                    derivePromptConfig(framework, (value) => ({
+                      value: value === "hono" ? "npm" : "deno",
+                    })),
+                  ),
+                }),
+                i2: object({ z: option("--z", choice(["9"] as const)) }),
+              },
+            ),
+          }),
+          b: object({ y: option("--y", choice(["2"] as const)) }),
+        },
+      ),
+      framework: prompt(option("--framework", framework), { value: "hono" }),
+    });
+
+    const result = await parseAsync(parser, ["--a", "x"]);
+
+    assert.ok(result.success);
+    assert.deepEqual(calls, [
+      { value: "a" },
+      { value: "hono" },
+      { value: "i1" },
+      { value: "npm" },
+    ]);
+  });
+
+  it("demands a branch-internal prerequisite for a demanded branch consumer", async () => {
+    const kind = dependency(choice(["a", "z"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const { mode, level } = createModeFixture();
+    const { prompt, calls } = createTestPrompt();
+    let phase2Cond: unknown;
+    const dynamicContext: SourceContext = {
+      id: Symbol.for("@optique/prompt/test-branch-internal-demand"),
+      phase: "two-pass",
+      getAnnotations(request?: unknown) {
+        if (isPhase2ContextRequest(request)) {
+          phase2Cond = (request.parsed as { readonly cond?: unknown })?.cond;
+        }
+        return {};
+      },
+    };
+    // The demanded consumer's prerequisite lives inside the same
+    // branch: the demand edge must not subtract branch-provided IDs,
+    // or the internal framework prompt would defer out of the seed
+    // pass and stall the consumer.
+    const parser = object({
+      cond: conditional(
+        prompt(option("--kind", kind), { value: "a" }),
+        {
+          a: object({
+            framework: prompt(option("--framework", framework), {
+              value: "hono",
+            }),
+            mode: prompt(
+              option("--mode", mode),
+              derivePromptConfig(framework, (value) => ({
+                value: value === "hono" ? "prod" : "dev",
+              })),
+            ),
+          }),
+          z: object({ za: option("--za", choice(["1"] as const)) }),
+        },
+      ),
+      level: option("--level", level),
+    });
+
+    const result = await runWith(parser, "test", [dynamicContext], {
+      args: ["--level", "silent"],
+    });
+
+    assert.equal((result as { readonly level: string }).level, "silent");
+    assert.ok(phase2Cond != null);
+    assert.deepEqual(calls, [
+      { value: "a" },
+      { value: "hono" },
+      { value: "prod" },
+    ]);
+  });
+
+  it("does not demand another branch consumer's prerequisites", async () => {
+    const kind = dependency(choice(["a", "z"] as const));
+    const other = dependency(choice(["one", "two"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const { mode, level } = createModeFixture();
+    const { prompt, calls } = createTestPrompt();
+    const dynamicContext: SourceContext = {
+      id: Symbol.for("@optique/prompt/test-branch-demand-precision"),
+      phase: "two-pass",
+      getAnnotations() {
+        return {};
+      },
+    };
+    // Only mode is demanded.  The sibling consumer's framework
+    // prerequisite belongs to a different demand edge, so it must not
+    // prompt during the seed pass; it runs in the final pass, still
+    // ordered before the barrier.
+    const parser = object({
+      cond: conditional(
+        prompt(option("--kind", kind), { value: "a" }),
+        {
+          a: object({
+            mode: prompt(option("--mode", mode), { value: "prod" }),
+            extra: prompt(
+              option("--extra", other),
+              derivePromptConfig(framework, (value) => ({
+                value: value === "hono" ? "two" : "one",
+              })),
+            ),
+          }),
+          z: object({ za: option("--za", choice(["1"] as const)) }),
+        },
+      ),
+      framework: prompt(option("--framework", framework), { value: "hono" }),
+      level: option("--level", level),
+    });
+
+    const result = await runWith(parser, "test", [dynamicContext], {
+      args: ["--level", "silent"],
+    });
+
+    assert.equal((result as { readonly level: string }).level, "silent");
+    assert.deepEqual(calls, [
+      { value: "a" },
+      { value: "prod" },
+      { value: "hono" },
+      { value: "two" },
+    ]);
+  });
+
+  it("includes the dependency chain when a branch prompt depends on a failed source", async () => {
+    const kind = dependency(choice(["a", "b"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const middle = dependency(framework.deriveSync({
+      metavar: "MIDDLE",
+      factory: (value) =>
+        choice(value === "fresh" ? (["deno"] as const) : (["npm"] as const)),
+      defaultValue: () => "fresh" as const,
+    }));
+    const { prompt, calls } = createTestPrompt();
+    const parser = object({
+      framework: option("--framework", framework),
+      middle: option("--middle", middle),
+      cond: conditional(
+        prompt(option("--kind", kind), { value: "a" }),
+        {
+          a: object({
+            pm: prompt(
+              option("--pm", dependency(choice(["deno", "npm"] as const))),
+              derivePromptConfig(middle, (value) => ({ value })),
+            ),
+          }),
+          b: object({ y: option("--y", choice(["2"] as const)) }),
+        },
+      ),
+    });
+
+    const result = await parseAsync(parser, [
+      "--framework",
+      "hono",
+      "--middle",
+      "deno",
+    ]);
+
+    assert.ok(!result.success);
+    assert.match(formatMessage(result.error), /Dependency chain:/);
+    // Matching the flat case, the failed source stops the run before
+    // any prompt executes.
+    assert.deepEqual(calls, []);
+  });
+
+  it("stops the branch prompt when an effectful provider fails before the barrier", async () => {
+    const kind = dependency(choice(["a", "b"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const resolverCalls: unknown[] = [];
+    const { prompt, calls } = createTestPrompt();
+    const parser = object({
+      cond: conditional(
+        prompt(option("--kind", kind), { value: "a" }),
+        {
+          a: object({
+            pm: prompt(
+              option("--pm", dependency(choice(["deno", "npm"] as const))),
+              derivePromptConfig(framework, (value) => {
+                resolverCalls.push(value);
+                return { value: "npm" };
+              }),
+            ),
+          }),
+          b: object({ y: option("--y", choice(["2"] as const)) }),
+        },
+      ),
+      framework: prompt(option("--framework", framework), {
+        value: "hono",
+        reject: true,
+      }),
+    });
+
+    const result = await parseAsync(parser, []);
+
+    assert.ok(!result.success);
+    assert.match(formatMessage(result.error), /Prompt rejected/);
+    // The provider is ordered before the barrier, so its failure stops
+    // the pass before the branch resolver ever runs.
+    assert.deepEqual(resolverCalls, []);
+    assert.equal(calls.length, 2);
+  });
+
+  it("never runs a rejected speculative branch's configuration resolver", async () => {
+    const kind = dependency(choice(["a", "b"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const resolverCalls: unknown[] = [];
+    const { prompt, calls } = createTestPrompt();
+    // "--d 1" guesses the a branch, but the discriminator answers "b":
+    // the guessed branch's derived configuration must never resolve.
+    const parser = conditional(
+      prompt(option("--kind", kind), { value: "b" }),
+      {
+        a: object({
+          d: option("--d", string()),
+          pm: prompt(
+            option("--pm", dependency(choice(["deno", "npm"] as const))),
+            derivePromptConfig(framework, (value) => {
+              resolverCalls.push(value);
+              return { value: "npm" };
+            }),
+          ),
+        }),
+        b: object({ p: option("--p", string()) }),
+      },
+    );
+
+    const result = await parseAsync(parser, ["--d", "1"]);
+
+    assert.ok(!result.success);
+    assert.deepEqual(resolverCalls, []);
+    assert.deepEqual(calls, [{ value: "b" }]);
+  });
+
+  it("shares one branch parser object across keys", async () => {
+    const kind = dependency(choice(["a", "b"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const { prompt, calls } = createTestPrompt();
+    const shared = object({
+      pm: prompt(
+        option("--pm", dependency(choice(["deno", "npm"] as const))),
+        derivePromptConfig(framework, (value) => ({
+          value: value === "hono" ? "npm" : "deno",
+        })),
+      ),
+    });
+    const parser = object({
+      cond: conditional(
+        prompt(option("--kind", kind), { value: "b" }),
+        { a: shared, b: shared },
+      ),
+      framework: prompt(option("--framework", framework), { value: "hono" }),
+    });
+
+    const result = await parseAsync(parser, []);
+
+    assert.ok(result.success);
+    assert.deepEqual(result.value.cond, ["b", { pm: "npm" }]);
+    assert.deepEqual(calls, [
+      { value: "b" },
+      { value: "hono" },
+      { value: "npm" },
+    ]);
+  });
+
+  // The remaining tests pin accepted limitations of the static
+  // aggregation, so a behavior change there is deliberate rather than
+  // accidental.
+
+  it("keeps a branch-internal provider for the branch consumer while a later occurrence wins outside", async () => {
+    const kind = dependency(choice(["a", "b"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const frameworkDerived = framework.deriveSync({
+      metavar: "FW_DERIVED",
+      factory: (value: "fresh" | "hono") =>
+        choice(value === "fresh" ? (["deno"] as const) : (["npm"] as const)),
+      defaultValue: () => "fresh" as const,
+    });
+    const { prompt } = createTestPrompt();
+    // The branch both provides and consumes the framework source, so
+    // the barrier stays atomic: its consumer reads the internal
+    // occurrence, while the occurrence declared after the conditional
+    // wins for post-conditional consumers.
+    const parser = object({
+      cond: conditional(
+        prompt(option("--kind", kind), { value: "a" }),
+        {
+          a: object({
+            fw: prompt(option("--fw", framework), { value: "fresh" }),
+            pm: prompt(
+              option("--pm", dependency(choice(["deno", "npm"] as const))),
+              derivePromptConfig(framework, (value) => ({
+                value: value === "fresh" ? "deno" : "npm",
+              })),
+            ),
+          }),
+          b: object({ y: option("--y", choice(["2"] as const)) }),
+        },
+      ),
+      fw2: prompt(option("--fw2", framework), { value: "hono" }),
+      out: option("--out", frameworkDerived),
+    });
+
+    const result = await parseAsync(parser, ["--out", "npm"]);
+
+    assert.ok(result.success);
+    assert.deepEqual(result.value.cond, ["a", { fw: "fresh", pm: "deno" }]);
+    assert.equal(result.value.fw2, "hono");
+    assert.equal(result.value.out, "npm");
+  });
+
+  it("lets an absent branch provider hide a later external provider", async () => {
+    const kind = dependency(choice(["a", "b"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const resolved: unknown[] = [];
+    const { prompt } = createTestPrompt();
+    // The branch statically provides the framework source through an
+    // optional occurrence that parses nothing, so the ordering union
+    // drops the edge to the later occurrence: the resolver keeps its
+    // declared default.
+    const parser = object({
+      cond: conditional(
+        prompt(option("--kind", kind), { value: "a" }),
+        {
+          a: object({
+            fw: optional(option("--fw", framework)),
+            pm: prompt(
+              option("--pm", dependency(choice(["deno", "npm"] as const))),
+              derivePromptConfig(framework, (value, { usedDefault }) => {
+                resolved.push([value, usedDefault]);
+                return { value: value === "hono" ? "npm" : "deno" };
+              }, { defaultValue: () => "fresh" as const }),
+            ),
+          }),
+          b: object({ y: option("--y", choice(["2"] as const)) }),
+        },
+      ),
+      fw2: prompt(option("--fw2", framework), { value: "hono" }),
+    });
+
+    const result = await parseAsync(parser, []);
+
+    assert.ok(result.success);
+    assert.deepEqual(resolved, [["fresh", true]]);
+  });
+
+  it("keeps a nested alternative's static provides hiding an outer provider", async () => {
+    const kindOuter = dependency(choice(["a", "b"] as const));
+    const kindInner = dependency(choice(["i1", "i2"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const resolved: unknown[] = [];
+    const { prompt } = createTestPrompt();
+    // The outer branch's static walk sees the unselected i1
+    // alternative providing the framework source, so the subtraction
+    // happens at outer-branch granularity and the selected i2
+    // consumer cannot wait for the provider declared after the outer
+    // conditional: it keeps its declared default.
+    const parser = object({
+      cond: conditional(
+        prompt(option("--kind", kindOuter), { value: "a" }),
+        {
+          a: object({
+            inner: conditional(
+              prompt(option("--inner", kindInner), { value: "i2" }),
+              {
+                i1: object({ fw: option("--fw", framework) }),
+                i2: object({
+                  pm: prompt(
+                    option(
+                      "--pm",
+                      dependency(choice(["deno", "npm"] as const)),
+                    ),
+                    derivePromptConfig(framework, (value) => {
+                      resolved.push(value);
+                      return { value: value === "hono" ? "npm" : "deno" };
+                    }, { defaultValue: () => "fresh" as const }),
+                  ),
+                }),
+              },
+            ),
+          }),
+          b: object({ y: option("--y", choice(["2"] as const)) }),
+        },
+      ),
+      fw2: prompt(option("--fw2", framework), { value: "hono" }),
+    });
+
+    const result = await parseAsync(parser, []);
+
+    assert.ok(result.success);
+    assert.deepEqual(resolved, ["fresh"]);
+  });
+});


### PR DESCRIPTION
A `conditional()` whose branch is selected only during completion joins the outer scheduling pass as an opaque barrier node. Completion dependencies declared inside its branches were invisible to that pass, so the branch ran at the conditional's declaration position and a derived prompt configuration inside it could not wait for a provider declared after the conditional.

Splicing the selected branch into the outer schedule would give up the barrier's atomicity, so `conditional()` instead walks every selectable branch once at construction time and attaches the resulting estimate to its barrier node. The estimate is split in two because ordering and demand tolerate errors differently. For ordering, each branch's statically providable IDs are subtracted from that branch's completion dependency IDs before the remainders are unioned; internal prerequisites resolve in the nested pass. Demand edges keep branch-internal prerequisites, since a demanded consumer must pull even an internal source prompt into the seed pass, and each edge propagates only while its consumer's own source ID is demanded, so neither a demanded discriminator nor an unrelated sibling source forces a prompt. Keeping the estimate on `RuntimeNode` rather than on parser dependency metadata keeps these advisory edges out of failure lineage; a failed prerequisite of an unselected branch must not fail the whole conditional.

The speculative barrier refines the static estimate against the guessed branch's parsed states, mirroring the flat inactive-completion rule: a consumer already satisfied by the command line or a binding contributes neither edges nor demand. Two limitations of the static estimate remain, each pinned by a test so a change there is deliberate. Aggregation across siblings that consume each other's sources can report a false circular dependency, and a statically visible but inactive branch provider, such as an absent `optional()` occurrence or an unselected nested alternative, hides a later outer provider. The stopgap advice in *docs/integrations/prompt.md* is replaced by a description of the new ordering.

Closes #919. Part of #869.
