### PR TITLE
Add shared prompt validation and retries

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -131,6 +131,11 @@ To be released.
     now skip a fallback with a synchronous or asynchronous `when` check and
     return a typed `otherwise` value.  The check runs only when parsing reaches
     the prompt fallback.  [[#882]]
+ -  Added shared validation and retry options to prompt adapters.  Generated
+    prompt wrappers can validate returned values synchronously or
+    asynchronously, pass the preceding validation message to another attempt,
+    limit attempts, and abort active prompt or validator work without
+    publishing rejected answers.  [[#873], [#935], [#938]]
  -  Fixed `prompt()` so that a prompted value for a wrapped dependency
     source registers in the dependency runtime, letting derived parsers
     observe the selected value during the same parse operation.  The fix
@@ -138,6 +143,10 @@ To be released.
     *@optique/inquirer* and *@optique/clack*.  A dependency-source prompt
     now runs before dependency replay, so it may be displayed before an
     earlier-declared non-source prompt.  [[#869], [#870], [#912]]
+
+[#873]: https://github.com/dahlia/optique/issues/873
+[#935]: https://github.com/dahlia/optique/issues/935
+[#938]: https://github.com/dahlia/optique/pull/938
 
 
 Version 1.2.5

--- a/changes.d/prompt/shared-prompt-validation.md
+++ b/changes.d/prompt/shared-prompt-validation.md
@@ -1,0 +1,11 @@
+---
+links:
+  '#873': https://github.com/dahlia/optique/issues/873
+  '#935': https://github.com/dahlia/optique/issues/935
+  '#938': https://github.com/dahlia/optique/pull/938
+---
+ -  Added shared validation and retry options to prompt adapters.  Generated
+    prompt wrappers can validate returned values synchronously or
+    asynchronously, pass the preceding validation message to another attempt,
+    limit attempts, and abort active prompt or validator work without
+    publishing rejected answers.  [[#873], [#935], [#938]]

--- a/docs/integrations/prompt.md
+++ b/docs/integrations/prompt.md
@@ -63,8 +63,8 @@ integration:
 
 The shared wrapper exists so each integration does not need to reimplement the
 same parser semantics.  Your integration supplies a config type and an
-`execute()` function; *@optique/prompt* supplies the `prompt(parser, config)`
-wrapper.
+`execute()` function; *@optique/prompt* supplies the
+`prompt(parser, config, options?)` wrapper.
 
 
 Basic usage
@@ -184,11 +184,16 @@ Adapter contract
 
 `createPromptAdapter(adapter)` accepts a small object:
 
-`execute(config)`
+`execute(config, context)`
 :   Runs the prompt library and returns a `ValueParserResult<TValue>`.
     Return `{ success: true, value }` for a prompted value, or
     `{ success: false, error }` for a prompt-level failure such as
-    cancellation.
+    cancellation.  `context.attempt` identifies this execution, starting from 1.
+    After shared validation rejects a value,
+    `context.previousValidationMessage` contains that message on the next
+    execution.  An adapter should display it before asking again.
+    `context.signal`, when present, should also be forwarded to prompt-library
+    APIs that support cancellation.
 
 `getDefaultValue(config)`
 :   *(optional)* Returns a config default for documentation fragments.  If it
@@ -224,8 +229,8 @@ turn thrown exceptions into parse failures; they propagate to the caller.
 Generated parser behavior
 -------------------------
 
-The generated `prompt(parser, config)` wrapper preserves the inner parser's
-shape while changing how missing values are completed.
+The generated `prompt(parser, config, options?)` wrapper preserves the inner
+parser's shape while changing how missing values are completed.
 
 ### CLI values skip prompting
 
@@ -349,6 +354,74 @@ failure.
 `otherwise` is a static value with the parser's result type.  It is returned
 as-is, without running the inner parser's validation or normalization, and it
 is not used as a documented default.
+
+### Shared validation and retries
+
+Pass a validator in the wrapper's third argument when a prompted value needs a
+recoverable check.  It receives the typed value returned by the adapter.  Return
+`undefined` to accept the value, or a `Message` to reject it and run another
+adapter execution:
+
+~~~~ typescript twoslash
+declare function askPackageManager(attempt: number): Promise<string>;
+declare function commandExists(command: string): Promise<boolean>;
+// ---cut-before---
+import { message } from "@optique/core/message";
+import { option } from "@optique/core/primitives";
+import { string } from "@optique/core/valueparser";
+import {
+  createPromptAdapter,
+  type PromptExecutionContext,
+} from "@optique/prompt";
+
+interface PromptConfig {
+  readonly message: string;
+}
+
+const prompt = createPromptAdapter<PromptConfig>({
+  async execute<TValue>(
+    _config: PromptConfig,
+    context: PromptExecutionContext,
+  ) {
+    const value = await askPackageManager(context.attempt);
+    return { success: true, value: value as TValue };
+  },
+});
+
+const packageManager = prompt(
+  option("--package-manager", string()),
+  { message: "Package manager:" },
+  {
+    maxAttempts: 3,
+    async validate(value) {
+      return await commandExists(value)
+        ? undefined
+        : message`${value} is not available.`;
+    },
+  },
+);
+~~~~
+
+Each `execute()` call is one attempt inside a single prompt completion.  A
+validator may be synchronous or asynchronous.  Adapter-native validation stays
+inside an attempt, while shared validation runs only after the adapter returns
+a successful value.  Cancellation or another failed `ValueParserResult` ends
+the completion without another retry.  Exceptions from the adapter or
+validator propagate unchanged.
+
+`maxAttempts` must be a positive integer and defaults to no limit.  Exhausting
+the limit returns the last validation message as a parse failure.  A derived
+prompt configuration resolves only once, and every attempt receives that same
+resolved config.  Rejected values are not cached or published as dependency
+values; only the terminal result reaches the existing completion cache.
+
+An optional `AbortSignal` stops an active adapter execution or validator and
+propagates its reason.  CLI values, source-bound values, a false runtime
+condition, help, suggestions, and completion probes do not consult the signal.
+The signal does not add general cancellation to parsing, dependency scheduling,
+or derived configuration resolution.  If it aborts while a resolver is
+pending, the reason is observed immediately after the resolver settles and
+before an adapter starts.
 
 ### Missing values run the adapter
 
@@ -503,10 +576,11 @@ a value comes from the CLI, the inner parser's full constraint pipeline
 is applied.  When a value comes from a prompt, it is whatever your adapter
 returns.
 
-This is intentional: prompt libraries usually already validate prompted
-values, and combinators like `map()` can transform the value domain in ways
-that are not valid CLI input.  Your integration should validate prompted
-values before returning `{ success: true, value }`.
+This is intentional: combinators like `map()` can transform the value domain in
+ways that are not valid CLI input.  An adapter can validate a library-native
+answer before returning `{ success: true, value }`; callers can then use the
+shared `validate` option for recoverable checks on the returned typed value.
+Neither path feeds a prompted value through the wrapped parser.
 
 For example, a number prompt adapter should parse and validate the prompt's
 string result before returning a number:
@@ -699,11 +773,11 @@ dependency chain in the diagnostic.  A failed upstream source likewise
 fails the prompt before the resolver runs.  Mutually dependent
 configurations are rejected with a circular dependency error.
 
-The optional third argument accepts the same `when`/`otherwise` pair as
-static configurations, evaluated before the resolver, so a skipped
-prompt performs no configuration work.  Note that upstream sources may
-already have prompted by then: the condition skips this prompt's own
-question, not the dependency resolution that scheduled before it.
+The optional third argument to `derivePromptConfig()` accepts the same
+`when`/`otherwise` pair as static configurations, evaluated before the
+resolver, so a skipped prompt performs no configuration work.  Note that
+upstream sources may already have prompted by then: the condition skips this
+prompt's own question, not the dependency resolution that scheduled before it.
 
 Because probes, help, and suggestions never run resolvers, generated
 documentation cannot reflect a derived configuration.  `getDocFragments`
@@ -745,6 +819,10 @@ The core behavior to test is:
  -  Source bindings such as `bindEnv()` skip prompt execution.
  -  Runtime conditions run only at the real prompt fallback.
  -  A false runtime condition returns `otherwise` without calling `execute()`.
+ -  Shared validation retries with increasing attempt numbers and the preceding
+    message.
+ -  Retry exhaustion, cancellation, abort, and thrown errors remain distinct
+    terminal outcomes.
  -  Prompt failures are returned as parse failures.
  -  Prompt fields run serially in dependency order, with parser order breaking
     ties between independent prompts.
@@ -786,7 +864,7 @@ API reference
 
 ### `createPromptAdapter(adapter)`
 
-Creates a `prompt(parser, config)` wrapper for one prompt library.
+Creates a `prompt(parser, config, options?)` wrapper for one prompt library.
 
 Parameters
 :   `adapter`: A [`PromptAdapter<TConfig>`](#promptadaptertconfig) that
@@ -797,7 +875,11 @@ Returns
     `FluentParser<"async", TValue, TState>`.  Its config accepts the adapter's
     fields together with [`PromptCondition<TValue>`](#promptconditiontvalue),
     or a [`DerivedPromptConfig`](#derivepromptconfigsource-resolver-options)
-    whose resolver returns the adapter's config type.
+    whose resolver returns the adapter's config type.  The optional third
+    argument accepts [`PromptOptions<TValue>`](#promptoptionstvalue).
+
+Throws
+:   `RangeError` when `options.maxAttempts` is not a positive integer.
 
 ### `PromptCondition<TValue>`
 
@@ -815,13 +897,52 @@ Provide both fields or neither:
 
 Adapter object accepted by `createPromptAdapter()`.
 
-`execute(config)`
+`execute(config, context)`
 :   Executes the library-specific prompt and returns a
-    `Promise<ValueParserResult<TValue>>`.
+    `Promise<ValueParserResult<TValue>>`.  Each call represents one attempt.
+    The context is a [`PromptExecutionContext`](#promptexecutioncontext).
 
 `getDefaultValue(config)`
 :   Optional function that returns a prompt-level default for documentation
     fragments.  Never called with a derived configuration.
+
+### `PromptValidator<TValue>`
+
+*Available since Optique 1.3.0.*
+
+Validates the typed value returned by an adapter.  It returns `undefined` to
+accept the value, or a `Message` to reject it and request another attempt.  A
+promise of either result is also accepted.
+
+### `PromptOptions<TValue>`
+
+*Available since Optique 1.3.0.*
+
+`validate`
+:   Optional [`PromptValidator<TValue>`](#promptvalidatortvalue) applied after
+    each successful adapter execution.
+
+`maxAttempts`
+:   Optional positive integer limiting adapter executions within one
+    completion.  Omit it for unlimited retries.
+
+`signal`
+:   Optional `AbortSignal` for the interactive fallback.  Its reason propagates
+    when it stops an active adapter execution or validator.
+
+### `PromptExecutionContext`
+
+*Available since Optique 1.3.0.*
+
+`attempt`
+:   One-based number of the current adapter execution.
+
+`previousValidationMessage`
+:   Message returned by shared validation after the preceding execution.  It
+    is absent on the first attempt.
+
+`signal`
+:   Signal supplied through `PromptOptions`, when present.
 
 ### `derivePromptConfig(source, resolver, options?)`
 
@@ -874,7 +995,11 @@ When adding a concrete prompt integration, make sure it:
  -  Returns failed `ValueParserResult` values for expected outcomes such as
     cancellation.
  -  Throws only for unexpected prompt-library failures.
- -  Validates and converts prompted values before returning success.
+ -  Validates and converts library-native values before returning success.
+ -  Accepts shared `PromptOptions` in its public wrapper and passes the options
+    to the generated prompt function.
+ -  Displays `previousValidationMessage` before another attempt and forwards
+    the signal where the prompt library supports it.
  -  Exposes prompt-level defaults through `getDefaultValue()` if the library
     does not use a `default` config property.
  -  Accepts `derivePromptConfig()` results in its public `prompt()`

--- a/packages/core/skills/optique/SKILL.md
+++ b/packages/core/skills/optique/SKILL.md
@@ -65,6 +65,16 @@ Core rules
     the wrapped parser separately when the CLI domain should change, and make
     it a dependency source only if another consumer needs its answer. Keep
     static prompt configs for everything else.
+ -  For a custom adapter built with `createPromptAdapter()`, pass shared
+    validation options as the generated wrapper's third argument:
+    `{ validate, maxAttempts, signal }`. The validator receives the prompted
+    value and returns `undefined` to accept it or a structured `Message` to
+    retry; it may be synchronous or asynchronous. Attempt limits must be
+    positive integers and default to unlimited retries.
+ -  Implement a custom adapter's `execute(config, context)` so retries can show
+    `context.previousValidationMessage`, and forward `context.signal` when the
+    prompt library supports aborting active work. Adapter-native validation
+    remains separate and completes inside one shared attempt.
  -  Build subcommands with `command()` combined by `or()`. Put a literal field
     such as `command: constant("serve")` in each branch when you want a
     discriminated union.

--- a/packages/prompt/README.md
+++ b/packages/prompt/README.md
@@ -27,7 +27,8 @@ Documentation
 
 For full documentation, visit the [prompt integration docs].
 The guide covers dependency-derived configurations with
-`derivePromptConfig()` as well as adapter construction.
+`derivePromptConfig()`, shared validation and retries, abort signals, and
+adapter construction.
 
 [prompt integration docs]: https://optique.dev/integrations/prompt
 

--- a/packages/prompt/src/index.test.ts
+++ b/packages/prompt/src/index.test.ts
@@ -47,6 +47,9 @@ import {
   createPromptAdapter,
   derivePromptConfig,
   type PromptCondition,
+  type PromptExecutionContext,
+  type PromptOptions,
+  type PromptValidator,
 } from "@optique/prompt";
 
 type TestPromptConfig<TValue> = {
@@ -54,11 +57,18 @@ type TestPromptConfig<TValue> = {
   readonly reject?: boolean;
 };
 
+type EmptyPromptConfig = Record<never, never>;
+
 function createTestPrompt() {
   const calls: TestPromptConfig<unknown>[] = [];
+  const contexts: PromptExecutionContext[] = [];
   const prompt = createPromptAdapter<TestPromptConfig<unknown>>({
-    execute<TValue>(config: TestPromptConfig<unknown>) {
+    execute<TValue>(
+      config: TestPromptConfig<unknown>,
+      context: PromptExecutionContext,
+    ) {
       calls.push(config);
+      contexts.push(context);
       if (config.reject === true) {
         return Promise.resolve({
           success: false,
@@ -68,7 +78,23 @@ function createTestPrompt() {
       return Promise.resolve({ success: true, value: config.value as TValue });
     },
   });
-  return { prompt, calls };
+  return { prompt, calls, contexts };
+}
+
+interface Deferred<T> {
+  readonly promise: Promise<T>;
+  readonly resolve: (value: T) => void;
+  readonly reject: (reason: unknown) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
 }
 
 function createRegionConfigContext() {
@@ -155,7 +181,7 @@ describe("createPromptAdapter()", () => {
   });
 
   it("runs the adapter when the CLI value is absent", async () => {
-    const { prompt, calls } = createTestPrompt();
+    const { prompt, calls, contexts } = createTestPrompt();
     const config = { value: "Bob" };
     const parser = prompt(option("--name", string()), config);
 
@@ -164,6 +190,421 @@ describe("createPromptAdapter()", () => {
     assert.ok(result.success);
     assert.equal(result.value, "Bob");
     assert.deepEqual(calls, [config]);
+    assert.deepEqual(contexts, [{ attempt: 1 }]);
+  });
+
+  it("should infer shared validator values from the wrapped parser", () => {
+    const { prompt } = createTestPrompt();
+    const validator =
+      ((value) =>
+        value.length > 0
+          ? undefined
+          : message`Enter a name.`) satisfies PromptValidator<string>;
+    const options = { validate: validator } satisfies PromptOptions<string>;
+
+    const parser = prompt(
+      option("--name", string()),
+      { value: "Alice" },
+      options,
+    );
+    prompt(option("--name", string()), { value: "Alice" }, {
+      // @ts-expect-error The parser, not the validator, determines TValue.
+      validate: (_value: number) => undefined,
+    });
+    // @ts-expect-error Validators reject with Message, not string.
+    const invalidValidator: PromptValidator<string> = (_value: string) =>
+      "Enter a name.";
+
+    assert.equal(parser.mode, "async");
+    assert.equal(options.validate, validator);
+    assert.equal(invalidValidator(""), "Enter a name.");
+  });
+
+  it("should reject invalid maximum attempt counts at construction", () => {
+    const { prompt, calls } = createTestPrompt();
+
+    for (const maxAttempts of [0, -1, 1.5, Number.NaN, Infinity]) {
+      assert.throws(
+        () =>
+          prompt(option("--name", string()), { value: "Alice" }, {
+            maxAttempts,
+          }),
+        {
+          name: "RangeError",
+          message: "maxAttempts must be an integer greater than or equal to 1.",
+        },
+      );
+    }
+    assert.throws(
+      () =>
+        prompt(option("--name", string()), { value: "Alice" }, {
+          validate: () => undefined,
+          maxAttempts: 0,
+        }),
+      RangeError,
+    );
+    assert.deepEqual(calls, []);
+  });
+
+  it("should accept a synchronously validated prompt value", async () => {
+    const { prompt, calls, contexts } = createTestPrompt();
+    const validated: string[] = [];
+    const parser = prompt(option("--name", string()), { value: "Alice" }, {
+      validate(value) {
+        validated.push(value);
+        return undefined;
+      },
+    });
+
+    const result = await parseAsync(parser, []);
+
+    assert.ok(result.success);
+    assert.equal(result.value, "Alice");
+    assert.deepEqual(validated, ["Alice"]);
+    assert.deepEqual(calls, [{ value: "Alice" }]);
+    assert.deepEqual(contexts, [{ attempt: 1 }]);
+  });
+
+  it("should retry asynchronous validation with the previous message", async () => {
+    const values = ["npm", "pnpm", "deno"] as const;
+    const contexts: PromptExecutionContext[] = [];
+    const verdicts = [
+      message`npm is unavailable.`,
+      message`pnpm is unavailable.`,
+    ] as const;
+    let validationCalls = 0;
+    const prompt = createPromptAdapter<{
+      readonly values: readonly string[];
+    }>({
+      execute<TValue>(
+        config: { readonly values: readonly string[] },
+        context: PromptExecutionContext,
+      ) {
+        contexts.push(context);
+        return Promise.resolve({
+          success: true,
+          value: config.values[context.attempt - 1] as TValue,
+        });
+      },
+    });
+    const parser = prompt(option("--pm", string()), { values }, {
+      async validate(value) {
+        await Promise.resolve();
+        const verdict = verdicts[validationCalls];
+        validationCalls++;
+        return value === "deno" ? undefined : verdict;
+      },
+    });
+
+    const result = await parseAsync(parser, []);
+
+    assert.ok(result.success);
+    assert.equal(result.value, "deno");
+    assert.equal(validationCalls, 3);
+    assert.deepEqual(contexts, [
+      { attempt: 1 },
+      { attempt: 2, previousValidationMessage: verdicts[0] },
+      { attempt: 3, previousValidationMessage: verdicts[1] },
+    ]);
+    assert.equal(contexts[1].previousValidationMessage, verdicts[0]);
+    assert.equal(contexts[2].previousValidationMessage, verdicts[1]);
+  });
+
+  it("should return the final validation message when attempts are exhausted", async () => {
+    const verdicts = [message`Try again.`, []] as const;
+    let attempt = 0;
+    const { prompt, contexts } = createTestPrompt();
+    const parser = prompt(option("--name", string()), { value: "Alice" }, {
+      maxAttempts: 2,
+      validate() {
+        return verdicts[attempt++];
+      },
+    });
+
+    const result = await parseAsync(parser, []);
+
+    assert.ok(!result.success);
+    assert.equal(result.error, verdicts[1]);
+    assert.equal(attempt, 2);
+    assert.deepEqual(contexts, [
+      { attempt: 1 },
+      { attempt: 2, previousValidationMessage: verdicts[0] },
+    ]);
+  });
+
+  it("should keep attempt counts and limits consistent", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.integer({ min: 1, max: 6 }),
+        fc.integer({ min: 1, max: 7 }),
+        async (maxAttempts, requestedAcceptanceAttempt) => {
+          const acceptanceAttempt = Math.min(
+            requestedAcceptanceAttempt,
+            maxAttempts + 1,
+          );
+          const attempts: number[] = [];
+          let validationCalls = 0;
+          const prompt = createPromptAdapter<EmptyPromptConfig>({
+            execute<TValue>(
+              _config: EmptyPromptConfig,
+              context: PromptExecutionContext,
+            ) {
+              attempts.push(context.attempt);
+              return Promise.resolve({
+                success: true,
+                value: "answer" as TValue,
+              });
+            },
+          });
+          const parser = prompt(option("--answer", string()), {}, {
+            maxAttempts,
+            validate() {
+              validationCalls++;
+              return validationCalls === acceptanceAttempt
+                ? undefined
+                : message`Try again.`;
+            },
+          });
+
+          const result = await parseAsync(parser, []);
+          const expectedAttempts = Math.min(
+            acceptanceAttempt,
+            maxAttempts,
+          );
+
+          assert.deepEqual(
+            attempts,
+            Array.from({ length: expectedAttempts }, (_, index) => index + 1),
+          );
+          assert.equal(validationCalls, expectedAttempts);
+          assert.equal(result.success, acceptanceAttempt <= maxAttempts);
+        },
+      ),
+    );
+  });
+
+  it("should stop retrying when a later adapter attempt fails", async () => {
+    const firstRejection = message`Try again.`;
+    const cancellation = message`Prompt cancelled.`;
+    const contexts: PromptExecutionContext[] = [];
+    let validationCalls = 0;
+    const prompt = createPromptAdapter<EmptyPromptConfig>({
+      execute<TValue>(
+        _config: EmptyPromptConfig,
+        context: PromptExecutionContext,
+      ) {
+        contexts.push(context);
+        return Promise.resolve(
+          context.attempt === 1
+            ? { success: true, value: "first" as TValue }
+            : { success: false, error: cancellation },
+        );
+      },
+    });
+    const parser = prompt(option("--name", string()), {}, {
+      validate() {
+        validationCalls++;
+        return firstRejection;
+      },
+    });
+
+    const result = await parseAsync(parser, []);
+
+    assert.ok(!result.success);
+    assert.equal(result.error, cancellation);
+    assert.equal(validationCalls, 1);
+    assert.deepEqual(contexts, [
+      { attempt: 1 },
+      { attempt: 2, previousValidationMessage: firstRejection },
+    ]);
+  });
+
+  it("should propagate adapter and validator exceptions without retrying", async () => {
+    const adapterError = new TypeError("Prompt failed.");
+    const validatorError = new TypeError("Validation failed.");
+    let adapterCalls = 0;
+    const throwingPrompt = createPromptAdapter<EmptyPromptConfig>({
+      execute<TValue>(
+        _config: EmptyPromptConfig,
+        _context: PromptExecutionContext,
+      ) {
+        adapterCalls++;
+        throw adapterError;
+      },
+    });
+    const validatorPrompt = createPromptAdapter<EmptyPromptConfig>({
+      execute<TValue>(
+        _config: EmptyPromptConfig,
+        _context: PromptExecutionContext,
+      ) {
+        return Promise.resolve({ success: true, value: "Alice" as TValue });
+      },
+    });
+
+    await assert.rejects(
+      () =>
+        parseAsync(
+          throwingPrompt(option("--name", string()), {}, {
+            validate: () => message`Unused.`,
+          }),
+          [],
+        ),
+      (error: unknown) => error === adapterError,
+    );
+    for (
+      const validate of [
+        () => {
+          throw validatorError;
+        },
+        () => Promise.reject(validatorError),
+      ]
+    ) {
+      await assert.rejects(
+        () =>
+          parseAsync(
+            validatorPrompt(option("--name", string()), {}, {
+              validate,
+            }),
+            [],
+          ),
+        (error: unknown) => error === validatorError,
+      );
+    }
+    assert.equal(adapterCalls, 1);
+  });
+
+  it("should ignore an aborted signal when no prompt attempt runs", async () => {
+    const controller = new AbortController();
+    const reason = new Error("Stopped.");
+    controller.abort(reason);
+    const { prompt, calls } = createTestPrompt();
+    let validationCalls = 0;
+    const skipped = prompt(
+      option("--name", string()),
+      { value: "Prompted", when: () => false, otherwise: "Skipped" },
+      {
+        signal: controller.signal,
+        validate() {
+          validationCalls++;
+          return undefined;
+        },
+      },
+    );
+    const fromCli = prompt(option("--other", string()), { value: "Prompted" }, {
+      signal: controller.signal,
+      validate() {
+        validationCalls++;
+        return undefined;
+      },
+    });
+
+    const skippedResult = await parseAsync(skipped, []);
+    const cliResult = await parseAsync(fromCli, ["--other", "CLI"]);
+
+    assert.ok(skippedResult.success);
+    assert.equal(skippedResult.value, "Skipped");
+    assert.ok(cliResult.success);
+    assert.equal(cliResult.value, "CLI");
+    assert.deepEqual(calls, []);
+    assert.equal(validationCalls, 0);
+  });
+
+  it("should propagate a pre-aborted signal before an adapter attempt", async () => {
+    const controller = new AbortController();
+    const reason = { code: "stopped" };
+    controller.abort(reason);
+    const { prompt, calls } = createTestPrompt();
+    const parser = prompt(option("--name", string()), { value: "Prompted" }, {
+      signal: controller.signal,
+    });
+
+    await assert.rejects(
+      () => parseAsync(parser, []),
+      (error: unknown) => error === reason,
+    );
+    assert.deepEqual(calls, []);
+  });
+
+  it("should abort an active adapter attempt and observe a late rejection", async () => {
+    const controller = new AbortController();
+    const reason = { code: "stopped" };
+    const started = deferred<void>();
+    const attempt = deferred<never>();
+    const contexts: PromptExecutionContext[] = [];
+    const prompt = createPromptAdapter<EmptyPromptConfig>({
+      execute<TValue>(
+        _config: EmptyPromptConfig,
+        context: PromptExecutionContext,
+      ) {
+        contexts.push(context);
+        started.resolve();
+        return attempt.promise;
+      },
+    });
+    const parser = prompt(option("--name", string()), {}, {
+      signal: controller.signal,
+    });
+
+    const parsing = parseAsync(parser, []);
+    await started.promise;
+    controller.abort(reason);
+    await assert.rejects(
+      () => parsing,
+      (error: unknown) => error === reason,
+    );
+    attempt.reject(new Error("Late prompt failure."));
+    await Promise.resolve();
+    assert.equal(contexts.length, 1);
+    assert.equal(contexts[0].signal, controller.signal);
+  });
+
+  it("should abort an active asynchronous validator", async () => {
+    const controller = new AbortController();
+    const reason = { code: "stopped" };
+    const started = deferred<void>();
+    const validation = deferred<undefined>();
+    const { prompt, calls } = createTestPrompt();
+    const parser = prompt(option("--name", string()), { value: "Alice" }, {
+      signal: controller.signal,
+      validate() {
+        started.resolve();
+        return validation.promise;
+      },
+    });
+
+    const parsing = parseAsync(parser, []);
+    await started.promise;
+    controller.abort(reason);
+
+    await assert.rejects(
+      () => parsing,
+      (error: unknown) => error === reason,
+    );
+    validation.resolve(undefined);
+    await Promise.resolve();
+    assert.deepEqual(calls, [{ value: "Alice" }]);
+  });
+
+  it("should observe an abort triggered synchronously by the adapter", async () => {
+    const controller = new AbortController();
+    const reason = { code: "stopped" };
+    const prompt = createPromptAdapter<EmptyPromptConfig>({
+      execute<TValue>(
+        _config: EmptyPromptConfig,
+        _context: PromptExecutionContext,
+      ) {
+        controller.abort(reason);
+        return Promise.resolve({ success: true, value: "Alice" as TValue });
+      },
+    });
+    const parser = prompt(option("--name", string()), {}, {
+      signal: controller.signal,
+    });
+
+    await assert.rejects(
+      () => parseAsync(parser, []),
+      (error: unknown) => error === reason,
+    );
   });
 
   it("should run the adapter when a synchronous condition is true", async () => {
@@ -412,6 +853,7 @@ describe("createPromptAdapter()", () => {
     }
     const { prompt, calls } = createTestPrompt();
     let conditionCalls = 0;
+    let validationCalls = 0;
     const parser = prompt(
       bindEnv(option("--name", string()), {
         context: envContext,
@@ -426,6 +868,12 @@ describe("createPromptAdapter()", () => {
         },
         otherwise: "SkippedName",
       },
+      {
+        validate() {
+          validationCalls++;
+          return undefined;
+        },
+      },
     );
 
     const result = await parseAsync(parser, [], { annotations });
@@ -433,6 +881,7 @@ describe("createPromptAdapter()", () => {
     assert.ok(result.success);
     assert.equal(result.value, "EnvName");
     assert.equal(conditionCalls, 0);
+    assert.equal(validationCalls, 0);
     assert.deepEqual(calls, []);
   });
 
@@ -1298,6 +1747,111 @@ describe("prompted values as dependency sources", () => {
     assert.equal(calls.length, 1);
   });
 
+  it("publishes only the value that passes shared validation", async () => {
+    const mode = dependency(choice(["dev", "prod"] as const));
+    const level = mode.deriveSync({
+      metavar: "LEVEL",
+      factory: (value: "dev" | "prod") =>
+        choice(
+          value === "dev" ? (["debug"] as const) : (["silent"] as const),
+        ),
+      defaultValue: () => "dev" as const,
+    });
+    const answers = ["dev", "prod"] as const;
+    const attempts: number[] = [];
+    const prompt = createPromptAdapter<{
+      readonly answers: readonly ("dev" | "prod")[];
+    }>({
+      execute<TValue>(
+        config: { readonly answers: readonly ("dev" | "prod")[] },
+        context: PromptExecutionContext,
+      ) {
+        attempts.push(context.attempt);
+        return Promise.resolve({
+          success: true,
+          value: config.answers[context.attempt - 1] as TValue,
+        });
+      },
+    });
+    const parser = object({
+      mode: prompt(option("--mode", mode), { answers }, {
+        validate: (value) =>
+          value === "dev"
+            ? message`Development mode is unavailable.`
+            : undefined,
+      }),
+      level: option("--level", level),
+    });
+
+    const result = await parseAsync(parser, ["--level", "silent"]);
+
+    assert.ok(result.success);
+    assert.deepEqual(result.value, { mode: "prod", level: "silent" });
+    assert.deepEqual(attempts, [1, 2]);
+  });
+
+  it("stops later source prompts when validation attempts are exhausted", async () => {
+    const first = createModeFixture();
+    const second = createModeFixture();
+    const rejection = message`No supported mode was selected.`;
+    const { prompt, calls } = createTestPrompt();
+    let validationCalls = 0;
+    const parser = object({
+      a: prompt(option("--a", first.mode), { value: "dev" }, {
+        maxAttempts: 2,
+        validate() {
+          validationCalls++;
+          return rejection;
+        },
+      }),
+      b: prompt(option("--b", second.mode), { value: "dev" }),
+      aLevel: option("--a-level", first.level),
+      bLevel: option("--b-level", second.level),
+    });
+
+    const result = await parseAsync(parser, [
+      "--a-level",
+      "debug",
+      "--b-level",
+      "debug",
+    ]);
+
+    assert.ok(!result.success);
+    assert.match(
+      formatMessage(result.error),
+      /^No supported mode was selected\. Dependency chain:/,
+    );
+    assert.equal(validationCalls, 2);
+    assert.equal(calls.length, 2);
+  });
+
+  it("propagates adapter exceptions through source scheduling", async () => {
+    const { mode, level } = createModeFixture();
+    const expected = new TypeError("Prompt library failed.");
+    const prompt = createPromptAdapter<EmptyPromptConfig>({
+      execute<TValue>(
+        _config: EmptyPromptConfig,
+        _context: PromptExecutionContext,
+      ) {
+        throw expected;
+      },
+    });
+    const later = createTestPrompt();
+    const parser = object({
+      mode: prompt(option("--mode", mode), {}, {
+        validate: () => message`Unused.`,
+      }),
+      level: option("--level", level),
+      name: later.prompt(option("--name", string()), { value: "Alice" }),
+    });
+
+    await assert.rejects(
+      () => parseAsync(parser, ["--level", "silent"]),
+      (error: unknown) => error === expected,
+    );
+    assert.deepEqual(later.calls, []);
+  });
+
   it("does not register a successful undefined prompt value", async () => {
     const { mode, level } = createModeFixture();
     const { prompt, calls } = createTestPrompt();
@@ -1354,6 +1908,7 @@ describe("prompted values as dependency sources", () => {
     async () => {
       const { mode, level } = createModeFixture();
       const { prompt, calls } = createTestPrompt();
+      const seenValues: string[] = [];
       let phase2Parsed:
         | { readonly mode?: string; readonly level?: string }
         | undefined;
@@ -1369,7 +1924,12 @@ describe("prompted values as dependency sources", () => {
         },
       };
       const parser = object({
-        mode: prompt(option("--mode", mode), { value: "prod" }),
+        mode: prompt(option("--mode", mode), { value: "prod" }, {
+          validate(value) {
+            seenValues.push(value);
+            return seenValues.length === 1 ? message`Try again.` : undefined;
+          },
+        }),
         level: option("--level", level),
       });
 
@@ -1380,7 +1940,8 @@ describe("prompted values as dependency sources", () => {
       assert.deepEqual(result, { mode: "prod", level: "silent" });
       assert.equal(phase2Parsed?.mode, "prod");
       assert.equal(phase2Parsed?.level, "silent");
-      assert.equal(calls.length, 1);
+      assert.equal(calls.length, 2);
+      assert.deepEqual(seenValues, ["prod", "prod"]);
     },
   );
 
@@ -1607,9 +2168,17 @@ describe("prompted values as dependency sources", () => {
         defaultValue: () => "dev" as const,
       });
       const { prompt, calls } = createTestPrompt();
+      let laterValidationCalls = 0;
       const parser = object({
         a: prompt(option("--a", shared), { value: "dev" }),
-        b: prompt(option("--b", shared), { value: "prod" }),
+        b: prompt(option("--b", shared), { value: "prod" }, {
+          validate() {
+            laterValidationCalls++;
+            return laterValidationCalls === 1
+              ? message`Confirm production mode.`
+              : undefined;
+          },
+        }),
         level: option("--level", level),
       });
 
@@ -1621,7 +2190,8 @@ describe("prompted values as dependency sources", () => {
       assert.equal(result.value.a, "dev");
       assert.equal(result.value.b, "prod");
       assert.equal(result.value.level, "silent");
-      assert.equal(calls.length, 2);
+      assert.equal(laterValidationCalls, 2);
+      assert.equal(calls.length, 3);
     },
   );
 
@@ -2519,6 +3089,7 @@ describe("prompted values as dependency sources", () => {
       const mode = dependency(choice(["dev", "prod"] as const));
       const other = dependency(string());
       const { prompt, calls } = createTestPrompt();
+      let branchValidationCalls = 0;
       // "--d 1" speculatively selects the dev branch, but the prompted
       // discriminator answers "prod": the guessed branch must produce no
       // interactive side effects before the mismatch is verified.
@@ -2527,7 +3098,12 @@ describe("prompted values as dependency sources", () => {
         {
           dev: object({
             d: option("--d", string()),
-            dp: prompt(option("--dp", other), { value: "DP" }),
+            dp: prompt(option("--dp", other), { value: "DP" }, {
+              validate() {
+                branchValidationCalls++;
+                return undefined;
+              },
+            }),
           }),
           prod: object({ p: option("--p", string()) }),
         },
@@ -2537,6 +3113,7 @@ describe("prompted values as dependency sources", () => {
 
       assert.ok(!result.success);
       assert.deepEqual(calls, [{ value: "prod" }]);
+      assert.equal(branchValidationCalls, 0);
     },
   );
 
@@ -2713,6 +3290,7 @@ describe("prompted values as dependency sources", () => {
       const kind = dependency(choice(["a", "b"] as const));
       const { mode, level } = createModeFixture();
       const { prompt, calls } = createTestPrompt();
+      let branchValidationCalls = 0;
       // "--a x" speculatively selects branch a while the prompted
       // discriminator defers; the answer "b" rejects the guess, so the
       // parent's scheduling pass must not run the guessed branch's
@@ -2723,7 +3301,12 @@ describe("prompted values as dependency sources", () => {
           {
             a: object({
               ax: option("--a", choice(["x"] as const)),
-              mode: prompt(option("--mode", mode), { value: "prod" }),
+              mode: prompt(option("--mode", mode), { value: "prod" }, {
+                validate() {
+                  branchValidationCalls++;
+                  return undefined;
+                },
+              }),
             }),
             b: object({ y: option("--y", choice(["2"] as const)) }),
           },
@@ -2739,6 +3322,7 @@ describe("prompted values as dependency sources", () => {
       assert.ok(!result.success);
       // Only the discriminator prompt ran.
       assert.equal(calls.length, 1);
+      assert.equal(branchValidationCalls, 0);
     },
   );
 
@@ -3393,6 +3977,102 @@ describe("derived prompt configurations", () => {
       storage: "redis",
     });
     assert.deepEqual(calls, [{ value: "hono" }, { value: "npm" }]);
+  });
+
+  it("resolves a derived configuration once across validation retries", async () => {
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const resolvedConfig = { value: "npm" };
+    const { prompt, calls } = createTestPrompt();
+    let resolverCalls = 0;
+    let validationCalls = 0;
+    const parser = object({
+      framework: option("--framework", framework),
+      packageManager: prompt(
+        option("--package-manager", string()),
+        derivePromptConfig(framework, () => {
+          resolverCalls++;
+          return resolvedConfig;
+        }),
+        {
+          validate() {
+            validationCalls++;
+            return validationCalls === 1 ? message`Try again.` : undefined;
+          },
+        },
+      ),
+    });
+
+    const result = await parseAsync(parser, ["--framework", "hono"]);
+
+    assert.ok(result.success);
+    assert.deepEqual(result.value, {
+      framework: "hono",
+      packageManager: "npm",
+    });
+    assert.equal(resolverCalls, 1);
+    assert.equal(validationCalls, 2);
+    assert.equal(calls.length, 2);
+    assert.equal(calls[0], resolvedConfig);
+    assert.equal(calls[1], resolvedConfig);
+  });
+
+  it("checks an aborted signal before resolving a derived configuration", async () => {
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const controller = new AbortController();
+    const reason = { code: "stopped" };
+    controller.abort(reason);
+    const { prompt, calls } = createTestPrompt();
+    let resolverCalls = 0;
+    const parser = object({
+      framework: option("--framework", framework),
+      packageManager: prompt(
+        option("--package-manager", string()),
+        derivePromptConfig(framework, () => {
+          resolverCalls++;
+          return { value: "npm" };
+        }),
+        { signal: controller.signal },
+      ),
+    });
+
+    await assert.rejects(
+      () => parseAsync(parser, ["--framework", "hono"]),
+      (error: unknown) => error === reason,
+    );
+    assert.equal(resolverCalls, 0);
+    assert.deepEqual(calls, []);
+  });
+
+  it("observes abort after a pending derived configuration settles", async () => {
+    const framework = dependency(choice(["fresh", "hono"] as const));
+    const controller = new AbortController();
+    const reason = { code: "stopped" };
+    const started = deferred<void>();
+    const resolution = deferred<void>();
+    const { prompt, calls } = createTestPrompt();
+    const parser = object({
+      framework: option("--framework", framework),
+      packageManager: prompt(
+        option("--package-manager", string()),
+        derivePromptConfig(framework, async () => {
+          started.resolve();
+          await resolution.promise;
+          throw new TypeError("Late resolver failure.");
+        }),
+        { signal: controller.signal },
+      ),
+    });
+
+    const parsing = parseAsync(parser, ["--framework", "hono"]);
+    await started.promise;
+    controller.abort(reason);
+    resolution.resolve();
+
+    await assert.rejects(
+      () => parsing,
+      (error: unknown) => error === reason,
+    );
+    assert.deepEqual(calls, []);
   });
 
   it("orders prompts topologically regardless of field order", async () => {

--- a/packages/prompt/src/index.ts
+++ b/packages/prompt/src/index.ts
@@ -702,9 +702,8 @@ export type PromptConfigInput<TConfig, TValue> =
  * @param adapter Library-specific prompt executor.
  * @returns A `prompt(parser, config, options?)` wrapper that always produces
  *          an async parser.  The configuration may be a static `TConfig` or a
- *          {@link DerivedPromptConfig} whose resolver returns `TConfig`.  The
- *          returned wrapper throws a `RangeError` when `maxAttempts` is not a
- *          positive integer.
+ *          {@link DerivedPromptConfig} whose resolver returns `TConfig`.
+ * @throws {RangeError} If `maxAttempts` is not a positive integer.
  * @since 1.2.0
  */
 export function createPromptAdapter<TConfig>(

--- a/packages/prompt/src/index.ts
+++ b/packages/prompt/src/index.ts
@@ -59,12 +59,71 @@ export type PromptCondition<TValue> =
   };
 
 /**
+ * Validates a value returned by a prompt adapter.
+ *
+ * Return `undefined` to accept the value, or a structured message to reject it
+ * and ask the adapter to try again.  The validator receives the prompted value
+ * directly; it is not converted back into command-line input or passed through
+ * the wrapped value parser.
+ *
+ * @typeParam TValue Value type produced by the wrapped parser.
+ * @since 1.3.0
+ */
+export type PromptValidator<TValue> = (
+  value: TValue,
+) => Message | undefined | Promise<Message | undefined>;
+
+/**
+ * Shared validation, retry, and cancellation options for a prompt fallback.
+ *
+ * These options are separate from adapter-native validation fields.  They
+ * apply only when the interactive fallback runs; CLI values, source-bound
+ * values, and skipped runtime conditions do not consult them.
+ *
+ * @typeParam TValue Value type produced by the wrapped parser.
+ * @since 1.3.0
+ */
+export interface PromptOptions<TValue> {
+  /** Validator applied to each value returned by the adapter. */
+  readonly validate?: PromptValidator<TValue>;
+
+  /**
+   * Maximum number of adapter executions in one completion.  Must be a
+   * positive integer.  When omitted, validation may retry without a limit.
+   */
+  readonly maxAttempts?: number;
+
+  /**
+   * Signal that stops the active adapter execution or validator.  Its reason
+   * is propagated to the caller without becoming a parse failure.
+   */
+  readonly signal?: AbortSignal;
+}
+
+/**
+ * Context passed to one execution of a prompt adapter.
+ *
+ * @since 1.3.0
+ */
+export interface PromptExecutionContext {
+  /** One-based number of the current adapter execution. */
+  readonly attempt: number;
+
+  /** Message returned by the validator after the preceding execution. */
+  readonly previousValidationMessage?: Message;
+
+  /** Signal supplied through the prompt's shared options, when present. */
+  readonly signal?: AbortSignal;
+}
+
+/**
  * Prompt adapter used by {@link createPromptAdapter}.
  *
  * The adapter owns library-specific prompt execution and maps the result into
  * Optique's value-parser result shape.  The shared parser wrapping behavior,
  * including CLI priority, source bindings, deferred completion, suggestions,
- * and usage metadata, is handled by *@optique/prompt*.
+ * usage metadata, validation retries, and abort handling, is handled by
+ * *@optique/prompt*.
  *
  * @typeParam TConfig Prompt configuration accepted by the adapter.
  * @since 1.2.0
@@ -76,11 +135,14 @@ export interface PromptAdapter<TConfig> {
    * @typeParam TValue Value type produced by the wrapped parser.
    * @param config Prompt configuration supplied to the generated `prompt()`
    *               wrapper.
+   * @param context Attempt number, preceding validation message, and optional
+   *                abort signal for this execution.
    * @returns The prompted value or a prompt failure.
    * @throws Any unexpected prompt execution failure.
    */
   readonly execute: <TValue>(
     config: TConfig,
+    context: PromptExecutionContext,
   ) => Promise<ValueParserResult<TValue>>;
 
   /**
@@ -569,6 +631,50 @@ function unwrapCompleteResult<TValue>(
   };
 }
 
+function throwIfPromptAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted === true) throw signal.reason;
+}
+
+function racePromptWorkWithAbort<T>(
+  signal: AbortSignal | undefined,
+  work: () => Promise<T>,
+): Promise<T> {
+  if (signal == null) {
+    try {
+      return work();
+    } catch (error) {
+      return Promise.reject(error);
+    }
+  }
+  if (signal.aborted) return Promise.reject(signal.reason);
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => {
+      signal.removeEventListener("abort", onAbort);
+      reject(signal.reason);
+    };
+    const cleanup = () => signal.removeEventListener("abort", onAbort);
+    signal.addEventListener("abort", onAbort, { once: true });
+    let outcome: Promise<T>;
+    try {
+      outcome = work();
+    } catch (error) {
+      cleanup();
+      reject(error);
+      return;
+    }
+    outcome.then(
+      (value) => {
+        cleanup();
+        resolve(value);
+      },
+      (error) => {
+        cleanup();
+        reject(error);
+      },
+    );
+  });
+}
+
 /**
  * Prompt configuration accepted by a generated `prompt()` wrapper: either
  * a static adapter configuration (optionally with a runtime condition) or
@@ -594,9 +700,11 @@ export type PromptConfigInput<TConfig, TValue> =
  *
  * @typeParam TConfig Prompt configuration accepted by the adapter.
  * @param adapter Library-specific prompt executor.
- * @returns A `prompt(parser, config)` wrapper that always produces an async
- *          parser.  The configuration may be a static `TConfig` or a
- *          {@link DerivedPromptConfig} whose resolver returns `TConfig`.
+ * @returns A `prompt(parser, config, options?)` wrapper that always produces
+ *          an async parser.  The configuration may be a static `TConfig` or a
+ *          {@link DerivedPromptConfig} whose resolver returns `TConfig`.  The
+ *          returned wrapper throws a `RangeError` when `maxAttempts` is not a
+ *          positive integer.
  * @since 1.2.0
  */
 export function createPromptAdapter<TConfig>(
@@ -604,11 +712,22 @@ export function createPromptAdapter<TConfig>(
 ): <M extends Mode, TValue, TState>(
   parser: Parser<M, TValue, TState>,
   config: PromptConfigInput<TConfig, TValue>,
+  options?: PromptOptions<NoInfer<TValue>>,
 ) => FluentParser<"async", TValue, TState> {
   return function prompt<M extends Mode, TValue, TState>(
     parser: Parser<M, TValue, TState>,
     config: PromptConfigInput<TConfig, TValue>,
+    options: PromptOptions<NoInfer<TValue>> = {},
   ): FluentParser<"async", TValue, TState> {
+    if (
+      options.maxAttempts !== undefined &&
+      (!Number.isInteger(options.maxAttempts) || options.maxAttempts < 1)
+    ) {
+      throw new RangeError(
+        "maxAttempts must be an integer greater than or equal to 1.",
+      );
+    }
+    const { validate, maxAttempts, signal } = options;
     const promptBindStateKey: unique symbol = Symbol(
       "@optique/prompt/promptState",
     );
@@ -718,18 +837,47 @@ export function createPromptAdapter<TConfig>(
       if (config.when != null && !(await config.when())) {
         return { success: true, value: config.otherwise as TValue };
       }
+      throwIfPromptAborted(signal);
+      let resolvedConfig: TConfig;
       if (!isDerivedPromptConfig(config)) {
-        return adapter.execute<TValue>(config as TConfig);
+        resolvedConfig = config as TConfig;
+      } else {
+        const source = promptedParser.dependencyMetadata?.source;
+        const resolved = await resolveDerivedPromptConfig(
+          config as DerivedPromptConfig<TConfig, unknown>,
+          exec,
+          source?.sourceId,
+          source?.metavar,
+        );
+        throwIfPromptAborted(signal);
+        if (!resolved.ok) return { success: false, error: resolved.error };
+        resolvedConfig = resolved.config;
       }
-      const source = promptedParser.dependencyMetadata?.source;
-      const resolved = await resolveDerivedPromptConfig(
-        config as DerivedPromptConfig<TConfig, unknown>,
-        exec,
-        source?.sourceId,
-        source?.metavar,
-      );
-      if (!resolved.ok) return { success: false, error: resolved.error };
-      return adapter.execute<TValue>(resolved.config);
+
+      let previousValidationMessage: Message | undefined;
+      for (let attempt = 1;; attempt++) {
+        const context: PromptExecutionContext = {
+          attempt,
+          ...(previousValidationMessage === undefined
+            ? {}
+            : { previousValidationMessage }),
+          ...(signal === undefined ? {} : { signal }),
+        };
+        const result = await racePromptWorkWithAbort(
+          signal,
+          () => adapter.execute<TValue>(resolvedConfig, context),
+        );
+        if (!result.success || validate == null) return result;
+        const validationMessage = await racePromptWorkWithAbort(
+          signal,
+          () => Promise.resolve(validate(result.value)),
+        );
+        if (validationMessage === undefined) return result;
+        if (maxAttempts !== undefined && attempt >= maxAttempts) {
+          return { success: false, error: validationMessage };
+        }
+        previousValidationMessage = validationMessage;
+      }
     }
 
     const parserInheritsAnnotations = getTraits(parser).inheritsAnnotations ===


### PR DESCRIPTION
Closes #935. Part of #873.


Why
---

Prompt integrations should not each reinvent validation and retry control flow. Keeping that contract in individual adapters also makes it easier for a rejected answer to reach completion caching or dependency publication too early.


How
---

The wrapper generated by `createPromptAdapter()` now keeps prompting, validation, and publication inside one effectful completion.  It resolves a derived configuration once, validates each successful adapter result before it can be cached, and passes the attempt number and previous validation message to the next execution.

`maxAttempts` turns the final rejection into a normal parse failure. `AbortSignal` races only active prompt/validator work, preserving the existing ordering of conditions and configuration resolution.