### PR TITLE
Preserve bound prompts across config passes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,15 @@ Version 1.2.5
 
 To be released.
 
+### @optique/config
+
+ -  Fixed `bindConfig()` around prompt wrappers to supply configuration or
+    prompted values to sibling dependency consumers during two-pass runs.
+    [[#930], [#933]]
+
+[#930]: https://github.com/dahlia/optique/issues/930
+[#933]: https://github.com/dahlia/optique/pull/933
+
 
 Version 1.2.4
 -------------

--- a/changes.d/config/bound-prompt-fallbacks.md
+++ b/changes.d/config/bound-prompt-fallbacks.md
@@ -1,0 +1,8 @@
+---
+links:
+  '#930': https://github.com/dahlia/optique/issues/930
+  '#933': https://github.com/dahlia/optique/pull/933
+---
+ -  Fixed `bindConfig()` around prompt wrappers to supply configuration or
+    prompted values to sibling dependency consumers during two-pass runs.
+    [[#930], [#933]]

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -417,6 +417,38 @@ describe("bindConfig", () => {
     assert.equal(result.value, "localhost");
   });
 
+  test("does not delegate to a resolved nested config binding", () => {
+    const schema = z.object({
+      outer: z.string().optional(),
+      inner: z.string().optional(),
+    });
+    const outerContext = createConfigContext({ schema });
+    const innerContext = createConfigContext({ schema });
+    const parser = bindConfig(
+      bindConfig(option("--value", string()), {
+        context: innerContext,
+        key: "inner",
+      }),
+      {
+        context: outerContext,
+        key: "outer",
+      },
+    );
+    const annotations: Annotations = {
+      [outerContext.id]: { data: {} },
+      [innerContext.id]: { data: { inner: "inner-value" } },
+    };
+
+    const result = parse(parser, [], { annotations });
+
+    assert.ok(!result.success);
+    if (result.success) return;
+    assert.equal(
+      formatMessage(result.error),
+      "Missing required configuration value.",
+    );
+  });
+
   test("lets seq skip config-bound positional defaults before commands", () => {
     const schema = z.object({
       profile: z.string().optional(),

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -698,12 +698,16 @@ export function bindConfig<
       configBindStateKey in value;
   }
 
-  function shouldDeferPromptUntilConfigResolves(
-    state: unknown,
-    _exec?: ExecutionContext,
+  function shouldDeferCompletion(
+    state: TState,
+    exec?: ExecutionContext,
   ): boolean {
     const annotations = getAnnotations(state);
-    return annotations?.[options.context.id] === phase1ConfigAnnotationMarker;
+    if (annotations?.[options.context.id] === phase1ConfigAnnotationMarker) {
+      return true;
+    }
+    return typeof parser.shouldDeferCompletion === "function" &&
+      parser.shouldDeferCompletion(getInnerState(state), exec) === true;
   }
 
   // bindConfig() resolves fallbacks through config annotations at completion
@@ -870,7 +874,14 @@ export function bindConfig<
       // No CLI value, check config.  Thread the inner parser through so
       // that fallback values are re-validated against its constraints
       // (see issue #414).
-      return getConfigOrDefault(state, options, parser.mode, parser);
+      return getConfigOrDefault(
+        state,
+        options,
+        parser.mode,
+        parser,
+        getInnerState(state),
+        exec,
+      );
     },
 
     suggest: (context, prefix) => {
@@ -880,7 +891,7 @@ export function bindConfig<
         : context;
       return parser.suggest(innerContext, prefix);
     },
-    shouldDeferCompletion: shouldDeferPromptUntilConfigResolves,
+    shouldDeferCompletion,
     getDocFragments(state, upperDefaultValue?) {
       const defaultValue = upperDefaultValue ?? options.default;
       return parser.getDocFragments(state, defaultValue);
@@ -1003,6 +1014,8 @@ export function bindConfig<
  *                 config-sourced value or the configured `default`
  *                 against the inner CLI parser's constraints (see
  *                 issue #414).
+ * @throws {Error} Propagates errors thrown by `innerParser.complete()` when
+ *                 falling through to a deferred inner parser.
  */
 function getConfigOrDefault<
   M extends "sync" | "async",
@@ -1014,6 +1027,8 @@ function getConfigOrDefault<
   options: BindConfigOptions<T, TValue, TConfigMeta>,
   mode: M,
   innerParser?: Parser<M, TValue, unknown>,
+  innerState?: unknown,
+  exec?: ExecutionContext,
 ): ModeValue<M, Result<TValue>> {
   // Read from the per-instance context id so that the correct config data is
   // selected even when annotations from multiple config contexts are merged.
@@ -1033,6 +1048,8 @@ function getConfigOrDefault<
   // to avoid misleading low-level callers.
   const configContextAbsent = annotations != null &&
     !(contextId in annotations);
+  const configPending = annotations?.[contextId] ===
+    phase1ConfigAnnotationMarker;
   const annotationValue = annotations?.[contextId] as
     | { readonly data: T; readonly meta?: TConfigMeta | undefined }
     | undefined;
@@ -1072,15 +1089,52 @@ function getConfigOrDefault<
     return validateFallbackValue(mode, innerParser, options.default);
   }
 
-  // Distinguish between the config context not being registered at all
-  // (key absent from annotations) and a registered context with no matching
-  // value (file not found, key absent in config data, etc.).
+  if (
+    configPending &&
+    innerParser != null &&
+    typeof innerParser.shouldDeferCompletion === "function" &&
+    innerParser.shouldDeferCompletion(
+        innerState ?? innerParser.initialState,
+        exec,
+      ) === true
+  ) {
+    return wrapForMode(mode, {
+      success: true as const,
+      value: undefined as TValue,
+      deferred: true as const,
+    });
+  }
+
+  // Preserve the targeted error for an omitted config context before a
+  // deferred inner wrapper gets a chance to run.  Calling prompt() here would
+  // execute it once for the seed pass and again for the final pass.
   if (configContextAbsent) {
     return wrapForMode(mode, {
       success: false,
       error:
         message`Configuration value could not be read: the config context was not passed to run()'s contexts option.`,
     });
+  }
+
+  // A deferred inner wrapper can provide its own fallback after configuration
+  // has resolved.  In particular, bindConfig(prompt(...)) must let the prompt
+  // run when the loaded config has no matching key.  Keep ordinary bound
+  // parsers on the established config-specific error path below.
+  if (
+    !configPending &&
+    annotations != null &&
+    contextId in annotations &&
+    innerParser != null &&
+    typeof innerParser.shouldDeferCompletion === "function" &&
+    innerParser.shouldDeferCompletion(
+        innerState ?? innerParser.initialState,
+        exec,
+      ) === true
+  ) {
+    return innerParser.complete(
+      innerState ?? innerParser.initialState,
+      exec,
+    );
   }
 
   return wrapForMode(mode, {

--- a/packages/prompt/src/index.test.ts
+++ b/packages/prompt/src/index.test.ts
@@ -2,12 +2,15 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { type Annotations, getAnnotations } from "@optique/core/annotations";
 import { object } from "@optique/core/constructs";
+import { dependency } from "@optique/core/dependency";
 import { defineTraits, getTraits } from "@optique/core/extension";
-import { message } from "@optique/core/message";
+import { runWith } from "@optique/core/facade";
+import { formatMessage, message } from "@optique/core/message";
 import { multiple, optional, withDefault } from "@optique/core/modifiers";
 import { parseAsync, type Parser } from "@optique/core/parser";
 import { constant, fail, option } from "@optique/core/primitives";
-import { integer, string } from "@optique/core/valueparser";
+import { choice, integer, string } from "@optique/core/valueparser";
+import { bindConfig, createConfigContext } from "@optique/config";
 import { bindEnv, createEnvContext } from "@optique/env";
 import { createPromptAdapter } from "@optique/prompt";
 
@@ -31,6 +34,20 @@ function createTestPrompt() {
     },
   });
   return { prompt, calls };
+}
+
+function createRegionConfigContext() {
+  return createConfigContext<{ readonly region?: "us" | "eu" }>({
+    schema: {
+      "~standard": {
+        version: 1,
+        vendor: "test",
+        validate: (input: unknown) => ({
+          value: input as { readonly region?: "us" | "eu" },
+        }),
+      },
+    },
+  });
 }
 
 describe("createPromptAdapter()", () => {
@@ -150,6 +167,228 @@ describe("createPromptAdapter()", () => {
     assert.equal(result.value, "EnvName");
     assert.deepEqual(calls, []);
   });
+
+  // https://github.com/dahlia/optique/issues/930
+  it(
+    "supplies a config-bound prompt to a sibling dependency consumer",
+    async () => {
+      const region = dependency(choice(["us", "eu"] as const));
+      const regionDerived = region.deriveSync({
+        metavar: "REGION_DERIVED",
+        factory: (value: "us" | "eu") =>
+          choice(value === "us" ? (["z1"] as const) : (["z2"] as const)),
+        defaultValue: () => "us" as const,
+      });
+      const context = createRegionConfigContext();
+      const { prompt, calls } = createTestPrompt();
+      const parser = object({
+        region: bindConfig(
+          prompt(option("--region", region), { value: "us" }),
+          { context, key: "region" },
+        ),
+        out: option("--out", regionDerived),
+      });
+
+      const result = await runWith(parser, "test", [context], {
+        args: ["--out", "z2"],
+        contextOptions: {
+          load: () => ({
+            config: { region: "eu" as const },
+            meta: undefined,
+          }),
+        },
+      });
+
+      assert.deepEqual(result, { region: "eu", out: "z2" });
+      assert.deepEqual(calls, []);
+    },
+  );
+
+  it(
+    "prompts a config-bound dependency source when its key is absent",
+    async () => {
+      const region = dependency(choice(["us", "eu"] as const));
+      const regionDerived = region.deriveSync({
+        metavar: "REGION_DERIVED",
+        factory: (value: "us" | "eu") =>
+          choice(value === "us" ? (["z1"] as const) : (["z2"] as const)),
+        defaultValue: () => "us" as const,
+      });
+      const context = createRegionConfigContext();
+      const { prompt, calls } = createTestPrompt();
+      const promptConfig = { value: "us" as const };
+      const parser = object({
+        region: bindConfig(
+          prompt(option("--region", region), promptConfig),
+          { context, key: "region" },
+        ),
+        out: option("--out", regionDerived),
+      });
+
+      const result = await runWith(parser, "test", [context], {
+        args: ["--out", "z1"],
+        contextOptions: {
+          load: () => ({ config: {}, meta: undefined }),
+        },
+      });
+
+      assert.deepEqual(result, { region: "us", out: "z1" });
+      assert.deepEqual(calls, [promptConfig]);
+    },
+  );
+
+  it(
+    "prompts a config-bound dependency source when no config is loaded",
+    async () => {
+      const region = dependency(choice(["us", "eu"] as const));
+      const regionDerived = region.deriveSync({
+        metavar: "REGION_DERIVED",
+        factory: (value: "us" | "eu") =>
+          choice(value === "us" ? (["z1"] as const) : (["z2"] as const)),
+        defaultValue: () => "us" as const,
+      });
+      const context = createRegionConfigContext();
+      const { prompt, calls } = createTestPrompt();
+      const promptConfig = { value: "us" as const };
+      const parser = object({
+        region: bindConfig(
+          prompt(option("--region", region), promptConfig),
+          { context, key: "region" },
+        ),
+        out: option("--out", regionDerived),
+      });
+
+      const result = await runWith(parser, "test", [context], {
+        args: ["--out", "z1"],
+        contextOptions: { load: () => undefined },
+      });
+
+      assert.deepEqual(result, { region: "us", out: "z1" });
+      assert.deepEqual(calls, [promptConfig]);
+    },
+  );
+
+  it(
+    "does not prompt when its config context is omitted from a two-pass run",
+    async () => {
+      const boundContext = createRegionConfigContext();
+      const otherContext = createRegionConfigContext();
+      const { prompt, calls } = createTestPrompt();
+      let errorOutput = "";
+      const parser = object({
+        region: bindConfig(
+          prompt(option("--region", choice(["us", "eu"] as const)), {
+            value: "us",
+          }),
+          { context: boundContext, key: "region" },
+        ),
+      });
+
+      await assert.rejects(
+        runWith(parser, "test", [otherContext], {
+          args: [],
+          contextOptions: {
+            load: () => ({ config: {}, meta: undefined }),
+          },
+          stderr: (text) => {
+            errorOutput += text;
+          },
+        }),
+      );
+      assert.match(errorOutput, /contexts option/);
+      assert.deepEqual(calls, []);
+    },
+  );
+
+  it("does not prompt without config annotations", async () => {
+    const context = createRegionConfigContext();
+    const { prompt, calls } = createTestPrompt();
+    const parser = bindConfig(
+      prompt(option("--region", choice(["us", "eu"] as const)), {
+        value: "us",
+      }),
+      { context, key: "region" },
+    );
+
+    const result = await parseAsync(parser, []);
+
+    assert.ok(!result.success);
+    if (result.success) return;
+    assert.equal(
+      formatMessage(result.error),
+      "Missing required configuration value.",
+    );
+    assert.deepEqual(calls, []);
+  });
+
+  it(
+    "supplies an env-bound prompt to a sibling dependency consumer",
+    async () => {
+      const region = dependency(choice(["us", "eu"] as const));
+      const regionDerived = region.deriveSync({
+        metavar: "REGION_DERIVED",
+        factory: (value: "us" | "eu") =>
+          choice(value === "us" ? (["z1"] as const) : (["z2"] as const)),
+        defaultValue: () => "us" as const,
+      });
+      const context = createEnvContext({
+        source: (key) => key === "REGION" ? "eu" : undefined,
+      });
+      const { prompt, calls } = createTestPrompt();
+      const parser = object({
+        region: bindEnv(
+          prompt(option("--region", region), { value: "us" }),
+          {
+            context,
+            key: "REGION",
+            parser: choice(["us", "eu"] as const),
+          },
+        ),
+        out: option("--out", regionDerived),
+      });
+
+      const result = await runWith(parser, "test", [context], {
+        args: ["--out", "z2"],
+      });
+
+      assert.deepEqual(result, { region: "eu", out: "z2" });
+      assert.deepEqual(calls, []);
+    },
+  );
+
+  it(
+    "prompts an env-bound dependency source when its variable is absent",
+    async () => {
+      const region = dependency(choice(["us", "eu"] as const));
+      const regionDerived = region.deriveSync({
+        metavar: "REGION_DERIVED",
+        factory: (value: "us" | "eu") =>
+          choice(value === "us" ? (["z1"] as const) : (["z2"] as const)),
+        defaultValue: () => "us" as const,
+      });
+      const context = createEnvContext({ source: () => undefined });
+      const { prompt, calls } = createTestPrompt();
+      const promptConfig = { value: "us" as const };
+      const parser = object({
+        region: bindEnv(
+          prompt(option("--region", region), promptConfig),
+          {
+            context,
+            key: "REGION",
+            parser: choice(["us", "eu"] as const),
+          },
+        ),
+        out: option("--out", regionDerived),
+      });
+
+      const result = await runWith(parser, "test", [context], {
+        args: ["--out", "z1"],
+      });
+
+      assert.deepEqual(result, { region: "us", out: "z1" });
+      assert.deepEqual(calls, [promptConfig]);
+    },
+  );
 
   it("preserves source-completion traits through map()", () => {
     const envContext = createEnvContext({

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,8 @@ packages:
 - examples/*
 - docs
 
+ignoreWorkspaceCycles: true
+
 catalog:
   "@clack/prompts": ^1.6.0
   "@inquirer/prompts": ^8.3.0


### PR DESCRIPTION
Why
---

`bindConfig(prompt(...))` lost the prompt's completion deferral during a two-pass run. A sibling dependency consumer could then cache a missing-config failure before configuration annotations arrived, discarding both the bound value and the interactive fallback.

Closes #930.


How
---

`bindConfig()` now carries a deferred placeholder through the seed pass and forwards the wrapped parser's deferral contract after configuration loads. It keeps config/default precedence, then runs the prompt only when a registered config context resolves without a value. This avoids prompting during the seed pass or for an omitted context.

Regression tests in *packages/prompt/src/index.test.ts* cover config and env bindings with sibling consumers across both passes.
