### PR TITLE
Track active providers across `conditional()` branches

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,9 +20,20 @@ To be released.
     ordering and demand rules apply inside a `conditional()` whose branch is
     selected only during completion: the branches' completion dependencies
     propagate through the conditional's scheduling barrier, so a branch
-    configuration can read a source declared after the conditional.  Cycles
-    introduced this way are rejected with the existing circular-dependency
-    error.  [[#869], [#872], [#919], [#923]]
+    configuration can read a source declared after the conditional.  Once
+    the discriminator resolves the selection, the scheduler replaces the
+    static estimate with the selected branch's actual dependencies, and a
+    branch occurrence hides an outer provider only when it will actively
+    publish the source itself—an unconditional prompt, a `withDefault()`
+    fallback, a nested conditional providing the source on every route, or
+    a value the branch already parsed or bound—so an absent `optional()`
+    occurrence or an unselected nested alternative no longer keeps a
+    provider declared after the conditional from serving the branch.
+    Cycles among the selected branch's actual providers and consumers
+    are rejected with the existing circular-dependency error, while an
+    apparent cycle whose edges belong to branches that cannot be
+    selected together is no longer rejected.
+    [[#869], [#872], [#919], [#923], [#924], [#926]]
  -  Added `termWidth: "auto"` to `formatDocPage()` for aligning descriptions
     after the widest visible term using terminal display width while reserving
     description space under `maxWidth`.  The existing default and explicit
@@ -89,6 +100,8 @@ To be released.
 [#915]: https://github.com/dahlia/optique/pull/915
 [#919]: https://github.com/dahlia/optique/issues/919
 [#923]: https://github.com/dahlia/optique/pull/923
+[#924]: https://github.com/dahlia/optique/issues/924
+[#926]: https://github.com/dahlia/optique/pull/926
 
 ### @optique/run
 

--- a/changes.d/core/completion-dependency-scheduling.md
+++ b/changes.d/core/completion-dependency-scheduling.md
@@ -4,6 +4,8 @@ links:
   '#872': https://github.com/dahlia/optique/issues/872
   '#919': https://github.com/dahlia/optique/issues/919
   '#923': https://github.com/dahlia/optique/pull/923
+  '#924': https://github.com/dahlia/optique/issues/924
+  '#926': https://github.com/dahlia/optique/pull/926
 ---
  -  Added scheduling support for effectful completions that consume
     dependency values, such as prompts with derived configurations.  The
@@ -13,6 +15,17 @@ links:
     ordering and demand rules apply inside a `conditional()` whose branch is
     selected only during completion: the branches' completion dependencies
     propagate through the conditional's scheduling barrier, so a branch
-    configuration can read a source declared after the conditional.  Cycles
-    introduced this way are rejected with the existing circular-dependency
-    error.  [[#869], [#872], [#919], [#923]]
+    configuration can read a source declared after the conditional.  Once
+    the discriminator resolves the selection, the scheduler replaces the
+    static estimate with the selected branch's actual dependencies, and a
+    branch occurrence hides an outer provider only when it will actively
+    publish the source itself—an unconditional prompt, a `withDefault()`
+    fallback, a nested conditional providing the source on every route, or
+    a value the branch already parsed or bound—so an absent `optional()`
+    occurrence or an unselected nested alternative no longer keeps a
+    provider declared after the conditional from serving the branch.
+    Cycles among the selected branch's actual providers and consumers
+    are rejected with the existing circular-dependency error, while an
+    apparent cycle whose edges belong to branches that cannot be
+    selected together is no longer rejected.
+    [[#869], [#872], [#919], [#923], [#924], [#926]]

--- a/docs/concepts/dependencies.md
+++ b/docs/concepts/dependencies.md
@@ -657,7 +657,13 @@ providers, so they resolve first, and the prompt runs after them regardless of
 field order.  A branch that a `conditional()` selects only during completion
 contributes its completion dependencies to the enclosing graph as well: the
 conditional waits for the providers its selectable branches read, even when
-they are declared after it.
+they are declared after it.  Once the discriminator resolves the selection,
+the estimate is replaced by the selected branch's actual dependencies, and a
+branch occurrence hides an outer provider only when it will actively publish
+the source itself—through a guaranteed completion or default, or a value the
+branch already parsed or bound—so an absent `optional()` occurrence or an
+unselected nested alternative does not stop a later provider from serving the
+branch.
 
 An invalid source never falls back to its default. The failure propagates
 through every derived source that consumes it—including prompts whose
@@ -666,3 +672,6 @@ path. Optique also rejects a cycle in the active runtime graph with the
 involved paths/metavars, although ordinary `derive()` and `deriveFrom()`
 composition constructs an acyclic graph by value; derived prompt
 configurations can introduce cycles, which fail with the same diagnostic.
+An apparent cycle whose edges belong to `conditional()` branches that cannot
+be selected together is not a real cycle and is not rejected: the judgment is
+made against the selected branch's actual providers and consumers.

--- a/docs/integrations/prompt.md
+++ b/docs/integrations/prompt.md
@@ -711,20 +711,33 @@ completion dependencies of every selectable branch, so the conditional
 waits for the sources a branch configuration reads even when they are
 declared *after* the conditional, and the demand-only seed pass of a
 `runWith()` run reaches a prerequisite only through the branch consumer
-that actually reads it.  Three caveats follow from the branch estimates
-being static.  A dependency on a source that another sibling might
-publish, such as a completion consumer next to a conditional whose
-branch consumes the sibling's own source, can be rejected as a circular
-dependency even though only one of them would run.  A branch that
-*could* provide a source itself—through an unselected nested
-alternative, or an `optional()` occurrence that ends up parsing
-nothing—resolves that source inside the branch, so a matching provider
-declared after the conditional is not waited for and the configuration
-falls back to its declared default.  And a speculative selection that
-the discriminator ultimately rejects may already have demanded its
-configuration prerequisites, so a prerequisite prompt can run before
-the branch-mismatch error surfaces, although the rejected branch's own
-resolver never runs.
+that actually reads it.  Once the discriminator resolves the selection,
+the scheduler replaces that estimate with the selected branch's actual
+dependencies.  A branch occurrence counts as an *active* provider only
+when it is guaranteed to publish—an unconditional prompt, a
+`withDefault()` fallback, or a nested conditional that provides the
+source on every selectable route—or when its state already holds a
+parsed or bound value.  A merely possible provider, such as an
+`optional()` occurrence that ends up parsing nothing or a provider in
+an unselected nested alternative, no longer hides a matching provider
+declared after the conditional: the branch configuration waits for that
+provider and reads its value.  An apparent dependency cycle whose edges
+come from branches that cannot be selected together—say, a completion
+consumer next to a conditional whose branch consumes the consumer's own
+source—is no longer rejected; only a cycle among the selected branch's
+actual providers and consumers still raises the circular dependency
+error.
+
+Two caveats remain.  A speculative selection that the discriminator
+ultimately rejects may already have demanded its configuration
+prerequisites, so a prerequisite prompt can run before the
+branch-mismatch error surfaces, although the rejected branch's own
+resolver never runs.  And a nested conditional that guarantees a source
+on only *some* of its routes is treated as a merely possible provider,
+so the outer conditional waits for a later occurrence when one exists;
+if the nested route that does provide the source is then selected, its
+value publishes after that occurrence and wins for consumers declared
+after the outer conditional.
 
 
 Testing adapters

--- a/packages/core/src/constructs.ts
+++ b/packages/core/src/constructs.ts
@@ -16,6 +16,7 @@ import {
 import {
   type BarrierCompletionDemandEdge,
   type BarrierCompletionDependencies,
+  type BarrierResolution,
   buildRuntimeNodesFromArray,
   buildRuntimeNodesFromPairs,
   collectExplicitSourceValues,
@@ -25,14 +26,17 @@ import {
   createDependencyRuntimeContext,
   type EffectfulSchedulingNodesFn,
   effectfulSchedulingNodesKey,
+  exclusiveSourceScopeKey,
   fillMissingSourceDefaults,
   fillMissingSourceDefaultsAsync,
+  guaranteedStaticSourceIdsKey,
   hasInactiveCompletion,
   resolveDerivedSourceValues,
   resolveDerivedSourceValuesAsync,
   resolveStateWithRuntime,
   resolveStateWithRuntimeAsync,
   type RuntimeNode,
+  type SchedulingBarrierContext,
   serializeSchedulingPath,
   sourceCollectionExpansionKey,
   staticSourceScopeKey,
@@ -94,7 +98,10 @@ import {
   type ParseLane,
   unmatchedNonCliDependencySourceStateMarker,
 } from "./internal/parser.ts";
-import type { ParserDependencyMetadata } from "./dependency-metadata.ts";
+import type {
+  DependencySourceCapability,
+  ParserDependencyMetadata,
+} from "./dependency-metadata.ts";
 
 /**
  * Helper type to extract Mode from a Parser.
@@ -402,26 +409,92 @@ interface PreparedConditionalSelection {
 let conditionalInstanceCounter = 0;
 
 /**
- * Statically collects the dependency source IDs reachable through a
- * parser's composed metadata and flattened field pairs.  Used as the
- * `providesSourceIds` estimate for a conditional()'s branches: an
- * undercount only delays an effectful completion from the seed pass to
- * the final pass of a `runWith()` run.
+ * The statically estimated dependency sources a subtree can provide,
+ * split by how certain the publication is.
  */
-function collectStaticSourceIds(
+interface StaticProvidesEstimate {
+  /**
+   * Every source ID any occurrence in the subtree could publish.  An
+   * overcount only delays an effectful completion from the seed pass to
+   * the final pass of a `runWith()` run.
+   */
+  readonly may: Set<symbol>;
+
+  /**
+   * Source IDs some occurrence publishes whenever the subtree runs: an
+   * unconditional effectful completion (a prompt without a runtime
+   * condition) or a publishable missing-value default.  Only these may
+   * be subtracted from a branch's ordering dependencies—a merely
+   * possible provider must not hide a matching provider declared after
+   * the conditional (see issue #924).
+   */
+  readonly guaranteed: Set<symbol>;
+}
+
+/**
+ * Whether a source occurrence publishes a value even when its state
+ * holds no parsed one: its composed effectful completion always fires
+ * (`completesWhenMissing`), or it exposes a publishable missing-value
+ * default.
+ */
+function isGuaranteedSourceProvider(
+  source: DependencySourceCapability,
+): boolean {
+  return (
+    source.completeSource != null && source.completesWhenMissing === true
+  ) || (
+    source.getMissingSourceValue != null &&
+    source.preservesSourceValue !== false
+  );
+}
+
+/**
+ * Statically collects the dependency source IDs reachable through a
+ * parser's composed metadata and flattened field pairs, classifying each
+ * as merely possible or guaranteed.
+ *
+ * `exclusive` marks descent through a mutually exclusive edge (an `or()`
+ * alternative, a `conditional()` branch, an unmatched `command()`); an
+ * occurrence reached that way never counts as guaranteed.  `suppressId`
+ * carries the source ID of an enclosing wrapper whose composed metadata
+ * already decided that chain's classification, so the raw inner
+ * occurrence (e.g., the bare prompt inside `optional(prompt(...))`) does
+ * not overrule the wrapper.
+ */
+function collectStaticProvides(
   parser: Parser<Mode, unknown, unknown>,
-  out: Set<symbol>,
-  seen: Set<object>,
+  out: StaticProvidesEstimate,
+  exclusive: boolean,
+  suppressId: symbol | undefined,
+  seen: Map<object, number>,
 ): void {
-  if (seen.has(parser as object)) return;
-  seen.add(parser as object);
+  const visitBit = 1 << ((exclusive ? 1 : 0) | (suppressId != null ? 2 : 0));
+  const visited = seen.get(parser as object) ?? 0;
+  if ((visited & visitBit) !== 0) return;
+  seen.set(parser as object, visited | visitBit);
   const source = parser.dependencyMetadata?.source;
+  let childSuppressId = suppressId;
   if (source != null) {
     // A composed source (e.g., a mixed or() delegating to its committed
     // branch) can sit on a parser whose alternatives provide further
     // sources, so record it and keep walking the field and static
     // scopes rather than stopping here.
-    out.add(source.sourceId);
+    out.may.add(source.sourceId);
+    if (
+      !exclusive && source.sourceId !== suppressId &&
+      isGuaranteedSourceProvider(source)
+    ) {
+      out.guaranteed.add(source.sourceId);
+    }
+    childSuppressId = source.sourceId;
+  }
+  const routeGuaranteed = (parser as {
+    readonly [guaranteedStaticSourceIdsKey]?: ReadonlySet<symbol>;
+  })[guaranteedStaticSourceIdsKey];
+  if (routeGuaranteed != null && !exclusive) {
+    // A nested conditional() guarantees the IDs every selectable route
+    // publishes, even though each branch edge below is exclusive.
+    for (const id of routeGuaranteed) out.guaranteed.add(id);
   }
   const pairs = (parser as {
     readonly [fieldParsersKey]?: ReadonlyArray<
@@ -429,7 +502,9 @@ function collectStaticSourceIds(
     >;
   })[fieldParsersKey];
   if (pairs != null) {
-    for (const [, child] of pairs) collectStaticSourceIds(child, out, seen);
+    for (const [, child] of pairs) {
+      collectStaticProvides(child, out, exclusive, childSuppressId, seen);
+    }
   }
   const scope = (parser as {
     readonly [staticSourceScopeKey]?: ReadonlyArray<
@@ -437,7 +512,19 @@ function collectStaticSourceIds(
     >;
   })[staticSourceScopeKey];
   if (scope != null) {
-    for (const child of scope) collectStaticSourceIds(child, out, seen);
+    for (const child of scope) {
+      collectStaticProvides(child, out, exclusive, childSuppressId, seen);
+    }
+  }
+  const exclusiveScope = (parser as {
+    readonly [exclusiveSourceScopeKey]?: ReadonlyArray<
+      Parser<Mode, unknown, unknown>
+    >;
+  })[exclusiveSourceScopeKey];
+  if (exclusiveScope != null) {
+    for (const child of exclusiveScope) {
+      collectStaticProvides(child, out, true, childSuppressId, seen);
+    }
   }
 }
 
@@ -500,6 +587,81 @@ function collectStaticCompletionDependencies(
       );
     }
   }
+  // Completion consumers union across exclusive alternatives too: an
+  // unselected consumer merely overestimates the ordering wait.
+  const exclusiveScope = (parser as {
+    readonly [exclusiveSourceScopeKey]?: ReadonlyArray<
+      Parser<Mode, unknown, unknown>
+    >;
+  })[exclusiveSourceScopeKey];
+  if (exclusiveScope != null) {
+    for (const child of exclusiveScope) {
+      collectStaticCompletionDependencies(
+        child,
+        orderingDependencyIds,
+        demandEdges,
+        seen,
+      );
+    }
+  }
+}
+
+/**
+ * A branch's construction-time dependency estimate: the sources it may
+ * or certainly provides, and the barrier dependencies its completion
+ * consumers aggregate.
+ */
+interface BranchDependencyEstimate {
+  readonly mayProvides: ReadonlySet<symbol>;
+  readonly guaranteedProvides: ReadonlySet<symbol>;
+  readonly dependencies?: BarrierCompletionDependencies;
+}
+
+/**
+ * Collects the source IDs a set of expanded branch nodes will actively
+ * publish: a guaranteed occurrence (an unconditional effectful
+ * completion or a publishable default), an occurrence whose state
+ * already extracts a value, or a nested barrier's every-route
+ * guarantees.  Synchronous extraction only;
+ * {@link computeActiveBarrierDependencies} additionally awaits
+ * promise-shaped extractions, so a bound value that validates
+ * asynchronously still counts as active.
+ */
+function collectActiveProvidesSync(
+  nodes: readonly RuntimeNode[],
+): Set<symbol> {
+  const active = new Set<symbol>();
+  for (const node of nodes) {
+    const source = node.parser.dependencyMetadata?.source;
+    if (source != null && !active.has(source.sourceId)) {
+      if (isGuaranteedSourceProvider(source)) {
+        active.add(source.sourceId);
+      } else if (source.extractSourceValue != null) {
+        let extracted: ReturnType<typeof source.extractSourceValue>;
+        try {
+          extracted = source.extractSourceValue(node.state);
+        } catch {
+          extracted = undefined;
+        }
+        if (extracted != null && isPromiseLike(extracted)) {
+          // The synchronous estimate cannot await; discard the promise
+          // but never let its rejection surface as unhandled.
+          void Promise.resolve(extracted).catch(() => {});
+        } else if (
+          extracted?.success === true && extracted.value !== undefined
+        ) {
+          active.add(source.sourceId);
+        }
+      }
+    }
+    for (const id of node.guaranteedProvidesSourceIds ?? []) active.add(id);
+  }
+  return active;
+}
+
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  return typeof (value as { readonly then?: unknown } | null)?.then ===
+    "function";
 }
 
 /**
@@ -507,12 +669,14 @@ function collectStaticCompletionDependencies(
  * guessed branch's expanded runtime nodes, so an occurrence already
  * satisfied by the command line or a binding contributes neither
  * ordering edges nor demand, mirroring the flat inactive-completion
- * rule.  Nested barriers contribute their own aggregates, which remain
- * static estimates.
+ * rule.  Only *active* provides are subtracted from the ordering
+ * union—a merely possible provider (an absent `optional()`, an
+ * unselected nested alternative) must not hide a matching provider
+ * declared after the conditional (issue #924).  Nested barriers
+ * contribute their own aggregates, which remain static estimates.
  */
 function computeBarrierDependenciesFromNodes(
   nodes: readonly RuntimeNode[],
-  provides: ReadonlySet<symbol>,
 ): BarrierCompletionDependencies | undefined {
   const ordering = new Set<symbol>();
   const demandEdges: BarrierCompletionDemandEdge[] = [];
@@ -535,11 +699,78 @@ function computeBarrierDependenciesFromNodes(
       demandEdges.push(...nested.demandEdges);
     }
   }
-  const orderingDependencyIds = [...ordering].filter((id) => !provides.has(id));
+  const active = collectActiveProvidesSync(nodes);
+  const orderingDependencyIds = [...ordering].filter((id) => !active.has(id));
   if (orderingDependencyIds.length < 1 && demandEdges.length < 1) {
     return undefined;
   }
   return { orderingDependencyIds, demandEdges };
+}
+
+/**
+ * Computes a resolved barrier's concrete dependencies from the selected
+ * branch's expanded runtime nodes: the completion dependencies its
+ * active consumers read, minus the sources the branch actively
+ * provides, and the active provides themselves.  Unlike the
+ * synchronous estimate, promise-shaped state extractions are awaited,
+ * so an asynchronously validating bound value counts as active.
+ */
+async function computeActiveBarrierDependencies(
+  nodes: readonly RuntimeNode[],
+): Promise<BarrierResolution> {
+  const active = new Set<symbol>();
+  const ordering = new Set<symbol>();
+  for (const node of nodes) {
+    const metadata = node.parser.dependencyMetadata;
+    const source = metadata?.source;
+    const completion = metadata?.completion;
+    // Each extractor is invoked at most once per node, and the single
+    // awaited result decides both provider activity and consumer
+    // inactivity, so a stateful or asynchronously validating extractor
+    // cannot make the two classifications disagree.  A rejected
+    // extraction counts as neither: the provider stays inactive (the
+    // barrier conservatively waits for an outer provider) and the
+    // consumer stays active (its completion is the recovery path).
+    const guaranteed = source != null && isGuaranteedSourceProvider(source);
+    let extracted: ValueParserResult<unknown> | undefined;
+    if (
+      source?.extractSourceValue != null &&
+      (completion != null || (!guaranteed && !active.has(source.sourceId)))
+    ) {
+      try {
+        extracted = await source.extractSourceValue(node.state);
+      } catch {
+        extracted = undefined;
+      }
+    }
+    if (source != null) {
+      if (
+        guaranteed ||
+        (extracted?.success === true && extracted.value !== undefined)
+      ) {
+        active.add(source.sourceId);
+      }
+    }
+    for (const id of node.guaranteedProvidesSourceIds ?? []) active.add(id);
+    if (completion != null) {
+      // Mirrors the memoized synchronous rule: an occurrence whose own
+      // state already extracts a value bypasses its completion.
+      const inactive = source?.extractSourceValue != null
+        ? extracted?.success === true
+        : hasInactiveCompletion(node);
+      if (!inactive) {
+        for (const id of completion.dependencyIds) ordering.add(id);
+      }
+    }
+    const nested = node.barrierCompletionDependencies;
+    if (nested != null) {
+      for (const id of nested.orderingDependencyIds) ordering.add(id);
+    }
+  }
+  return {
+    orderingDependencyIds: [...ordering].filter((id) => !active.has(id)),
+    activeProvidesSourceIds: active,
+  };
 }
 
 function isDeferredCompletionResult(result: unknown): boolean {
@@ -2192,7 +2423,9 @@ function defineExclusiveSchedulingNodes(
       enumerable: false,
     });
   }
-  Object.defineProperty(exclusiveParser, staticSourceScopeKey, {
+  // Alternatives are mutually exclusive, so a source occurrence inside
+  // one of them is never a guaranteed provider for the whole parser.
+  Object.defineProperty(exclusiveParser, exclusiveSourceScopeKey, {
     value: parsers,
     configurable: true,
     enumerable: false,
@@ -2240,6 +2473,11 @@ function composeExclusiveDependencyMetadata(
     source: {
       ...sharedSource,
       getMissingSourceValue: undefined,
+      // The composed completion delegates to the committed branch only,
+      // and the run may commit an alternative that is not the source,
+      // so the exclusive parser is never a guaranteed publisher even
+      // when a source alternative would be.
+      completesWhenMissing: false,
       preservesSourceValue: everyBranchPreserves,
       extractSourceValue(state) {
         if (
@@ -16144,23 +16382,23 @@ export function conditional(
   // branches must contribute to every branch's estimate.
   const {
     branchProvidedSourceIds,
+    branchGuaranteedIntersection,
     mergedBarrierDependencies,
     barrierDependenciesByKey,
   } = (() => {
     const provided = new Set<symbol>();
-    interface BranchDependencyEstimate {
-      readonly provides: ReadonlySet<symbol>;
-      readonly dependencies?: BarrierCompletionDependencies;
-    }
     const byParser = new Map<object, BranchDependencyEstimate>();
     const computeBranch = (
       branch: Parser<Mode, unknown, unknown>,
     ): BranchDependencyEstimate => {
       const memoized = byParser.get(branch as object);
       if (memoized != null) return memoized;
-      const provides = new Set<symbol>();
-      collectStaticSourceIds(branch, provides, new Set());
-      for (const id of provides) provided.add(id);
+      const provides: StaticProvidesEstimate = {
+        may: new Set(),
+        guaranteed: new Set(),
+      };
+      collectStaticProvides(branch, provides, false, undefined, new Map());
+      for (const id of provides.may) provided.add(id);
       const ordering = new Set<symbol>();
       const demandEdges: BarrierCompletionDemandEdge[] = [];
       collectStaticCompletionDependencies(
@@ -16169,16 +16407,20 @@ export function conditional(
         demandEdges,
         new Set(),
       );
-      // The ordering union subtracts the branch's own statically
-      // providable IDs: those prerequisites resolve inside the
-      // barrier's nested pass.  Demand edges keep them—a demanded
+      // The ordering union subtracts only the branch's *guaranteed*
+      // provides: those prerequisites certainly resolve inside the
+      // barrier's nested pass.  A merely possible provider—an
+      // `optional()` occurrence, an unselected nested alternative—must
+      // not hide a matching provider declared after the conditional
+      // (issue #924).  Demand edges keep every internal ID—a demanded
       // consumer must still demand a branch-internal source prompt so
       // it does not defer out of the seed pass.
       const orderingDependencyIds = [...ordering].filter(
-        (id) => !provides.has(id),
+        (id) => !provides.guaranteed.has(id),
       );
       const estimate: BranchDependencyEstimate = {
-        provides,
+        mayProvides: provides.may,
+        guaranteedProvides: provides.guaranteed,
         ...(orderingDependencyIds.length < 1 && demandEdges.length < 1
           ? {}
           : { dependencies: { orderingDependencyIds, demandEdges } }),
@@ -16186,12 +16428,26 @@ export function conditional(
       byParser.set(branch as object, estimate);
       return estimate;
     };
+    const routes: BranchDependencyEstimate[] = [];
     const byKey = new Map<string, BranchDependencyEstimate>();
     for (const key of Object.keys(branches)) {
       const estimate = computeBranch(branches[key]);
-      if (estimate.dependencies != null) byKey.set(key, estimate);
+      routes.push(estimate);
+      byKey.set(key, estimate);
     }
-    if (defaultBranch != null) computeBranch(defaultBranch);
+    if (defaultBranch != null) routes.push(computeBranch(defaultBranch));
+    // The IDs every selectable route guarantees stay guaranteed for an
+    // enclosing scope even though each branch edge is exclusive.
+    let intersection: Set<symbol> | undefined;
+    for (const route of routes) {
+      if (intersection == null) {
+        intersection = new Set(route.guaranteedProvides);
+      } else {
+        for (const id of intersection) {
+          if (!route.guaranteedProvides.has(id)) intersection.delete(id);
+        }
+      }
+    }
     const orderingUnion = new Set<symbol>();
     const mergedEdges: BarrierCompletionDemandEdge[] = [];
     for (const estimate of new Set(byParser.values())) {
@@ -16209,6 +16465,7 @@ export function conditional(
       };
     return {
       branchProvidedSourceIds: provided,
+      branchGuaranteedIntersection: intersection ?? new Set<symbol>(),
       mergedBarrierDependencies: merged,
       barrierDependenciesByKey: byKey,
     };
@@ -16310,28 +16567,31 @@ export function conditional(
       }
       teeDiscriminatorNode();
       const speculativeKey = selected.key;
+      const expandGuessedBranchNodes = (): readonly RuntimeNode[] => {
+        const branchParser = branches[speculativeKey];
+        if (branchParser == null) return [];
+        return expandEffectfulRuntimeNodes([{
+          path: [...(parentPath ?? []), "_branch"],
+          parser: branchParser,
+          state: getAnnotatedChildState(
+            conditionalState,
+            conditionalState.branchState,
+            branchParser,
+          ),
+        }]);
+      };
       // The guessed branch was parsed, so its occurrence states can
       // refine the static estimate: a consumer already satisfied by the
       // command line or a binding bypasses its completion, and its
       // prerequisites must contribute neither ordering edges nor
       // demand, mirroring the flat inactive-completion rule.
+      const speculativeEstimate = barrierDependenciesByKey.get(speculativeKey);
       const speculativeBarrierDependencies = (() => {
-        const estimate = barrierDependenciesByKey.get(speculativeKey);
-        if (estimate?.dependencies == null) return undefined;
-        const branchParser = branches[speculativeKey];
-        if (branchParser == null) return estimate.dependencies;
-        return computeBarrierDependenciesFromNodes(
-          expandEffectfulRuntimeNodes([{
-            path: [...(parentPath ?? []), "_branch"],
-            parser: branchParser,
-            state: getAnnotatedChildState(
-              conditionalState,
-              conditionalState.branchState,
-              branchParser,
-            ),
-          }]),
-          estimate.provides,
-        );
+        if (speculativeEstimate?.dependencies == null) return undefined;
+        if (branches[speculativeKey] == null) {
+          return speculativeEstimate.dependencies;
+        }
+        return computeBarrierDependenciesFromNodes(expandGuessedBranchNodes());
       })();
       nodes.push({
         path: [...(parentPath ?? []), "_branch"],
@@ -16341,9 +16601,42 @@ export function conditional(
           ? { requiresSourceId: discriminatorSource.sourceId }
           : {}),
         providesSourceIds: branchProvidedSourceIds,
+        ...(speculativeEstimate != null &&
+            speculativeEstimate.guaranteedProvides.size > 0
+          ? {
+            guaranteedProvidesSourceIds: speculativeEstimate.guaranteedProvides,
+          }
+          : {}),
         ...(speculativeBarrierDependencies != null
           ? { barrierCompletionDependencies: speculativeBarrierDependencies }
           : {}),
+        resolveBarrier: async (ctx) => {
+          const session = ctx.exec?.effectfulCompletionSession;
+          if (session == null) return undefined;
+          const result = cell.result ??
+            session.completedByPath.get(discriminatorPathKey);
+          if (
+            result == null || isDeferredCompletionResult(result) ||
+            result.success !== true
+          ) {
+            return undefined;
+          }
+          if (
+            String(result.value) !== speculativeKey ||
+            branches[speculativeKey] == null
+          ) {
+            // A rejected speculation schedules no branch, so it has no
+            // concrete dependencies and provides nothing; the mismatch
+            // itself is reported by the completion phase.
+            return {
+              orderingDependencyIds: [],
+              activeProvidesSourceIds: new Set<symbol>(),
+            };
+          }
+          return await computeActiveBarrierDependencies(
+            expandGuessedBranchNodes(),
+          );
+        },
         prepare: async (ctx) => {
           const session = ctx.exec?.effectfulCompletionSession;
           if (session == null) return undefined;
@@ -16356,17 +16649,8 @@ export function conditional(
             return undefined;
           }
           if (String(result.value) !== speculativeKey) return undefined;
-          const branchParser = branches[speculativeKey];
-          if (branchParser == null) return undefined;
-          return await ctx.schedule(expandEffectfulRuntimeNodes([{
-            path: [...(parentPath ?? []), "_branch"],
-            parser: branchParser,
-            state: getAnnotatedChildState(
-              conditionalState,
-              conditionalState.branchState,
-              branchParser,
-            ),
-          }]));
+          if (branches[speculativeKey] == null) return undefined;
+          return await ctx.schedule(expandGuessedBranchNodes());
         },
       });
       return nodes;
@@ -16385,6 +16669,103 @@ export function conditional(
     }
 
     teeDiscriminatorNode();
+    // Resolves the branch selection once per run: completes the
+    // discriminator (or reads the teed effectful result), replays the
+    // branch against an empty buffer, and caches the decision in the
+    // run-scoped session so barrier resolution, preparation, and final
+    // completion all consume the same selection.
+    const resolvePreparedSelection = async (
+      ctx: SchedulingBarrierContext,
+    ): Promise<PreparedConditionalSelection | undefined> => {
+      const session = ctx.exec?.effectfulCompletionSession;
+      if (session == null) return undefined;
+      const key = preparedKeyFor(parentPath);
+      let prepared = session.preparedByPath.get(key) as
+        | PreparedConditionalSelection
+        | undefined;
+      if (prepared == null) {
+        let discriminatorResult = cell.result ??
+          session.completedByPath.get(discriminatorPathKey);
+        if (
+          discriminatorResult == null && innerCompleteSource == null
+        ) {
+          // Effect-free discriminator: complete it once here; final
+          // completion reuses the prepared result, so non-idempotent
+          // completions (e.g., lazy defaults) still evaluate once.
+          const discriminatorExec = ctx.exec == null ? undefined : {
+            ...ctx.exec,
+            path: [...(parentPath ?? []), "_discriminator"],
+          };
+          discriminatorResult = unwrapCompleteResult(
+            await discriminator.complete(
+              annotatedDiscriminatorState,
+              discriminatorExec,
+            ),
+          );
+        }
+        if (
+          discriminatorResult == null ||
+          isDeferredCompletionResult(discriminatorResult)
+        ) {
+          return undefined;
+        }
+        const namedBranch = discriminatorResult.success
+          ? branches[String(discriminatorResult.value)]
+          : undefined;
+        const branchParser = namedBranch ?? defaultBranch;
+        let branchState: unknown;
+        if (branchParser != null) {
+          // Mirror final completion's empty-input replay parse so the
+          // prepared branch state matches what completion would build.
+          const branchExec = ctx.exec == null ? undefined : {
+            ...ctx.exec,
+            path: [...(parentPath ?? []), "_branch"],
+          };
+          const annotatedInitial = getAnnotatedChildState(
+            conditionalState,
+            branchParser.initialState,
+            branchParser,
+          );
+          const replayResult = await branchParser.parse({
+            buffer: [] as string[],
+            optionsTerminated: false,
+            usage: [] as never[],
+            exec: branchExec,
+            dependencyRegistry: ctx.exec?.dependencyRegistry,
+            state: annotatedInitial,
+          } as ParserContext<unknown>);
+          branchState = replayResult.success
+            ? replayResult.next.state
+            : annotatedInitial;
+        }
+        prepared = {
+          discriminatorResult,
+          branchParser,
+          branchKey: namedBranch != null
+            ? String(
+              (discriminatorResult as { readonly value: unknown }).value,
+            )
+            : undefined,
+          branchState,
+        };
+        session.preparedByPath.set(key, prepared);
+      }
+      return prepared;
+    };
+    const expandPreparedBranchNodes = (
+      prepared: PreparedConditionalSelection,
+    ): readonly RuntimeNode[] => {
+      if (prepared.branchParser == null) return [];
+      return expandEffectfulRuntimeNodes([{
+        path: [...(parentPath ?? []), "_branch"],
+        parser: prepared.branchParser,
+        state: getAnnotatedChildState(
+          conditionalState,
+          prepared.branchState,
+          prepared.branchParser,
+        ),
+      }]);
+    };
     nodes.push({
       path: [...(parentPath ?? []), "_branch"],
       parser: {},
@@ -16393,93 +16774,29 @@ export function conditional(
         ? { requiresSourceId: discriminatorSource.sourceId }
         : {}),
       providesSourceIds: branchProvidedSourceIds,
+      ...(branchGuaranteedIntersection.size > 0
+        ? { guaranteedProvidesSourceIds: branchGuaranteedIntersection }
+        : {}),
       ...(mergedBarrierDependencies != null
         ? { barrierCompletionDependencies: mergedBarrierDependencies }
         : {}),
-      prepare: async (ctx) => {
-        const session = ctx.exec?.effectfulCompletionSession;
-        if (session == null) return undefined;
-        const key = preparedKeyFor(parentPath);
-        let prepared = session.preparedByPath.get(key) as
-          | PreparedConditionalSelection
-          | undefined;
-        if (prepared == null) {
-          let discriminatorResult = cell.result ??
-            session.completedByPath.get(discriminatorPathKey);
-          if (
-            discriminatorResult == null && innerCompleteSource == null
-          ) {
-            // Effect-free discriminator: complete it once here; final
-            // completion reuses the prepared result, so non-idempotent
-            // completions (e.g., lazy defaults) still evaluate once.
-            const discriminatorExec = ctx.exec == null ? undefined : {
-              ...ctx.exec,
-              path: [...(parentPath ?? []), "_discriminator"],
-            };
-            discriminatorResult = unwrapCompleteResult(
-              await discriminator.complete(
-                annotatedDiscriminatorState,
-                discriminatorExec,
-              ),
-            );
-          }
-          if (
-            discriminatorResult == null ||
-            isDeferredCompletionResult(discriminatorResult)
-          ) {
-            return undefined;
-          }
-          const namedBranch = discriminatorResult.success
-            ? branches[String(discriminatorResult.value)]
-            : undefined;
-          const branchParser = namedBranch ?? defaultBranch;
-          let branchState: unknown;
-          if (branchParser != null) {
-            // Mirror final completion's empty-input replay parse so the
-            // prepared branch state matches what completion would build.
-            const branchExec = ctx.exec == null ? undefined : {
-              ...ctx.exec,
-              path: [...(parentPath ?? []), "_branch"],
-            };
-            const annotatedInitial = getAnnotatedChildState(
-              conditionalState,
-              branchParser.initialState,
-              branchParser,
-            );
-            const replayResult = await branchParser.parse({
-              buffer: [] as string[],
-              optionsTerminated: false,
-              usage: [] as never[],
-              exec: branchExec,
-              dependencyRegistry: ctx.exec?.dependencyRegistry,
-              state: annotatedInitial,
-            } as ParserContext<unknown>);
-            branchState = replayResult.success
-              ? replayResult.next.state
-              : annotatedInitial;
-          }
-          prepared = {
-            discriminatorResult,
-            branchParser,
-            branchKey: namedBranch != null
-              ? String(
-                (discriminatorResult as { readonly value: unknown }).value,
-              )
-              : undefined,
-            branchState,
+      resolveBarrier: async (ctx) => {
+        const prepared = await resolvePreparedSelection(ctx);
+        if (prepared == null) return undefined;
+        if (prepared.branchParser == null) {
+          return {
+            orderingDependencyIds: [],
+            activeProvidesSourceIds: new Set<symbol>(),
           };
-          session.preparedByPath.set(key, prepared);
         }
-        if (prepared.branchParser == null) return undefined;
-        return await ctx.schedule(expandEffectfulRuntimeNodes([{
-          path: [...(parentPath ?? []), "_branch"],
-          parser: prepared.branchParser,
-          state: getAnnotatedChildState(
-            conditionalState,
-            prepared.branchState,
-            prepared.branchParser,
-          ),
-        }]));
+        return await computeActiveBarrierDependencies(
+          expandPreparedBranchNodes(prepared),
+        );
+      },
+      prepare: async (ctx) => {
+        const prepared = await resolvePreparedSelection(ctx);
+        if (prepared?.branchParser == null) return undefined;
+        return await ctx.schedule(expandPreparedBranchNodes(prepared));
       },
     });
     return nodes;
@@ -17630,16 +17947,31 @@ export function conditional(
     configurable: true,
     enumerable: false,
   });
-  // Static source estimation reaches the discriminator and every branch
-  // (see staticSourceScopeKey); an overcount is harmless.
+  // Static source estimation reaches the discriminator and every branch;
+  // an overcount is harmless for the may-provide union.  The
+  // discriminator always runs when the conditional is active, so its
+  // sources keep their guarantees; branches are mutually exclusive, so
+  // their occurrences are merely possible providers—except the IDs every
+  // selectable route guarantees, which the conditional re-exposes below.
   Object.defineProperty(conditionalParser, staticSourceScopeKey, {
+    value: [discriminator],
+    configurable: true,
+    enumerable: false,
+  });
+  Object.defineProperty(conditionalParser, exclusiveSourceScopeKey, {
     value: [
-      discriminator,
       ...Object.values(branches),
       ...(defaultBranch != null ? [defaultBranch] : []),
     ],
     configurable: true,
     enumerable: false,
   });
+  if (branchGuaranteedIntersection.size > 0) {
+    Object.defineProperty(conditionalParser, guaranteedStaticSourceIdsKey, {
+      value: branchGuaranteedIntersection,
+      configurable: true,
+      enumerable: false,
+    });
+  }
   return fluent(conditionalParser);
 }

--- a/packages/core/src/dependency-metadata.test.ts
+++ b/packages/core/src/dependency-metadata.test.ts
@@ -498,6 +498,32 @@ describe("composeDependencyMetadata", () => {
     assert.ok(afterOptional.source?.getMissingSourceValue !== undefined);
   });
 
+  // https://github.com/dahlia/optique/issues/924
+  test("optional clears completesWhenMissing; withDefault and map keep it", () => {
+    const env = createEnvSource();
+    const inner = extractDependencyMetadata(env);
+    assert.ok(inner?.source != null);
+    const effectful: ParserDependencyMetadata = {
+      ...inner,
+      source: {
+        ...inner.source,
+        completeSource: () =>
+          Promise.resolve({ success: true as const, value: "dev" }),
+        completesWhenMissing: true,
+      },
+    };
+    // An absent optional occurrence declines its inner completion, so
+    // the composed completion is no longer a guaranteed publisher.
+    const afterOptional = composeDependencyMetadata(effectful, "optional");
+    assert.equal(afterOptional?.source?.completesWhenMissing, false);
+    const afterDefault = composeDependencyMetadata(effectful, "withDefault", {
+      defaultValue: () => ({ success: true as const, value: "dev" }),
+    });
+    assert.equal(afterDefault?.source?.completesWhenMissing, true);
+    const afterMap = composeDependencyMetadata(effectful, "map");
+    assert.equal(afterMap?.source?.completesWhenMissing, true);
+  });
+
   test("optional extractSourceValue unwraps [state]", async () => {
     const env = createEnvSource();
     const inner = extractDependencyMetadata(env);

--- a/packages/core/src/dependency-metadata.ts
+++ b/packages/core/src/dependency-metadata.ts
@@ -101,6 +101,22 @@ export interface DependencySourceCapability {
   ) => Promise<ValueParserResult<unknown> | undefined>;
 
   /**
+   * Whether the composed {@link completeSource}, invoked on a state with
+   * no parsed value, publishes a registrable result.
+   *
+   * A prompt wrapper without a runtime condition sets this to `true`: the
+   * prompt always asks and registers its answer.  An `optional()` wrapper
+   * clears it, because an absent optional occurrence declines its inner
+   * completion and publishes nothing.  Scheduling barriers use this flag
+   * to tell a *guaranteed* branch provider (one that publishes whenever
+   * its branch runs) apart from a merely *possible* one, without running
+   * any effect.
+   *
+   * @since 1.3.0
+   */
+  readonly completesWhenMissing?: boolean;
+
+  /**
    * Whether the parser's output value is the actual dependency source value.
    * `false` when a transform like `map()` has been applied.
    */
@@ -429,6 +445,13 @@ export function composeDependencyMetadata(
             extractSourceValue: unwrapArrayThenExtract(
               inner.source.extractSourceValue,
             ),
+            // An absent optional occurrence legitimately holds no
+            // value—its completion declines, and even a wrapper added
+            // later (e.g. prompt() around this optional) may answer
+            // `undefined`, which the scheduler never registers—so the
+            // chain is not a guaranteed publisher.  Outer wrappers
+            // preserve an explicit `false`.
+            completesWhenMissing: false,
             ...(inner.source.completeSource != null && {
               completeSource: unwrapArrayThenComplete(
                 inner.source.completeSource,

--- a/packages/core/src/dependency-runtime.test.ts
+++ b/packages/core/src/dependency-runtime.test.ts
@@ -2762,6 +2762,127 @@ describe("completeEffectfulSourcesAsync", () => {
     assert.ok(result.success);
     assert.ok(!session.demanded.has(prerequisiteId));
   });
+
+  // https://github.com/dahlia/optique/issues/924
+  test("resolves a barrier ahead of an advisory provider it refines away", async () => {
+    const runtime = createDependencyRuntimeContext();
+    const session = createEffectfulCompletionSession("eager");
+    const providerId = Symbol("provider");
+    const discriminatorId = Symbol("discriminator");
+    const order: string[] = [];
+    // The static estimate orders the barrier after the later provider,
+    // but resolution—eligible once its control dependency is satisfied
+    // and never blocked by advisory edges—reports no concrete
+    // dependencies, so the barrier executes first at its declaration
+    // position.
+    const barrier: RuntimeNode = {
+      path: ["barrier"],
+      parser: {},
+      state: undefined,
+      requiresSourceId: discriminatorId,
+      barrierCompletionDependencies: {
+        orderingDependencyIds: [providerId],
+        demandEdges: [],
+      },
+      resolveBarrier: () =>
+        Promise.resolve({
+          orderingDependencyIds: [],
+          activeProvidesSourceIds: new Set<symbol>(),
+        }),
+      prepare: () => {
+        order.push("barrier");
+        return Promise.resolve(undefined);
+      },
+    };
+    const provider: RuntimeNode = {
+      path: ["provider"],
+      parser: {
+        dependencyMetadata: {
+          source: {
+            kind: "source",
+            sourceId: providerId,
+            metavar: "PROVIDER",
+            extractSourceValue: () => undefined,
+            completeSource: () => {
+              order.push("provider");
+              return Promise.resolve({ success: true, value: "x" });
+            },
+            preservesSourceValue: true,
+          },
+        },
+      },
+      state: undefined,
+    };
+
+    const result = await completeEffectfulSourcesAsync(
+      [barrier, provider],
+      undefined,
+      runtime,
+      createCompleteExecFixture(session),
+    );
+
+    assert.ok(result.success);
+    assert.deepEqual(order, ["barrier", "provider"]);
+  });
+
+  // https://github.com/dahlia/optique/issues/924
+  test("keeps a resolved concrete dependency ordered after its provider", async () => {
+    const runtime = createDependencyRuntimeContext();
+    const session = createEffectfulCompletionSession("eager");
+    const providerId = Symbol("provider");
+    const discriminatorId = Symbol("discriminator");
+    const order: string[] = [];
+    // Resolution confirms the barrier's dependency, so the concrete
+    // edge holds: the provider still completes first.
+    const barrier: RuntimeNode = {
+      path: ["barrier"],
+      parser: {},
+      state: undefined,
+      requiresSourceId: discriminatorId,
+      barrierCompletionDependencies: {
+        orderingDependencyIds: [providerId],
+        demandEdges: [],
+      },
+      resolveBarrier: () =>
+        Promise.resolve({
+          orderingDependencyIds: [providerId],
+          activeProvidesSourceIds: new Set<symbol>(),
+        }),
+      prepare: () => {
+        order.push("barrier");
+        return Promise.resolve(undefined);
+      },
+    };
+    const provider: RuntimeNode = {
+      path: ["provider"],
+      parser: {
+        dependencyMetadata: {
+          source: {
+            kind: "source",
+            sourceId: providerId,
+            metavar: "PROVIDER",
+            extractSourceValue: () => undefined,
+            completeSource: () => {
+              order.push("provider");
+              return Promise.resolve({ success: true, value: "x" });
+            },
+            preservesSourceValue: true,
+          },
+        },
+      },
+      state: undefined,
+    };
+
+    const result = await completeEffectfulSourcesAsync(
+      [barrier, provider],
+      undefined,
+      runtime,
+      createCompleteExecFixture(session),
+    );
+
+    assert.ok(result.success);
+    assert.deepEqual(order, ["provider", "barrier"]);
+  });
 });
 
 describe("collectDemandedDependencyIds", () => {
@@ -2995,9 +3116,15 @@ describe("orderDependencyNodes", () => {
     assert.deepEqual(ordered, [barrier]);
   });
 
-  test("detects a cycle between a barrier and a sibling consumer", () => {
+  // https://github.com/dahlia/optique/issues/924
+  test("relaxes an advisory cycle between a barrier and a sibling consumer", () => {
     const branchId = Symbol("branch");
     const siblingId = Symbol("sibling");
+    // The barrier's ordering dependency on the sibling comes from one
+    // selectable branch, while the branch source the sibling consumes
+    // could only be provided by another: the opposing edges cannot be
+    // active together, so the unresolved barrier's advisory in-edge is
+    // relaxed and declaration order prevails.
     const barrier = createBarrierNode({
       path: ["barrier"],
       providesSourceIds: new Set([branchId]),
@@ -3013,10 +3140,81 @@ describe("orderDependencyNodes", () => {
       metavar: "SIBLING",
     });
 
+    const ordered = orderDependencyNodes([barrier, sibling]);
+
+    assert.deepEqual(ordered, [barrier, sibling]);
+  });
+
+  // https://github.com/dahlia/optique/issues/924
+  test("detects a concrete cycle through a resolved barrier", () => {
+    const branchId = Symbol("branch");
+    const siblingId = Symbol("sibling");
+    // Once the barrier resolves its selection, its edges are concrete:
+    // the selected branch actively provides the source the sibling
+    // consumes while also waiting for the sibling, which is a genuine
+    // cycle.
+    const barrier = createBarrierNode({
+      path: ["barrier"],
+      providesSourceIds: new Set([branchId]),
+      barrierCompletionDependencies: {
+        orderingDependencyIds: [siblingId],
+        demandEdges: [],
+      },
+      barrierResolutionState: "resolved",
+    });
+    const sibling = createRuntimeSourceNode({
+      path: ["sibling"],
+      sourceId: siblingId,
+      completionDependencyIds: [branchId],
+      metavar: "SIBLING",
+    });
+
     assert.throws(
       () => orderDependencyNodes([barrier, sibling]),
       /Circular dependency/,
     );
+  });
+
+  // https://github.com/dahlia/optique/issues/924
+  test("keeps advisory relaxation local to the stalled component", () => {
+    const branchId = Symbol("branch");
+    const siblingId = Symbol("sibling");
+    const outsideId = Symbol("outside");
+    // A second barrier that merely waits for a provider outside the
+    // cycle keeps its advisory edge: only edges inside the strongly
+    // connected component are relaxed.
+    const cyclic = createBarrierNode({
+      path: ["cyclic"],
+      providesSourceIds: new Set([branchId]),
+      barrierCompletionDependencies: {
+        orderingDependencyIds: [siblingId],
+        demandEdges: [],
+      },
+    });
+    const sibling = createRuntimeSourceNode({
+      path: ["sibling"],
+      sourceId: siblingId,
+      completionDependencyIds: [branchId],
+      metavar: "SIBLING",
+    });
+    const waiting = createBarrierNode({
+      path: ["waiting"],
+      barrierCompletionDependencies: {
+        orderingDependencyIds: [outsideId],
+        demandEdges: [],
+      },
+    });
+    const provider = createRuntimeSourceNode({
+      path: ["provider"],
+      sourceId: outsideId,
+      metavar: "PROVIDER",
+    });
+
+    const ordered = orderDependencyNodes([cyclic, sibling, waiting, provider]);
+
+    // Ready nodes drain first; the stalled pair is relaxed afterwards,
+    // and the waiting barrier's advisory edge to its provider held.
+    assert.deepEqual(ordered, [provider, waiting, cyclic, sibling]);
   });
 
   test("reports the paths and metavars in a forged cycle", () => {
@@ -3049,6 +3247,7 @@ function createBarrierNode(options: {
   readonly requiresSourceId?: symbol;
   readonly providesSourceIds?: ReadonlySet<symbol>;
   readonly barrierCompletionDependencies?: BarrierCompletionDependencies;
+  readonly barrierResolutionState?: "resolved" | "unresolvable";
 }): RuntimeNode {
   return {
     path: options.path,
@@ -3064,6 +3263,9 @@ function createBarrierNode(options: {
       ? {
         barrierCompletionDependencies: options.barrierCompletionDependencies,
       }
+      : {}),
+    ...(options.barrierResolutionState != null
+      ? { barrierResolutionState: options.barrierResolutionState }
       : {}),
     prepare: () => Promise.resolve(undefined),
   };

--- a/packages/core/src/dependency-runtime.ts
+++ b/packages/core/src/dependency-runtime.ts
@@ -228,6 +228,39 @@ export interface RuntimeNode {
   >;
 
   /**
+   * Resolves this barrier's *active* dependencies once its control
+   * dependencies (see {@link RuntimeNode.requiresSourceId}) are
+   * satisfied, before the barrier itself executes.
+   *
+   * A `conditional()` resolves the selected branch here—completing an
+   * effect-free discriminator, or reading an effectful one's cached
+   * completion—and reports which completion dependencies the branch
+   * actually has and which sources it will actively provide, so the
+   * scheduler can replace the static advisory estimate with concrete
+   * edges (see issue #924).  Returning `undefined` leaves the static
+   * estimate in place; a failure aborts the pass.  The scheduler calls
+   * this at most once per pass, and never lets advisory ordering edges
+   * delay it.
+   *
+   * @since 1.3.0
+   */
+  readonly resolveBarrier?: (ctx: SchedulingBarrierContext) => Promise<
+    | { readonly success: false; readonly error: Message }
+    | BarrierResolution
+    | undefined
+  >;
+
+  /**
+   * Internal marker the effectful scheduler sets on the replacement
+   * node after {@link RuntimeNode.resolveBarrier} ran: `"resolved"`
+   * edges are concrete (a cycle through them is genuine), while
+   * `"unresolvable"` keeps the advisory estimate.
+   *
+   * @since 1.3.0
+   */
+  readonly barrierResolutionState?: "resolved" | "unresolvable";
+
+  /**
    * Source IDs that the subtree guarded by this barrier can provide.
    * Used by the demand-only pass: when any of them is demanded, the
    * barrier's {@link RuntimeNode.requiresSourceId} becomes demanded as
@@ -237,6 +270,16 @@ export interface RuntimeNode {
    * @since 1.3.0
    */
   readonly providesSourceIds?: ReadonlySet<symbol>;
+
+  /**
+   * Source IDs every selectable route through this barrier's subtree is
+   * guaranteed to provide, regardless of which branch is selected.  An
+   * enclosing barrier's resolution treats these as active provides; the
+   * rest of {@link RuntimeNode.providesSourceIds} stays merely possible.
+   *
+   * @since 1.3.0
+   */
+  readonly guaranteedProvidesSourceIds?: ReadonlySet<symbol>;
 
   /**
    * The source ID whose completion this barrier's preparation depends
@@ -308,6 +351,31 @@ export interface BarrierCompletionDependencies {
    * seed pass.
    */
   readonly demandEdges: readonly BarrierCompletionDemandEdge[];
+}
+
+/**
+ * The concrete dependencies a scheduling barrier reports from
+ * {@link RuntimeNode.resolveBarrier} once its selection is known.
+ *
+ * @internal
+ * @since 1.3.0
+ */
+export interface BarrierResolution {
+  /**
+   * The completion dependency IDs the selected subtree actually reads,
+   * minus the sources it actively provides itself.  These replace the
+   * static advisory ordering estimate with concrete edges.
+   */
+  readonly orderingDependencyIds: readonly symbol[];
+
+  /**
+   * The source IDs the selected subtree will actively publish: a
+   * guaranteed occurrence (an unconditional prompt or a publishable
+   * default) or one whose state already extracts a value.  These
+   * replace {@link RuntimeNode.providesSourceIds} for ordering, so a
+   * sibling consumer no longer waits for a merely possible provider.
+   */
+  readonly activeProvidesSourceIds: ReadonlySet<symbol>;
 }
 
 /**
@@ -954,6 +1022,32 @@ export async function collectExplicitSourceValuesAsync(
 export function orderDependencyNodes(
   nodes: readonly RuntimeNode[],
 ): readonly RuntimeNode[] {
+  return drainDependencyGraph(buildDependencyGraph(nodes));
+}
+
+/**
+ * The mutable edge graph {@link orderDependencyNodes} and the effectful
+ * completion scheduler drain.  `advisoryOnly` marks edges that exist
+ * solely because of an unresolved barrier's static ordering estimate;
+ * such an edge may be relaxed to break an apparent cycle that no single
+ * branch selection could produce (see issue #924).
+ */
+interface DependencyGraph {
+  readonly nodes: readonly RuntimeNode[];
+  readonly outgoing: Map<RuntimeNode, Map<RuntimeNode, boolean>>;
+  readonly indegree: Map<RuntimeNode, number>;
+  readonly declarationOrder: Map<RuntimeNode, number>;
+}
+
+/**
+ * Builds the provider-edge graph over runtime nodes.
+ *
+ * Scheduling barriers act as providers for the source IDs their
+ * selected subtree may expose and depend on their discriminator source
+ * as well as on outer providers of the completion dependencies their
+ * selectable subtrees aggregate.
+ */
+function buildDependencyGraph(nodes: readonly RuntimeNode[]): DependencyGraph {
   const providers = new Map<symbol, RuntimeNode[]>();
   const addProvider = (sourceId: symbol, node: RuntimeNode): void => {
     const existing = providers.get(sourceId);
@@ -968,13 +1062,22 @@ export function orderDependencyNodes(
     }
   }
 
-  const outgoing = new Map<RuntimeNode, Set<RuntimeNode>>();
+  const outgoing = new Map<RuntimeNode, Map<RuntimeNode, boolean>>();
   const indegree = new Map<RuntimeNode, number>();
   for (const node of nodes) indegree.set(node, 0);
-  const addEdge = (provider: RuntimeNode, consumer: RuntimeNode): void => {
-    const edges = outgoing.get(provider) ?? new Set<RuntimeNode>();
-    if (edges.has(consumer)) return;
-    edges.add(consumer);
+  const addEdge = (
+    provider: RuntimeNode,
+    consumer: RuntimeNode,
+    advisory: boolean,
+  ): void => {
+    const edges = outgoing.get(provider) ?? new Map<RuntimeNode, boolean>();
+    const existing = edges.get(consumer);
+    if (existing != null) {
+      // A non-advisory justification hardens an existing advisory edge.
+      if (existing && !advisory) edges.set(consumer, false);
+      return;
+    }
+    edges.set(consumer, advisory);
     outgoing.set(provider, edges);
     indegree.set(consumer, (indegree.get(consumer) ?? 0) + 1);
   };
@@ -984,7 +1087,7 @@ export function orderDependencyNodes(
     if (derived != null) {
       for (const dependencySourceId of derived.dependencyIds) {
         for (const provider of providers.get(dependencySourceId) ?? []) {
-          addEdge(provider, node);
+          addEdge(provider, node, false);
         }
       }
     }
@@ -1008,25 +1111,29 @@ export function orderDependencyNodes(
       for (const dependencySourceId of completion.dependencyIds) {
         if (dependencySourceId === ownSourceId) continue;
         for (const provider of providers.get(dependencySourceId) ?? []) {
-          if (provider !== node) addEdge(provider, node);
+          if (provider !== node) addEdge(provider, node, false);
         }
       }
     }
     if (node.requiresSourceId != null) {
       for (const provider of providers.get(node.requiresSourceId) ?? []) {
-        if (provider !== node) addEdge(provider, node);
+        if (provider !== node) addEdge(provider, node, false);
       }
     }
     // A scheduling barrier aggregates the completion dependencies its
     // selectable subtrees declare, so the barrier waits for outer
     // providers a branch's effectful completion reads.  The barrier
     // itself provides its branches' source IDs, so skipping self edges
-    // keeps a dependency on a sibling branch's source internal.
+    // keeps a dependency on a sibling branch's source internal.  Until
+    // the barrier resolves its selection, these edges are a static
+    // estimate over every selectable branch, so they stay advisory; a
+    // resolved barrier's edges are concrete.
     const barrierDeps = node.barrierCompletionDependencies;
     if (barrierDeps != null) {
+      const advisory = node.barrierResolutionState !== "resolved";
       for (const dependencySourceId of barrierDeps.orderingDependencyIds) {
         for (const provider of providers.get(dependencySourceId) ?? []) {
-          if (provider !== node) addEdge(provider, node);
+          if (provider !== node) addEdge(provider, node, advisory);
         }
       }
     }
@@ -1035,29 +1142,154 @@ export function orderDependencyNodes(
   const declarationOrder = new Map(
     nodes.map((node, index) => [node, index] as const),
   );
+  return { nodes, outgoing, indegree, declarationOrder };
+}
+
+/**
+ * Drains the graph in stable topological order.
+ *
+ * A stall—no node with indegree zero remains—normally means a genuine
+ * cycle.  When the stalled region contains an unresolved barrier's
+ * advisory ordering edges within one strongly connected component, the
+ * apparent cycle aggregates edges from branches that cannot be selected
+ * together, so those advisory edges are relaxed and the drain resumes;
+ * the barrier's own resolution later replaces the estimate with
+ * concrete edges, and a cycle among those still throws.
+ *
+ * @throws {TypeError} If active provider edges contain a cycle.
+ */
+function drainDependencyGraph(graph: DependencyGraph): readonly RuntimeNode[] {
+  const { nodes, outgoing, declarationOrder } = graph;
+  const indegree = new Map(graph.indegree);
   const ready = nodes.filter((node) => indegree.get(node) === 0);
   const ordered: RuntimeNode[] = [];
-  while (ready.length > 0) {
-    ready.sort((left, right) =>
-      declarationOrder.get(left)! - declarationOrder.get(right)!
-    );
-    const node = ready.shift()!;
-    ordered.push(node);
-    for (const consumer of outgoing.get(node) ?? []) {
-      const next = (indegree.get(consumer) ?? 0) - 1;
-      indegree.set(consumer, next);
-      if (next === 0) ready.push(consumer);
+  while (true) {
+    while (ready.length > 0) {
+      ready.sort((left, right) =>
+        declarationOrder.get(left)! - declarationOrder.get(right)!
+      );
+      const node = ready.shift()!;
+      ordered.push(node);
+      for (const consumer of outgoing.get(node)?.keys() ?? []) {
+        const next = (indegree.get(consumer) ?? 0) - 1;
+        indegree.set(consumer, next);
+        if (next === 0) ready.push(consumer);
+      }
+    }
+    if (ordered.length === nodes.length) return ordered;
+    const residual = nodes.filter((node) => (indegree.get(node) ?? 0) > 0);
+    const sccOf = findStronglyConnected(residual, outgoing);
+    let relaxed = false;
+    for (const provider of residual) {
+      const edges = outgoing.get(provider);
+      if (edges == null) continue;
+      for (const [consumer, advisory] of edges) {
+        if (!advisory) continue;
+        const providerScc = sccOf.get(provider);
+        if (providerScc == null || providerScc !== sccOf.get(consumer)) {
+          continue;
+        }
+        edges.delete(consumer);
+        const next = (indegree.get(consumer) ?? 0) - 1;
+        indegree.set(consumer, next);
+        if (next === 0) ready.push(consumer);
+        relaxed = true;
+      }
+    }
+    if (!relaxed) {
+      const labels = residual.map(formatDependencyNodeLabel).join(" -> ");
+      throw new TypeError(
+        `Circular dependency detected among dependency sources: ${labels}.`,
+      );
     }
   }
+}
 
-  if (ordered.length !== nodes.length) {
-    const cycle = nodes.filter((node) => (indegree.get(node) ?? 0) > 0);
-    const labels = cycle.map(formatDependencyNodeLabel).join(" -> ");
-    throw new TypeError(
-      `Circular dependency detected among dependency sources: ${labels}.`,
-    );
+/**
+ * Assigns each node in `subset` to a strongly connected component of
+ * the induced subgraph.  Only components with more than one node are
+ * recorded—an acyclic node cannot be part of an apparent cycle.
+ */
+function findStronglyConnected(
+  subset: readonly RuntimeNode[],
+  outgoing: ReadonlyMap<RuntimeNode, ReadonlyMap<RuntimeNode, boolean>>,
+): Map<RuntimeNode, number> {
+  const inSubset = new Set(subset);
+  const index = new Map<RuntimeNode, number>();
+  const lowLink = new Map<RuntimeNode, number>();
+  const onStack = new Set<RuntimeNode>();
+  const stack: RuntimeNode[] = [];
+  const sccOf = new Map<RuntimeNode, number>();
+  let nextIndex = 0;
+  let nextScc = 0;
+  const strongConnect = (root: RuntimeNode): void => {
+    // Iterative Tarjan: each frame tracks the node and its child cursor.
+    const frames: { node: RuntimeNode; children: RuntimeNode[]; i: number }[] =
+      [{
+        node: root,
+        children: [...(outgoing.get(root)?.keys() ?? [])].filter((child) =>
+          inSubset.has(child)
+        ),
+        i: 0,
+      }];
+    index.set(root, nextIndex);
+    lowLink.set(root, nextIndex);
+    nextIndex++;
+    stack.push(root);
+    onStack.add(root);
+    while (frames.length > 0) {
+      const frame = frames[frames.length - 1];
+      if (frame.i < frame.children.length) {
+        const child = frame.children[frame.i++];
+        if (!index.has(child)) {
+          index.set(child, nextIndex);
+          lowLink.set(child, nextIndex);
+          nextIndex++;
+          stack.push(child);
+          onStack.add(child);
+          frames.push({
+            node: child,
+            children: [...(outgoing.get(child)?.keys() ?? [])].filter((c) =>
+              inSubset.has(c)
+            ),
+            i: 0,
+          });
+        } else if (onStack.has(child)) {
+          lowLink.set(
+            frame.node,
+            Math.min(lowLink.get(frame.node)!, index.get(child)!),
+          );
+        }
+        continue;
+      }
+      frames.pop();
+      const node = frame.node;
+      if (lowLink.get(node) === index.get(node)) {
+        const members: RuntimeNode[] = [];
+        while (true) {
+          const member = stack.pop()!;
+          onStack.delete(member);
+          members.push(member);
+          if (member === node) break;
+        }
+        if (members.length > 1) {
+          for (const member of members) sccOf.set(member, nextScc);
+          nextScc++;
+        }
+      }
+      const parent = frames[frames.length - 1];
+      if (parent != null) {
+        lowLink.set(
+          parent.node,
+          Math.min(lowLink.get(parent.node)!, lowLink.get(node)!),
+        );
+      }
+    }
+  };
+  for (const node of subset) {
+    if (!index.has(node)) strongConnect(node);
   }
-  return ordered;
+  return sccOf;
 }
 
 /** Resolves and publishes matched derived sources in stable dependency order. */
@@ -1825,6 +2057,41 @@ export const staticSourceScopeKey: unique symbol = Symbol(
 );
 
 /**
+ * Static child parsers reachable only through a mutually exclusive
+ * selection, such as `or()` alternatives, a `conditional()`'s branches,
+ * or a `command()`'s inner parser.
+ *
+ * The walk unions sources and completion dependencies from this scope
+ * exactly like {@link staticSourceScopeKey}, but a source occurrence
+ * reached through an exclusive edge is never a *guaranteed* provider:
+ * the run may select a sibling instead, so a scheduling barrier must not
+ * assume the occurrence will publish.  See issue #924.
+ *
+ * @internal
+ * @since 1.3.0
+ */
+export const exclusiveSourceScopeKey: unique symbol = Symbol(
+  "@optique/core/dependency-runtime/exclusiveSourceScope",
+);
+
+/**
+ * Source IDs a parser guarantees to provide on every successful route
+ * through it, regardless of which internal alternative is selected.
+ *
+ * A `conditional()` installs the intersection of its branches' guaranteed
+ * provides here (including the default branch when present), so an outer
+ * scheduling barrier can treat a source that *every* selectable route
+ * publishes as guaranteed even though each individual branch edge is
+ * exclusive.  See issue #924.
+ *
+ * @internal
+ * @since 1.3.0
+ */
+export const guaranteedStaticSourceIdsKey: unique symbol = Symbol(
+  "@optique/core/dependency-runtime/guaranteedStaticSourceIds",
+);
+
+/**
  * Forwards effectful scheduling through a shape-preserving wrapper such
  * as `map()`, `optional()`, `withDefault()`, or `nonEmpty()`, so the
  * wrapped parser—a selected exclusive or command branch, or an ordinary
@@ -2186,26 +2453,98 @@ export async function completeEffectfulSourcesAsync(
   }
 
   const completed: EffectfulSourceCompletion[] = [];
-  for (const node of orderDependencyNodes(nodes)) {
+  const barrierContext: SchedulingBarrierContext = {
+    runtime,
+    exec,
+    // The barrier's subtree is part of the construct's delivery
+    // scope: its structural values re-register at the barrier's
+    // declaration position (isCollected), while its completion
+    // results stay out of the owning construct's pre-completed
+    // cache (isReusable) and deduplicate through the session.
+    schedule: (barrierNodes) =>
+      completeEffectfulSourcesAsync(barrierNodes, state, runtime, exec, {
+        isReusable: () => false,
+        isCollected: () => true,
+        includeStructural: true,
+      }).then((result) => result.success ? undefined : result),
+  };
+  // Incremental scheduling: a barrier resolves its concrete dependencies
+  // as soon as its control dependencies are satisfied—advisory ordering
+  // edges never delay resolution—and the resolved edges replace the
+  // static estimate before the barrier itself executes.  Each iteration
+  // re-orders the remaining nodes and executes the earliest ready one,
+  // so declaration order still breaks ties and a cycle among concrete
+  // resolved edges surfaces as the usual circular-dependency error.
+  const pending: RuntimeNode[] = [...nodes];
+  const providesId = (node: RuntimeNode, id: symbol): boolean =>
+    node.parser.dependencyMetadata?.source?.sourceId === id ||
+    node.providesSourceIds?.has(id) === true;
+  const resolveBarrierAt = async (
+    index: number,
+  ): Promise<
+    { readonly success: false; readonly error: Message } | undefined
+  > => {
+    const candidate = pending[index];
+    const resolution = await candidate.resolveBarrier!(barrierContext);
+    if (resolution != null && "success" in resolution) {
+      return resolution;
+    }
+    pending[index] = resolution == null
+      ? { ...candidate, barrierResolutionState: "unresolvable" }
+      : {
+        ...candidate,
+        barrierResolutionState: "resolved",
+        providesSourceIds: resolution.activeProvidesSourceIds,
+        barrierCompletionDependencies: {
+          orderingDependencyIds: resolution.orderingDependencyIds,
+          demandEdges: [],
+        },
+      };
+    return undefined;
+  };
+  while (pending.length > 0) {
+    for (let i = 0; i < pending.length; i++) {
+      const candidate = pending[i];
+      if (
+        candidate.resolveBarrier == null ||
+        candidate.barrierResolutionState != null
+      ) {
+        continue;
+      }
+      const requires = candidate.requiresSourceId;
+      // A barrier without a control dependency (an effect-free
+      // discriminator that is not a dependency source) would have to
+      // complete its discriminator here, ahead of every other pending
+      // node, which could reorder observable evaluations; it resolves
+      // at its ordered position below instead.
+      if (requires == null) continue;
+      if (
+        pending.some((other) =>
+          other !== candidate && providesId(other, requires)
+        )
+      ) {
+        continue;
+      }
+      const failure = await resolveBarrierAt(i);
+      if (failure != null) return failure;
+    }
+    const node = orderDependencyNodes(pending)[0];
+    if (node.resolveBarrier != null && node.barrierResolutionState == null) {
+      // The barrier reached its execution position without early
+      // resolution (no control dependency): resolve it here—exactly
+      // where its preparation used to complete the discriminator—and
+      // re-order, so a concrete cycle in the refined edges still
+      // surfaces and stale advisory edges are replaced.
+      const failure = await resolveBarrierAt(pending.indexOf(node));
+      if (failure != null) return failure;
+      continue;
+    }
+    pending.splice(pending.indexOf(node), 1);
     // A scheduling barrier runs at its declaration position; its
     // preparation may schedule further nodes through the nested call,
     // which shares this pass's runtime, session, and exec.
     if (node.prepare != null) {
-      const barrierFailure = await node.prepare({
-        runtime,
-        exec,
-        // The barrier's subtree is part of the construct's delivery
-        // scope: its structural values re-register at the barrier's
-        // declaration position (isCollected), while its completion
-        // results stay out of the owning construct's pre-completed
-        // cache (isReusable) and deduplicate through the session.
-        schedule: (barrierNodes) =>
-          completeEffectfulSourcesAsync(barrierNodes, state, runtime, exec, {
-            isReusable: () => false,
-            isCollected: () => true,
-            includeStructural: true,
-          }).then((result) => result.success ? undefined : result),
-      });
+      const barrierFailure = await node.prepare(barrierContext);
       if (barrierFailure != null) return barrierFailure;
       continue;
     }
@@ -2272,6 +2611,66 @@ export async function completeEffectfulSourcesAsync(
       const extracted = await source.extractSourceValue(node.state);
       if (extracted?.success === true && extracted.value !== undefined) {
         runtime.registerSource(source.sourceId, extracted.value);
+        continue;
+      }
+      // Inside a barrier's nested pass (the only includeStructural
+      // caller), a structural occurrence with a publishable
+      // missing-value default (withDefault()) registers that default at
+      // its declaration position, so a branch-internal consumer reads
+      // it just like any other active provider, while a later outer
+      // occurrence still re-registers afterward and wins outside.  The
+      // ordinary missing-default phase runs only after this pass, so it
+      // cannot serve this occurrence in time.  Defaults stay fill-only,
+      // mirroring fillMissingSourceDefaults: a value another occurrence
+      // already registered—an explicit command-line value before the
+      // conditional, say—is never displaced, and explicit failures are
+      // never overridden.
+      if (
+        options?.includeStructural === true &&
+        extracted?.success !== false &&
+        node.matched !== true &&
+        source.preservesSourceValue &&
+        source.getMissingSourceValue != null &&
+        !runtime.hasSource(source.sourceId) &&
+        !runtime.isSourceFailed(source.sourceId)
+      ) {
+        // Cache by the occurrence's composed default function across
+        // the run's passes, so a non-idempotent default thunk evaluates
+        // once even when nested scheduling repeats, the registered
+        // value stays stable, and a changed branch selection between
+        // passes never reuses another branch's default.
+        let fallback = session?.missingDefaultsByOccurrence.get(
+          source.getMissingSourceValue,
+        );
+        if (fallback == null) {
+          try {
+            fallback = await source.getMissingSourceValue();
+          } catch (e) {
+            const msg = e instanceof Error ? e.message : String(e);
+            fallback = {
+              success: false,
+              error: message`Default value evaluation failed: ${msg}`,
+            };
+          }
+          session?.missingDefaultsByOccurrence.set(
+            source.getMissingSourceValue,
+            fallback,
+          );
+        }
+        if (fallback.success) {
+          runtime.registerSource(source.sourceId, fallback.value);
+        } else {
+          runtime.markSourceFailed(source.sourceId);
+          propagateRuntimeSourceFailures(nodes, runtime);
+          return {
+            success: false,
+            error: includeSourceFailureChain(
+              fallback.error,
+              source.sourceId,
+              runtime,
+            ),
+          };
+        }
       }
       continue;
     }

--- a/packages/core/src/internal/parser.ts
+++ b/packages/core/src/internal/parser.ts
@@ -566,6 +566,26 @@ export interface EffectfulCompletionSession {
    * re-completing the discriminator or re-selecting a branch.
    */
   readonly preparedByPath: Map<string, unknown>;
+
+  /**
+   * Missing-value default results published for structural source
+   * occurrences inside a scheduling barrier's nested pass, keyed by the
+   * occurrence's composed `getMissingSourceValue` function.  The
+   * function identifies the exact wrapper instance, so two branches of
+   * a `conditional()` sharing a node path never observe each other's
+   * defaults even when a phase-two binding changes the selection
+   * between passes.  Unlike {@link completedByPath} this cache is
+   * shared across the passes of a run: a default does not depend on
+   * pass-specific state, so caching it keeps a non-idempotent
+   * `withDefault()` thunk at one evaluation per run even when the
+   * nested pass repeats.
+   *
+   * @since 1.3.0
+   */
+  readonly missingDefaultsByOccurrence: WeakMap<
+    object,
+    ValueParserResult<unknown>
+  >;
 }
 
 /**
@@ -584,6 +604,7 @@ export function createEffectfulCompletionSession(
     effectfulSources: new Set(),
     completedByPath: new Map(),
     preparedByPath: new Map(),
+    missingDefaultsByOccurrence: new WeakMap(),
   };
 }
 

--- a/packages/core/src/primitives.ts
+++ b/packages/core/src/primitives.ts
@@ -17,12 +17,12 @@ import { extractDependencyMetadata } from "./dependency-metadata.ts";
 import {
   type EffectfulSchedulingNodesFn,
   effectfulSchedulingNodesKey,
+  exclusiveSourceScopeKey,
   includeSourceFailureChain,
   recordDerivedRawInput,
   replayDerivedParser,
   replayDerivedParserAsync,
   sourceCollectionExpansionKey,
-  staticSourceScopeKey,
 } from "./dependency-runtime.ts";
 import {
   mergeChildExec,
@@ -3693,8 +3693,10 @@ export function command<M extends Mode, T, TState>(
     enumerable: false,
   });
   // Static source estimation reaches the inner parser even while the
-  // command is unmatched (see staticSourceScopeKey).
-  Object.defineProperty(result, staticSourceScopeKey, {
+  // command is unmatched.  The edge is exclusive: an unmatched command
+  // never provides its inner sources, so they must not count as
+  // guaranteed providers (see exclusiveSourceScopeKey).
+  Object.defineProperty(result, exclusiveSourceScopeKey, {
     value: [parser],
     configurable: true,
     enumerable: false,

--- a/packages/prompt/src/index.test.ts
+++ b/packages/prompt/src/index.test.ts
@@ -4712,9 +4712,11 @@ describe("branch completion dependencies across scheduling barriers", () => {
     ]);
   });
 
-  // The remaining tests pin accepted limitations of the static
-  // aggregation, so a behavior change there is deliberate rather than
-  // accidental.
+  // The remaining tests pin the active-provider rule for branch
+  // provides (https://github.com/dahlia/optique/issues/924): a
+  // guaranteed internal occurrence serves its branch, while a merely
+  // possible one no longer hides a provider declared after the
+  // conditional.
 
   it("keeps a branch-internal provider for the branch consumer while a later occurrence wins outside", async () => {
     const kind = dependency(choice(["a", "b"] as const));
@@ -4758,15 +4760,15 @@ describe("branch completion dependencies across scheduling barriers", () => {
     assert.equal(result.value.out, "npm");
   });
 
-  it("lets an absent branch provider hide a later external provider", async () => {
+  it("resolves a later external provider despite an absent branch provider", async () => {
     const kind = dependency(choice(["a", "b"] as const));
     const framework = dependency(choice(["fresh", "hono"] as const));
     const resolved: unknown[] = [];
     const { prompt } = createTestPrompt();
-    // The branch statically provides the framework source through an
-    // optional occurrence that parses nothing, so the ordering union
-    // drops the edge to the later occurrence: the resolver keeps its
-    // declared default.
+    // The branch's optional occurrence parses nothing, so it is a
+    // merely possible provider: the barrier keeps its ordering edge to
+    // the occurrence declared after the conditional, whose prompted
+    // value reaches the branch resolver.
     const parser = object({
       cond: conditional(
         prompt(option("--kind", kind), { value: "a" }),
@@ -4790,20 +4792,19 @@ describe("branch completion dependencies across scheduling barriers", () => {
     const result = await parseAsync(parser, []);
 
     assert.ok(result.success);
-    assert.deepEqual(resolved, [["fresh", true]]);
+    assert.deepEqual(resolved, [["hono", false]]);
   });
 
-  it("keeps a nested alternative's static provides hiding an outer provider", async () => {
+  it("resolves an outer provider despite an unselected nested alternative's provides", async () => {
     const kindOuter = dependency(choice(["a", "b"] as const));
     const kindInner = dependency(choice(["i1", "i2"] as const));
     const framework = dependency(choice(["fresh", "hono"] as const));
     const resolved: unknown[] = [];
     const { prompt } = createTestPrompt();
-    // The outer branch's static walk sees the unselected i1
-    // alternative providing the framework source, so the subtraction
-    // happens at outer-branch granularity and the selected i2
-    // consumer cannot wait for the provider declared after the outer
-    // conditional: it keeps its declared default.
+    // The i1 alternative provides the framework source only if it is
+    // selected, so it is a merely possible provider for the outer
+    // branch: the selected i2 consumer waits for the provider declared
+    // after the outer conditional and reads its prompted value.
     const parser = object({
       cond: conditional(
         prompt(option("--kind", kindOuter), { value: "a" }),
@@ -4837,6 +4838,595 @@ describe("branch completion dependencies across scheduling barriers", () => {
     const result = await parseAsync(parser, []);
 
     assert.ok(result.success);
+    assert.deepEqual(resolved, ["hono"]);
+  });
+
+  it("resolves a later external provider despite an absent optional prompt provider", async () => {
+    const kind = dependency(choice(["a", "b"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const resolved: unknown[] = [];
+    const { prompt } = createTestPrompt();
+    // optional(prompt(...)) keeps an effectful completion, but an
+    // absent optional occurrence declines it and publishes nothing, so
+    // it is a merely possible provider: the consumer still waits for
+    // the occurrence declared after the conditional.
+    const parser = object({
+      cond: conditional(
+        prompt(option("--kind", kind), { value: "a" }),
+        {
+          a: object({
+            fw: optional(
+              prompt(option("--fw", framework), { value: "fresh" }),
+            ),
+            pm: prompt(
+              option("--pm", dependency(choice(["deno", "npm"] as const))),
+              derivePromptConfig(framework, (value) => {
+                resolved.push(value);
+                return { value: value === "hono" ? "npm" : "deno" };
+              }, { defaultValue: () => "fresh" as const }),
+            ),
+          }),
+          b: object({ y: option("--y", choice(["2"] as const)) }),
+        },
+      ),
+      fw2: prompt(option("--fw2", framework), { value: "hono" }),
+    });
+
+    const result = await parseAsync(parser, []);
+
+    assert.ok(result.success);
+    assert.deepEqual(resolved, ["hono"]);
+  });
+
+  it("keeps a runtime-conditioned branch prompt guaranteed through its otherwise value", async () => {
+    const kind = dependency(choice(["a", "b"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const resolved: unknown[] = [];
+    const { prompt } = createTestPrompt();
+    // A prompt guarded by a runtime `when` condition publishes its
+    // `otherwise` value when the condition declines, so it remains a
+    // guaranteed provider: the branch consumer reads that value instead
+    // of waiting for the occurrence declared after the conditional.
+    const parser = object({
+      cond: conditional(
+        prompt(option("--kind", kind), { value: "a" }),
+        {
+          a: object({
+            fw: prompt(option("--fw", framework), {
+              value: "hono",
+              when: () => false,
+              otherwise: "fresh" as const,
+            }),
+            pm: prompt(
+              option("--pm", dependency(choice(["deno", "npm"] as const))),
+              derivePromptConfig(framework, (value) => {
+                resolved.push(value);
+                return { value: value === "hono" ? "npm" : "deno" };
+              }),
+            ),
+          }),
+          b: object({ y: option("--y", choice(["2"] as const)) }),
+        },
+      ),
+      fw2: prompt(option("--fw2", framework), { value: "hono" }),
+    });
+
+    const result = await parseAsync(parser, []);
+
+    assert.ok(result.success);
     assert.deepEqual(resolved, ["fresh"]);
+  });
+
+  it("serves a branch consumer from a withDefault provider while a later occurrence wins outside", async () => {
+    const kind = dependency(choice(["a", "b"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const frameworkDerived = framework.deriveSync({
+      metavar: "FW_DERIVED",
+      factory: (value: "fresh" | "hono") =>
+        choice(value === "fresh" ? (["deno"] as const) : (["npm"] as const)),
+      defaultValue: () => "fresh" as const,
+    });
+    const resolved: unknown[] = [];
+    const { prompt } = createTestPrompt();
+    // withDefault() publishes its default whenever the branch runs, so
+    // it is a guaranteed provider: the barrier does not wait for the
+    // later occurrence, the branch consumer reads the default, and the
+    // later occurrence still wins for post-conditional consumers.
+    const parser = object({
+      cond: conditional(
+        prompt(option("--kind", kind), { value: "a" }),
+        {
+          a: object({
+            fw: withDefault(option("--fw", framework), "fresh" as const),
+            pm: prompt(
+              option("--pm", dependency(choice(["deno", "npm"] as const))),
+              derivePromptConfig(framework, (value) => {
+                resolved.push(value);
+                return { value: value === "fresh" ? "deno" : "npm" };
+              }),
+            ),
+          }),
+          b: object({ y: option("--y", choice(["2"] as const)) }),
+        },
+      ),
+      fw2: prompt(option("--fw2", framework), { value: "hono" }),
+      out: option("--out", frameworkDerived),
+    });
+
+    const result = await parseAsync(parser, ["--out", "npm"]);
+
+    assert.ok(result.success);
+    assert.deepEqual(resolved, ["fresh"]);
+    assert.deepEqual(result.value.cond, ["a", { fw: "fresh", pm: "deno" }]);
+    assert.equal(result.value.fw2, "hono");
+    assert.equal(result.value.out, "npm");
+  });
+
+  it("publishes a branch withDefault thunk once per run", async () => {
+    const kind = dependency(choice(["a", "b"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const resolved: unknown[] = [];
+    let thunkCalls = 0;
+    const { prompt } = createTestPrompt();
+    const parser = object({
+      cond: conditional(
+        prompt(option("--kind", kind), { value: "a" }),
+        {
+          a: object({
+            fw: withDefault(option("--fw", framework), () => {
+              thunkCalls++;
+              return "fresh" as const;
+            }),
+            pm: prompt(
+              option("--pm", dependency(choice(["deno", "npm"] as const))),
+              derivePromptConfig(framework, (value) => {
+                resolved.push(value);
+                return { value: value === "fresh" ? "deno" : "npm" };
+              }),
+            ),
+          }),
+          b: object({ y: option("--y", choice(["2"] as const)) }),
+        },
+      ),
+    });
+
+    const result = await parseAsync(parser, []);
+
+    assert.ok(result.success);
+    assert.deepEqual(resolved, ["fresh"]);
+    assert.deepEqual(result.value.cond, ["a", { fw: "fresh", pm: "deno" }]);
+    // The nested scheduling pass publishes the default at most once per
+    // run, on top of the pre-existing parse-probe and field-completion
+    // evaluations flat compositions already perform; without the
+    // run-scoped cache, repeated nested passes would keep adding more.
+    assert.ok(
+      thunkCalls <= 3,
+      `Expected at most 3 thunk evaluations, got ${thunkCalls}`,
+    );
+  });
+
+  it("never lets a branch default displace an explicit earlier value", async () => {
+    const kind = dependency(choice(["a", "b"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const resolved: unknown[] = [];
+    const { prompt } = createTestPrompt();
+    // Defaults are fill-only: the user's explicit --fw value, collected
+    // from the occurrence declared before the conditional, must not be
+    // overwritten by the branch's unmatched withDefault() fallback.
+    const parser = object({
+      fw1: option("--fw", framework),
+      cond: conditional(
+        prompt(option("--kind", kind), { value: "a" }),
+        {
+          a: object({
+            fw: withDefault(option("--fw2", framework), "hono" as const),
+            pm: prompt(
+              option("--pm", dependency(choice(["deno", "npm"] as const))),
+              derivePromptConfig(framework, (value) => {
+                resolved.push(value);
+                return { value: value === "fresh" ? "deno" : "npm" };
+              }),
+            ),
+          }),
+          b: object({ y: option("--y", choice(["2"] as const)) }),
+        },
+      ),
+    });
+
+    const result = await parseAsync(parser, ["--fw", "fresh"]);
+
+    assert.ok(result.success);
+    assert.equal(result.value.fw1, "fresh");
+    assert.deepEqual(resolved, ["fresh"]);
+  });
+
+  it("serves a branch consumer from a withDefault prompt provider", async () => {
+    const kind = dependency(choice(["a", "b"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const resolved: unknown[] = [];
+    const { prompt } = createTestPrompt();
+    // withDefault(prompt(...)) keeps both the effectful completion and
+    // the publishable default, so it stays a guaranteed provider: the
+    // prompt answers inside the branch and the consumer reads it.
+    const parser = object({
+      cond: conditional(
+        prompt(option("--kind", kind), { value: "a" }),
+        {
+          a: object({
+            fw: withDefault(
+              prompt(option("--fw", framework), { value: "fresh" }),
+              "fresh" as const,
+            ),
+            pm: prompt(
+              option("--pm", dependency(choice(["deno", "npm"] as const))),
+              derivePromptConfig(framework, (value) => {
+                resolved.push(value);
+                return { value: value === "fresh" ? "deno" : "npm" };
+              }),
+            ),
+          }),
+          b: object({ y: option("--y", choice(["2"] as const)) }),
+        },
+      ),
+      fw2: prompt(option("--fw2", framework), { value: "hono" }),
+    });
+
+    const result = await parseAsync(parser, []);
+
+    assert.ok(result.success);
+    assert.deepEqual(resolved, ["fresh"]);
+  });
+
+  it("treats a nested conditional providing on every route as guaranteed", async () => {
+    const kindOuter = dependency(choice(["a", "b"] as const));
+    const kindInner = dependency(choice(["i1", "i2"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const frameworkDerived = framework.deriveSync({
+      metavar: "FW_DERIVED",
+      factory: (value: "fresh" | "hono") =>
+        choice(value === "fresh" ? (["deno"] as const) : (["npm"] as const)),
+      defaultValue: () => "fresh" as const,
+    });
+    const resolved: unknown[] = [];
+    const { prompt } = createTestPrompt();
+    // Every route through the inner conditional prompts the framework
+    // source, so the outer branch is guaranteed to provide it: the
+    // outer barrier does not wait for the later occurrence, the branch
+    // consumer reads the inner answer, and the later occurrence wins
+    // for post-conditional consumers.
+    const parser = object({
+      cond: conditional(
+        prompt(option("--kind", kindOuter), { value: "a" }),
+        {
+          a: object({
+            inner: conditional(
+              prompt(option("--inner", kindInner), { value: "i2" }),
+              {
+                i1: object({
+                  fw: prompt(option("--fw", framework), { value: "hono" }),
+                }),
+                i2: object({
+                  fw: prompt(option("--fw-b", framework), { value: "fresh" }),
+                }),
+              },
+            ),
+            pm: prompt(
+              option("--pm", dependency(choice(["deno", "npm"] as const))),
+              derivePromptConfig(framework, (value) => {
+                resolved.push(value);
+                return { value: value === "fresh" ? "deno" : "npm" };
+              }),
+            ),
+          }),
+          b: object({ y: option("--y", choice(["2"] as const)) }),
+        },
+      ),
+      fw2: prompt(option("--fw2", framework), { value: "hono" }),
+      out: option("--out", frameworkDerived),
+    });
+
+    const result = await parseAsync(parser, ["--out", "npm"]);
+
+    assert.ok(result.success);
+    assert.deepEqual(resolved, ["fresh"]);
+    assert.equal(result.value.out, "npm");
+  });
+
+  it("parses a barrier and sibling consumer whose opposing edges cannot coexist", async () => {
+    const kind = dependency(choice(["a", "b"] as const));
+    const alpha = dependency(choice(["a1", "a2"] as const));
+    const beta = dependency(choice(["b1", "b2"] as const));
+    const resolved: unknown[] = [];
+    const { prompt } = createTestPrompt();
+    // Branch a consumes the sibling's source while only branch b could
+    // provide the source the sibling consumes.  The opposing edges come
+    // from branches that cannot be selected together, so the parser is
+    // no longer rejected as circular: once the discriminator selects
+    // branch a, the barrier is only a consumer, so the sibling resolves
+    // first against its own default and the branch consumer reads the
+    // sibling's published value.
+    const parser = object({
+      cond: conditional(
+        prompt(option("--kind", kind), { value: "a" }),
+        {
+          a: object({
+            pa: prompt(
+              option("--pa", dependency(choice(["x", "y"] as const))),
+              derivePromptConfig(alpha, (value) => {
+                resolved.push(["pa", value]);
+                return { value: value === "a1" ? "x" : "y" };
+              }, { defaultValue: () => "a1" as const }),
+            ),
+          }),
+          b: object({
+            pb: prompt(option("--pb", beta), { value: "b1" }),
+          }),
+        },
+      ),
+      sibling: prompt(
+        option("--sibling", alpha),
+        derivePromptConfig(beta, (value) => {
+          resolved.push(["sibling", value]);
+          return { value: value === "b1" ? "a1" : "a2" };
+        }, { defaultValue: () => "b2" as const }),
+      ),
+    });
+
+    const result = await parseAsync(parser, []);
+
+    assert.ok(result.success);
+    assert.deepEqual(resolved, [["sibling", "b2"], ["pa", "a2"]]);
+  });
+
+  it("rejects a genuine cycle between an active branch provider and a sibling consumer", async () => {
+    const kind = dependency(choice(["a", "b"] as const));
+    const alpha = dependency(choice(["a1", "a2"] as const));
+    const beta = dependency(choice(["b1", "b2"] as const));
+    const { prompt } = createTestPrompt();
+    // The selected branch actively provides the source the sibling
+    // consumes while also waiting for the sibling's source: once the
+    // discriminator resolves the branch, both edges are concrete and
+    // the cycle is genuine.
+    const parser = object({
+      cond: conditional(
+        prompt(option("--kind", kind), { value: "a" }),
+        {
+          a: object({
+            pb: prompt(option("--pb", beta), { value: "b1" }),
+            pa: prompt(
+              option("--pa", dependency(choice(["x", "y"] as const))),
+              derivePromptConfig(alpha, (value) => ({
+                value: value === "a1" ? "x" : "y",
+              }), { defaultValue: () => "a1" as const }),
+            ),
+          }),
+          b: object({ y: option("--y", choice(["2"] as const)) }),
+        },
+      ),
+      sibling: prompt(
+        option("--sibling", alpha),
+        derivePromptConfig(beta, (value) => ({
+          value: value === "b1" ? "a1" : "a2",
+        }), { defaultValue: () => "b2" as const }),
+      ),
+    });
+
+    await assert.rejects(
+      () => parseAsync(parser, []),
+      /Circular dependency/,
+    );
+  });
+
+  it("resolves an absent optional provider's consumer under runWith", async () => {
+    const kind = dependency(choice(["a", "z"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const { mode, level } = createModeFixture();
+    const { prompt, calls } = createTestPrompt();
+    const dynamicContext: SourceContext = {
+      id: Symbol.for("@optique/prompt/test-active-provider-demand"),
+      phase: "two-pass",
+      getAnnotations() {
+        return {};
+      },
+    };
+    // The demanded branch consumer's prerequisite reaches the seed
+    // pass, and the absent optional occurrence does not hide the
+    // later provider under the two-pass path either.
+    const parser = object({
+      cond: conditional(
+        prompt(option("--kind", kind), { value: "a" }),
+        {
+          a: object({
+            fw: optional(option("--fw", framework)),
+            mode: prompt(
+              option("--mode", mode),
+              derivePromptConfig(framework, (value) => ({
+                value: value === "hono" ? "prod" : "dev",
+              }), { defaultValue: () => "fresh" as const }),
+            ),
+          }),
+          z: object({ y: option("--y", choice(["2"] as const)) }),
+        },
+      ),
+      framework: prompt(option("--framework", framework), { value: "hono" }),
+      level: option("--level", level),
+    });
+
+    const result = await runWith(parser, "test", [dynamicContext], {
+      args: ["--level", "silent"],
+    });
+
+    assert.equal((result as { readonly level: string }).level, "silent");
+    assert.deepEqual(
+      (result as { readonly cond: unknown }).cond,
+      ["a", { fw: undefined, mode: "prod" }],
+    );
+    assert.deepEqual(calls, [
+      { value: "a" },
+      { value: "hono" },
+      { value: "prod" },
+    ]);
+  });
+
+  it("keeps a mixed alternative a merely possible provider", async () => {
+    const kind = dependency(choice(["a", "b"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const resolved: unknown[] = [];
+    const { prompt } = createTestPrompt();
+    // The or() may commit its non-source alternative, so the branch is
+    // not guaranteed to publish the framework source even though one
+    // alternative is an unconditional prompt: the consumer waits for
+    // the occurrence declared after the conditional.
+    const parser = object({
+      cond: conditional(
+        prompt(option("--kind", kind), { value: "a" }),
+        {
+          a: object({
+            fw: or(
+              prompt(option("--fw", framework), { value: "fresh" }),
+              constant("none"),
+            ),
+            pm: prompt(
+              option("--pm", dependency(choice(["deno", "npm"] as const))),
+              derivePromptConfig(framework, (value) => {
+                resolved.push(value);
+                return { value: value === "hono" ? "npm" : "deno" };
+              }, { defaultValue: () => "fresh" as const }),
+            ),
+          }),
+          b: object({ y: option("--y", choice(["2"] as const)) }),
+        },
+      ),
+      fw2: prompt(option("--fw2", framework), { value: "hono" }),
+    });
+
+    const result = await parseAsync(parser, []);
+
+    assert.ok(result.success);
+    assert.deepEqual(resolved, ["hono"]);
+  });
+
+  it("keeps a prompted optional branch provider merely possible", async () => {
+    const kind = dependency(choice(["a", "b"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const resolved: unknown[] = [];
+    const { prompt } = createTestPrompt();
+    // prompt(optional(...)) may legitimately answer `undefined`, which
+    // the scheduler never registers, so the occurrence stays a merely
+    // possible provider and the consumer waits for the later one.
+    const parser = object({
+      cond: conditional(
+        prompt(option("--kind", kind), { value: "a" }),
+        {
+          a: object({
+            fw: prompt(optional(option("--fw", framework)), {
+              value: undefined,
+            }),
+            pm: prompt(
+              option("--pm", dependency(choice(["deno", "npm"] as const))),
+              derivePromptConfig(framework, (value) => {
+                resolved.push(value);
+                return { value: value === "hono" ? "npm" : "deno" };
+              }, { defaultValue: () => "fresh" as const }),
+            ),
+          }),
+          b: object({ y: option("--y", choice(["2"] as const)) }),
+        },
+      ),
+      fw2: prompt(option("--fw2", framework), { value: "hono" }),
+    });
+
+    const result = await parseAsync(parser, []);
+
+    assert.ok(result.success);
+    assert.deepEqual(resolved, ["hono"]);
+  });
+
+  it("rejects a genuine cycle behind an effect-free discriminator", async () => {
+    const alpha = dependency(choice(["a1", "a2"] as const));
+    const beta = dependency(choice(["b1", "b2"] as const));
+    const { prompt } = createTestPrompt();
+    // The discriminator is not a dependency source, so the barrier
+    // resolves at its execution position; the selected branch actively
+    // provides the source the sibling consumes while waiting for the
+    // sibling's source, which is a genuine concrete cycle.
+    const parser = object({
+      cond: conditional(
+        withDefault(option("--kind", choice(["a", "b"] as const)), "a"),
+        {
+          a: object({
+            pb: prompt(option("--pb", beta), { value: "b1" }),
+            pa: prompt(
+              option("--pa", dependency(choice(["x", "y"] as const))),
+              derivePromptConfig(alpha, (value) => ({
+                value: value === "a1" ? "x" : "y",
+              }), { defaultValue: () => "a1" as const }),
+            ),
+          }),
+          b: object({ y: option("--y", choice(["2"] as const)) }),
+        },
+      ),
+      sibling: prompt(
+        option("--sibling", alpha),
+        derivePromptConfig(beta, (value) => ({
+          value: value === "b1" ? "a1" : "a2",
+        }), { defaultValue: () => "b2" as const }),
+      ),
+    });
+
+    await assert.rejects(
+      () => parseAsync(parser, []),
+      /Circular dependency/,
+    );
+  });
+
+  it("confirms a config-bound branch provider once its value binds", async () => {
+    const kind = dependency(choice(["a", "b"] as const));
+    const region = dependency(choice(["us", "eu"] as const));
+    const resolved: unknown[] = [];
+    const context = createRegionConfigContext();
+    const { prompt } = createTestPrompt();
+    // The bound occurrence extracts its configuration value when the
+    // barrier resolves, so it is an active provider: the branch
+    // consumer reads the bound value instead of waiting for the later
+    // occurrence.
+    const parser = object({
+      cond: conditional(
+        prompt(option("--kind", kind), { value: "a" }),
+        {
+          a: object({
+            region: bindConfig(option("--region", region), {
+              context,
+              key: "region",
+            }),
+            zone: prompt(
+              option("--zone", dependency(choice(["z1", "z2"] as const))),
+              derivePromptConfig(region, (value) => {
+                resolved.push(value);
+                return { value: value === "eu" ? "z2" : "z1" };
+              }, { defaultValue: () => "us" as const }),
+            ),
+          }),
+          b: object({ y: option("--y", choice(["2"] as const)) }),
+        },
+      ),
+      region2: prompt(option("--region2", region), { value: "us" }),
+    });
+
+    const result = await runWith(parser, "test", [context], {
+      args: [],
+      contextOptions: {
+        load: () => ({
+          config: { region: "eu" as const },
+          meta: undefined,
+        }),
+      },
+    });
+
+    assert.deepEqual(resolved, ["eu"]);
+    assert.deepEqual((result as { readonly cond: unknown }).cond, [
+      "a",
+      { region: "eu", zone: "z2" },
+    ]);
   });
 });

--- a/packages/prompt/src/index.ts
+++ b/packages/prompt/src/index.ts
@@ -1151,6 +1151,20 @@ export function createPromptAdapter<TConfig>(
           promptedParser.complete(state as TState, exec) as Promise<
             ValueParserResult<unknown>
           >,
+        // Without a runtime `when` condition, the prompt always asks and
+        // registers its answer, so an absent occurrence still publishes.
+        // A conditioned prompt publishes its `otherwise` value when the
+        // condition declines, so it stays guaranteed unless that value
+        // is `undefined`, which the scheduler never registers.  A
+        // wrapped parser whose own chain already declines when missing
+        // (e.g. prompt() around an optional()) keeps its explicit
+        // `false`: its answer may legitimately be `undefined`.
+        ...(source.preservesSourceValue !== false && {
+          completesWhenMissing: source.completesWhenMissing !== false &&
+            (config.when == null ||
+              (config as { readonly otherwise?: unknown }).otherwise !==
+                undefined),
+        }),
       }),
     );
     // A derived configuration makes this prompt a dependency consumer:


### PR DESCRIPTION
The barrier scheduling from #923 represented each branch as flat sets of source IDs, which cannot say whether an occurrence will actually publish. Any statically visible provider suppressed the barrier's ordering edge to a later occurrence, so an absent `optional()` or an unselected nested alternative hid a real provider, and edges aggregated from branches that can never run together could form a cycle no execution contains.

Static branch estimates now subtract only guaranteed providers. A new `completesWhenMissing` capability records whether a composed effectful completion publishes for an absent occurrence, derived from the effective hooks rather than wrapper names, because wrappers compose in ways names do not capture: `optional(withDefault(x))` keeps its default while `prompt(map(x))` exposes no scheduler-visible completion at all. A merely possible provider leaves the ordering edge in place. A branch-internal `withDefault()` also has to deliver what it promises, so the nested pass publishes its fill-only default, cached per run and keyed by the composed default function rather than the node path, since both branches share the *\_branch* path and a phase-two binding may change the selection.

Active providers are known only after branch selection, so the barrier gains a `resolveBarrier` hook and the effectful scheduler becomes incremental. Once the discriminator's completion settles the selection, the hook replays the branch and reports its concrete dependencies, invoking each needed state extractor at most once and awaiting asynchronous results, so a bound value that validates asynchronously counts. The scheduler swaps those edges in for the advisory estimate and re-orders the remaining nodes; advisory ordering edges do not delay resolution, which lets a state-confirmed binding shed a stale wait before the provider it named has run. On a stall, unresolved barriers relax their advisory edges within the stalled strongly connected component, because the static union can combine mutually exclusive branches; a cycle among a resolved barrier's concrete edges still raises the existing diagnostic. Demand-only seeding keeps the conservative static edges, since no selection has resolved when it runs. The two corresponding caveats are gone from *docs/integrations/prompt.md*; the rejected-speculation caveat stays for #925.

Closes #924. Part of #869.
