### PR TITLE
Serve deferred branch consumers from the branch's own publish

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,10 +46,12 @@ To be released.
     when the conditional waited for a source occurrence declared after
     it and the selected branch then publishes the same source—through a
     nested route that provides it on only some of its routes, a prompt,
-    a parsed value, or a binding: the branch's value serves consumers
-    inside the branch, while consumers outside the conditional read the
+    a parsed value, or a binding: the branch's value serves every
+    consumer inside the branch, a derived value parser such as
+    `option("--pm", source.deriveSync(...))` as much as a derived prompt
+    configuration, while consumers outside the conditional read the
     later occurrence, which no longer loses to the branch's publish.
-    [[#869], [#872], [#919], [#923], [#924], [#925], [#926], [#927], [#928], [#931]]
+    [[#869], [#872], [#919], [#923], [#924], [#925], [#926], [#927], [#928], [#929], [#931], [#932]]
  -  Added `termWidth: "auto"` to `formatDocPage()` for aligning descriptions
     after the widest visible term using terminal display width while reserving
     description space under `maxWidth`.  The existing default and explicit
@@ -121,7 +123,9 @@ To be released.
 [#926]: https://github.com/dahlia/optique/pull/926
 [#927]: https://github.com/dahlia/optique/pull/927
 [#928]: https://github.com/dahlia/optique/issues/928
+[#929]: https://github.com/dahlia/optique/issues/929
 [#931]: https://github.com/dahlia/optique/pull/931
+[#932]: https://github.com/dahlia/optique/pull/932
 
 ### @optique/run
 

--- a/changes.d/core/completion-dependency-scheduling.md
+++ b/changes.d/core/completion-dependency-scheduling.md
@@ -9,7 +9,9 @@ links:
   '#926': https://github.com/dahlia/optique/pull/926
   '#927': https://github.com/dahlia/optique/pull/927
   '#928': https://github.com/dahlia/optique/issues/928
+  '#929': https://github.com/dahlia/optique/issues/929
   '#931': https://github.com/dahlia/optique/pull/931
+  '#932': https://github.com/dahlia/optique/pull/932
 ---
  -  Added scheduling support for effectful completions that consume
     dependency values, such as prompts with derived configurations.  The
@@ -45,7 +47,9 @@ links:
     when the conditional waited for a source occurrence declared after
     it and the selected branch then publishes the same source—through a
     nested route that provides it on only some of its routes, a prompt,
-    a parsed value, or a binding: the branch's value serves consumers
-    inside the branch, while consumers outside the conditional read the
+    a parsed value, or a binding: the branch's value serves every
+    consumer inside the branch, a derived value parser such as
+    `option("--pm", source.deriveSync(...))` as much as a derived prompt
+    configuration, while consumers outside the conditional read the
     later occurrence, which no longer loses to the branch's publish.
-    [[#869], [#872], [#919], [#923], [#924], [#925], [#926], [#927], [#928], [#931]]
+    [[#869], [#872], [#919], [#923], [#924], [#925], [#926], [#927], [#928], [#929], [#931], [#932]]

--- a/docs/concepts/dependencies.md
+++ b/docs/concepts/dependencies.md
@@ -673,7 +673,8 @@ prerequisite runs.
 Declaration order holds across that wait as well.  When the conditional waited
 for a source occurrence declared after it and the selected branch then
 publishes the same source—through a nested route, a prompt, a parsed value, or
-a binding—the branch's value serves consumers inside the branch, while the
+a binding—the branch's value serves every consumer inside the branch, a
+derived value parser and a derived prompt configuration alike, while the
 later occurrence is restored for consumers outside the conditional.  A
 fill-only `withDefault()` occurrence supplies the source only while nothing
 has published it, so it never displaces the awaited later occurrence's value,

--- a/docs/integrations/prompt.md
+++ b/docs/integrations/prompt.md
@@ -741,7 +741,8 @@ provider, so the outer conditional waits for a matching occurrence declared
 after it, and a selected route that omits the source reads that later value.
 When the selected route does provide the source, its explicit publish—a prompt
 answer, a parsed value, or a bound value—serves consumers inside the enclosing
-branch, and the later occurrence is restored afterward, so consumers declared
+branch, derived value parsers and derived prompt configurations alike, and the
+later occurrence is restored afterward, so consumers declared
 after the outer conditional read the later occurrence, exactly as declaration
 order promises.  A fill-only `withDefault()` occurrence in such a route
 supplies the source only while nothing has published it: once the awaited

--- a/packages/core/src/constructs.ts
+++ b/packages/core/src/constructs.ts
@@ -165,6 +165,25 @@ function withDependencyRuntimeExec(
   };
 }
 
+/**
+ * Drops a parent's one-shot
+ * {@link ExecutionContext.republishCachedCompletions} instruction from an
+ * execution context handed to a child parser.  A construct that runs the
+ * effectful scheduling pass consumes the instruction in that pass; its
+ * children must not inherit it, or their own passes would re-assert cached
+ * completions over a later sibling occurrence.
+ */
+function withoutRepublishInstruction(exec: ExecutionContext): ExecutionContext;
+function withoutRepublishInstruction(
+  exec: ExecutionContext | undefined,
+): ExecutionContext | undefined;
+function withoutRepublishInstruction(
+  exec: ExecutionContext | undefined,
+): ExecutionContext | undefined {
+  if (exec?.republishCachedCompletions == null) return exec;
+  return { ...exec, republishCachedCompletions: undefined };
+}
+
 function withChildContext<TState>(
   context: ParserContext<unknown>,
   segment: PropertyKey,
@@ -904,6 +923,14 @@ async function scheduleEffectfulSourceCompletions(
       if (optedIn || expandedNode === node) collected.add(expandedNode);
     }
   }
+  // A pass asked to re-publish cached completions (the first pass of a
+  // branch a conditional() selected during completion) replays the
+  // barrier's nested pass onto the branch's fresh runtime: every expanded
+  // node re-registers structurally at its declaration position, and the
+  // pass runs even when the branch holds no effectful node, so a bound or
+  // parsed branch occurrence lands in declaration order beside the cached
+  // effectful ones (https://github.com/dahlia/optique/issues/929).
+  const republish = exec?.republishCachedCompletions === true;
   const effectful = await completeEffectfulSourcesAsync(
     expandedNodes,
     state,
@@ -914,7 +941,8 @@ async function scheduleEffectfulSourceCompletions(
         ? { demandNodes: expandEffectfulRuntimeNodes(demandNodes) }
         : {}),
       isReusable: (node) => direct.has(node),
-      isCollected: (node) => collected.has(node),
+      isCollected: republish ? () => true : (node) => collected.has(node),
+      ...(republish ? { includeStructural: true } : {}),
     },
   );
   if (!effectful.success) {
@@ -7506,6 +7534,7 @@ export function object<
           const phase3Exec: ExecutionContext = {
             ...childExec,
             preCompletedByParser: undefined,
+            republishCachedCompletions: undefined,
           } as ExecutionContext;
 
           // Phase 2: Resolve all DeferredParseState in the state tree
@@ -7636,6 +7665,7 @@ export function object<
           const phase3Exec: ExecutionContext = {
             ...childExec,
             preCompletedByParser: undefined,
+            republishCachedCompletions: undefined,
           } as ExecutionContext;
 
           // Phase 2: Build the full annotated state, then resolve the
@@ -7813,6 +7843,7 @@ export function object<
           const phase3Exec: ExecutionContext = {
             ...childExec,
             preCompletedByParser: undefined,
+            republishCachedCompletions: undefined,
           } as ExecutionContext;
 
           const getFieldState = createFieldStateGetter(state);
@@ -7925,6 +7956,7 @@ export function object<
           const phase3Exec: ExecutionContext = {
             ...childExec,
             preCompletedByParser: undefined,
+            republishCachedCompletions: undefined,
           } as ExecutionContext;
 
           const getFieldState = createFieldStateGetter(state);
@@ -8767,6 +8799,7 @@ function createSeqComplete(
         const phase3Exec: ExecutionContext = {
           ...childExec,
           preCompletedByParser: undefined,
+          republishCachedCompletions: undefined,
         } as ExecutionContext;
         const resolvedArray = resolveStateWithRuntime(
           stateArray,
@@ -8870,6 +8903,7 @@ function createSeqComplete(
         const phase3Exec: ExecutionContext = {
           ...childExec,
           preCompletedByParser: undefined,
+          republishCachedCompletions: undefined,
         } as ExecutionContext;
         const resolvedArray = await resolveStateWithRuntimeAsync(
           stateArray,
@@ -9866,6 +9900,7 @@ export function tuple<
           const phase3Exec: ExecutionContext = {
             ...childExec,
             preCompletedByParser: undefined,
+            republishCachedCompletions: undefined,
           } as ExecutionContext;
 
           // Phase 2: Resolve all DeferredParseState in the state array.
@@ -9983,6 +10018,7 @@ export function tuple<
           const phase3Exec: ExecutionContext = {
             ...childExec,
             preCompletedByParser: undefined,
+            republishCachedCompletions: undefined,
           } as ExecutionContext;
 
           // Phase 2: Resolve all DeferredParseState in the state array.
@@ -10084,6 +10120,7 @@ export function tuple<
           const phase3Exec: ExecutionContext = {
             ...childExec,
             preCompletedByParser: undefined,
+            republishCachedCompletions: undefined,
           } as ExecutionContext;
           const resolvedArray = resolveStateWithRuntime(
             stateArray,
@@ -10191,6 +10228,7 @@ export function tuple<
           const phase3Exec: ExecutionContext = {
             ...childExec,
             preCompletedByParser: undefined,
+            republishCachedCompletions: undefined,
           } as ExecutionContext;
           const resolvedArray = await resolveStateWithRuntimeAsync(
             stateArray,
@@ -10717,6 +10755,7 @@ export function seq<
           const phase3Exec: ExecutionContext = {
             ...childExec,
             preCompletedByParser: undefined,
+            republishCachedCompletions: undefined,
           } as ExecutionContext;
           const resolvedArray = resolveStateWithRuntime(
             stateArray,
@@ -10824,6 +10863,7 @@ export function seq<
           const phase3Exec: ExecutionContext = {
             ...childExec,
             preCompletedByParser: undefined,
+            republishCachedCompletions: undefined,
           } as ExecutionContext;
           const resolvedArray = await resolveStateWithRuntimeAsync(
             stateArray,
@@ -12315,7 +12355,10 @@ export function merge(
           const parser = syncParsers[i];
           const parserState = extractCompleteState(parser, resolvedState, i);
           const { cache, excludedSourceFields } = perChildPhase1[i];
-          const childCompleteExec = withChildExecPath(childExec, i);
+          const childCompleteExec = withChildExecPath(
+            withoutRepublishInstruction(childExec),
+            i,
+          );
           // Keep duplicate-key exclusion at the merge level.  A child that
           // owns duplicate output keys still needs to seed its own local
           // dependency sources during completion, but those sources must not
@@ -12514,7 +12557,10 @@ export function merge(
           const parser = parsers[i];
           const parserState = extractCompleteState(parser, resolvedState, i);
           const { cache: asyncCache, excludedSourceFields } = perChildPhase1[i];
-          const childCompleteExec = withChildExecPath(childExec, i);
+          const childCompleteExec = withChildExecPath(
+            withoutRepublishInstruction(childExec),
+            i,
+          );
           const completeExec = excludedSourceFields == null
             ? {
               ...childCompleteExec,
@@ -12691,7 +12737,10 @@ export function merge(
               i,
             );
             const { cache, excludedSourceFields } = perChildPhase1[i];
-            const childCompleteExec = withChildExecPath(childExec, i);
+            const childCompleteExec = withChildExecPath(
+              withoutRepublishInstruction(childExec),
+              i,
+            );
             const completeExec = excludedSourceFields == null
               ? {
                 ...childCompleteExec,
@@ -12874,7 +12923,10 @@ export function merge(
             const { cache: asyncCache, excludedSourceFields } = perChildPhase1[
               i
             ];
-            const childCompleteExec = withChildExecPath(childExec, i);
+            const childCompleteExec = withChildExecPath(
+              withoutRepublishInstruction(childExec),
+              i,
+            );
             const completeExec = excludedSourceFields == null
               ? {
                 ...childCompleteExec,
@@ -14187,6 +14239,7 @@ export function concat(
     const phase3Exec: ExecutionContext = {
       ...childExec,
       preCompletedByParser: undefined,
+      republishCachedCompletions: undefined,
     } as ExecutionContext;
 
     // Phase 2: Resolve deferred parse states across all tuples using runtime.
@@ -14318,6 +14371,7 @@ export function concat(
     const phase3Exec: ExecutionContext = {
       ...childExec,
       preCompletedByParser: undefined,
+      republishCachedCompletions: undefined,
     } as ExecutionContext;
 
     // Phase 2: Resolve deferred parse states across all tuples using runtime.
@@ -14465,6 +14519,7 @@ export function concat(
           const phase3Exec: ExecutionContext = {
             ...childExec,
             preCompletedByParser: undefined,
+            republishCachedCompletions: undefined,
           } as ExecutionContext;
           const resolvedArray = resolveStateWithRuntime(
             stateArray,
@@ -14561,6 +14616,7 @@ export function concat(
           const phase3Exec: ExecutionContext = {
             ...childExec,
             preCompletedByParser: undefined,
+            republishCachedCompletions: undefined,
           } as ExecutionContext;
           const resolvedArray = await resolveStateWithRuntimeAsync(
             stateArray,
@@ -16846,6 +16902,7 @@ export function conditional(
           const discriminatorExec = ctx.exec == null ? undefined : {
             ...ctx.exec,
             path: [...(parentPath ?? []), "_discriminator"],
+            republishCachedCompletions: undefined,
           };
           discriminatorResult = unwrapCompleteResult(
             await discriminator.complete(
@@ -16871,6 +16928,7 @@ export function conditional(
           const branchExec = ctx.exec == null ? undefined : {
             ...ctx.exec,
             path: [...(parentPath ?? []), "_branch"],
+            republishCachedCompletions: undefined,
           };
           const annotatedInitial = getAnnotatedChildState(
             conditionalState,
@@ -17034,6 +17092,10 @@ export function conditional(
           state.discriminatorState,
           discriminator,
         );
+        // The scheduling pass above consumed any re-publication
+        // instruction a parent conditional handed down; the children
+        // completed below must not inherit it.
+        const childExec = withoutRepublishInstruction(exec);
         // Consume the prepared decision instead of re-completing the
         // discriminator, so a non-idempotent completion cannot select
         // a different branch than the one whose sources were scheduled.
@@ -17042,14 +17104,14 @@ export function conditional(
           : unwrapCompleteResult(
             await discriminator.complete(
               annotatedDiscriminatorStateForDeferred,
-              withChildExecPath(exec, "_discriminator"),
+              withChildExecPath(childExec, "_discriminator"),
             ),
           );
         if (deferredDiscriminatorResult.success) {
           const deferredValue = deferredDiscriminatorResult.value as string;
           const deferredBranch = branches[deferredValue];
           if (deferredBranch) {
-            const branchExec = withChildExecPath(exec, "_branch");
+            const branchExec = withChildExecPath(childExec, "_branch");
             let branchState: unknown;
             if (prepared != null && prepared.branchKey === deferredValue) {
               branchState = prepared.branchState;
@@ -17169,7 +17231,7 @@ export function conditional(
         const defaultResult = unwrapCompleteResult(
           await defaultBranch.complete(
             branchState,
-            withChildExecPath(exec, "_branch"),
+            withChildExecPath(withoutRepublishInstruction(exec), "_branch"),
           ),
         );
         if (!defaultResult.success) {
@@ -17278,6 +17340,11 @@ export function conditional(
       );
       if (schedulingFailure != null) return schedulingFailure;
     }
+    // The scheduling pass above consumed any re-publication instruction
+    // a parent conditional handed down (see the branch completion below
+    // for the instruction this conditional issues itself); the
+    // discriminator and branch completions must not inherit it.
+    const childCompletionExec = withoutRepublishInstruction(completionExec);
     // Only complete the discriminator when needed
     // (see sync counterpart for rationale).
     const needsDiscriminatorCompletion = state.selectedBranch.kind !==
@@ -17294,7 +17361,7 @@ export function conditional(
     // the same source key as the discriminator could circularly
     // confirm itself.  Build a discriminator-only runtime so that
     // the verification is independent of branch-local sources.
-    let discriminatorCompletionExec = completionExec;
+    let discriminatorCompletionExec = childCompletionExec;
     if (wasSpeculative && needsDiscriminatorCompletion) {
       const discOnlyState = { _discriminator: annotatedDiscriminatorState };
       const discOnlyRuntime = createDependencyRuntimeContext(
@@ -17312,7 +17379,7 @@ export function conditional(
       );
       collectSourcesFromState(discOnlyState, discOnlyRuntime);
       discriminatorCompletionExec = {
-        ...completionExec,
+        ...childCompletionExec,
         dependencyRuntime: discOnlyRuntime,
         dependencyRegistry: discOnlyRuntime.registry,
       };
@@ -17373,6 +17440,61 @@ export function conditional(
       );
     }
 
+    // A branch confirmed only now completes against this conditional's
+    // fresh runtime, whose registry was cloned after the enclosing pass
+    // restored the occurrences declared after the conditional.  The
+    // branch's effectful completions already ran in that pass and are
+    // cached in the run-scoped session, and its bound occurrences have
+    // no carrier in the branch state, so the branch's publications are
+    // replayed onto this runtime in declaration order before the branch
+    // completes: once here, over the branch's expanded nodes (the only
+    // replay a branch without a scheduling pass of its own, such as a
+    // synchronous object(), ever gets), and again in the branch's own
+    // first pass, which follows its structural re-collection.  No effect
+    // runs twice; only cached values re-register, so the branch's
+    // deferred derived consumers read the branch's own publish
+    // (https://github.com/dahlia/optique/issues/929).  A branch
+    // committed on the command line has no completion boundary and
+    // keeps the enclosing scope's declaration order instead.
+    const branchCompletionExec: ExecutionContext = {
+      ...childCompletionExec,
+      path: [...childCompletionExec.path, "_branch"],
+      ...(wasSpeculative ? { republishCachedCompletions: true } : {}),
+    };
+    if (wasSpeculative) {
+      // The first node is the discriminator, already completed above.
+      const replayFailure = await scheduleEffectfulSourceCompletions(
+        buildConditionalSchedulingNodes(state, exec?.path).slice(1),
+        combinedState,
+        runtime,
+        { ...completionExec, republishCachedCompletions: true },
+        new Map<string | symbol, unknown>(),
+      );
+      if (replayFailure != null) {
+        // Without an enclosing pass this replay is where the branch's
+        // effects first run, so a failing one (a cancelled prompt) gets
+        // the branchError wrap the branch completion below applies.  A
+        // nested barrier's failure already carries the wrap from its
+        // pre-expanded node (see wrapBranchBarrierNodes) and is cached
+        // in the session, which is how it is told apart here.
+        const branchError = options?.errors?.branchError;
+        if (
+          branchError == null || discriminatorValue === undefined ||
+          replaceCachedBarrierFailure(
+            completionExec.effectfulCompletionSession,
+            replayFailure,
+            replayFailure,
+          )
+        ) {
+          return replayFailure;
+        }
+        return {
+          success: false,
+          error: branchError(discriminatorValue, replayFailure.error),
+        };
+      }
+    }
+
     // Now that the speculative branch (if any) is verified, it is
     // safe to replay deferred dependency parsing for the chosen
     // branch state.  Doing this before the mismatch check above
@@ -17384,10 +17506,7 @@ export function conditional(
     );
 
     const branchResult = unwrapCompleteResult(
-      await branchParser.complete(
-        resolvedBranchState,
-        withChildExecPath(completionExec, "_branch"),
-      ),
+      await branchParser.complete(resolvedBranchState, branchCompletionExec),
     );
 
     if (!branchResult.success) {

--- a/packages/core/src/dependency-runtime.test.ts
+++ b/packages/core/src/dependency-runtime.test.ts
@@ -3639,6 +3639,199 @@ describe("completeEffectfulSourcesAsync", () => {
     assert.deepEqual(executed, []);
     assert.equal(runtime.registry.get(sourceId), "branch");
   });
+
+  // The remaining tests pin the one-shot re-publication instruction a
+  // conditional() hands to the completion of a branch it selected during
+  // completion (https://github.com/dahlia/optique/issues/929): a cached
+  // completion re-registers its value at its declaration position without
+  // re-running, so declaration order within the pass still decides.
+  test("re-registers a cached completion when asked to republish", async () => {
+    const runtime = createDependencyRuntimeContext();
+    const session = createEffectfulCompletionSession();
+    const sourceId = Symbol("framework");
+    const executed: string[] = [];
+    const writes: unknown[] = [];
+    const originalRegister = runtime.registerSource.bind(runtime);
+    runtime.registerSource = (id, value) => {
+      writes.push(value);
+      originalRegister(id, value);
+    };
+    const branchProvider = createEffectfulSourceNode(
+      "branch",
+      sourceId,
+      () => Promise.resolve({ success: true, value: "branch" }),
+    );
+    const barrier: RuntimeNode = {
+      path: ["barrier"],
+      parser: {},
+      state: undefined,
+      providesSourceIds: new Set([sourceId]),
+      prepare: (ctx) => ctx.schedule([branchProvider]),
+    };
+    const cached = createEffectfulSourceNode(
+      "cached",
+      sourceId,
+      () => {
+        executed.push("cached");
+        return Promise.resolve({ success: true, value: "cached" });
+      },
+    );
+    session.completedByPath.set(
+      serializeSchedulingPath(cached.path),
+      { success: true, value: "cached" },
+    );
+
+    const result = await completeEffectfulSourcesAsync(
+      [barrier, cached],
+      undefined,
+      runtime,
+      {
+        ...createCompleteExecFixture(session),
+        republishCachedCompletions: true,
+      },
+    );
+
+    assert.ok(result.success);
+    assert.deepEqual(executed, []);
+    assert.deepEqual(writes, ["branch", "cached"]);
+    assert.equal(runtime.registry.get(sourceId), "cached");
+  });
+
+  test("lets a later occurrence win over a republished cached completion", async () => {
+    const runtime = createDependencyRuntimeContext();
+    const session = createEffectfulCompletionSession();
+    const sourceId = Symbol("framework");
+    const writes: unknown[] = [];
+    const originalRegister = runtime.registerSource.bind(runtime);
+    runtime.registerSource = (id, value) => {
+      writes.push(value);
+      originalRegister(id, value);
+    };
+    const cached = createEffectfulSourceNode(
+      "cached",
+      sourceId,
+      () => Promise.resolve({ success: true, value: "cached" }),
+    );
+    session.completedByPath.set(
+      serializeSchedulingPath(cached.path),
+      { success: true, value: "cached" },
+    );
+    const later = createEffectfulSourceNode(
+      "later",
+      sourceId,
+      () => Promise.resolve({ success: true, value: "later" }),
+    );
+
+    const result = await completeEffectfulSourcesAsync(
+      [cached, later],
+      undefined,
+      runtime,
+      {
+        ...createCompleteExecFixture(session),
+        republishCachedCompletions: true,
+      },
+    );
+
+    assert.ok(result.success);
+    assert.deepEqual(writes, ["cached", "later"]);
+    assert.equal(runtime.registry.get(sourceId), "later");
+  });
+
+  test("never republishes a cached successful undefined completion", async () => {
+    const runtime = createDependencyRuntimeContext();
+    const session = createEffectfulCompletionSession();
+    const sourceId = Symbol("framework");
+    const writes: unknown[] = [];
+    const originalRegister = runtime.registerSource.bind(runtime);
+    runtime.registerSource = (id, value) => {
+      writes.push(value);
+      originalRegister(id, value);
+    };
+    const cached = createEffectfulSourceNode(
+      "cached",
+      sourceId,
+      () => Promise.resolve({ success: true, value: undefined }),
+    );
+    session.completedByPath.set(
+      serializeSchedulingPath(cached.path),
+      { success: true, value: undefined },
+    );
+
+    const result = await completeEffectfulSourcesAsync(
+      [cached],
+      undefined,
+      runtime,
+      {
+        ...createCompleteExecFixture(session),
+        republishCachedCompletions: true,
+      },
+    );
+
+    assert.ok(result.success);
+    assert.deepEqual(writes, []);
+    assert.ok(!runtime.hasSource(sourceId));
+  });
+
+  test("republishes through a barrier's nested pass but not into completions", async () => {
+    const runtime = createDependencyRuntimeContext();
+    const session = createEffectfulCompletionSession();
+    const sourceId = Symbol("framework");
+    const otherId = Symbol("other");
+    const executed: string[] = [];
+    const seenFlags: unknown[] = [];
+    const writes: unknown[] = [];
+    const originalRegister = runtime.registerSource.bind(runtime);
+    runtime.registerSource = (id, value) => {
+      writes.push(value);
+      originalRegister(id, value);
+    };
+    const branchProvider = createEffectfulSourceNode(
+      "branch",
+      sourceId,
+      () => {
+        executed.push("branch");
+        return Promise.resolve({ success: true, value: "branch" });
+      },
+    );
+    session.completedByPath.set(
+      serializeSchedulingPath(branchProvider.path),
+      { success: true, value: "branch" },
+    );
+    const barrier: RuntimeNode = {
+      path: ["barrier"],
+      parser: {},
+      state: undefined,
+      providesSourceIds: new Set([sourceId]),
+      prepare: (ctx) => ctx.schedule([branchProvider]),
+    };
+    const fresh = createEffectfulSourceNode(
+      "fresh",
+      otherId,
+      (_state, exec) => {
+        seenFlags.push(exec?.republishCachedCompletions);
+        return Promise.resolve({ success: true, value: "fresh" });
+      },
+    );
+
+    const result = await completeEffectfulSourcesAsync(
+      [barrier, fresh],
+      undefined,
+      runtime,
+      {
+        ...createCompleteExecFixture(session),
+        republishCachedCompletions: true,
+      },
+    );
+
+    // The nested pass shares the instruction, so the cached branch
+    // completion re-registers without running; the effect itself never
+    // sees the instruction on its execution context.
+    assert.ok(result.success);
+    assert.deepEqual(executed, []);
+    assert.deepEqual(writes, ["branch", "fresh"]);
+    assert.deepEqual(seenFlags, [undefined]);
+    assert.equal(runtime.registry.get(sourceId), "branch");
+  });
 });
 
 describe("collectDemandedDependencyIds", () => {

--- a/packages/core/src/dependency-runtime.ts
+++ b/packages/core/src/dependency-runtime.ts
@@ -2918,10 +2918,11 @@ export async function completeEffectfulSourcesAsync(
         publishFromNode(node, source.sourceId, extracted.value);
         continue;
       }
-      // Inside a barrier's nested pass (the only includeStructural
-      // caller), a structural occurrence with a publishable
-      // missing-value default (withDefault()) registers that default at
-      // its declaration position, so a branch-internal consumer reads
+      // Inside a barrier's nested pass or a branch's re-publishing pass
+      // (the includeStructural callers), a structural occurrence with a
+      // publishable missing-value default (withDefault()) registers that
+      // default at its declaration position, so a branch-internal
+      // consumer reads
       // it just like any other active provider, while a later outer
       // occurrence still re-registers afterward and wins outside.  The
       // ordinary missing-default phase runs only after this pass, so it
@@ -2996,6 +2997,19 @@ export async function completeEffectfulSourcesAsync(
           result: priorResult,
         });
       }
+      // A pass asked to re-publish (the first pass of a branch that a
+      // conditional() selected during completion, which runs against a
+      // runtime the cached completion never published into) re-registers
+      // the reused value at this node's declaration position, so
+      // declaration order within the pass still decides while no effect
+      // runs again.  A successful `undefined` stays unpublished, exactly
+      // as it did when the completion first ran.
+      if (
+        exec.republishCachedCompletions === true &&
+        priorResult.success && priorResult.value !== undefined
+      ) {
+        publishFromNode(node, source.sourceId, priorResult.value);
+      }
       continue;
     }
 
@@ -3024,7 +3038,13 @@ export async function completeEffectfulSourcesAsync(
     // is deduplicated through the run-scoped session.
     if (!reusable && session == null) continue;
 
-    const childExec: ExecutionContext = { ...exec, path: node.path };
+    // The re-publication instruction belongs to this pass alone; an
+    // effect must not carry it into a scheduler of its own.
+    const childExec: ExecutionContext = {
+      ...exec,
+      path: node.path,
+      republishCachedCompletions: undefined,
+    };
     const result = await source.completeSource(node.state, childExec);
     if (result == null) continue;
     if (!result.success) {

--- a/packages/core/src/internal/parser.ts
+++ b/packages/core/src/internal/parser.ts
@@ -552,7 +552,9 @@ export interface EffectfulCompletionSession {
    * owning nested construct's own scheduling pass reuses it instead of
    * completing the same node again—keeping lazy wrapper defaults at one
    * evaluation per pass and the registered dependency value identical to
-   * the field's final value.
+   * the field's final value.  A pass whose execution context carries
+   * {@link ExecutionContext.republishCachedCompletions} re-registers a
+   * reused result's value at the node's declaration position.
    */
   readonly completedByPath: Map<string, ValueParserResult<unknown>>;
 
@@ -687,6 +689,30 @@ export interface ExecutionContext {
    * @internal
    */
   readonly preCompletedByParser?: ReadonlyMap<string | symbol, unknown>;
+
+  /**
+   * Re-registers effectful completion results already cached in the
+   * run-scoped session at their declaration positions during the
+   * receiving construct's own effectful scheduling pass.  A
+   * `conditional()` sets this for the completion of a branch it selected
+   * during completion: the branch completes against a fresh runtime
+   * cloned after the enclosing pass restored later-declared occurrences,
+   * and the branch's cached publishes have no structural carrier, so
+   * without this the branch's deferred derived consumers would read the
+   * outer occurrence instead of the branch's own publish.  No effect
+   * re-runs; only the cached value is re-registered.
+   *
+   * Path-transparent wrappers (`command()`, `or()`, modifiers) forward
+   * it unchanged.  A construct that runs the scheduling pass consumes it
+   * there and must drop it from the execution contexts of its own
+   * children, exactly as it drops {@link preCompletedByParser}, so nested
+   * passes keep skipping cached completions instead of re-asserting them
+   * over a later sibling occurrence.
+   *
+   * @see https://github.com/dahlia/optique/issues/929
+   * @internal
+   */
+  readonly republishCachedCompletions?: boolean;
 
   /**
    * Field names that should be ignored when a construct seeds dependency

--- a/packages/prompt/src/index.test.ts
+++ b/packages/prompt/src/index.test.ts
@@ -6706,4 +6706,595 @@ describe("branch completion dependencies across scheduling barriers", () => {
     assert.deepEqual(resolved, [["inner", "t1"], ["mid", "hono"]]);
     assert.equal(result.value.out, "npm");
   });
+
+  // The remaining tests pin that a branch selected during completion serves
+  // its own publish to deferred derived consumers (parse-time derived value
+  // parsers) exactly as it serves derived prompt configurations
+  // (https://github.com/dahlia/optique/issues/929).
+  it("serves a deferred derived consumer from a nested route's publish", async () => {
+    const kindOuter = dependency(choice(["a", "b"] as const));
+    const kindInner = dependency(choice(["i1", "i2"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const frameworkDerived = framework.deriveSync({
+      metavar: "PM",
+      factory: (value: "fresh" | "hono") =>
+        choice(value === "fresh" ? (["deno"] as const) : (["npm"] as const)),
+      defaultValue: () => "fresh" as const,
+    });
+    const { prompt, calls } = createTestPrompt();
+    // `--pm deno` commits the outer branch speculatively; the nested route
+    // publishes framework = "fresh", so the branch's deferred consumer
+    // validates against "fresh" while the consumer declared after the
+    // conditional reads the later occurrence.
+    const parser = object({
+      cond: conditional(
+        prompt(option("--kind", kindOuter), { value: "a" }),
+        {
+          a: object({
+            inner: conditional(
+              prompt(option("--inner", kindInner), { value: "i1" }),
+              {
+                i1: object({
+                  fw: prompt(option("--fw", framework), { value: "fresh" }),
+                }),
+                i2: object({ z: constant("1") }),
+              },
+            ),
+            pm: option("--pm", frameworkDerived),
+          }),
+          b: object({ y: constant("2") }),
+        },
+      ),
+      fw2: prompt(option("--fw2", framework), { value: "hono" }),
+      out: option("--out", frameworkDerived),
+    });
+
+    const result = await parseAsync(parser, ["--pm", "deno", "--out", "npm"]);
+
+    assert.ok(result.success);
+    assert.deepEqual(result.value.cond, [
+      "a",
+      { inner: ["i1", { fw: "fresh" }], pm: "deno" },
+    ]);
+    assert.equal(result.value.fw2, "hono");
+    assert.equal(result.value.out, "npm");
+    assert.deepEqual(
+      calls.map((call) => call.value),
+      ["a", "i1", "fresh", "hono"],
+    );
+  });
+
+  it("serves deferred and completion consumers alike from a branch publish", async () => {
+    const kind = dependency(choice(["a", "b"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const frameworkDerived = framework.deriveSync({
+      metavar: "PM",
+      factory: (value: "fresh" | "hono") =>
+        choice(value === "fresh" ? (["deno"] as const) : (["npm"] as const)),
+      defaultValue: () => "fresh" as const,
+    });
+    const resolved: unknown[] = [];
+    const { prompt } = createTestPrompt();
+    const parser = object({
+      cond: conditional(
+        prompt(option("--kind", kind), { value: "a" }),
+        {
+          a: object({
+            fw: prompt(option("--fw", framework), { value: "fresh" }),
+            pm: option("--pm", frameworkDerived),
+            tool: prompt(
+              option(
+                "--tool",
+                dependency(choice(["t-deno", "t-npm"] as const)),
+              ),
+              derivePromptConfig(framework, (value) => {
+                resolved.push(value);
+                return { value: value === "fresh" ? "t-deno" : "t-npm" };
+              }, { defaultValue: () => "hono" as const }),
+            ),
+          }),
+          b: object({ y: constant("2") }),
+        },
+      ),
+      fw2: prompt(option("--fw2", framework), { value: "hono" }),
+      out: option("--out", frameworkDerived),
+    });
+
+    const result = await parseAsync(parser, ["--pm", "deno", "--out", "npm"]);
+
+    assert.ok(result.success);
+    assert.deepEqual(result.value.cond, [
+      "a",
+      { fw: "fresh", pm: "deno", tool: "t-deno" },
+    ]);
+    assert.deepEqual(resolved, ["fresh"]);
+    assert.equal(result.value.out, "npm");
+  });
+
+  it("follows a later prompted branch occurrence over an earlier parsed one", async () => {
+    const kind = dependency(choice(["a", "b"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const frameworkDerived = framework.deriveSync({
+      metavar: "PM",
+      factory: (value: "fresh" | "hono") =>
+        choice(value === "fresh" ? (["deno"] as const) : (["npm"] as const)),
+      defaultValue: () => "fresh" as const,
+    });
+    const { prompt } = createTestPrompt();
+    // Inside the branch, declaration order still decides: the prompted
+    // occurrence nested in a plain object() is declared after the parsed
+    // one, so the branch consumer reads the prompted value even though
+    // the branch's own completion re-collects the parsed value first.
+    const parser = object({
+      cond: conditional(
+        prompt(option("--kind", kind), { value: "a" }),
+        {
+          a: object({
+            fw0: option("--fw0", framework),
+            inner: object({
+              fw: prompt(option("--fw", framework), { value: "hono" }),
+            }),
+            pm: option("--pm", frameworkDerived),
+          }),
+          b: object({ y: constant("2") }),
+        },
+      ),
+      fw2: prompt(option("--fw2", framework), { value: "fresh" }),
+    });
+
+    const result = await parseAsync(parser, ["--fw0", "fresh", "--pm", "npm"]);
+
+    assert.ok(result.success);
+    assert.deepEqual(result.value.cond, [
+      "a",
+      { fw0: "fresh", inner: { fw: "hono" }, pm: "npm" },
+    ]);
+  });
+
+  it("keeps a later parsed branch occurrence over an earlier prompted one", async () => {
+    const kind = dependency(choice(["a", "b"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const frameworkDerived = framework.deriveSync({
+      metavar: "PM",
+      factory: (value: "fresh" | "hono") =>
+        choice(value === "fresh" ? (["deno"] as const) : (["npm"] as const)),
+      defaultValue: () => "fresh" as const,
+    });
+    const { prompt } = createTestPrompt();
+    const parser = object({
+      cond: conditional(
+        prompt(option("--kind", kind), { value: "a" }),
+        {
+          a: object({
+            inner: object({
+              fw: prompt(option("--fw", framework), { value: "hono" }),
+            }),
+            fw0: option("--fw0", framework),
+            pm: option("--pm", frameworkDerived),
+          }),
+          b: object({ y: constant("2") }),
+        },
+      ),
+      fw2: prompt(option("--fw2", framework), { value: "hono" }),
+    });
+
+    const result = await parseAsync(parser, ["--fw0", "fresh", "--pm", "deno"]);
+
+    assert.ok(result.success);
+    assert.deepEqual(result.value.cond, [
+      "a",
+      { inner: { fw: "hono" }, fw0: "fresh", pm: "deno" },
+    ]);
+  });
+
+  it("keeps a later prompted sibling over a nested object's earlier publish", async () => {
+    const kind = dependency(choice(["a", "b"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const frameworkDerived = framework.deriveSync({
+      metavar: "PM",
+      factory: (value: "fresh" | "hono") =>
+        choice(value === "fresh" ? (["deno"] as const) : (["npm"] as const)),
+      defaultValue: () => "fresh" as const,
+    });
+    const { prompt } = createTestPrompt();
+    // The nested object's own completion must not re-assert its cached
+    // publish over the later sibling occurrence in the same branch.
+    const parser = object({
+      cond: conditional(
+        prompt(option("--kind", kind), { value: "a" }),
+        {
+          a: object({
+            inner: object({
+              fw: prompt(option("--fw", framework), { value: "hono" }),
+            }),
+            fw3: prompt(option("--fw3", framework), { value: "fresh" }),
+            pm: option("--pm", frameworkDerived),
+          }),
+          b: object({ y: constant("2") }),
+        },
+      ),
+      fw2: prompt(option("--fw2", framework), { value: "hono" }),
+    });
+
+    const result = await parseAsync(parser, ["--pm", "deno"]);
+
+    assert.ok(result.success);
+    assert.deepEqual(result.value.cond, [
+      "a",
+      { inner: { fw: "hono" }, fw3: "fresh", pm: "deno" },
+    ]);
+  });
+
+  it("serves a deferred consumer from a prompted occurrence behind bindEnv()", async () => {
+    const kind = dependency(choice(["a", "b"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const frameworkDerived = framework.deriveSync({
+      metavar: "PM",
+      factory: (value: "fresh" | "hono") =>
+        choice(value === "fresh" ? (["deno"] as const) : (["npm"] as const)),
+      defaultValue: () => "fresh" as const,
+    });
+    const envContext = createEnvContext({ source: () => undefined });
+    const { prompt, calls } = createTestPrompt();
+    const parser = object({
+      cond: conditional(
+        prompt(option("--kind", kind), { value: "a" }),
+        {
+          a: object({
+            fw: bindEnv(
+              prompt(option("--fw", framework), { value: "fresh" }),
+              { context: envContext, key: "FW", parser: framework },
+            ),
+            pm: option("--pm", frameworkDerived),
+          }),
+          b: object({ y: constant("2") }),
+        },
+      ),
+      fw2: prompt(option("--fw2", framework), { value: "hono" }),
+      out: option("--out", frameworkDerived),
+    });
+
+    const result = await parseAsync(parser, ["--pm", "deno", "--out", "npm"]);
+
+    assert.ok(result.success);
+    assert.deepEqual(result.value.cond, ["a", { fw: "fresh", pm: "deno" }]);
+    assert.equal(result.value.out, "npm");
+    assert.deepEqual(calls.map((call) => call.value), ["a", "fresh", "hono"]);
+  });
+
+  it("serves a deferred consumer from a bound branch occurrence under runWith", async () => {
+    const kind = dependency(choice(["a", "b"] as const));
+    const region = dependency(choice(["us", "eu"] as const));
+    const zoneDerived = region.deriveSync({
+      metavar: "ZONE",
+      factory: (value: "us" | "eu") =>
+        choice(value === "us" ? (["z1"] as const) : (["z2"] as const)),
+      defaultValue: () => "us" as const,
+    });
+    const context = createRegionConfigContext();
+    const { prompt, calls } = createTestPrompt();
+    // The branch occurrence takes its value from a configuration binding
+    // under the two-pass runWith() path; the branch consumer validates
+    // against that bound value, and the consumer declared after the
+    // conditional against the later prompted occurrence.
+    const parser = object({
+      cond: conditional(
+        prompt(option("--kind", kind), { value: "a" }),
+        {
+          a: object({
+            region: bindConfig(option("--region", region), {
+              context,
+              key: "region",
+            }),
+            zone: option("--zone", zoneDerived),
+          }),
+          b: object({ y: constant("2") }),
+        },
+      ),
+      region2: prompt(option("--region2", region), { value: "eu" }),
+      zone2: option("--zone2", zoneDerived),
+    });
+
+    const result = await runWith(parser, "test", [context], {
+      args: ["--zone", "z1", "--zone2", "z2"],
+      contextOptions: {
+        load: () => ({
+          config: { region: "us" as const },
+          meta: undefined,
+        }),
+      },
+    });
+
+    assert.deepEqual(result, {
+      cond: ["a", { region: "us", zone: "z1" }],
+      region2: "eu",
+      zone2: "z2",
+    });
+    assert.deepEqual(calls.map((call) => call.value), ["a", "eu"]);
+  });
+
+  it("serves a deferred consumer through an outer branchError hook", async () => {
+    const kind = dependency(choice(["a", "b"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const frameworkDerived = framework.deriveSync({
+      metavar: "PM",
+      factory: (value: "fresh" | "hono") =>
+        choice(value === "fresh" ? (["deno"] as const) : (["npm"] as const)),
+      defaultValue: () => "fresh" as const,
+    });
+    const { prompt } = createTestPrompt();
+    // A branchError hook makes the conditional pre-expand its confirmed
+    // branch's nodes; the deferred consumer still reads the branch value.
+    const parser = object({
+      cond: conditional(
+        prompt(option("--kind", kind), { value: "a" }),
+        {
+          a: object({
+            fw: prompt(option("--fw", framework), { value: "fresh" }),
+            pm: option("--pm", frameworkDerived),
+          }),
+          b: object({ y: constant("2") }),
+        },
+        constant("default"),
+        {
+          errors: {
+            branchError: (key: string | undefined, error) =>
+              message`Branch ${key ?? "?"} failed: ${error}`,
+          },
+        },
+      ),
+      fw2: prompt(option("--fw2", framework), { value: "hono" }),
+      out: option("--out", frameworkDerived),
+    });
+
+    const result = await parseAsync(parser, ["--pm", "deno", "--out", "npm"]);
+
+    assert.ok(result.success);
+    assert.deepEqual(result.value.cond, ["a", { fw: "fresh", pm: "deno" }]);
+    assert.equal(result.value.out, "npm");
+  });
+
+  it("keeps a command-line-committed branch's deferred consumer in the enclosing scope", async () => {
+    const kind = dependency(choice(["a", "b"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const frameworkDerived = framework.deriveSync({
+      metavar: "PM",
+      factory: (value: "fresh" | "hono") =>
+        choice(value === "fresh" ? (["deno"] as const) : (["npm"] as const)),
+      defaultValue: () => "fresh" as const,
+    });
+    const { prompt } = createTestPrompt();
+    // Committing the branch on the command line leaves no completion
+    // boundary: the deferred consumer follows plain declaration order and
+    // reads the later occurrence, like the completion consumer pinned by
+    // "keeps a command-line-committed branch in the enclosing scope".
+    const parser = object({
+      cond: conditional(
+        prompt(option("--kind", kind), { value: "a" }),
+        {
+          a: object({
+            fw: prompt(option("--fw", framework), { value: "fresh" }),
+            pm: option("--pm", frameworkDerived),
+          }),
+          b: object({ y: constant("2") }),
+        },
+      ),
+      fw2: prompt(option("--fw2", framework), { value: "hono" }),
+      out: option("--out", frameworkDerived),
+    });
+
+    const accepted = await parseAsync(
+      parser,
+      ["--kind", "a", "--pm", "npm", "--out", "npm"],
+    );
+    assert.ok(accepted.success);
+    assert.deepEqual(accepted.value.cond, ["a", { fw: "fresh", pm: "npm" }]);
+
+    const rejected = await parseAsync(
+      parser,
+      ["--kind", "a", "--pm", "deno", "--out", "npm"],
+    );
+    assert.ok(!rejected.success);
+    assert.match(formatMessage(rejected.error), /--pm/);
+  });
+
+  it("serves a top-level speculative branch's deferred consumer once", async () => {
+    const kind = dependency(choice(["a", "b"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const frameworkDerived = framework.deriveSync({
+      metavar: "PM",
+      factory: (value: "fresh" | "hono") =>
+        choice(value === "fresh" ? (["deno"] as const) : (["npm"] as const)),
+      defaultValue: () => "hono" as const,
+    });
+    const { prompt, calls } = createTestPrompt();
+    // Without an enclosing construct nothing is cached ahead of the
+    // branch's own pass, which runs each effect exactly once.
+    const parser = conditional(
+      prompt(option("--kind", kind), { value: "a" }),
+      {
+        a: object({
+          fw: prompt(option("--fw", framework), { value: "fresh" }),
+          pm: option("--pm", frameworkDerived),
+        }),
+        b: object({ y: constant("2") }),
+      },
+    );
+
+    const result = await parseAsync(parser, ["--pm", "deno"]);
+
+    assert.ok(result.success);
+    assert.deepEqual(result.value, ["a", { fw: "fresh", pm: "deno" }]);
+    assert.deepEqual(calls.map((call) => call.value), ["a", "fresh"]);
+  });
+
+  it("wraps a top-level speculative branch's failed effect with branchError", async () => {
+    const kind = dependency(choice(["a", "b"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const frameworkDerived = framework.deriveSync({
+      metavar: "PM",
+      factory: (value: "fresh" | "hono") =>
+        choice(value === "fresh" ? (["deno"] as const) : (["npm"] as const)),
+      defaultValue: () => "hono" as const,
+    });
+    const { prompt, calls } = createTestPrompt();
+    // Without an enclosing construct the branch's effects first run while
+    // the conditional replays the branch's publications; a failure there
+    // still reports through the branchError hook, like a failure of the
+    // branch's own completion.
+    const parser = conditional(
+      prompt(option("--kind", kind), { value: "a" }),
+      {
+        a: object({
+          fw: prompt(option("--fw", framework), {
+            value: "fresh",
+            reject: true,
+          }),
+          pm: option("--pm", frameworkDerived),
+        }),
+        b: object({ y: constant("2") }),
+      },
+      constant("default"),
+      {
+        errors: {
+          branchError: (key: string | undefined, error) =>
+            message`Branch ${key ?? "?"} failed: ${error}`,
+        },
+      },
+    );
+
+    const result = await parseAsync(parser, ["--pm", "deno"]);
+
+    assert.ok(!result.success);
+    assert.match(
+      formatMessage(result.error),
+      /Branch "a" failed: .*Prompt rejected/,
+    );
+    assert.deepEqual(calls.map((call) => call.value), ["a", "fresh"]);
+  });
+
+  it("serves a deferred consumer through transparent branch wrappers", async () => {
+    const kind = dependency(choice(["a", "b"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const frameworkDerived = framework.deriveSync({
+      metavar: "PM",
+      factory: (value: "fresh" | "hono") =>
+        choice(value === "fresh" ? (["deno"] as const) : (["npm"] as const)),
+      defaultValue: () => "fresh" as const,
+    });
+    const { prompt } = createTestPrompt();
+    // command() and or() own no scheduling pass of their own; they forward
+    // the branch completion to the first construct that does, singly and
+    // chained.
+    const branch = () =>
+      object({
+        fw: prompt(option("--fw", framework), { value: "fresh" }),
+        pm: option("--pm", frameworkDerived),
+      });
+    const other = object({ q: option("--q", string()) });
+    const wrappers = {
+      command: [command("x", branch()), ["x", "--pm", "deno"]],
+      or: [or(branch(), other), ["--pm", "deno"]],
+      orCommand: [or(command("x", branch()), other), ["x", "--pm", "deno"]],
+    } as const;
+
+    for (const [name, [wrapped, args]] of Object.entries(wrappers)) {
+      const parser = object({
+        cond: conditional(
+          prompt(option("--kind", kind), { value: "a" }),
+          { a: wrapped, b: object({ y: constant("2") }) },
+        ),
+        fw2: prompt(option("--fw2", framework), { value: "hono" }),
+        out: option("--out", frameworkDerived),
+      });
+
+      const result = await parseAsync(parser, [...args, "--out", "npm"]);
+
+      assert.ok(result.success, name);
+      assert.deepEqual(
+        result.value.cond,
+        ["a", { fw: "fresh", pm: "deno" }],
+        name,
+      );
+      assert.equal(result.value.out, "npm", name);
+    }
+  });
+
+  it("serves a deferred consumer when the branch is itself a conditional", async () => {
+    const kindOuter = dependency(choice(["a", "b"] as const));
+    const kindInner = dependency(choice(["i1", "i2"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const frameworkDerived = framework.deriveSync({
+      metavar: "PM",
+      factory: (value: "fresh" | "hono") =>
+        choice(value === "fresh" ? (["deno"] as const) : (["npm"] as const)),
+      defaultValue: () => "fresh" as const,
+    });
+    const { prompt } = createTestPrompt();
+    // The inner conditional is committed on the command line and is the
+    // first pass owner under the outer branch's completion.
+    const parser = object({
+      cond: conditional(
+        prompt(option("--kind", kindOuter), { value: "a" }),
+        {
+          a: conditional(option("--inner", kindInner), {
+            i1: object({
+              fw: prompt(option("--fw", framework), { value: "fresh" }),
+              pm: option("--pm", frameworkDerived),
+            }),
+            i2: object({ z: constant("1") }),
+          }),
+          b: object({ y: constant("2") }),
+        },
+      ),
+      fw2: prompt(option("--fw2", framework), { value: "hono" }),
+      out: option("--out", frameworkDerived),
+    });
+
+    const result = await parseAsync(
+      parser,
+      ["--inner", "i1", "--pm", "deno", "--out", "npm"],
+    );
+
+    assert.ok(result.success);
+    assert.deepEqual(result.value.cond, [
+      "a",
+      ["i1", { fw: "fresh", pm: "deno" }],
+    ]);
+    assert.equal(result.value.out, "npm");
+  });
+
+  it("serves a deferred consumer when the branch is a merge()", async () => {
+    const kind = dependency(choice(["a", "b"] as const));
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const frameworkDerived = framework.deriveSync({
+      metavar: "PM",
+      factory: (value: "fresh" | "hono") =>
+        choice(value === "fresh" ? (["deno"] as const) : (["npm"] as const)),
+      defaultValue: () => "fresh" as const,
+    });
+    const { prompt } = createTestPrompt();
+    const parser = object({
+      cond: conditional(
+        prompt(option("--kind", kind), { value: "a" }),
+        {
+          a: merge(
+            object({
+              fw: prompt(option("--fw", framework), { value: "fresh" }),
+            }),
+            object({ pm: option("--pm", frameworkDerived) }),
+          ),
+          b: object({ y: constant("2") }),
+        },
+      ),
+      fw2: prompt(option("--fw2", framework), { value: "hono" }),
+      out: option("--out", frameworkDerived),
+    });
+
+    const result = await parseAsync(parser, ["--pm", "deno", "--out", "npm"]);
+
+    assert.ok(result.success);
+    assert.deepEqual(result.value.cond, ["a", { fw: "fresh", pm: "deno" }]);
+    assert.equal(result.value.out, "npm");
+  });
 });


### PR DESCRIPTION
A `conditional()` branch selected during completion completes against a clone of the enclosing registry, taken after the enclosing pass has restored the occurrences declared after the conditional (#928). The branch's prompted and bound occurrences published earlier, in the barrier's nested pass, and only their results survive, cached in the run-scoped session. Every later pass on the clone reused those results without re-registering their values, so a derived value parser inside the branch, `option("--pm", framework.deriveSync({...}))`, replayed against the outer occurrence while a `derivePromptConfig()` consumer beside it read the branch's value.

Branch completion now carries a re-publication instruction on the internal `ExecutionContext`, `republishCachedCompletions`. A scheduling pass that receives it re-registers each cached completion at its declaration position and re-collects the branch's structural occurrences, which restores declaration order without running any effect again. The instruction follows the `preCompletedByParser` contract: path-transparent wrappers such as `command()` and `or()` forward it, and a construct that runs a pass consumes it there instead of passing it to its children, so a nested pass never puts a cached value back over a later sibling occurrence. Two passes carry it. `conditional()` replays the branch right after the speculative selection is confirmed, which is the only replay a branch without a pass of its own (a synchronous `object()`) gets, and the branch's first pass replays again after its own structural collection, which would otherwise put an earlier parsed value back over a later prompted one. A branch committed on the command line has no completion boundary and keeps the enclosing scope's declaration order.

Four pre-existing quirks surfaced by the review loop are left for follow-up issues: a committed branch's parsed occurrence is already branch-scoped for deferred consumers while a prompted one is not, structural values in nested plain `object()`s register late and race sibling consumers, `merge()` completes duplicated fields against a cloned runtime, and the speculative pre-verification filter also matches a nested discriminator when `branchError` pre-expands the branch.

Closes #929. Part of #869.
