### PR TITLE
Defer speculative `conditional()` branch effects until selection is confirmed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,8 +32,18 @@ To be released.
     Cycles among the selected branch's actual providers and consumers
     are rejected with the existing circular-dependency error, while an
     apparent cycle whose edges belong to branches that cannot be
-    selected together is no longer rejected.
-    [[#869], [#872], [#919], [#923], [#924], [#926]]
+    selected together is no longer rejected.  The discriminator's
+    resolution is also the boundary for branch-only effects: under the
+    demand-only seed pass a prerequisite that only a branch
+    configuration reads is demanded once the resolved selection
+    consumes it, never on the strength of the pre-selection estimate,
+    and a speculative parse-time guess the discriminator rejects now
+    fails the run at that boundary—so a prompt needed only by the
+    rejected guess is no longer asked right before the branch-mismatch
+    error.  When a guessed branch's prerequisites chain through an
+    earlier conditional, that discriminator now answers after the
+    confirming one instead of before it.
+    [[#869], [#872], [#919], [#923], [#924], [#925], [#926], [#927]]
  -  Added `termWidth: "auto"` to `formatDocPage()` for aligning descriptions
     after the widest visible term using terminal display width while reserving
     description space under `maxWidth`.  The existing default and explicit
@@ -101,7 +111,9 @@ To be released.
 [#919]: https://github.com/dahlia/optique/issues/919
 [#923]: https://github.com/dahlia/optique/pull/923
 [#924]: https://github.com/dahlia/optique/issues/924
+[#925]: https://github.com/dahlia/optique/issues/925
 [#926]: https://github.com/dahlia/optique/pull/926
+[#927]: https://github.com/dahlia/optique/pull/927
 
 ### @optique/run
 

--- a/changes.d/core/completion-dependency-scheduling.md
+++ b/changes.d/core/completion-dependency-scheduling.md
@@ -5,7 +5,9 @@ links:
   '#919': https://github.com/dahlia/optique/issues/919
   '#923': https://github.com/dahlia/optique/pull/923
   '#924': https://github.com/dahlia/optique/issues/924
+  '#925': https://github.com/dahlia/optique/issues/925
   '#926': https://github.com/dahlia/optique/pull/926
+  '#927': https://github.com/dahlia/optique/pull/927
 ---
  -  Added scheduling support for effectful completions that consume
     dependency values, such as prompts with derived configurations.  The
@@ -27,5 +29,15 @@ links:
     Cycles among the selected branch's actual providers and consumers
     are rejected with the existing circular-dependency error, while an
     apparent cycle whose edges belong to branches that cannot be
-    selected together is no longer rejected.
-    [[#869], [#872], [#919], [#923], [#924], [#926]]
+    selected together is no longer rejected.  The discriminator's
+    resolution is also the boundary for branch-only effects: under the
+    demand-only seed pass a prerequisite that only a branch
+    configuration reads is demanded once the resolved selection
+    consumes it, never on the strength of the pre-selection estimate,
+    and a speculative parse-time guess the discriminator rejects now
+    fails the run at that boundary—so a prompt needed only by the
+    rejected guess is no longer asked right before the branch-mismatch
+    error.  When a guessed branch's prerequisites chain through an
+    earlier conditional, that discriminator now answers after the
+    confirming one instead of before it.
+    [[#869], [#872], [#919], [#923], [#924], [#925], [#926], [#927]]

--- a/docs/concepts/dependencies.md
+++ b/docs/concepts/dependencies.md
@@ -663,7 +663,12 @@ branch occurrence hides an outer provider only when it will actively publish
 the source itself—through a guaranteed completion or default, or a value the
 branch already parsed or bound—so an absent `optional()` occurrence or an
 unselected nested alternative does not stop a later provider from serving the
-branch.
+branch.  The resolution is also a scheduling boundary for effects: a
+prerequisite that only a branch configuration reads runs after the
+discriminator has picked a branch that consumes it, never on the strength of
+the pre-selection estimate alone, and a speculative parse-time guess the
+discriminator rejects fails the run at that boundary before such a
+prerequisite runs.
 
 An invalid source never falls back to its default. The failure propagates
 through every derived source that consumes it—including prompts whose

--- a/docs/integrations/prompt.md
+++ b/docs/integrations/prompt.md
@@ -709,30 +709,32 @@ Derived configurations also work inside a `conditional()` whose branch
 is selected only during completion.  The scheduler aggregates the
 completion dependencies of every selectable branch, so the conditional
 waits for the sources a branch configuration reads even when they are
-declared *after* the conditional, and the demand-only seed pass of a
-`runWith()` run reaches a prerequisite only through the branch consumer
-that actually reads it.  Once the discriminator resolves the selection,
-the scheduler replaces that estimate with the selected branch's actual
-dependencies.  A branch occurrence counts as an *active* provider only
-when it is guaranteed to publish—an unconditional prompt, a
-`withDefault()` fallback, or a nested conditional that provides the
-source on every selectable route—or when its state already holds a
-parsed or bound value.  A merely possible provider, such as an
-`optional()` occurrence that ends up parsing nothing or a provider in
-an unselected nested alternative, no longer hides a matching provider
-declared after the conditional: the branch configuration waits for that
-provider and reads its value.  An apparent dependency cycle whose edges
-come from branches that cannot be selected together—say, a completion
-consumer next to a conditional whose branch consumes the consumer's own
-source—is no longer rejected; only a cycle among the selected branch's
-actual providers and consumers still raises the circular dependency
-error.
+declared *after* the conditional.  Once the discriminator resolves the
+selection, the scheduler replaces that estimate with the selected
+branch's actual dependencies.  The demand-only seed pass of a
+`runWith()` run treats that resolution as a boundary: a prerequisite is
+demanded only once the discriminator has picked a branch whose consumer
+actually reads it, so a prerequisite that only an unselected branch
+would read is never demanded, and a speculative parse-time guess the
+discriminator ultimately rejects fails the run at that boundary with
+the branch-mismatch error, before any effect the guess alone would have
+scheduled.  The boundary also orders chained questions: a speculative
+discriminator answers before an earlier-declared prerequisite whose
+demand is discovered only by its confirmation.  A branch occurrence counts as
+an *active* provider only when it is guaranteed to publish—an unconditional
+prompt, a `withDefault()` fallback, or a nested conditional that provides the
+source on every selectable route—or when its state already holds a parsed or
+bound value.  A merely possible provider, such as an `optional()` occurrence
+that ends up parsing nothing or a provider in an unselected nested alternative,
+no longer hides a matching provider declared after the conditional: the branch
+configuration waits for that provider and reads its value.  An apparent
+dependency cycle whose edges come from branches that cannot be selected
+together—say, a completion consumer next to a conditional whose branch consumes
+the consumer's own source—is no longer rejected; only a cycle among the
+selected branch's actual providers and consumers still raises the circular
+dependency error.
 
-Two caveats remain.  A speculative selection that the discriminator
-ultimately rejects may already have demanded its configuration
-prerequisites, so a prerequisite prompt can run before the
-branch-mismatch error surfaces, although the rejected branch's own
-resolver never runs.  And a nested conditional that guarantees a source
+One caveat remains.  A nested conditional that guarantees a source
 on only *some* of its routes is treated as a merely possible provider,
 so the outer conditional waits for a later occurrence when one exists;
 if the nested route that does provide the source is then selected, its

--- a/packages/core/src/constructs.ts
+++ b/packages/core/src/constructs.ts
@@ -31,6 +31,7 @@ import {
   fillMissingSourceDefaultsAsync,
   guaranteedStaticSourceIdsKey,
   hasInactiveCompletion,
+  replaceCachedBarrierFailure,
   resolveDerivedSourceValues,
   resolveDerivedSourceValuesAsync,
   resolveStateWithRuntime,
@@ -93,6 +94,7 @@ import type {
 import {
   defineInheritedAnnotationParser,
   defineParseLanes,
+  type EffectfulCompletionSession,
   getOwnParseLanes,
   getParserSuggestRuntimeNodes,
   type ParseLane,
@@ -250,6 +252,15 @@ function filterSchedulableRuntimeNodes(
  * prompt); the construct should propagate it as its own completion
  * failure.  Returns `undefined` on success.
  */
+/**
+ * Nodes a `conditional()` pre-expanded from a committed branch so a
+ * `branchError` wrap can ride on the nested barrier nodes.  They are
+ * expanded descendants despite appearing in a scheduling call's direct
+ * node list, so {@link scheduleEffectfulSourceCompletions} must not
+ * treat them as reusable or collected.
+ */
+const preExpandedBranchNodes = new WeakSet<RuntimeNode>();
+
 /**
  * Expands runtime nodes through nested constructs for effectful source
  * scheduling and demand detection.
@@ -711,15 +722,20 @@ function computeBarrierDependenciesFromNodes(
  * Computes a resolved barrier's concrete dependencies from the selected
  * branch's expanded runtime nodes: the completion dependencies its
  * active consumers read, minus the sources the branch actively
- * provides, and the active provides themselves.  Unlike the
- * synchronous estimate, promise-shaped state extractions are awaited,
- * so an asynchronously validating bound value counts as active.
+ * provides, the active provides themselves, and the selection's demand
+ * edges.  Unlike the synchronous estimate, promise-shaped state
+ * extractions are awaited, so an asynchronously validating bound value
+ * counts as active.  A nested barrier whose demand activation is
+ * `"after-resolution"` contributes only its ordering aggregate: its
+ * demand edges stay behind its own confirmation boundary and are
+ * promoted by its own resolution within the nested scheduling pass.
  */
 async function computeActiveBarrierDependencies(
   nodes: readonly RuntimeNode[],
 ): Promise<BarrierResolution> {
   const active = new Set<symbol>();
   const ordering = new Set<symbol>();
+  const demandEdges: BarrierCompletionDemandEdge[] = [];
   for (const node of nodes) {
     const metadata = node.parser.dependencyMetadata;
     const source = metadata?.source;
@@ -760,16 +776,29 @@ async function computeActiveBarrierDependencies(
         : hasInactiveCompletion(node);
       if (!inactive) {
         for (const id of completion.dependencyIds) ordering.add(id);
+        if (source != null) {
+          demandEdges.push({
+            consumerSourceId: source.sourceId,
+            dependencyIds: completion.dependencyIds,
+          });
+        }
       }
     }
     const nested = node.barrierCompletionDependencies;
     if (nested != null) {
       for (const id of nested.orderingDependencyIds) ordering.add(id);
+      if (
+        node.barrierDemandActivation !== "after-resolution" ||
+        node.barrierResolutionState === "resolved"
+      ) {
+        demandEdges.push(...nested.demandEdges);
+      }
     }
   }
   return {
     orderingDependencyIds: [...ordering].filter((id) => !active.has(id)),
     activeProvidesSourceIds: active,
+    demandEdges,
   };
 }
 
@@ -853,16 +882,25 @@ async function scheduleEffectfulSourceCompletions(
   // session instead.  Nodes expanded from a collection-opted-in child
   // (a conditional()/command()) did participate in the construct's
   // explicit source collection, so they re-register structurally in
-  // declaration order even though their results are not reusable.
-  const direct = new Set<RuntimeNode>(nodes);
+  // declaration order even though their results are not reusable.  A
+  // node a conditional() pre-expanded itself (a committed branch's
+  // subtree, wrapped for branchError) is an expanded descendant even
+  // when it arrives in the direct list, so it keeps the session-only
+  // treatment: reusability would bypass the no-session guard and could
+  // run a branch effect twice.
+  const direct = new Set<RuntimeNode>(
+    nodes.filter((node) => !preExpandedBranchNodes.has(node)),
+  );
   const collected = new Set<RuntimeNode>();
   const expandedNodes: RuntimeNode[] = [];
   for (const node of nodes) {
     const optedIn = (node.parser as {
       readonly [sourceCollectionExpansionKey]?: boolean;
     })[sourceCollectionExpansionKey] === true;
+    const preExpanded = preExpandedBranchNodes.has(node);
     for (const expandedNode of expandEffectfulRuntimeNodes([node])) {
       expandedNodes.push(expandedNode);
+      if (preExpanded) continue;
       if (optedIn || expandedNode === node) collected.add(expandedNode);
     }
   }
@@ -16373,6 +16411,92 @@ export function conditional(
   const preparedKeyFor = (
     parentPath: readonly PropertyKey[] | undefined,
   ): string => preparedKeyPrefix + serializeSchedulingPath(parentPath ?? []);
+  // The branch-mismatch failure shared by speculative barrier
+  // resolution and the completion-phase verification, so both surfaces
+  // report the identical message—including the defensive coercion of a
+  // discriminator that violates its return-type contract by yielding a
+  // non-string value.
+  const branchMismatchFailure = (
+    resolvedValue: unknown,
+    speculativeKey: string,
+  ): { readonly success: false; readonly error: Message } => {
+    const resolvedKey = typeof resolvedValue === "string"
+      ? resolvedValue
+      : "<unknown>";
+    return {
+      success: false,
+      error: options?.errors?.branchMismatch
+        ? options.errors.branchMismatch(resolvedKey, speculativeKey)
+        : message`Branch mismatch: tokens for ${speculativeKey} were consumed, but the discriminator resolved to ${resolvedKey}.`,
+    };
+  };
+  // A nested conditional's rejected speculation fails its barrier, and
+  // the failure surfaces through this conditional's branch scheduling
+  // rather than through branch completion.  Mirror the completion-phase
+  // contract: wrap a *barrier* failure from a named branch with the
+  // branchError hook, and update the run-scoped cache so later passes
+  // (the eager fallback after a failed seed pass) surface the wrapped
+  // error too.  A non-barrier failure—a cancelled branch prompt—is not
+  // in the cache under a barrier key and propagates untouched, exactly
+  // as scheduling failures always have.
+  const wrapCachedBarrierFailure = (
+    session: EffectfulCompletionSession | undefined,
+    failure: { readonly success: false; readonly error: Message },
+    branchKey: string | undefined,
+  ): { readonly success: false; readonly error: Message } => {
+    const branchError = options?.errors?.branchError;
+    if (branchKey == null || branchError == null) return failure;
+    const wrapped = {
+      success: false as const,
+      error: branchError(branchKey, failure.error),
+    };
+    return replaceCachedBarrierFailure(session, failure, wrapped)
+      ? wrapped
+      : failure;
+  };
+  // For a branch committed at parse time, nested barriers flatten into
+  // the enclosing pass, so the wrap has to travel on the nodes
+  // themselves: a nested barrier's own resolution failure is wrapped
+  // directly, and a failure a nested preparation forwards from deeper
+  // scheduling is wrapped through the cache check above.
+  const wrapBranchBarrierNodes = (
+    nodes: readonly RuntimeNode[],
+    branchKey: string | undefined,
+  ): readonly RuntimeNode[] => {
+    const branchError = options?.errors?.branchError;
+    if (branchKey == null || branchError == null) return nodes;
+    return nodes.map((node) => {
+      const resolveBarrier = node.resolveBarrier;
+      const prepare = node.prepare;
+      if (resolveBarrier == null && prepare == null) return node;
+      return {
+        ...node,
+        ...(resolveBarrier == null ? {} : {
+          resolveBarrier: async (ctx: SchedulingBarrierContext) => {
+            const result = await resolveBarrier(ctx);
+            if (result != null && "success" in result) {
+              return {
+                success: false as const,
+                error: branchError(branchKey, result.error),
+              };
+            }
+            return result;
+          },
+        }),
+        ...(prepare == null ? {} : {
+          prepare: async (ctx: SchedulingBarrierContext) => {
+            const failure = await prepare(ctx);
+            if (failure == null) return undefined;
+            return wrapCachedBarrierFailure(
+              ctx.exec?.effectfulCompletionSession,
+              failure,
+              branchKey,
+            );
+          },
+        }),
+      };
+    });
+  };
   // Source IDs the branches can provide, for demand-only control
   // dependency detection (see RuntimeNode.providesSourceIds), and the
   // branches' aggregated completion dependencies, so a scheduling
@@ -16507,7 +16631,7 @@ export function conditional(
         ? defaultBranch
         : branches[selected.key];
       if (branchParser != null) {
-        nodes.push({
+        const branchNode: RuntimeNode = {
           path: [...(parentPath ?? []), "_branch"],
           parser: branchParser,
           state: getAnnotatedChildState(
@@ -16515,7 +16639,27 @@ export function conditional(
             conditionalState.branchState,
             branchParser,
           ),
-        });
+        };
+        const branchKey = selected.kind === "branch" ? selected.key : undefined;
+        if (branchKey != null && options?.errors?.branchError != null) {
+          // A committed branch's nested barriers flatten into the
+          // enclosing pass, so pre-expand here and carry the
+          // branchError wrap on the barrier nodes themselves; the
+          // expansion is the same one the enclosing pass would apply,
+          // and the nodes stay marked as expanded descendants so the
+          // scheduling call never treats them as reusable.
+          for (
+            const expanded of wrapBranchBarrierNodes(
+              expandEffectfulRuntimeNodes([branchNode]),
+              branchKey,
+            )
+          ) {
+            preExpandedBranchNodes.add(expanded);
+            nodes.push(expanded);
+          }
+        } else {
+          nodes.push(branchNode);
+        }
       }
       return nodes;
     }
@@ -16610,6 +16754,7 @@ export function conditional(
         ...(speculativeBarrierDependencies != null
           ? { barrierCompletionDependencies: speculativeBarrierDependencies }
           : {}),
+        barrierDemandActivation: "after-resolution",
         resolveBarrier: async (ctx) => {
           const session = ctx.exec?.effectfulCompletionSession;
           if (session == null) return undefined;
@@ -16621,16 +16766,20 @@ export function conditional(
           ) {
             return undefined;
           }
-          if (
-            String(result.value) !== speculativeKey ||
-            branches[speculativeKey] == null
-          ) {
-            // A rejected speculation schedules no branch, so it has no
-            // concrete dependencies and provides nothing; the mismatch
-            // itself is reported by the completion phase.
+          if (String(result.value) !== speculativeKey) {
+            // A rejected speculation fails the pass at the barrier's
+            // slot: the run cannot succeed anymore, and failing here
+            // keeps later-declared effects—prerequisite prompts among
+            // them—from running before the mismatch surfaces.  The
+            // completion phase reports the identical failure on paths
+            // that never reach barrier scheduling.
+            return branchMismatchFailure(result.value, speculativeKey);
+          }
+          if (branches[speculativeKey] == null) {
             return {
               orderingDependencyIds: [],
               activeProvidesSourceIds: new Set<symbol>(),
+              demandEdges: [],
             };
           }
           return await computeActiveBarrierDependencies(
@@ -16650,7 +16799,9 @@ export function conditional(
           }
           if (String(result.value) !== speculativeKey) return undefined;
           if (branches[speculativeKey] == null) return undefined;
-          return await ctx.schedule(expandGuessedBranchNodes());
+          const failure = await ctx.schedule(expandGuessedBranchNodes());
+          if (failure == null) return undefined;
+          return wrapCachedBarrierFailure(session, failure, speculativeKey);
         },
       });
       return nodes;
@@ -16780,6 +16931,7 @@ export function conditional(
       ...(mergedBarrierDependencies != null
         ? { barrierCompletionDependencies: mergedBarrierDependencies }
         : {}),
+      barrierDemandActivation: "after-resolution",
       resolveBarrier: async (ctx) => {
         const prepared = await resolvePreparedSelection(ctx);
         if (prepared == null) return undefined;
@@ -16787,6 +16939,7 @@ export function conditional(
           return {
             orderingDependencyIds: [],
             activeProvidesSourceIds: new Set<symbol>(),
+            demandEdges: [],
           };
         }
         return await computeActiveBarrierDependencies(
@@ -16796,7 +16949,13 @@ export function conditional(
       prepare: async (ctx) => {
         const prepared = await resolvePreparedSelection(ctx);
         if (prepared?.branchParser == null) return undefined;
-        return await ctx.schedule(expandPreparedBranchNodes(prepared));
+        const failure = await ctx.schedule(expandPreparedBranchNodes(prepared));
+        if (failure == null) return undefined;
+        return wrapCachedBarrierFailure(
+          ctx.exec?.effectfulCompletionSession,
+          failure,
+          prepared.branchKey,
+        );
       },
     });
     return nodes;
@@ -17203,24 +17362,15 @@ export function conditional(
       state.selectedBranch.kind === "branch" &&
       discriminatorValue !== state.selectedBranch.key
     ) {
-      const speculativeKey = state.selectedBranch.key;
       // `discriminatorValue` is statically `string | undefined`.  In
       // this branch it should always be a string (the only path that
       // sets `undefined` is the default-branch case, which is excluded
-      // by the `kind === "branch"` guard above).  Defensively coerce
-      // anyway: a buggy discriminator that violates its return-type
-      // contract by yielding a non-string would otherwise produce a
-      // confusing "resolved to ." message in both the default error
-      // and the `branchMismatch` hook.
-      const resolvedKey = typeof discriminatorValue === "string"
-        ? discriminatorValue
-        : "<unknown>";
-      return {
-        success: false,
-        error: options?.errors?.branchMismatch
-          ? options.errors.branchMismatch(resolvedKey, speculativeKey)
-          : message`Branch mismatch: tokens for ${speculativeKey} were consumed, but the discriminator resolved to ${resolvedKey}.`,
-      };
+      // by the `kind === "branch"` guard above); the shared helper
+      // coerces defensively.
+      return branchMismatchFailure(
+        discriminatorValue,
+        state.selectedBranch.key,
+      );
     }
 
     // Now that the speculative branch (if any) is verified, it is

--- a/packages/core/src/dependency-runtime.test.ts
+++ b/packages/core/src/dependency-runtime.test.ts
@@ -2763,6 +2763,421 @@ describe("completeEffectfulSourcesAsync", () => {
     assert.ok(!session.demanded.has(prerequisiteId));
   });
 
+  // https://github.com/dahlia/optique/issues/925
+  test("withholds a gated barrier's demand edges until resolution", async () => {
+    const runtime = createDependencyRuntimeContext();
+    const session = createEffectfulCompletionSession("demand-only");
+    const consumerId = Symbol("consumer");
+    const prerequisiteId = Symbol("prerequisite");
+    const discriminatorId = Symbol("discriminator");
+    const order: string[] = [];
+    session.demanded.add(consumerId);
+    // The prerequisite is declared first: without parking it would pass
+    // its slot (and defer) before the barrier's resolution promotes it.
+    const prerequisite = createEffectfulSourceNode(
+      "prerequisite",
+      prerequisiteId,
+      (_state, exec) => {
+        const s = exec?.effectfulCompletionSession;
+        if (s?.policy === "demand-only" && !s.demanded.has(prerequisiteId)) {
+          order.push("prerequisite-deferred");
+          return Promise.resolve(undefined);
+        }
+        order.push("prerequisite");
+        return Promise.resolve({ success: true, value: "p" });
+      },
+    );
+    const discriminator = createEffectfulSourceNode(
+      "discriminator",
+      discriminatorId,
+      () => {
+        order.push("discriminator");
+        return Promise.resolve({ success: true, value: "a" });
+      },
+    );
+    const barrier: RuntimeNode = {
+      path: ["barrier"],
+      parser: {},
+      state: undefined,
+      requiresSourceId: discriminatorId,
+      providesSourceIds: new Set([consumerId]),
+      barrierCompletionDependencies: {
+        orderingDependencyIds: [prerequisiteId],
+        demandEdges: [{
+          consumerSourceId: consumerId,
+          dependencyIds: [prerequisiteId],
+        }],
+      },
+      barrierDemandActivation: "after-resolution",
+      resolveBarrier: () =>
+        Promise.resolve({
+          orderingDependencyIds: [prerequisiteId],
+          activeProvidesSourceIds: new Set([consumerId]),
+          demandEdges: [{
+            consumerSourceId: consumerId,
+            dependencyIds: [prerequisiteId],
+          }],
+        }),
+      prepare: () => {
+        order.push("barrier");
+        return Promise.resolve(undefined);
+      },
+    };
+
+    const result = await completeEffectfulSourcesAsync(
+      [prerequisite, discriminator, barrier],
+      undefined,
+      runtime,
+      createCompleteExecFixture(session),
+    );
+
+    assert.ok(result.success);
+    // The resolution promoted the parked prerequisite into its
+    // dependency slot: discriminator, prerequisite provider, barrier.
+    assert.deepEqual(order, ["discriminator", "prerequisite", "barrier"]);
+    assert.ok(session.demanded.has(prerequisiteId));
+  });
+
+  // https://github.com/dahlia/optique/issues/925
+  test("leaves a gated prerequisite undemanded without promotion", async () => {
+    const runtime = createDependencyRuntimeContext();
+    const session = createEffectfulCompletionSession("demand-only");
+    const consumerId = Symbol("consumer");
+    const prerequisiteId = Symbol("prerequisite");
+    const discriminatorId = Symbol("discriminator");
+    const order: string[] = [];
+    session.demanded.add(consumerId);
+    const prerequisite = createEffectfulSourceNode(
+      "prerequisite",
+      prerequisiteId,
+      (_state, exec) => {
+        const s = exec?.effectfulCompletionSession;
+        if (s?.policy === "demand-only" && !s.demanded.has(prerequisiteId)) {
+          order.push("prerequisite-deferred");
+          return Promise.resolve(undefined);
+        }
+        order.push("prerequisite");
+        return Promise.resolve({ success: true, value: "p" });
+      },
+    );
+    const discriminator = createEffectfulSourceNode(
+      "discriminator",
+      discriminatorId,
+      () => {
+        order.push("discriminator");
+        return Promise.resolve({ success: true, value: "b" });
+      },
+    );
+    // The resolution keeps no demand edges (the selection does not read
+    // the prerequisite), so the parked prerequisite stays undemanded
+    // and defers once parking lifts.
+    const barrier: RuntimeNode = {
+      path: ["barrier"],
+      parser: {},
+      state: undefined,
+      requiresSourceId: discriminatorId,
+      providesSourceIds: new Set([consumerId]),
+      barrierCompletionDependencies: {
+        orderingDependencyIds: [prerequisiteId],
+        demandEdges: [{
+          consumerSourceId: consumerId,
+          dependencyIds: [prerequisiteId],
+        }],
+      },
+      barrierDemandActivation: "after-resolution",
+      resolveBarrier: () =>
+        Promise.resolve({
+          orderingDependencyIds: [],
+          activeProvidesSourceIds: new Set<symbol>(),
+          demandEdges: [],
+        }),
+      prepare: () => {
+        order.push("barrier");
+        return Promise.resolve(undefined);
+      },
+    };
+
+    const result = await completeEffectfulSourcesAsync(
+      [prerequisite, discriminator, barrier],
+      undefined,
+      runtime,
+      createCompleteExecFixture(session),
+    );
+
+    assert.ok(result.success);
+    assert.deepEqual(order, [
+      "discriminator",
+      "prerequisite-deferred",
+      "barrier",
+    ]);
+    assert.ok(!session.demanded.has(prerequisiteId));
+  });
+
+  // https://github.com/dahlia/optique/issues/925
+  test("terminates when gated barriers await each other's demand", async () => {
+    const runtime = createDependencyRuntimeContext();
+    const session = createEffectfulCompletionSession("demand-only");
+    const order: string[] = [];
+    const makeSide = (label: string): readonly RuntimeNode[] => {
+      const discriminatorId = Symbol(`${label}-discriminator`);
+      const branchId = Symbol(`${label}-branch`);
+      const discriminator = createEffectfulSourceNode(
+        `${label}-discriminator`,
+        discriminatorId,
+        (_state, exec) => {
+          const s = exec?.effectfulCompletionSession;
+          if (s?.policy === "demand-only" && !s.demanded.has(discriminatorId)) {
+            order.push(`${label}-deferred`);
+            return Promise.resolve(undefined);
+          }
+          order.push(label);
+          return Promise.resolve({ success: true, value: label });
+        },
+      );
+      const barrier: RuntimeNode = {
+        path: [`${label}-barrier`],
+        parser: {},
+        state: undefined,
+        requiresSourceId: discriminatorId,
+        providesSourceIds: new Set([branchId]),
+        barrierCompletionDependencies: {
+          orderingDependencyIds: [],
+          demandEdges: [],
+        },
+        barrierDemandActivation: "after-resolution",
+        // The discriminator never completed, so resolution reports
+        // "not yet resolvable" and the barrier becomes unresolvable.
+        resolveBarrier: () => Promise.resolve(undefined),
+        prepare: () => {
+          order.push(`${label}-barrier`);
+          return Promise.resolve(undefined);
+        },
+      };
+      return [discriminator, barrier];
+    };
+
+    // Neither discriminator is demanded, so both barriers are skipped
+    // and both discriminators parked: the all-blocked fallback must
+    // resolve the barriers (to unresolvable) and let the pass drain
+    // with both prompts deferring to the eager pass.
+    const result = await completeEffectfulSourcesAsync(
+      [...makeSide("a"), ...makeSide("b")],
+      undefined,
+      runtime,
+      createCompleteExecFixture(session),
+    );
+
+    assert.ok(result.success);
+    assert.deepEqual(order, [
+      "a-deferred",
+      "a-barrier",
+      "b-deferred",
+      "b-barrier",
+    ]);
+  });
+
+  // https://github.com/dahlia/optique/issues/925
+  test("chains late demand through a resolved barrier's edges", async () => {
+    const runtime = createDependencyRuntimeContext();
+    const session = createEffectfulCompletionSession("demand-only");
+    const c1 = Symbol("firstConsumer");
+    const c2 = Symbol("secondConsumer");
+    const p1 = Symbol("prerequisite");
+    const disc1 = Symbol("firstDiscriminator");
+    const disc2 = Symbol("secondDiscriminator");
+    const order: string[] = [];
+    session.demanded.add(disc1);
+    session.demanded.add(c2);
+    const prerequisite = createEffectfulSourceNode(
+      "prerequisite",
+      p1,
+      (_state, exec) => {
+        const s = exec?.effectfulCompletionSession;
+        if (s?.policy === "demand-only" && !s.demanded.has(p1)) {
+          order.push("prerequisite-deferred");
+          return Promise.resolve(undefined);
+        }
+        order.push("prerequisite");
+        return Promise.resolve({ success: true, value: "p" });
+      },
+    );
+    const effectful = (key: string, sourceId: symbol): RuntimeNode =>
+      createEffectfulSourceNode(key, sourceId, () => {
+        order.push(key);
+        return Promise.resolve({ success: true, value: key });
+      });
+    const gatedBarrier = (options: {
+      readonly path: string;
+      readonly requires: symbol;
+      readonly provides: symbol;
+      readonly edges: readonly {
+        readonly consumerSourceId: symbol;
+        readonly dependencyIds: readonly symbol[];
+      }[];
+    }): RuntimeNode => ({
+      path: [options.path],
+      parser: {},
+      state: undefined,
+      requiresSourceId: options.requires,
+      providesSourceIds: new Set([options.provides]),
+      barrierCompletionDependencies: {
+        orderingDependencyIds: [],
+        demandEdges: options.edges,
+      },
+      barrierDemandActivation: "after-resolution",
+      resolveBarrier: () =>
+        Promise.resolve({
+          orderingDependencyIds: [],
+          activeProvidesSourceIds: new Set([options.provides]),
+          demandEdges: options.edges,
+        }),
+      prepare: () => {
+        order.push(options.path);
+        return Promise.resolve(undefined);
+      },
+    });
+    // The first barrier resolves (and prepares) before its consumer is
+    // demanded; the second barrier's later resolution demands that
+    // consumer, and the chain must still reach the prerequisite through
+    // the first barrier's resolved edges even though the first barrier
+    // already left the pending list.
+    const first = gatedBarrier({
+      path: "first-barrier",
+      requires: disc1,
+      provides: c1,
+      edges: [{ consumerSourceId: c1, dependencyIds: [p1] }],
+    });
+    const second = gatedBarrier({
+      path: "second-barrier",
+      requires: disc2,
+      provides: c2,
+      edges: [{ consumerSourceId: c2, dependencyIds: [c1] }],
+    });
+
+    const result = await completeEffectfulSourcesAsync(
+      [
+        prerequisite,
+        effectful("first-discriminator", disc1),
+        first,
+        effectful("second-discriminator", disc2),
+        second,
+      ],
+      undefined,
+      runtime,
+      createCompleteExecFixture(session),
+    );
+
+    assert.ok(result.success);
+    assert.ok(session.demanded.has(p1));
+    assert.deepEqual(order, [
+      "first-discriminator",
+      "first-barrier",
+      "second-discriminator",
+      "prerequisite",
+      "second-barrier",
+    ]);
+  });
+
+  // https://github.com/dahlia/optique/issues/925
+  test("parks hard-edge descendants of a parked provider", async () => {
+    const runtime = createDependencyRuntimeContext();
+    const session = createEffectfulCompletionSession("demand-only");
+    const consumerId = Symbol("consumer");
+    const providerId = Symbol("provider");
+    const derivedId = Symbol("derivedSource");
+    const discriminatorId = Symbol("discriminator");
+    const order: string[] = [];
+    session.demanded.add(consumerId);
+    // The derived node consumed raw input, so visiting it replays
+    // immediately; the hard-edge closure must keep it parked behind
+    // its parked provider until the gated barrier's resolution
+    // promotes the provider.
+    const derivedNode: RuntimeNode = {
+      path: ["derived"],
+      parser: {
+        dependencyMetadata: {
+          source: {
+            kind: "source",
+            sourceId: derivedId,
+            metavar: "DERIVED",
+            extractSourceValue: () => undefined,
+            preservesSourceValue: true,
+          },
+          derived: {
+            kind: "derived",
+            dependencyIds: [providerId],
+            metavar: "DERIVED",
+            replayParse: (rawInput) => {
+              order.push("derived-replay");
+              return { success: true, value: rawInput };
+            },
+          },
+        },
+      },
+      state: undefined,
+      rawInput: "x",
+    };
+    const provider = createEffectfulSourceNode(
+      "provider",
+      providerId,
+      () => {
+        order.push("provider");
+        return Promise.resolve({ success: true, value: "p" });
+      },
+    );
+    const discriminator = createEffectfulSourceNode(
+      "discriminator",
+      discriminatorId,
+      () => {
+        order.push("discriminator");
+        return Promise.resolve({ success: true, value: "a" });
+      },
+    );
+    const barrier: RuntimeNode = {
+      path: ["barrier"],
+      parser: {},
+      state: undefined,
+      requiresSourceId: discriminatorId,
+      providesSourceIds: new Set([consumerId]),
+      barrierCompletionDependencies: {
+        orderingDependencyIds: [providerId],
+        demandEdges: [{
+          consumerSourceId: consumerId,
+          dependencyIds: [providerId],
+        }],
+      },
+      barrierDemandActivation: "after-resolution",
+      resolveBarrier: () =>
+        Promise.resolve({
+          orderingDependencyIds: [providerId],
+          activeProvidesSourceIds: new Set([consumerId]),
+          demandEdges: [{
+            consumerSourceId: consumerId,
+            dependencyIds: [providerId],
+          }],
+        }),
+      prepare: () => {
+        order.push("barrier");
+        return Promise.resolve(undefined);
+      },
+    };
+
+    const result = await completeEffectfulSourcesAsync(
+      [derivedNode, provider, discriminator, barrier],
+      undefined,
+      runtime,
+      createCompleteExecFixture(session),
+    );
+
+    assert.ok(result.success);
+    assert.deepEqual(order, [
+      "discriminator",
+      "provider",
+      "derived-replay",
+      "barrier",
+    ]);
+  });
+
   // https://github.com/dahlia/optique/issues/924
   test("resolves a barrier ahead of an advisory provider it refines away", async () => {
     const runtime = createDependencyRuntimeContext();
@@ -2788,6 +3203,7 @@ describe("completeEffectfulSourcesAsync", () => {
         Promise.resolve({
           orderingDependencyIds: [],
           activeProvidesSourceIds: new Set<symbol>(),
+          demandEdges: [],
         }),
       prepare: () => {
         order.push("barrier");
@@ -2847,6 +3263,7 @@ describe("completeEffectfulSourcesAsync", () => {
         Promise.resolve({
           orderingDependencyIds: [providerId],
           activeProvidesSourceIds: new Set<symbol>(),
+          demandEdges: [],
         }),
       prepare: () => {
         order.push("barrier");

--- a/packages/core/src/dependency-runtime.ts
+++ b/packages/core/src/dependency-runtime.ts
@@ -22,6 +22,7 @@ import {
 import type { InputTrace } from "./input-trace.ts";
 import { type Message, message } from "./message.ts";
 import {
+  type EffectfulCompletionSession,
   type ExecutionContext,
   unmatchedNonCliDependencySourceStateMarker,
 } from "./internal/parser.ts";
@@ -305,6 +306,23 @@ export interface RuntimeNode {
    * @since 1.3.0
    */
   readonly barrierCompletionDependencies?: BarrierCompletionDependencies;
+
+  /**
+   * When `"after-resolution"`, the demand edges in
+   * {@link RuntimeNode.barrierCompletionDependencies} join demand
+   * propagation only once {@link RuntimeNode.resolveBarrier} has
+   * replaced the static estimate with the resolved selection's actual
+   * edges.  Until then the demand-only pass parks not-yet-demanded
+   * effectful nodes instead of letting them defer, so a prerequisite
+   * demanded only by an unselected branch never runs, while one the
+   * resolved selection reads still completes in its dependency slot.
+   * A barrier the pass marks `"unresolvable"` never activates its
+   * edges within that pass.  Ordering and control edges are unaffected.
+   * Default: `"immediate"`.
+   *
+   * @since 1.3.0
+   */
+  readonly barrierDemandActivation?: "immediate" | "after-resolution";
 }
 
 /**
@@ -376,6 +394,20 @@ export interface BarrierResolution {
    * sibling consumer no longer waits for a merely possible provider.
    */
   readonly activeProvidesSourceIds: ReadonlySet<symbol>;
+
+  /**
+   * The demand edges of the resolved selection: empty when the
+   * selection was rejected or has no completion consumers.  A
+   * demand-only pass applies them once the barrier resolves, so a
+   * prerequisite is demanded only for a selection that actually reads
+   * it.  Edges belonging to a nested barrier whose own demand
+   * activation is `"after-resolution"` and which is still unresolved
+   * must not appear here; the nested barrier promotes them itself
+   * within its own scheduling pass.
+   *
+   * @since 1.3.0
+   */
+  readonly demandEdges: readonly BarrierCompletionDemandEdge[];
 }
 
 /**
@@ -2289,6 +2321,178 @@ export interface CompleteEffectfulSourcesOptions {
 }
 
 /**
+ * Runs the monotonic demand fixed point over the given nodes' metadata,
+ * adding to the session's demanded set until nothing changes:
+ *
+ * - a demanded derived source demands its dependency IDs;
+ * - a demanded source whose effectful completion consumes other
+ *   dependency values (a prompt with a derived configuration) demands
+ *   those prerequisites, unless this occurrence is already satisfied;
+ * - a barrier's demand edges mirror the flat completion rule for the
+ *   consumers hidden behind it—only when a branch consumer's own source
+ *   is demanded do its completion prerequisites become demanded—but a
+ *   barrier whose {@link RuntimeNode.barrierDemandActivation} is
+ *   `"after-resolution"` contributes its edges only once it has
+ *   resolved, so an unselected branch's prerequisites are never
+ *   demanded on the strength of a static estimate;
+ * - when a source a barrier can provide is demanded, the barrier's
+ *   control dependency (its discriminator source) becomes demanded.
+ *
+ * One barrier's branches can provide another barrier's discriminator
+ * source, and the chain must propagate regardless of declaration order.
+ * Each iteration adds at least one demanded ID, so the loop terminates.
+ * The scheduler re-runs this after a gated barrier resolves, passing
+ * the pass's metadata universe with resolved replacement nodes swapped
+ * in, so promotion chains through already-visited metadata as well.
+ */
+function propagateDemand(
+  universe: readonly RuntimeNode[],
+  session: EffectfulCompletionSession,
+): void {
+  let demandAdded = true;
+  while (demandAdded) {
+    demandAdded = false;
+    for (const node of universe) {
+      const metadata = node.parser.dependencyMetadata;
+      if (
+        metadata?.source != null && metadata.derived != null &&
+        session.demanded.has(metadata.source.sourceId)
+      ) {
+        for (const dependencySourceId of metadata.derived.dependencyIds) {
+          if (session.demanded.has(dependencySourceId)) continue;
+          session.demanded.add(dependencySourceId);
+          demandAdded = true;
+        }
+      }
+      if (
+        metadata?.source != null && metadata.completion != null &&
+        session.demanded.has(metadata.source.sourceId) &&
+        !hasInactiveCompletion(node)
+      ) {
+        for (const dependencySourceId of metadata.completion.dependencyIds) {
+          if (session.demanded.has(dependencySourceId)) continue;
+          session.demanded.add(dependencySourceId);
+          demandAdded = true;
+        }
+      }
+      if (
+        node.barrierCompletionDependencies != null &&
+        (node.barrierDemandActivation !== "after-resolution" ||
+          node.barrierResolutionState === "resolved")
+      ) {
+        for (const edge of node.barrierCompletionDependencies.demandEdges) {
+          if (!session.demanded.has(edge.consumerSourceId)) continue;
+          for (const dependencySourceId of edge.dependencyIds) {
+            if (session.demanded.has(dependencySourceId)) continue;
+            session.demanded.add(dependencySourceId);
+            demandAdded = true;
+          }
+        }
+      }
+      if (node.requiresSourceId == null || node.providesSourceIds == null) {
+        continue;
+      }
+      if (session.demanded.has(node.requiresSourceId)) continue;
+      for (const provided of node.providesSourceIds) {
+        if (session.demanded.has(provided)) {
+          session.demanded.add(node.requiresSourceId);
+          demandAdded = true;
+          break;
+        }
+      }
+    }
+  }
+}
+
+const barrierFailureDescription = "optique.barrierFailure";
+
+/**
+ * Replaces a barrier failure cached in the run-scoped session with a
+ * wrapped version of the same failure, identified by object identity.
+ * A construct that decorates a nested barrier failure on its way out—a
+ * `conditional()` applying its `branchError` hook—uses this so later
+ * passes sharing the session (the eager fallback after a failed seed
+ * pass) surface the wrapped error rather than the raw one.
+ *
+ * @param session The run-scoped effectful completion session.
+ * @param original The failure exactly as the scheduling pass returned
+ *   it.
+ * @param replacement The decorated failure to cache in its place.
+ * @returns Whether a cached barrier failure was found and replaced;
+ *   `false` means the failure did not come from a barrier resolution
+ *   and should propagate untouched.
+ * @internal
+ * @since 1.3.0
+ */
+export function replaceCachedBarrierFailure(
+  session: EffectfulCompletionSession | undefined,
+  original: { readonly success: false; readonly error: Message },
+  replacement: { readonly success: false; readonly error: Message },
+): boolean {
+  if (session == null) return false;
+  let replaced = false;
+  for (const [key, value] of session.results) {
+    if (key.description === barrierFailureDescription && value === original) {
+      session.results.set(key, replacement);
+      replaced = true;
+    }
+  }
+  return replaced;
+}
+
+/**
+ * Whether the node is a scheduling barrier whose demand edges are gated
+ * on resolution and whose resolution has not happened yet.  While any
+ * such barrier is pending in a demand-only pass, the scheduler parks
+ * not-yet-demanded effectful nodes instead of letting them defer, so a
+ * later resolution can still demand them into their dependency slot.
+ */
+function isGatedUnresolvedBarrier(node: RuntimeNode): boolean {
+  return node.resolveBarrier != null &&
+    node.barrierDemandActivation === "after-resolution" &&
+    node.barrierResolutionState == null;
+}
+
+/**
+ * Collects the nodes a demand-only pass must not visit yet while a
+ * gated barrier is unresolved: every effectful source node whose own
+ * source is not demanded (its completion would defer irrevocably for
+ * this pass, yet a barrier's resolution may still demand it), plus
+ * every node reachable from a parked node along hard (non-advisory)
+ * dependency edges, so a dependent—a derived replay, a barrier whose
+ * control dependency is a parked discriminator—never runs ahead of a
+ * parked provider.  The scheduling loop's all-blocked fallback keeps
+ * the pass progressing even when this parks every pending node.
+ */
+function collectParkedNodes(
+  pending: readonly RuntimeNode[],
+  session: EffectfulCompletionSession,
+): ReadonlySet<RuntimeNode> {
+  const parked = new Set<RuntimeNode>();
+  for (const node of pending) {
+    const source = node.parser.dependencyMetadata?.source;
+    if (
+      source?.completeSource != null &&
+      !session.demanded.has(source.sourceId)
+    ) {
+      parked.add(node);
+    }
+  }
+  if (parked.size === 0) return parked;
+  const graph = buildDependencyGraph(pending);
+  const queue = [...parked];
+  while (queue.length > 0) {
+    const provider = queue.pop()!;
+    for (const [consumer, advisoryOnly] of graph.outgoing.get(provider) ?? []) {
+      if (advisoryOnly || parked.has(consumer)) continue;
+      parked.add(consumer);
+      queue.push(consumer);
+    }
+  }
+  return parked;
+}
+
+/**
  * Runs effectful source completions (e.g., interactive prompts) serially
  * in declaration order for source nodes whose value is not yet registered.
  *
@@ -2365,71 +2569,7 @@ export async function completeEffectfulSourcesAsync(
     // A barrier's discriminator is a control dependency: when a source
     // it can provide is demanded, resolving the branch requires the
     // discriminator even though no consumer demands it directly.
-    // Iterate to a fixed point: one barrier's branches can provide
-    // another barrier's discriminator source, and the chain must
-    // propagate regardless of declaration order.  Each iteration adds
-    // at least one demanded ID, so the loop is bounded by the number
-    // of barriers.
-    let demandAdded = true;
-    while (demandAdded) {
-      demandAdded = false;
-      for (const node of nodes) {
-        const metadata = node.parser.dependencyMetadata;
-        if (
-          metadata?.source != null && metadata.derived != null &&
-          session.demanded.has(metadata.source.sourceId)
-        ) {
-          for (const dependencySourceId of metadata.derived.dependencyIds) {
-            if (session.demanded.has(dependencySourceId)) continue;
-            session.demanded.add(dependencySourceId);
-            demandAdded = true;
-          }
-        }
-        // A demanded source whose effectful completion consumes other
-        // dependency values (a prompt with a derived configuration)
-        // demands those prerequisites too—but only when its own value is
-        // demanded and this occurrence is not already satisfied, so a
-        // CLI- or binding-satisfied prompt never demands its upstream
-        // prompts.
-        if (
-          metadata?.source != null && metadata.completion != null &&
-          session.demanded.has(metadata.source.sourceId) &&
-          !hasInactiveCompletion(node)
-        ) {
-          for (const dependencySourceId of metadata.completion.dependencyIds) {
-            if (session.demanded.has(dependencySourceId)) continue;
-            session.demanded.add(dependencySourceId);
-            demandAdded = true;
-          }
-        }
-        // A barrier's demand edges mirror the flat completion rule for
-        // the consumers hidden behind it: only when a branch consumer's
-        // own source is demanded do its completion prerequisites become
-        // demanded, so a demanded discriminator or an unrelated branch
-        // source never forces another consumer's prerequisites.
-        if (node.barrierCompletionDependencies != null) {
-          for (const edge of node.barrierCompletionDependencies.demandEdges) {
-            if (!session.demanded.has(edge.consumerSourceId)) continue;
-            for (const dependencySourceId of edge.dependencyIds) {
-              if (session.demanded.has(dependencySourceId)) continue;
-              session.demanded.add(dependencySourceId);
-              demandAdded = true;
-            }
-          }
-        }
-        if (node.requiresSourceId == null || node.providesSourceIds == null) {
-          continue;
-        }
-        if (session.demanded.has(node.requiresSourceId)) continue;
-        for (const provided of node.providesSourceIds) {
-          if (session.demanded.has(provided)) {
-            session.demanded.add(node.requiresSourceId);
-            demandAdded = true;
-            break;
-          }
-        }
-      }
-    }
+    propagateDemand(nodes, session);
   }
 
   // A failed effectful completion cached in the run-scoped session (a
@@ -2476,9 +2616,16 @@ export async function completeEffectfulSourcesAsync(
   // so declaration order still breaks ties and a cycle among concrete
   // resolved edges surfaces as the usual circular-dependency error.
   const pending: RuntimeNode[] = [...nodes];
+  // The pass's metadata universe: the nodes whose derived, completion,
+  // control, and barrier metadata demand propagation scans.  Resolved
+  // barrier replacements take their original entry's place, so a later
+  // promotion still chains through a resolved barrier's actual demand
+  // edges even after the barrier itself left the pending list.
+  const metadataUniverse: RuntimeNode[] = [...nodes];
   const providesId = (node: RuntimeNode, id: symbol): boolean =>
     node.parser.dependencyMetadata?.source?.sourceId === id ||
     node.providesSourceIds?.has(id) === true;
+  const demandSession = session?.policy === "demand-only" ? session : undefined;
   const resolveBarrierAt = async (
     index: number,
   ): Promise<
@@ -2487,9 +2634,15 @@ export async function completeEffectfulSourcesAsync(
     const candidate = pending[index];
     const resolution = await candidate.resolveBarrier!(barrierContext);
     if (resolution != null && "success" in resolution) {
+      // A barrier failure (a rejected speculation) is terminal for the
+      // whole run, not just this pass: cache it in the run-scoped
+      // session so a later pass sharing the session—the eager fallback
+      // after a failed seed pass, or an outer pass around a failed
+      // nested one—aborts before running any further effect.
+      session?.results.set(Symbol(barrierFailureDescription), resolution);
       return resolution;
     }
-    pending[index] = resolution == null
+    const replacement: RuntimeNode = resolution == null
       ? { ...candidate, barrierResolutionState: "unresolvable" }
       : {
         ...candidate,
@@ -2497,12 +2650,27 @@ export async function completeEffectfulSourcesAsync(
         providesSourceIds: resolution.activeProvidesSourceIds,
         barrierCompletionDependencies: {
           orderingDependencyIds: resolution.orderingDependencyIds,
-          demandEdges: [],
+          demandEdges: resolution.demandEdges,
         },
       };
+    pending[index] = replacement;
+    const universeIndex = metadataUniverse.indexOf(candidate);
+    if (universeIndex >= 0) metadataUniverse[universeIndex] = replacement;
+    // A resolved selection's actual demand edges may demand
+    // prerequisites a gated estimate withheld: re-run the fixed point
+    // so parked providers are promoted into their dependency slots
+    // before the loop reaches them.
+    if (resolution != null && demandSession != null) {
+      propagateDemand(metadataUniverse, demandSession);
+    }
     return undefined;
   };
   while (pending.length > 0) {
+    // While a gated barrier is unresolved, a demand-only pass must not
+    // let a not-yet-demanded node pass its execution slot: the
+    // barrier's resolution may still demand it.
+    const parkingActive = demandSession != null &&
+      pending.some(isGatedUnresolvedBarrier);
     for (let i = 0; i < pending.length; i++) {
       const candidate = pending[i];
       if (
@@ -2518,6 +2686,19 @@ export async function completeEffectfulSourcesAsync(
       // node, which could reorder observable evaluations; it resolves
       // at its ordered position below instead.
       if (requires == null) continue;
+      // While a gated barrier is unresolved, a barrier whose
+      // discriminator is not (yet) demanded is left alone rather than
+      // resolved: its discriminator prompt is parked and could still be
+      // demanded by a gated barrier's resolution, and resolving now
+      // would freeze the barrier as unresolvable—or actively complete
+      // an effect-free discriminator ahead of the confirmation
+      // boundary.
+      if (
+        parkingActive && demandSession != null &&
+        !demandSession.demanded.has(requires)
+      ) {
+        continue;
+      }
       if (
         pending.some((other) =>
           other !== candidate && providesId(other, requires)
@@ -2528,7 +2709,42 @@ export async function completeEffectfulSourcesAsync(
       const failure = await resolveBarrierAt(i);
       if (failure != null) return failure;
     }
-    const node = orderDependencyNodes(pending)[0];
+    const ordered = orderDependencyNodes(pending);
+    let node = ordered[0];
+    // The early-resolution scan may have resolved the last gated
+    // barrier, so recompute before selecting: once none is unresolved,
+    // parking lifts within the same iteration.
+    const parkingStillActive = demandSession != null &&
+      pending.some(isGatedUnresolvedBarrier);
+    if (parkingStillActive && demandSession != null) {
+      const parked = collectParkedNodes(pending, demandSession);
+      const isSkippedBarrier = (candidate: RuntimeNode): boolean =>
+        candidate.resolveBarrier != null &&
+        candidate.barrierResolutionState == null &&
+        candidate.requiresSourceId != null &&
+        !demandSession.demanded.has(candidate.requiresSourceId);
+      const selectable = ordered.find((candidate) =>
+        !parked.has(candidate) && !isSkippedBarrier(candidate)
+      );
+      if (selectable != null) {
+        node = selectable;
+      } else {
+        // Every pending node is parked or skipped: resolve the
+        // earliest unresolved barrier at its ordered position anyway
+        // (it may become unresolvable) so the pass keeps making
+        // progress; once no gated unresolved barrier remains, parking
+        // lifts and the drain continues as usual.
+        const stalled = ordered.find((candidate) =>
+          candidate.resolveBarrier != null &&
+          candidate.barrierResolutionState == null
+        );
+        if (stalled != null) {
+          const failure = await resolveBarrierAt(pending.indexOf(stalled));
+          if (failure != null) return failure;
+          continue;
+        }
+      }
+    }
     if (node.resolveBarrier != null && node.barrierResolutionState == null) {
       // The barrier reached its execution position without early
       // resolution (no control dependency): resolve it here—exactly

--- a/packages/prompt/src/index.test.ts
+++ b/packages/prompt/src/index.test.ts
@@ -4372,11 +4372,12 @@ describe("branch completion dependencies across scheduling barriers", () => {
         return {};
       },
     };
-    // "--bx x" guesses condB's branch; its recomputed demand edge must
-    // chain the framework prerequisite into the seed pass so condA's
-    // discriminator becomes demanded and every prompt keeps declaration
-    // order.  Without the edge, condA's discriminator defers and the
-    // prompts run out of order.
+    // "--bx x" guesses condB's branch; its demand edge is gated on the
+    // discriminator's confirmation, so condB's discriminator answers
+    // first, and only the confirmation promotes the framework
+    // prerequisite—which demands condA's discriminator through the
+    // control edge.  The parked prerequisites then drain in dependency
+    // order within the same seed pass, ahead of the branch consumer.
     const parser = object({
       condA: conditional(
         prompt(option("--kind-a", kindA), { value: "a" }),
@@ -4411,9 +4412,9 @@ describe("branch completion dependencies across scheduling barriers", () => {
 
     assert.equal((result as { readonly level: string }).level, "silent");
     assert.deepEqual(calls, [
+      { value: "b" },
       { value: "a" },
       { value: "hono" },
-      { value: "b" },
       { value: "prod" },
     ]);
   });
@@ -4679,6 +4680,470 @@ describe("branch completion dependencies across scheduling barriers", () => {
     assert.ok(!result.success);
     assert.deepEqual(resolverCalls, []);
     assert.deepEqual(calls, [{ value: "b" }]);
+  });
+
+  // https://github.com/dahlia/optique/issues/925
+  it("does not demand a rejected speculative branch's prerequisites", async () => {
+    const kind = dependency(choice(["a", "b"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const { mode, level } = createModeFixture();
+    const { prompt, calls } = createTestPrompt();
+    const dynamicContext: SourceContext = {
+      id: Symbol.for("@optique/prompt/test-rejected-speculation-demand"),
+      phase: "two-pass",
+      getAnnotations() {
+        return {};
+      },
+    };
+    // "--a x" guesses the branch, but the discriminator answers "b":
+    // the framework prerequisite is needed only by the guessed branch's
+    // configuration, so rejecting the guess must leave it unprompted in
+    // every pass, and the run fails with the branch mismatch.
+    const parser = object({
+      cond: conditional(
+        prompt(option("--kind", kind), { value: "b" }),
+        {
+          a: object({
+            ax: option("--a", choice(["x"] as const)),
+            mode: prompt(
+              option("--mode", mode),
+              derivePromptConfig(framework, (value) => ({
+                value: value === "hono" ? "prod" : "dev",
+              })),
+            ),
+          }),
+          b: object({ y: option("--y", choice(["2"] as const)) }),
+        },
+      ),
+      framework: prompt(option("--framework", framework), { value: "hono" }),
+      level: option("--level", level),
+    });
+
+    await assert.rejects(() =>
+      runWith(parser, "test", [dynamicContext], {
+        args: ["--a", "x", "--level", "silent"],
+      })
+    );
+
+    // Only the discriminator prompt ran; neither the guessed branch's
+    // prompt nor its framework prerequisite did.
+    assert.deepEqual(calls, [{ value: "b" }]);
+  });
+
+  // https://github.com/dahlia/optique/issues/925
+  it("stops a rejected speculation before later effects", async () => {
+    const kind = dependency(choice(["a", "b"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const resolverCalls: unknown[] = [];
+    const { prompt, calls } = createTestPrompt();
+    // Same rejection under an ordinary eager parse: the mismatch fails
+    // the run at the barrier, before the later-declared framework
+    // prompt executes.
+    const parser = object({
+      cond: conditional(
+        prompt(option("--kind", kind), { value: "b" }),
+        {
+          a: object({
+            ax: option("--a", choice(["x"] as const)),
+            pm: prompt(
+              option("--pm", dependency(choice(["deno", "npm"] as const))),
+              derivePromptConfig(framework, (value) => {
+                resolverCalls.push(value);
+                return { value: "npm" };
+              }),
+            ),
+          }),
+          b: object({ y: option("--y", choice(["2"] as const)) }),
+        },
+      ),
+      framework: prompt(option("--framework", framework), { value: "hono" }),
+    });
+
+    const result = await parseAsync(parser, ["--a", "x"]);
+
+    assert.ok(!result.success);
+    assert.match(formatMessage(result.error), /Branch mismatch/);
+    assert.deepEqual(resolverCalls, []);
+    assert.deepEqual(calls, [{ value: "b" }]);
+  });
+
+  // https://github.com/dahlia/optique/issues/925
+  it("keeps an independently demanded prerequisite on rejection", async () => {
+    const kind = dependency(choice(["a", "b"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const level = dependency(framework.deriveSync({
+      metavar: "LEVEL",
+      factory: (value) =>
+        choice(value === "hono" ? (["silent"] as const) : (["debug"] as const)),
+      defaultValue: () => "hono" as const,
+    }));
+    const { mode } = createModeFixture();
+    const { prompt, calls } = createTestPrompt();
+    const dynamicContext: SourceContext = {
+      id: Symbol.for("@optique/prompt/test-independent-prerequisite"),
+      phase: "two-pass",
+      getAnnotations() {
+        return {};
+      },
+    };
+    // The framework prerequisite is demanded by the sibling --level
+    // consumer on its own, so it completes in its slot before the
+    // discriminator rejects the guessed branch that also reads it.
+    const parser = object({
+      framework: prompt(option("--framework", framework), { value: "hono" }),
+      cond: conditional(
+        prompt(option("--kind", kind), { value: "b" }),
+        {
+          a: object({
+            ax: option("--a", choice(["x"] as const)),
+            mode: prompt(
+              option("--mode", mode),
+              derivePromptConfig(framework, (value) => ({
+                value: value === "hono" ? "prod" : "dev",
+              })),
+            ),
+          }),
+          b: object({ y: option("--y", choice(["2"] as const)) }),
+        },
+      ),
+      level: option("--level", level),
+    });
+
+    await assert.rejects(() =>
+      runWith(parser, "test", [dynamicContext], {
+        args: ["--a", "x", "--level", "silent"],
+      })
+    );
+
+    // The independently required prerequisite ran in its declaration
+    // slot; the rejection then stopped the pass at the barrier.
+    assert.deepEqual(calls, [{ value: "hono" }, { value: "b" }]);
+  });
+
+  // https://github.com/dahlia/optique/issues/925
+  it("keeps the confirmation boundary in a nested speculation", async () => {
+    const kindOuter = dependency(choice(["a", "b"] as const));
+    const kindInner = dependency(choice(["i", "j"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const { mode, level } = createModeFixture();
+    const resolverCalls: unknown[] = [];
+    const { prompt, calls } = createTestPrompt();
+    const dynamicContext: SourceContext = {
+      id: Symbol.for("@optique/prompt/test-nested-confirmation-boundary"),
+      phase: "two-pass",
+      getAnnotations() {
+        return {};
+      },
+    };
+    // "--a x" guesses (and the answer confirms) the outer branch, while
+    // "--i y" guesses the nested branch whose demanded mode consumer
+    // reads the framework prerequisite.  The outer confirmation must
+    // not promote the nested barrier's gated demand edge, and the inner
+    // discriminator's answer "j" rejects the nested guess before the
+    // prerequisite prompt declared after the outer conditional can run.
+    const parser = object({
+      cond: conditional(
+        prompt(option("--kind", kindOuter), { value: "a" }),
+        {
+          a: object({
+            ax: option("--a", choice(["x"] as const)),
+            inner: conditional(
+              prompt(option("--inner", kindInner), { value: "j" }),
+              {
+                i: object({
+                  iy: option("--i", choice(["y"] as const)),
+                  mode: prompt(
+                    option("--mode", mode),
+                    derivePromptConfig(framework, (value) => {
+                      resolverCalls.push(value);
+                      return { value: value === "hono" ? "prod" : "dev" };
+                    }),
+                  ),
+                }),
+                j: object({ z: option("--z", choice(["9"] as const)) }),
+              },
+            ),
+          }),
+          b: object({ y: option("--y", choice(["2"] as const)) }),
+        },
+      ),
+      framework: prompt(option("--framework", framework), { value: "hono" }),
+      level: option("--level", level),
+    });
+
+    await assert.rejects(() =>
+      runWith(parser, "test", [dynamicContext], {
+        args: ["--a", "x", "--i", "y", "--level", "silent"],
+      })
+    );
+
+    assert.deepEqual(resolverCalls, []);
+    // Outer and inner discriminators only; neither the rejected nested
+    // branch's prompt nor its framework prerequisite ran.
+    assert.deepEqual(calls, [{ value: "a" }, { value: "j" }]);
+  });
+
+  // https://github.com/dahlia/optique/issues/925
+  it("stops prerequisites after a cancelled speculative discriminator", async () => {
+    const kind = dependency(choice(["a", "b"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const { mode } = createModeFixture();
+    const { prompt, calls } = createTestPrompt();
+    const parser = object({
+      cond: conditional(
+        prompt(option("--kind", kind), { value: "a", reject: true }),
+        {
+          a: object({
+            ax: option("--a", choice(["x"] as const)),
+            mode: prompt(
+              option("--mode", mode),
+              derivePromptConfig(framework, (value) => ({
+                value: value === "hono" ? "prod" : "dev",
+              })),
+            ),
+          }),
+          b: object({ y: option("--y", choice(["2"] as const)) }),
+        },
+      ),
+      framework: prompt(option("--framework", framework), { value: "hono" }),
+    });
+
+    const result = await parseAsync(parser, ["--a", "x"]);
+
+    assert.ok(!result.success);
+    // The cancelled discriminator stopped the pass; neither the guessed
+    // branch's prompt nor its prerequisite ran.
+    assert.equal(calls.length, 1);
+  });
+
+  // https://github.com/dahlia/optique/issues/925
+  it("reports a custom mismatch from the scheduling barrier", async () => {
+    const kind = dependency(choice(["a", "b"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const { prompt, calls } = createTestPrompt();
+    const parser = object({
+      cond: conditional(
+        prompt(option("--kind", kind), { value: "b" }),
+        {
+          a: object({
+            ax: option("--a", choice(["x"] as const)),
+            pm: prompt(
+              option("--pm", dependency(choice(["deno", "npm"] as const))),
+              derivePromptConfig(framework, (value) => ({ value })),
+            ),
+          }),
+          b: object({ y: option("--y", choice(["2"] as const)) }),
+        },
+        constant("default"),
+        {
+          errors: {
+            branchMismatch: (resolvedKey: string, speculativeKey: string) =>
+              message`Expected ${speculativeKey}, got ${resolvedKey}.`,
+          },
+        },
+      ),
+      framework: prompt(option("--framework", framework), { value: "hono" }),
+    });
+
+    const result = await parseAsync(parser, ["--a", "x"]);
+
+    assert.ok(!result.success);
+    assert.match(formatMessage(result.error), /Expected .* got/);
+    assert.deepEqual(calls, [{ value: "b" }]);
+  });
+
+  // https://github.com/dahlia/optique/issues/925
+  it("wraps a nested mismatch with the outer branchError hook", async () => {
+    const kindOuter = dependency(choice(["a", "b"] as const));
+    const kindInner = dependency(choice(["i", "j"] as const));
+    const { prompt, calls } = createTestPrompt();
+    // The outer branch is confirmed speculatively, and the nested
+    // speculation is rejected: the mismatch must still surface through
+    // the outer conditional's branchError hook, as it does when the
+    // completion phase reports it.
+    const parser = object({
+      cond: conditional(
+        prompt(option("--kind", kindOuter), { value: "a" }),
+        {
+          a: object({
+            ax: option("--a", choice(["x"] as const)),
+            inner: conditional(
+              prompt(option("--inner", kindInner), { value: "j" }),
+              {
+                i: object({ iy: option("--i", choice(["y"] as const)) }),
+                j: object({ z: option("--z", choice(["9"] as const)) }),
+              },
+            ),
+          }),
+          b: object({ y: option("--y", choice(["2"] as const)) }),
+        },
+        constant("default"),
+        {
+          errors: {
+            branchError: (key: string | undefined, error) =>
+              message`Branch ${key ?? "?"} failed: ${error}`,
+          },
+        },
+      ),
+    });
+
+    const result = await parseAsync(parser, ["--a", "x", "--i", "y"]);
+
+    assert.ok(!result.success);
+    assert.match(
+      formatMessage(result.error),
+      /Branch "a" failed: .*Branch mismatch/,
+    );
+    assert.deepEqual(calls, [{ value: "a" }, { value: "j" }]);
+  });
+
+  // https://github.com/dahlia/optique/issues/925
+  it("wraps a committed branch's nested mismatch with branchError", async () => {
+    const kindOuter = dependency(choice(["a", "b"] as const));
+    const kindInner = dependency(choice(["i", "j"] as const));
+    const { prompt, calls } = createTestPrompt();
+    // The outer branch is committed by the command line; the nested
+    // speculation inside it is rejected, and the outer branchError hook
+    // must still wrap the mismatch.
+    const parser = object({
+      cond: conditional(
+        option("--kind", kindOuter),
+        {
+          a: object({
+            inner: conditional(
+              prompt(option("--inner", kindInner), { value: "j" }),
+              {
+                i: object({ iy: option("--i", choice(["y"] as const)) }),
+                j: object({ z: option("--z", choice(["9"] as const)) }),
+              },
+            ),
+          }),
+          b: object({ y: option("--y", choice(["2"] as const)) }),
+        },
+        constant("default"),
+        {
+          errors: {
+            branchError: (key: string | undefined, error) =>
+              message`Branch ${key ?? "?"} failed: ${error}`,
+          },
+        },
+      ),
+    });
+
+    const result = await parseAsync(parser, ["--kind", "a", "--i", "y"]);
+
+    assert.ok(!result.success);
+    assert.match(
+      formatMessage(result.error),
+      /Branch "a" failed: .*Branch mismatch/,
+    );
+    assert.deepEqual(calls, [{ value: "j" }]);
+  });
+
+  // https://github.com/dahlia/optique/issues/925
+  it("completes a committed branch prompt once without a session", async () => {
+    const kind = dependency(choice(["a", "b"] as const));
+    const { prompt, calls } = createTestPrompt();
+    // A bare completion exec without the run-scoped session must not
+    // run the committed branch's prompt during the scheduling pass:
+    // nothing would deduplicate it against the branch completion that
+    // follows, so the pre-expanded branch nodes the branchError wrap
+    // introduces have to stay session-only like any other expanded
+    // descendant.
+    const parser = object({
+      cond: conditional(
+        option("--kind", kind),
+        {
+          a: object({
+            p: prompt(option("--p", dependency(string())), { value: "v" }),
+          }),
+          b: object({ y: option("--y", choice(["2"] as const)) }),
+        },
+        constant("default"),
+        {
+          errors: {
+            branchError: (key: string | undefined, error) =>
+              message`Branch ${key ?? "?"} failed: ${error}`,
+          },
+        },
+      ),
+    });
+
+    const parsed = await parser.parse({
+      buffer: ["--kind", "a"],
+      optionsTerminated: false,
+      usage: parser.usage,
+      state: parser.initialState,
+    });
+    assert.ok(parsed.success);
+    const completed = await parser.complete(parsed.next.state, {
+      usage: parser.usage,
+      phase: "complete",
+      path: [],
+    });
+
+    assert.ok(completed.success);
+    assert.deepEqual(calls, [{ value: "v" }]);
+  });
+
+  // https://github.com/dahlia/optique/issues/925
+  it("does not demand an unselected branch's prerequisites", async () => {
+    const kind = dependency(choice(["a", "b"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const { mode, level } = createModeFixture();
+    const { prompt, calls } = createTestPrompt();
+    let phase2Framework: unknown = "unset";
+    const dynamicContext: SourceContext = {
+      id: Symbol.for("@optique/prompt/test-unselected-branch-demand"),
+      phase: "two-pass",
+      getAnnotations(request?: unknown) {
+        if (isPhase2ContextRequest(request)) {
+          phase2Framework = (request.parsed as {
+            readonly framework?: unknown;
+          })?.framework;
+        }
+        return {};
+      },
+    };
+    // Both branches provide mode, but only branch a's occurrence reads
+    // framework.  The discriminator answers "b", so the merged static
+    // estimate's mode -> framework edge must not demand the framework
+    // prompt into the seed pass; it defers to the final pass instead.
+    const parser = object({
+      cond: conditional(
+        prompt(option("--kind", kind), { value: "b" }),
+        {
+          a: object({
+            modeA: prompt(
+              option("--mode-a", mode),
+              derivePromptConfig(framework, (value) => ({
+                value: value === "hono" ? "prod" : "dev",
+              })),
+            ),
+          }),
+          b: object({
+            modeB: prompt(option("--mode-b", mode), { value: "prod" }),
+          }),
+        },
+      ),
+      framework: prompt(option("--framework", framework), { value: "hono" }),
+      level: option("--level", level),
+    });
+
+    const result = await runWith(parser, "test", [dynamicContext], {
+      args: ["--level", "silent"],
+    });
+
+    assert.equal((result as { readonly level: string }).level, "silent");
+    // The seed pass never demanded the unselected branch's framework
+    // prerequisite: the phase-two exchange saw it deferred, and its
+    // prompt ran only in the final pass, after the selected branch's.
+    assert.equal(phase2Framework, undefined);
+    assert.deepEqual(calls, [
+      { value: "b" },
+      { value: "prod" },
+      { value: "hono" },
+    ]);
   });
 
   it("shares one branch parser object across keys", async () => {


### PR DESCRIPTION
Under the demand-only seed pass, a speculative barrier's demand edges joined the up-front fixed point, so a prerequisite prompt that only the guessed branch reads could run before the discriminator confirmed the guess, immediately before the branch-mismatch error when the guess was rejected. The uncommitted barrier leaked the same way through its static union, demanding prerequisites that only an unselected branch reads. #923 documented the leak rather than gating it, because gating alone would let providers ordered before the barrier defer out of the pass before confirmation could demand them.

Selection barriers now withhold their demand edges until `resolveBarrier` returns a concrete resolution, and the scheduler keeps the affected execution slots open in the meantime: it parks undemanded effectful nodes and their hard-edge dependents, leaves barriers with undemanded discriminators unresolved, and forces the earliest unresolved barrier when no pending node is selectable, so the pass still terminates. A resolution reports the selection's actual demand edges (a nested gated barrier keeps its own behind its own boundary) and re-runs demand propagation over a metadata universe where resolved replacements supersede their estimates, so newly demanded providers complete after the discriminator and before their consumers. This moves one order on the speculative path: a prerequisite demanded only through a guessed branch, including an earlier conditional's discriminator, now runs after the confirming discriminator.

Gating the seed pass alone would not remove the symptom, since the eager final pass or fallback attempts the remaining effects and would still prompt before the completion phase reports the mismatch. A rejected speculation therefore fails the run at the barrier, through a mismatch helper shared with the completion phase so the message cannot drift; the failure is cached in the run-scoped session so any later pass sharing it stops first, and an enclosing conditional's `branchError` hook still wraps a nested mismatch however the enclosing branch was selected.

Closes #925. Part of #869.
