### PR TITLE
Preserve declaration-order source precedence through nested `conditional()` branches

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,8 +42,14 @@ To be released.
     rejected guess is no longer asked right before the branch-mismatch
     error.  When a guessed branch's prerequisites chain through an
     earlier conditional, that discriminator now answers after the
-    confirming one instead of before it.
-    [[#869], [#872], [#919], [#923], [#924], [#925], [#926], [#927]]
+    confirming one instead of before it.  Declaration order also holds
+    when the conditional waited for a source occurrence declared after
+    it and the selected branch then publishes the same source—through a
+    nested route that provides it on only some of its routes, a prompt,
+    a parsed value, or a binding: the branch's value serves consumers
+    inside the branch, while consumers outside the conditional read the
+    later occurrence, which no longer loses to the branch's publish.
+    [[#869], [#872], [#919], [#923], [#924], [#925], [#926], [#927], [#928], [#931]]
  -  Added `termWidth: "auto"` to `formatDocPage()` for aligning descriptions
     after the widest visible term using terminal display width while reserving
     description space under `maxWidth`.  The existing default and explicit
@@ -114,6 +120,8 @@ To be released.
 [#925]: https://github.com/dahlia/optique/issues/925
 [#926]: https://github.com/dahlia/optique/pull/926
 [#927]: https://github.com/dahlia/optique/pull/927
+[#928]: https://github.com/dahlia/optique/issues/928
+[#931]: https://github.com/dahlia/optique/pull/931
 
 ### @optique/run
 

--- a/changes.d/core/completion-dependency-scheduling.md
+++ b/changes.d/core/completion-dependency-scheduling.md
@@ -8,6 +8,8 @@ links:
   '#925': https://github.com/dahlia/optique/issues/925
   '#926': https://github.com/dahlia/optique/pull/926
   '#927': https://github.com/dahlia/optique/pull/927
+  '#928': https://github.com/dahlia/optique/issues/928
+  '#931': https://github.com/dahlia/optique/pull/931
 ---
  -  Added scheduling support for effectful completions that consume
     dependency values, such as prompts with derived configurations.  The
@@ -39,5 +41,11 @@ links:
     rejected guess is no longer asked right before the branch-mismatch
     error.  When a guessed branch's prerequisites chain through an
     earlier conditional, that discriminator now answers after the
-    confirming one instead of before it.
-    [[#869], [#872], [#919], [#923], [#924], [#925], [#926], [#927]]
+    confirming one instead of before it.  Declaration order also holds
+    when the conditional waited for a source occurrence declared after
+    it and the selected branch then publishes the same source—through a
+    nested route that provides it on only some of its routes, a prompt,
+    a parsed value, or a binding: the branch's value serves consumers
+    inside the branch, while consumers outside the conditional read the
+    later occurrence, which no longer loses to the branch's publish.
+    [[#869], [#872], [#919], [#923], [#924], [#925], [#926], [#927], [#928], [#931]]

--- a/docs/concepts/dependencies.md
+++ b/docs/concepts/dependencies.md
@@ -670,6 +670,17 @@ the pre-selection estimate alone, and a speculative parse-time guess the
 discriminator rejects fails the run at that boundary before such a
 prerequisite runs.
 
+Declaration order holds across that wait as well.  When the conditional waited
+for a source occurrence declared after it and the selected branch then
+publishes the same source—through a nested route, a prompt, a parsed value, or
+a binding—the branch's value serves consumers inside the branch, while the
+later occurrence is restored for consumers outside the conditional.  A
+fill-only `withDefault()` occurrence supplies the source only while nothing
+has published it, so it never displaces the awaited later occurrence's value,
+not even for its own branch consumer.  This confinement applies to a branch
+selected during completion; a branch committed on the command line joins the
+enclosing scope directly and follows plain declaration order.
+
 An invalid source never falls back to its default. The failure propagates
 through every derived source that consumes it—including prompts whose
 configurations read it—and diagnostics show the metavars along that dependency

--- a/docs/integrations/prompt.md
+++ b/docs/integrations/prompt.md
@@ -721,25 +721,35 @@ the branch-mismatch error, before any effect the guess alone would have
 scheduled.  The boundary also orders chained questions: a speculative
 discriminator answers before an earlier-declared prerequisite whose
 demand is discovered only by its confirmation.  A branch occurrence counts as
-an *active* provider only when it is guaranteed to publish—an unconditional
-prompt, a `withDefault()` fallback, or a nested conditional that provides the
-source on every selectable route—or when its state already holds a parsed or
-bound value.  A merely possible provider, such as an `optional()` occurrence
-that ends up parsing nothing or a provider in an unselected nested alternative,
-no longer hides a matching provider declared after the conditional: the branch
-configuration waits for that provider and reads its value.  An apparent
-dependency cycle whose edges come from branches that cannot be selected
-together—say, a completion consumer next to a conditional whose branch consumes
-the consumer's own source—is no longer rejected; only a cycle among the
-selected branch's actual providers and consumers still raises the circular
-dependency error.
+an *active* provider only when it is guaranteed to supply the source—an
+unconditional prompt, a `withDefault()` fallback (a default guarantees
+availability rather than an unconditional write), or a nested conditional that
+provides the source on every selectable route—or when its state already holds
+a parsed or bound value.  A merely possible provider, such as an `optional()`
+occurrence that ends up parsing nothing or a provider in an unselected nested
+alternative, no longer hides a matching provider declared after the
+conditional: the branch configuration waits for that provider and reads its
+value.  An apparent dependency cycle whose edges come from branches that
+cannot be selected together—say, a completion consumer next to a conditional
+whose branch consumes the consumer's own source—is no longer rejected; only a
+cycle among the selected branch's actual providers and consumers still raises
+the circular dependency error.
 
-One caveat remains.  A nested conditional that guarantees a source
-on only *some* of its routes is treated as a merely possible provider,
-so the outer conditional waits for a later occurrence when one exists;
-if the nested route that does provide the source is then selected, its
-value publishes after that occurrence and wins for consumers declared
-after the outer conditional.
+A branch's publish is also confined to its scope.  A nested conditional that
+guarantees a source on only *some* of its routes stays a merely possible
+provider, so the outer conditional waits for a matching occurrence declared
+after it, and a selected route that omits the source reads that later value.
+When the selected route does provide the source, its explicit publish—a prompt
+answer, a parsed value, or a bound value—serves consumers inside the enclosing
+branch, and the later occurrence is restored afterward, so consumers declared
+after the outer conditional read the later occurrence, exactly as declaration
+order promises.  A fill-only `withDefault()` occurrence in such a route
+supplies the source only while nothing has published it: once the awaited
+later occurrence has published, the default fills nothing and even the branch
+consumer reads the later value.  The confinement belongs to the completion
+boundary: a branch committed on the command line joins the enclosing scope
+directly, so its consumers follow plain declaration order and read the last
+occurrence of that whole scope.
 
 
 Testing adapters

--- a/packages/core/src/dependency-runtime.test.ts
+++ b/packages/core/src/dependency-runtime.test.ts
@@ -28,6 +28,7 @@ import {
   resolveStateWithRuntime,
   resolveStateWithRuntimeAsync,
   type RuntimeNode,
+  serializeSchedulingPath,
 } from "#src/dependency-runtime.ts";
 import { createInputTrace } from "#src/input-trace.ts";
 import type { ParserDependencyMetadata } from "#src/dependency-metadata.ts";
@@ -3299,6 +3300,288 @@ describe("completeEffectfulSourcesAsync", () => {
 
     assert.ok(result.success);
     assert.deepEqual(order, ["provider", "barrier"]);
+  });
+
+  // The remaining tests pin publication provenance and barrier-exit
+  // re-assertion (https://github.com/dahlia/optique/issues/928): a
+  // barrier's branch publish is confined to the branch when a
+  // later-declared occurrence has already published, while earlier
+  // occurrences and untouched sources keep the plain write order.
+  test("re-asserts a later occurrence over a barrier's branch publish", async () => {
+    const runtime = createDependencyRuntimeContext();
+    const session = createEffectfulCompletionSession();
+    const sourceId = Symbol("framework");
+    const branchProvider = createEffectfulSourceNode(
+      "branch",
+      sourceId,
+      () => Promise.resolve({ success: true, value: "branch" }),
+    );
+    // The ordering dependency ranks the later provider ahead of the
+    // barrier, so the branch publish lands on top of the later value.
+    const barrier: RuntimeNode = {
+      path: ["barrier"],
+      parser: {},
+      state: undefined,
+      providesSourceIds: new Set([sourceId]),
+      barrierCompletionDependencies: {
+        orderingDependencyIds: [sourceId],
+        demandEdges: [],
+      },
+      prepare: (ctx) => ctx.schedule([branchProvider]),
+    };
+    const later = createEffectfulSourceNode(
+      "later",
+      sourceId,
+      () => Promise.resolve({ success: true, value: "later" }),
+    );
+
+    const result = await completeEffectfulSourcesAsync(
+      [barrier, later],
+      undefined,
+      runtime,
+      createCompleteExecFixture(session),
+    );
+
+    assert.ok(result.success);
+    assert.equal(runtime.registry.get(sourceId), "later");
+  });
+
+  test("keeps a branch publish over an earlier-declared occurrence", async () => {
+    const runtime = createDependencyRuntimeContext();
+    const session = createEffectfulCompletionSession();
+    const sourceId = Symbol("framework");
+    const earlier = createEffectfulSourceNode(
+      "earlier",
+      sourceId,
+      () => Promise.resolve({ success: true, value: "earlier" }),
+    );
+    const branchProvider = createEffectfulSourceNode(
+      "branch",
+      sourceId,
+      () => Promise.resolve({ success: true, value: "branch" }),
+    );
+    const barrier: RuntimeNode = {
+      path: ["barrier"],
+      parser: {},
+      state: undefined,
+      providesSourceIds: new Set([sourceId]),
+      prepare: (ctx) => ctx.schedule([branchProvider]),
+    };
+
+    const result = await completeEffectfulSourcesAsync(
+      [earlier, barrier],
+      undefined,
+      runtime,
+      createCompleteExecFixture(session),
+    );
+
+    assert.ok(result.success);
+    assert.equal(runtime.registry.get(sourceId), "branch");
+  });
+
+  test("re-registers nothing when the branch does not publish", async () => {
+    const runtime = createDependencyRuntimeContext();
+    const session = createEffectfulCompletionSession();
+    const sourceId = Symbol("framework");
+    const writes: unknown[] = [];
+    const originalRegister = runtime.registerSource.bind(runtime);
+    runtime.registerSource = (id, value) => {
+      writes.push([id, value]);
+      originalRegister(id, value);
+    };
+    const barrier: RuntimeNode = {
+      path: ["barrier"],
+      parser: {},
+      state: undefined,
+      providesSourceIds: new Set([sourceId]),
+      barrierCompletionDependencies: {
+        orderingDependencyIds: [sourceId],
+        demandEdges: [],
+      },
+      prepare: (ctx) => ctx.schedule([]),
+    };
+    const later = createEffectfulSourceNode(
+      "later",
+      sourceId,
+      () => Promise.resolve({ success: true, value: "later" }),
+    );
+
+    const result = await completeEffectfulSourcesAsync(
+      [barrier, later],
+      undefined,
+      runtime,
+      createCompleteExecFixture(session),
+    );
+
+    assert.ok(result.success);
+    assert.equal(runtime.registry.get(sourceId), "later");
+    assert.deepEqual(writes, [[sourceId, "later"]]);
+  });
+
+  test("skips re-assertion when the barrier's preparation fails", async () => {
+    const runtime = createDependencyRuntimeContext();
+    const session = createEffectfulCompletionSession();
+    const sourceId = Symbol("framework");
+    const laterExecuted: string[] = [];
+    const writes: unknown[] = [];
+    const originalRegister = runtime.registerSource.bind(runtime);
+    runtime.registerSource = (id, value) => {
+      writes.push(value);
+      originalRegister(id, value);
+    };
+    const branchProvider = createEffectfulSourceNode(
+      "branch",
+      sourceId,
+      () => Promise.resolve({ success: true, value: "branch" }),
+    );
+    const failing = createEffectfulSourceNode(
+      "failing",
+      Symbol("failing"),
+      () =>
+        Promise.resolve({
+          success: false,
+          error: message`Cancelled.`,
+        }),
+    );
+    const barrier: RuntimeNode = {
+      path: ["barrier"],
+      parser: {},
+      state: undefined,
+      providesSourceIds: new Set([sourceId]),
+      barrierCompletionDependencies: {
+        orderingDependencyIds: [sourceId],
+        demandEdges: [],
+      },
+      prepare: (ctx) => ctx.schedule([branchProvider, failing]),
+    };
+    const later = createEffectfulSourceNode(
+      "later",
+      sourceId,
+      () => {
+        laterExecuted.push("later");
+        return Promise.resolve({ success: true, value: "later" });
+      },
+    );
+    const trailing = createEffectfulSourceNode(
+      "trailing",
+      Symbol("trailing"),
+      () => {
+        laterExecuted.push("trailing");
+        return Promise.resolve({ success: true, value: "t" });
+      },
+    );
+
+    const result = await completeEffectfulSourcesAsync(
+      [barrier, later, trailing],
+      undefined,
+      runtime,
+      createCompleteExecFixture(session),
+    );
+
+    // The nested failure aborts the pass at the barrier: the branch's
+    // publish is the last write, and no later effect runs after it.
+    assert.ok(!result.success);
+    assert.deepEqual(laterExecuted, ["later"]);
+    assert.deepEqual(writes, ["later", "branch"]);
+  });
+
+  test("restores a later sibling barrier's publish over an earlier barrier's", async () => {
+    const runtime = createDependencyRuntimeContext();
+    const session = createEffectfulCompletionSession();
+    const sourceId = Symbol("framework");
+    const prerequisiteId = Symbol("prerequisite");
+    const firstBranch = createEffectfulSourceNode(
+      "firstBranch",
+      sourceId,
+      () => Promise.resolve({ success: true, value: "first" }),
+    );
+    const secondBranch = createEffectfulSourceNode(
+      "secondBranch",
+      sourceId,
+      () => Promise.resolve({ success: true, value: "second" }),
+    );
+    // The earlier barrier waits for a prerequisite declared after the
+    // later barrier, so it executes last; its publish loses the
+    // provenance comparison against the later barrier's, but must still
+    // be observed as an overwrite and re-asserted away.
+    const firstBarrier: RuntimeNode = {
+      path: ["firstBarrier"],
+      parser: {},
+      state: undefined,
+      providesSourceIds: new Set([sourceId]),
+      barrierCompletionDependencies: {
+        orderingDependencyIds: [prerequisiteId],
+        demandEdges: [],
+      },
+      prepare: (ctx) => ctx.schedule([firstBranch]),
+    };
+    const secondBarrier: RuntimeNode = {
+      path: ["secondBarrier"],
+      parser: {},
+      state: undefined,
+      providesSourceIds: new Set([sourceId]),
+      prepare: (ctx) => ctx.schedule([secondBranch]),
+    };
+    const prerequisite = createEffectfulSourceNode(
+      "prerequisite",
+      prerequisiteId,
+      () => Promise.resolve({ success: true, value: "p" }),
+    );
+
+    const result = await completeEffectfulSourcesAsync(
+      [firstBarrier, secondBarrier, prerequisite],
+      undefined,
+      runtime,
+      createCompleteExecFixture(session),
+    );
+
+    assert.ok(result.success);
+    assert.equal(runtime.registry.get(sourceId), "second");
+  });
+
+  test("reuses a cached completion without a spurious re-assertion", async () => {
+    const runtime = createDependencyRuntimeContext();
+    const session = createEffectfulCompletionSession();
+    const sourceId = Symbol("framework");
+    const executed: string[] = [];
+    const branchProvider = createEffectfulSourceNode(
+      "branch",
+      sourceId,
+      () => Promise.resolve({ success: true, value: "branch" }),
+    );
+    const barrier: RuntimeNode = {
+      path: ["barrier"],
+      parser: {},
+      state: undefined,
+      providesSourceIds: new Set([sourceId]),
+      prepare: (ctx) => ctx.schedule([branchProvider]),
+    };
+    const cached = createEffectfulSourceNode(
+      "cached",
+      sourceId,
+      () => {
+        executed.push("cached");
+        return Promise.resolve({ success: true, value: "cached" });
+      },
+    );
+    session.completedByPath.set(
+      serializeSchedulingPath(cached.path),
+      { success: true, value: "cached" },
+    );
+
+    const result = await completeEffectfulSourcesAsync(
+      [barrier, cached],
+      undefined,
+      runtime,
+      createCompleteExecFixture(session),
+    );
+
+    // The cached occurrence neither re-runs its effect nor registers a
+    // new value, so the barrier's publish stands and no re-assertion
+    // fires for it.
+    assert.ok(result.success);
+    assert.deepEqual(executed, []);
+    assert.equal(runtime.registry.get(sourceId), "branch");
   });
 });
 

--- a/packages/core/src/dependency-runtime.test.ts
+++ b/packages/core/src/dependency-runtime.test.ts
@@ -3539,6 +3539,62 @@ describe("completeEffectfulSourcesAsync", () => {
     assert.equal(runtime.registry.get(sourceId), "second");
   });
 
+  test("re-asserts a later occurrence whose successful value is undefined", async () => {
+    const runtime = createDependencyRuntimeContext();
+    const session = createEffectfulCompletionSession();
+    const sourceId = Symbol("framework");
+    const writes: unknown[] = [];
+    const originalRegister = runtime.registerSource.bind(runtime);
+    runtime.registerSource = (id, value) => {
+      writes.push(value);
+      originalRegister(id, value);
+    };
+    const branchProvider = createEffectfulSourceNode(
+      "branch",
+      sourceId,
+      () => Promise.resolve({ success: true, value: "branch" }),
+    );
+    const barrier: RuntimeNode = {
+      path: ["barrier"],
+      parser: {},
+      state: undefined,
+      providesSourceIds: new Set([sourceId]),
+      barrierCompletionDependencies: {
+        orderingDependencyIds: [sourceId],
+        demandEdges: [],
+      },
+      prepare: (ctx) => ctx.schedule([branchProvider]),
+    };
+    // The extraction contract allows a successful `undefined` value, and
+    // explicit source collection registers it; the pass must record such
+    // a publication too, so the barrier exit can restore it.
+    const later: RuntimeNode = {
+      path: ["later"],
+      parser: {
+        dependencyMetadata: {
+          source: {
+            kind: "source",
+            sourceId,
+            extractSourceValue: () => ({ success: true, value: undefined }),
+            preservesSourceValue: true,
+          },
+        },
+      },
+      state: undefined,
+    };
+
+    const result = await completeEffectfulSourcesAsync(
+      [barrier, later],
+      undefined,
+      runtime,
+      createCompleteExecFixture(session),
+    );
+
+    assert.ok(result.success);
+    assert.ok(runtime.hasSource(sourceId));
+    assert.deepEqual(writes, [undefined, "branch", undefined]);
+  });
+
   test("reuses a cached completion without a spurious re-assertion", async () => {
     const runtime = createDependencyRuntimeContext();
     const session = createEffectfulCompletionSession();

--- a/packages/core/src/dependency-runtime.ts
+++ b/packages/core/src/dependency-runtime.ts
@@ -2903,8 +2903,18 @@ export async function completeEffectfulSourcesAsync(
       if (source.extractSourceValue == null || collected === false) {
         continue;
       }
+      // The extraction contract distinguishes a successful `undefined`
+      // value from an unpopulated `undefined` result, and explicit
+      // source collection registers the former (see
+      // registerExplicitSourceValue), so it re-registers here like any
+      // other successful extraction: the publication carries the
+      // occurrence's declaration position, letting a barrier exit
+      // re-assert it over a branch publish.  An absent occurrence (a
+      // withDefault() or optional() whose inner parsed nothing) yields
+      // an unpopulated result instead and still reaches the fill-only
+      // default below.
       const extracted = await source.extractSourceValue(node.state);
-      if (extracted?.success === true && extracted.value !== undefined) {
+      if (extracted?.success === true) {
         publishFromNode(node, source.sourceId, extracted.value);
         continue;
       }

--- a/packages/core/src/dependency-runtime.ts
+++ b/packages/core/src/dependency-runtime.ts
@@ -2318,6 +2318,18 @@ export interface CompleteEffectfulSourcesOptions {
    * return.
    */
   readonly includeStructural?: boolean;
+
+  /**
+   * Observes every source value this pass registers, including values a
+   * nested barrier pass reports through its own callback and values a
+   * barrier exit re-asserts.  A barrier's nested scheduling call sets
+   * this so the enclosing pass can attribute the branch's publications
+   * to the barrier's declaration position and restore a later-declared
+   * occurrence the branch overwrote; the callback carries no positional
+   * information of its own, because declaration indices are meaningful
+   * only within a single pass.
+   */
+  readonly onPublish?: (sourceId: symbol, value: unknown) => void;
 }
 
 /**
@@ -2622,6 +2634,42 @@ export async function completeEffectfulSourcesAsync(
   // promotion still chains through a resolved barrier's actual demand
   // edges even after the barrier itself left the pending list.
   const metadataUniverse: RuntimeNode[] = [...nodes];
+  // Publication provenance for declaration-order re-assertion through
+  // scheduling barriers (https://github.com/dahlia/optique/issues/928).
+  // Every registration this pass performs is recorded under the
+  // publishing node's declaration index, keeping the latest-declared
+  // occurrence's value (`>=` lets a later write at the same position
+  // replace an earlier one).  A barrier attributes its branch's
+  // publications to its own position through a per-barrier callback (see
+  // the preparation site below), and every registration also reports to
+  // an enclosing pass through `options.onPublish`, which carries no
+  // index: declaration indices are meaningful only within one pass.
+  const declarationIndex = new Map<RuntimeNode, number>(
+    nodes.map((node, index) => [node, index] as const),
+  );
+  const lastPublicationBySource = new Map<
+    symbol,
+    { readonly index: number; readonly value: unknown }
+  >();
+  const recordPublication = (
+    index: number,
+    sourceId: symbol,
+    value: unknown,
+  ): void => {
+    const existing = lastPublicationBySource.get(sourceId);
+    if (existing == null || index >= existing.index) {
+      lastPublicationBySource.set(sourceId, { index, value });
+    }
+    options?.onPublish?.(sourceId, value);
+  };
+  const publishFromNode = (
+    node: RuntimeNode,
+    sourceId: symbol,
+    value: unknown,
+  ): void => {
+    runtime.registerSource(sourceId, value);
+    recordPublication(declarationIndex.get(node) ?? 0, sourceId, value);
+  };
   const providesId = (node: RuntimeNode, id: symbol): boolean =>
     node.parser.dependencyMetadata?.source?.sourceId === id ||
     node.providesSourceIds?.has(id) === true;
@@ -2654,6 +2702,8 @@ export async function completeEffectfulSourcesAsync(
         },
       };
     pending[index] = replacement;
+    const originalIndex = declarationIndex.get(candidate);
+    if (originalIndex != null) declarationIndex.set(replacement, originalIndex);
     const universeIndex = metadataUniverse.indexOf(candidate);
     if (universeIndex >= 0) metadataUniverse[universeIndex] = replacement;
     // A resolved selection's actual demand edges may demand
@@ -2758,10 +2808,39 @@ export async function completeEffectfulSourcesAsync(
     pending.splice(pending.indexOf(node), 1);
     // A scheduling barrier runs at its declaration position; its
     // preparation may schedule further nodes through the nested call,
-    // which shares this pass's runtime, session, and exec.
+    // which shares this pass's runtime, session, and exec.  The nested
+    // pass reports every registration through the per-barrier callback:
+    // observation is unconditional, while the provenance entry keeps the
+    // latest-declared occurrence.  After a successful preparation, any
+    // source the branch published over a later-declared occurrence is
+    // re-asserted from that occurrence's recorded value, so the branch's
+    // publish serves its own consumers while declaration order keeps
+    // holding outside (https://github.com/dahlia/optique/issues/928).
     if (node.prepare != null) {
-      const barrierFailure = await node.prepare(barrierContext);
+      const barrierIndex = declarationIndex.get(node) ?? 0;
+      const publishedDuringPrepare = new Set<symbol>();
+      const nodeBarrierContext: SchedulingBarrierContext = {
+        ...barrierContext,
+        schedule: (barrierNodes) =>
+          completeEffectfulSourcesAsync(barrierNodes, state, runtime, exec, {
+            isReusable: () => false,
+            isCollected: () => true,
+            includeStructural: true,
+            onPublish: (sourceId, value) => {
+              publishedDuringPrepare.add(sourceId);
+              recordPublication(barrierIndex, sourceId, value);
+            },
+          }).then((result) => result.success ? undefined : result),
+      };
+      const barrierFailure = await node.prepare(nodeBarrierContext);
       if (barrierFailure != null) return barrierFailure;
+      for (const sourceId of publishedDuringPrepare) {
+        const entry = lastPublicationBySource.get(sourceId);
+        if (entry != null && entry.index > barrierIndex) {
+          runtime.registerSource(sourceId, entry.value);
+          options?.onPublish?.(sourceId, entry.value);
+        }
+      }
       continue;
     }
     const source = node.parser.dependencyMetadata?.source;
@@ -2798,7 +2877,7 @@ export async function completeEffectfulSourcesAsync(
           };
         }
         if (replayed.deferred === true) continue;
-        runtime.registerSource(source.sourceId, replayed.value);
+        publishFromNode(node, source.sourceId, replayed.value);
         if (
           source.preservesSourceValue &&
           (options?.isReusable?.(node) ?? true)
@@ -2826,7 +2905,7 @@ export async function completeEffectfulSourcesAsync(
       }
       const extracted = await source.extractSourceValue(node.state);
       if (extracted?.success === true && extracted.value !== undefined) {
-        runtime.registerSource(source.sourceId, extracted.value);
+        publishFromNode(node, source.sourceId, extracted.value);
         continue;
       }
       // Inside a barrier's nested pass (the only includeStructural
@@ -2874,7 +2953,7 @@ export async function completeEffectfulSourcesAsync(
           );
         }
         if (fallback.success) {
-          runtime.registerSource(source.sourceId, fallback.value);
+          publishFromNode(node, source.sourceId, fallback.value);
         } else {
           runtime.markSourceFailed(source.sourceId);
           propagateRuntimeSourceFailures(nodes, runtime);
@@ -2958,7 +3037,7 @@ export async function completeEffectfulSourcesAsync(
       completed.push({ key: node.path[node.path.length - 1], result });
     }
     if (result.value !== undefined) {
-      runtime.registerSource(source.sourceId, result.value);
+      publishFromNode(node, source.sourceId, result.value);
     }
   }
   return { success: true, completed };

--- a/packages/prompt/src/index.test.ts
+++ b/packages/prompt/src/index.test.ts
@@ -5894,4 +5894,762 @@ describe("branch completion dependencies across scheduling barriers", () => {
       { region: "eu", zone: "z2" },
     ]);
   });
+
+  // The remaining tests pin declaration-order precedence through nested
+  // conditional() branches (https://github.com/dahlia/optique/issues/928):
+  // a selected nested route's publish serves consumers inside its
+  // enclosing branch, while a matching occurrence declared after the
+  // outer conditional wins for consumers outside it.
+
+  it("confines a partial nested provider's publish to its branch", async () => {
+    const kindOuter = dependency(choice(["a", "b"] as const));
+    const kindInner = dependency(choice(["i1", "i2"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const frameworkDerived = framework.deriveSync({
+      metavar: "FW_DERIVED",
+      factory: (value: "fresh" | "hono") =>
+        choice(value === "fresh" ? (["deno"] as const) : (["npm"] as const)),
+      defaultValue: () => "fresh" as const,
+    });
+    const resolved: unknown[] = [];
+    const { prompt } = createTestPrompt();
+    // Only the i1 route provides the framework source, so the outer
+    // conditional waits for the later occurrence; when i1 is selected
+    // anyway, its publish serves the branch consumer, and the later
+    // occurrence is restored for the post-conditional consumer.
+    const parser = object({
+      cond: conditional(
+        prompt(option("--kind", kindOuter), { value: "a" }),
+        {
+          a: object({
+            inner: conditional(
+              prompt(option("--inner", kindInner), { value: "i1" }),
+              {
+                i1: object({
+                  fw: prompt(option("--fw", framework), { value: "fresh" }),
+                }),
+                i2: object({ z: constant("1") }),
+              },
+            ),
+            pm: prompt(
+              option("--pm", dependency(choice(["deno", "npm"] as const))),
+              derivePromptConfig(framework, (value) => {
+                resolved.push(value);
+                return { value: value === "fresh" ? "deno" : "npm" };
+              }, { defaultValue: () => "hono" as const }),
+            ),
+          }),
+          b: object({ y: option("--y", choice(["2"] as const)) }),
+        },
+      ),
+      fw2: prompt(option("--fw2", framework), { value: "hono" }),
+      out: option("--out", frameworkDerived),
+    });
+
+    const result = await parseAsync(parser, ["--out", "npm"]);
+
+    assert.ok(result.success);
+    assert.deepEqual(resolved, ["fresh"]);
+    assert.deepEqual(result.value.cond, [
+      "a",
+      { inner: ["i1", { fw: "fresh" }], pm: "deno" },
+    ]);
+    assert.equal(result.value.fw2, "hono");
+    assert.equal(result.value.out, "npm");
+  });
+
+  it("confines a CLI-selected nested route's publish to its branch", async () => {
+    const kindOuter = dependency(choice(["a", "b"] as const));
+    const kindInner = dependency(choice(["i1", "i2"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const frameworkDerived = framework.deriveSync({
+      metavar: "FW_DERIVED",
+      factory: (value: "fresh" | "hono") =>
+        choice(value === "fresh" ? (["deno"] as const) : (["npm"] as const)),
+      defaultValue: () => "fresh" as const,
+    });
+    const resolved: unknown[] = [];
+    const { prompt } = createTestPrompt();
+    // The nested route is selected on the command line instead of by a
+    // prompted discriminator; the precedence rule is the same.
+    const parser = object({
+      cond: conditional(
+        prompt(option("--kind", kindOuter), { value: "a" }),
+        {
+          a: object({
+            inner: conditional(
+              prompt(option("--inner", kindInner), { value: "i2" }),
+              {
+                i1: object({
+                  fw: prompt(option("--fw", framework), { value: "fresh" }),
+                }),
+                i2: object({ z: constant("1") }),
+              },
+            ),
+            pm: prompt(
+              option("--pm", dependency(choice(["deno", "npm"] as const))),
+              derivePromptConfig(framework, (value) => {
+                resolved.push(value);
+                return { value: value === "fresh" ? "deno" : "npm" };
+              }, { defaultValue: () => "hono" as const }),
+            ),
+          }),
+          b: object({ y: option("--y", choice(["2"] as const)) }),
+        },
+      ),
+      fw2: prompt(option("--fw2", framework), { value: "hono" }),
+      out: option("--out", frameworkDerived),
+    });
+
+    const result = await parseAsync(parser, ["--inner", "i1", "--out", "npm"]);
+
+    assert.ok(result.success);
+    assert.deepEqual(resolved, ["fresh"]);
+    assert.equal(result.value.out, "npm");
+  });
+
+  it("resolves both consumers from the later occurrence for a non-providing route", async () => {
+    const kindOuter = dependency(choice(["a", "b"] as const));
+    const kindInner = dependency(choice(["i1", "i2"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const frameworkDerived = framework.deriveSync({
+      metavar: "FW_DERIVED",
+      factory: (value: "fresh" | "hono") =>
+        choice(value === "fresh" ? (["deno"] as const) : (["npm"] as const)),
+      defaultValue: () => "fresh" as const,
+    });
+    const resolved: unknown[] = [];
+    const { prompt, calls } = createTestPrompt();
+    // The selected i2 route omits the framework source, so the branch
+    // consumer and the post-conditional consumer both read the later
+    // occurrence, and the unselected i1 route's prompt never runs.
+    const parser = object({
+      cond: conditional(
+        prompt(option("--kind", kindOuter), { value: "a" }),
+        {
+          a: object({
+            inner: conditional(
+              prompt(option("--inner", kindInner), { value: "i2" }),
+              {
+                i1: object({
+                  fw: prompt(option("--fw", framework), { value: "fresh" }),
+                }),
+                i2: object({ z: constant("1") }),
+              },
+            ),
+            pm: prompt(
+              option("--pm", dependency(choice(["deno", "npm"] as const))),
+              derivePromptConfig(framework, (value) => {
+                resolved.push(value);
+                return { value: value === "fresh" ? "deno" : "npm" };
+              }, { defaultValue: () => "fresh" as const }),
+            ),
+          }),
+          b: object({ y: option("--y", choice(["2"] as const)) }),
+        },
+      ),
+      fw2: prompt(option("--fw2", framework), { value: "hono" }),
+      out: option("--out", frameworkDerived),
+    });
+
+    const result = await parseAsync(parser, ["--out", "npm"]);
+
+    assert.ok(result.success);
+    assert.deepEqual(resolved, ["hono"]);
+    assert.equal(result.value.out, "npm");
+    assert.ok(!calls.some((config) => config.value === "fresh"));
+  });
+
+  it("confines a parsed nested provider while a later prompt wins outside", async () => {
+    const kindOuter = dependency(choice(["a", "b"] as const));
+    const kindInner = dependency(choice(["i1", "i2"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const frameworkDerived = framework.deriveSync({
+      metavar: "FW_DERIVED",
+      factory: (value: "fresh" | "hono") =>
+        choice(value === "fresh" ? (["deno"] as const) : (["npm"] as const)),
+      defaultValue: () => "fresh" as const,
+    });
+    const resolved: unknown[] = [];
+    const { prompt } = createTestPrompt();
+    // The selected route's occurrence is parsed from the command line
+    // rather than prompted; parsed, bound, and prompted publishes follow
+    // the same precedence rule.
+    const parser = object({
+      cond: conditional(
+        prompt(option("--kind", kindOuter), { value: "a" }),
+        {
+          a: object({
+            inner: conditional(
+              prompt(option("--inner", kindInner), { value: "i1" }),
+              {
+                i1: object({ fw: option("--fw", framework) }),
+                i2: object({ z: constant("1") }),
+              },
+            ),
+            pm: prompt(
+              option("--pm", dependency(choice(["deno", "npm"] as const))),
+              derivePromptConfig(framework, (value) => {
+                resolved.push(value);
+                return { value: value === "fresh" ? "deno" : "npm" };
+              }, { defaultValue: () => "hono" as const }),
+            ),
+          }),
+          b: object({ y: option("--y", choice(["2"] as const)) }),
+        },
+      ),
+      fw2: prompt(option("--fw2", framework), { value: "hono" }),
+      out: option("--out", frameworkDerived),
+    });
+
+    const result = await parseAsync(parser, ["--fw", "fresh", "--out", "npm"]);
+
+    assert.ok(result.success);
+    assert.deepEqual(resolved, ["fresh"]);
+    assert.equal(result.value.out, "npm");
+  });
+
+  it("confines a prompted nested provider while a later parsed occurrence wins outside", async () => {
+    const kindOuter = dependency(choice(["a", "b"] as const));
+    const kindInner = dependency(choice(["i1", "i2"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const frameworkDerived = framework.deriveSync({
+      metavar: "FW_DERIVED",
+      factory: (value: "fresh" | "hono") =>
+        choice(value === "fresh" ? (["deno"] as const) : (["npm"] as const)),
+      defaultValue: () => "fresh" as const,
+    });
+    const resolved: unknown[] = [];
+    const { prompt } = createTestPrompt();
+    // The later occurrence is parsed from the command line; it still
+    // wins outside the conditional over the prompted branch publish.
+    const parser = object({
+      cond: conditional(
+        prompt(option("--kind", kindOuter), { value: "a" }),
+        {
+          a: object({
+            inner: conditional(
+              prompt(option("--inner", kindInner), { value: "i1" }),
+              {
+                i1: object({
+                  fw: prompt(option("--fw", framework), { value: "fresh" }),
+                }),
+                i2: object({ z: constant("1") }),
+              },
+            ),
+            pm: prompt(
+              option("--pm", dependency(choice(["deno", "npm"] as const))),
+              derivePromptConfig(framework, (value) => {
+                resolved.push(value);
+                return { value: value === "fresh" ? "deno" : "npm" };
+              }, { defaultValue: () => "hono" as const }),
+            ),
+          }),
+          b: object({ y: option("--y", choice(["2"] as const)) }),
+        },
+      ),
+      fw2: option("--fw2", framework),
+      out: option("--out", frameworkDerived),
+    });
+
+    const result = await parseAsync(parser, [
+      "--fw2",
+      "hono",
+      "--out",
+      "npm",
+    ]);
+
+    assert.ok(result.success);
+    assert.deepEqual(resolved, ["fresh"]);
+    assert.equal(result.value.out, "npm");
+  });
+
+  it("confines a nested provider while a later bound occurrence wins under runWith", async () => {
+    const kindOuter = dependency(choice(["a", "b"] as const));
+    const kindInner = dependency(choice(["i1", "i2"] as const));
+    const region = dependency(choice(["us", "eu"] as const));
+    const resolved: unknown[] = [];
+    const resolvedOutside: unknown[] = [];
+    const context = createRegionConfigContext();
+    const { prompt } = createTestPrompt();
+    // The later occurrence takes its value from a configuration binding
+    // under the two-pass runWith() path; the bound value still wins for
+    // the consumer declared after it, outside the conditional, over the
+    // prompted branch publish.
+    const parser = object({
+      cond: conditional(
+        prompt(option("--kind", kindOuter), { value: "a" }),
+        {
+          a: object({
+            inner: conditional(
+              prompt(option("--inner", kindInner), { value: "i1" }),
+              {
+                i1: object({
+                  region: prompt(option("--region", region), { value: "us" }),
+                }),
+                i2: object({ z: constant("1") }),
+              },
+            ),
+            zone: prompt(
+              option("--zone", dependency(choice(["z1", "z2"] as const))),
+              derivePromptConfig(region, (value) => {
+                resolved.push(value);
+                return { value: value === "us" ? "z1" : "z2" };
+              }, { defaultValue: () => "eu" as const }),
+            ),
+          }),
+          b: object({ y: option("--y", choice(["2"] as const)) }),
+        },
+      ),
+      region2: bindConfig(option("--region2", region), {
+        context,
+        key: "region",
+      }),
+      zone2: prompt(
+        option("--zone2", dependency(choice(["z1", "z2"] as const))),
+        derivePromptConfig(region, (value) => {
+          resolvedOutside.push(value);
+          return { value: value === "us" ? "z1" : "z2" };
+        }, { defaultValue: () => "us" as const }),
+      ),
+    });
+
+    const result = await runWith(parser, "test", [context], {
+      args: [],
+      contextOptions: {
+        load: () => ({
+          config: { region: "eu" as const },
+          meta: undefined,
+        }),
+      },
+    });
+
+    assert.deepEqual(resolved, ["us"]);
+    assert.deepEqual(resolvedOutside, ["eu"]);
+    assert.deepEqual(
+      (result as { readonly zone2: string }).zone2,
+      "z2",
+    );
+  });
+
+  it("keeps nested-branch precedence under the demand-only seed pass", async () => {
+    const kindOuter = dependency(choice(["a", "b"] as const));
+    const kindInner = dependency(choice(["i1", "i2"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const frameworkDerived = framework.deriveSync({
+      metavar: "FW_DERIVED",
+      factory: (value: "fresh" | "hono") =>
+        choice(value === "fresh" ? (["deno"] as const) : (["npm"] as const)),
+      defaultValue: () => "fresh" as const,
+    });
+    const resolved: unknown[] = [];
+    const { prompt, calls } = createTestPrompt();
+    const dynamicContext: SourceContext = {
+      id: Symbol.for("@optique/prompt/test-nested-precedence-demand"),
+      phase: "two-pass",
+      getAnnotations() {
+        return {};
+      },
+    };
+    // The two-pass demand-only path preserves the same precedence: the
+    // providing route serves its branch, the later occurrence wins
+    // outside, and the unselected i2 route's prompt never runs.
+    const parser = object({
+      cond: conditional(
+        prompt(option("--kind", kindOuter), { value: "a" }),
+        {
+          a: object({
+            inner: conditional(
+              prompt(option("--inner", kindInner), { value: "i1" }),
+              {
+                i1: object({
+                  fw: prompt(option("--fw", framework), { value: "fresh" }),
+                }),
+                i2: object({
+                  other: prompt(
+                    option("--other", dependency(choice(["x"] as const))),
+                    { value: "x" },
+                  ),
+                }),
+              },
+            ),
+            pm: prompt(
+              option("--pm", dependency(choice(["deno", "npm"] as const))),
+              derivePromptConfig(framework, (value) => {
+                resolved.push(value);
+                return { value: value === "fresh" ? "deno" : "npm" };
+              }, { defaultValue: () => "hono" as const }),
+            ),
+          }),
+          b: object({ y: option("--y", choice(["2"] as const)) }),
+        },
+      ),
+      fw2: prompt(option("--fw2", framework), { value: "hono" }),
+      out: option("--out", frameworkDerived),
+    });
+
+    const result = await runWith(parser, "test", [dynamicContext], {
+      args: ["--out", "npm"],
+    });
+
+    assert.deepEqual(resolved, ["fresh"]);
+    assert.equal((result as { readonly out: string }).out, "npm");
+    assert.ok(!calls.some((config) => config.value === "x"));
+  });
+
+  it("keeps later-occurrence precedence for a non-providing route under runWith", async () => {
+    const kindOuter = dependency(choice(["a", "b"] as const));
+    const kindInner = dependency(choice(["i1", "i2"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const frameworkDerived = framework.deriveSync({
+      metavar: "FW_DERIVED",
+      factory: (value: "fresh" | "hono") =>
+        choice(value === "fresh" ? (["deno"] as const) : (["npm"] as const)),
+      defaultValue: () => "fresh" as const,
+    });
+    const resolved: unknown[] = [];
+    const { prompt, calls } = createTestPrompt();
+    const dynamicContext: SourceContext = {
+      id: Symbol.for("@optique/prompt/test-nested-omitting-demand"),
+      phase: "two-pass",
+      getAnnotations() {
+        return {};
+      },
+    };
+    // Selecting the route that omits the source under the two-pass path
+    // leaves both consumers on the later occurrence, and the unselected
+    // i1 route's prompt never runs.
+    const parser = object({
+      cond: conditional(
+        prompt(option("--kind", kindOuter), { value: "a" }),
+        {
+          a: object({
+            inner: conditional(
+              prompt(option("--inner", kindInner), { value: "i2" }),
+              {
+                i1: object({
+                  fw: prompt(option("--fw", framework), { value: "fresh" }),
+                }),
+                i2: object({ z: constant("1") }),
+              },
+            ),
+            pm: prompt(
+              option("--pm", dependency(choice(["deno", "npm"] as const))),
+              derivePromptConfig(framework, (value) => {
+                resolved.push(value);
+                return { value: value === "fresh" ? "deno" : "npm" };
+              }, { defaultValue: () => "fresh" as const }),
+            ),
+          }),
+          b: object({ y: option("--y", choice(["2"] as const)) }),
+        },
+      ),
+      fw2: prompt(option("--fw2", framework), { value: "hono" }),
+      out: option("--out", frameworkDerived),
+    });
+
+    const result = await runWith(parser, "test", [dynamicContext], {
+      args: ["--out", "npm"],
+    });
+
+    assert.deepEqual(resolved, ["hono"]);
+    assert.equal((result as { readonly out: string }).out, "npm");
+    assert.ok(!calls.some((config) => config.value === "fresh"));
+  });
+
+  it("keeps a nested fill-only default from displacing a later occurrence", async () => {
+    const kindOuter = dependency(choice(["a", "b"] as const));
+    const kindInner = dependency(choice(["i1", "i2"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const frameworkDerived = framework.deriveSync({
+      metavar: "FW_DERIVED",
+      factory: (value: "fresh" | "hono") =>
+        choice(value === "fresh" ? (["deno"] as const) : (["npm"] as const)),
+      defaultValue: () => "fresh" as const,
+    });
+    const resolved: unknown[] = [];
+    const { prompt } = createTestPrompt();
+    // The selected route's occurrence is a fill-only withDefault(): the
+    // later occurrence has already published when the route runs, so the
+    // default supplies nothing and both consumers read the later value.
+    const parser = object({
+      cond: conditional(
+        prompt(option("--kind", kindOuter), { value: "a" }),
+        {
+          a: object({
+            inner: conditional(
+              prompt(option("--inner", kindInner), { value: "i1" }),
+              {
+                i1: object({
+                  fw: withDefault(option("--fw", framework), "fresh" as const),
+                }),
+                i2: object({ z: constant("1") }),
+              },
+            ),
+            pm: prompt(
+              option("--pm", dependency(choice(["deno", "npm"] as const))),
+              derivePromptConfig(framework, (value) => {
+                resolved.push(value);
+                return { value: value === "fresh" ? "deno" : "npm" };
+              }, { defaultValue: () => "fresh" as const }),
+            ),
+          }),
+          b: object({ y: option("--y", choice(["2"] as const)) }),
+        },
+      ),
+      fw2: prompt(option("--fw2", framework), { value: "hono" }),
+      out: option("--out", frameworkDerived),
+    });
+
+    const result = await parseAsync(parser, ["--out", "npm"]);
+
+    assert.ok(result.success);
+    assert.deepEqual(resolved, ["hono"]);
+    assert.equal(result.value.out, "npm");
+  });
+
+  it("restores a later sibling conditional's publish over an earlier barrier's", async () => {
+    const kind1 = dependency(choice(["a", "b"] as const));
+    const kind2 = dependency(choice(["a", "b"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const extra = dependency(choice(["e1", "e2"] as const));
+    const frameworkDerived = framework.deriveSync({
+      metavar: "FW_DERIVED",
+      factory: (value: "fresh" | "hono") =>
+        choice(value === "fresh" ? (["deno"] as const) : (["npm"] as const)),
+      defaultValue: () => "fresh" as const,
+    });
+    const { prompt } = createTestPrompt();
+    // The earlier conditional waits for a prerequisite declared after
+    // the later conditional, so it executes last; its publish must not
+    // displace the later conditional's occurrence for consumers outside
+    // both.
+    const parser = object({
+      cond1: conditional(
+        prompt(option("--kind1", kind1), { value: "a" }),
+        {
+          a: object({
+            fw: prompt(option("--fw", framework), { value: "fresh" }),
+            pa: prompt(
+              option("--pa", dependency(choice(["x", "y"] as const))),
+              derivePromptConfig(extra, (value) => ({
+                value: value === "e1" ? "x" : "y",
+              }), { defaultValue: () => "e2" as const }),
+            ),
+          }),
+          b: object({ y: option("--y", choice(["2"] as const)) }),
+        },
+      ),
+      cond2: conditional(
+        prompt(option("--kind2", kind2), { value: "a" }),
+        {
+          a: object({
+            fwB: prompt(option("--fw-b", framework), { value: "hono" }),
+          }),
+          b: object({ z: option("--z", choice(["3"] as const)) }),
+        },
+      ),
+      extra: prompt(option("--extra", extra), { value: "e1" }),
+      out: option("--out", frameworkDerived),
+    });
+
+    const result = await parseAsync(parser, ["--out", "npm"]);
+
+    assert.ok(result.success);
+    assert.deepEqual(result.value.cond1, ["a", { fw: "fresh", pa: "x" }]);
+    assert.deepEqual(result.value.cond2, ["a", { fwB: "hono" }]);
+    assert.equal(result.value.out, "npm");
+  });
+
+  it("restores the latest later occurrence that actually published", async () => {
+    const kindOuter = dependency(choice(["a", "b"] as const));
+    const kindInner = dependency(choice(["i1", "i2"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const frameworkDerived = framework.deriveSync({
+      metavar: "FW_DERIVED",
+      factory: (value: "fresh" | "hono") =>
+        choice(value === "fresh" ? (["deno"] as const) : (["npm"] as const)),
+      defaultValue: () => "fresh" as const,
+    });
+    const resolved: unknown[] = [];
+    const { prompt } = createTestPrompt();
+    // The very last occurrence is an absent optional() that publishes
+    // nothing, so the restored value comes from the latest occurrence
+    // that actually published.
+    const parser = object({
+      cond: conditional(
+        prompt(option("--kind", kindOuter), { value: "a" }),
+        {
+          a: object({
+            inner: conditional(
+              prompt(option("--inner", kindInner), { value: "i1" }),
+              {
+                i1: object({
+                  fw: prompt(option("--fw", framework), { value: "fresh" }),
+                }),
+                i2: object({ z: constant("1") }),
+              },
+            ),
+            pm: prompt(
+              option("--pm", dependency(choice(["deno", "npm"] as const))),
+              derivePromptConfig(framework, (value) => {
+                resolved.push(value);
+                return { value: value === "fresh" ? "deno" : "npm" };
+              }, { defaultValue: () => "hono" as const }),
+            ),
+          }),
+          b: object({ y: option("--y", choice(["2"] as const)) }),
+        },
+      ),
+      fw2: prompt(option("--fw2", framework), { value: "hono" }),
+      fw3: optional(option("--fw3", framework)),
+      out: option("--out", frameworkDerived),
+    });
+
+    const result = await parseAsync(parser, ["--out", "npm"]);
+
+    assert.ok(result.success);
+    assert.deepEqual(resolved, ["fresh"]);
+    assert.equal(result.value.out, "npm");
+  });
+
+  it("keeps a command-line-committed branch in the enclosing scope", async () => {
+    const kindOuter = dependency(choice(["a", "b"] as const));
+    const kindInner = dependency(choice(["i1", "i2"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const frameworkDerived = framework.deriveSync({
+      metavar: "FW_DERIVED",
+      factory: (value: "fresh" | "hono") =>
+        choice(value === "fresh" ? (["deno"] as const) : (["npm"] as const)),
+      defaultValue: () => "fresh" as const,
+    });
+    const resolved: unknown[] = [];
+    const { prompt } = createTestPrompt();
+    // Committing the outer branch on the command line leaves no
+    // completion boundary to confine: the branch's nodes join the
+    // enclosing scope directly, so the branch consumer follows plain
+    // declaration order and reads the later occurrence.
+    const parser = object({
+      cond: conditional(
+        prompt(option("--kind", kindOuter), { value: "a" }),
+        {
+          a: object({
+            inner: conditional(
+              prompt(option("--inner", kindInner), { value: "i1" }),
+              {
+                i1: object({
+                  fw: prompt(option("--fw", framework), { value: "fresh" }),
+                }),
+                i2: object({ z: constant("1") }),
+              },
+            ),
+            pm: prompt(
+              option("--pm", dependency(choice(["deno", "npm"] as const))),
+              derivePromptConfig(framework, (value) => {
+                resolved.push(value);
+                return { value: value === "fresh" ? "deno" : "npm" };
+              }, { defaultValue: () => "hono" as const }),
+            ),
+          }),
+          b: object({ y: option("--y", choice(["2"] as const)) }),
+        },
+      ),
+      fw2: prompt(option("--fw2", framework), { value: "hono" }),
+      out: option("--out", frameworkDerived),
+    });
+
+    const result = await parseAsync(parser, ["--kind", "a", "--out", "npm"]);
+
+    assert.ok(result.success);
+    assert.deepEqual(resolved, ["hono"]);
+    assert.deepEqual(result.value.cond, [
+      "a",
+      { inner: ["i1", { fw: "fresh" }], pm: "npm" },
+    ]);
+    assert.equal(result.value.out, "npm");
+  });
+
+  it("chains branch-confined publishes through three conditional levels", async () => {
+    const kindOuter = dependency(choice(["a", "b"] as const));
+    const kindMid = dependency(choice(["m1", "m2"] as const));
+    const kindInner = dependency(choice(["i1", "i2"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const tool = dependency(choice(["t1", "t2"] as const));
+    const frameworkDerived = framework.deriveSync({
+      metavar: "FW_DERIVED",
+      factory: (value: "fresh" | "hono") =>
+        choice(value === "fresh" ? (["deno"] as const) : (["npm"] as const)),
+      defaultValue: () => "fresh" as const,
+    });
+    const resolved: unknown[] = [];
+    const { prompt } = createTestPrompt();
+    // Three levels deep.  The innermost route waits for a tool
+    // prerequisite declared after the mid-level framework occurrence, so
+    // it executes after that occurrence and its publish must be confined
+    // at the inner boundary: the mid-level consumer reads the mid-level
+    // occurrence.  The whole branch's publish is in turn confined at the
+    // outer boundary, so the post-conditional consumer reads the
+    // occurrence declared after the outer conditional.
+    const parser = object({
+      cond: conditional(
+        prompt(option("--kind", kindOuter), { value: "a" }),
+        {
+          a: object({
+            mid: conditional(
+              prompt(option("--mid", kindMid), { value: "m1" }),
+              {
+                m1: object({
+                  inner: conditional(
+                    prompt(option("--inner", kindInner), { value: "i1" }),
+                    {
+                      i1: object({
+                        fw: prompt(option("--fw", framework), {
+                          value: "fresh",
+                        }),
+                        pi: prompt(
+                          option(
+                            "--pi",
+                            dependency(choice(["x", "y"] as const)),
+                          ),
+                          derivePromptConfig(tool, (value) => {
+                            resolved.push(["inner", value]);
+                            return { value: value === "t1" ? "x" : "y" };
+                          }, { defaultValue: () => "t2" as const }),
+                        ),
+                      }),
+                      i2: object({ z: constant("1") }),
+                    },
+                  ),
+                  fwMid: prompt(option("--fw-mid", framework), {
+                    value: "hono",
+                  }),
+                  toolP: prompt(option("--tool", tool), { value: "t1" }),
+                  pmMid: prompt(
+                    option(
+                      "--pm-mid",
+                      dependency(choice(["deno", "npm"] as const)),
+                    ),
+                    derivePromptConfig(framework, (value) => {
+                      resolved.push(["mid", value]);
+                      return { value: value === "fresh" ? "deno" : "npm" };
+                    }, { defaultValue: () => "fresh" as const }),
+                  ),
+                }),
+                m2: object({ w: constant("2") }),
+              },
+            ),
+          }),
+          b: object({ y: option("--y", choice(["2"] as const)) }),
+        },
+      ),
+      fw2: prompt(option("--fw2", framework), { value: "hono" }),
+      out: option("--out", frameworkDerived),
+    });
+
+    const result = await parseAsync(parser, ["--out", "npm"]);
+
+    assert.ok(result.success);
+    assert.deepEqual(resolved, [["inner", "t1"], ["mid", "hono"]]);
+    assert.equal(result.value.out, "npm");
+  });
 });

--- a/packages/prompt/src/index.test.ts
+++ b/packages/prompt/src/index.test.ts
@@ -6513,6 +6513,60 @@ describe("branch completion dependencies across scheduling barriers", () => {
     assert.equal(result.value.out, "npm");
   });
 
+  it("restores a later occurrence nested in a sibling object", async () => {
+    const kindOuter = dependency(choice(["a", "b"] as const));
+    const kindInner = dependency(choice(["i1", "i2"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const frameworkDerived = framework.deriveSync({
+      metavar: "FW_DERIVED",
+      factory: (value: "fresh" | "hono") =>
+        choice(value === "fresh" ? (["deno"] as const) : (["npm"] as const)),
+      defaultValue: () => "fresh" as const,
+    });
+    const resolved: unknown[] = [];
+    const { prompt } = createTestPrompt();
+    // The later prompted occurrence sits inside a sibling plain
+    // object(); its node still joins the enclosing pass, so the branch
+    // publish is confined and the nested later occurrence wins outside.
+    const parser = object({
+      cond: conditional(
+        prompt(option("--kind", kindOuter), { value: "a" }),
+        {
+          a: object({
+            inner: conditional(
+              prompt(option("--inner", kindInner), { value: "i1" }),
+              {
+                i1: object({
+                  fw: prompt(option("--fw", framework), { value: "fresh" }),
+                }),
+                i2: object({ z: constant("1") }),
+              },
+            ),
+            pm: prompt(
+              option("--pm", dependency(choice(["deno", "npm"] as const))),
+              derivePromptConfig(framework, (value) => {
+                resolved.push(value);
+                return { value: value === "fresh" ? "deno" : "npm" };
+              }, { defaultValue: () => "hono" as const }),
+            ),
+          }),
+          b: object({ y: option("--y", choice(["2"] as const)) }),
+        },
+      ),
+      later: object({
+        fw2: prompt(option("--fw2", framework), { value: "hono" }),
+      }),
+      out: option("--out", frameworkDerived),
+    });
+
+    const result = await parseAsync(parser, ["--out", "npm"]);
+
+    assert.ok(result.success);
+    assert.deepEqual(resolved, ["fresh"]);
+    assert.deepEqual(result.value.later, { fw2: "hono" });
+    assert.equal(result.value.out, "npm");
+  });
+
   it("keeps a command-line-committed branch in the enclosing scope", async () => {
     const kindOuter = dependency(choice(["a", "b"] as const));
     const kindInner = dependency(choice(["i1", "i2"] as const));


### PR DESCRIPTION
The barrier scheduling from #926 keeps an ordering edge to a later source occurrence when a nested `conditional()` guarantees the source on only some of its routes, so the later occurrence executes before the barrier. When the selected route then published the source anyway, its value landed on top of the later occurrence in the shared registry, and consumers declared after the outer conditional read the branch's value—the caveat #926 left documented in *docs/integrations/prompt.md*.

Each scheduling pass now records every registration it performs under the publishing node's declaration index, keeping the latest-declared occurrence's value. A barrier attributes its branch's publications to its own position through a per-barrier callback that chains through arbitrarily nested passes—observation is unconditional, while the provenance entry follows the max-index rule—and after a successful preparation, any source the branch published over a later-declared occurrence is re-asserted from the recorded value. The branch's publish still serves consumers inside the branch (they resolve during the nested pass, before the re-assertion), while declaration order holds outside, without re-running any effect and without touching demand propagation, parking, or cycle detection. A fill-only `withDefault()` route stays fill-only: once the awaited later occurrence has published, even the branch consumer reads the later value. A branch committed on the command line has no completion boundary and keeps its flat declaration-order semantics, now pinned by a test; so is the previously untested case of a later prompted occurrence inside a sibling plain `object()`, which this change also fixes. The remaining nested-conditional caveat is gone from *docs/integrations/prompt.md*.

Two pre-existing defects surfaced by the review loop are tracked separately as #929 and #930.

Closes #928. Part of #869.