### PR TITLE
Unify validation across Inquirer.js prompts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -108,15 +108,24 @@ To be released.
 
 ### @optique/inquirer
 
- -  Added conditional prompt skipping to Inquirer prompt configurations with
+ -  Added conditional prompt skipping to Inquirer.js prompt configurations with
     `when` and `otherwise`, allowing applications to avoid prompts whose
     runtime prerequisites are unavailable.  [[#882]]
+ -  Added shared validation, retry limits, and abort signals to `prompt()`.
+    Every Inquirer.js prompt type can now reject a returned answer and prompt
+    again, while `input`, `password`, and `editor` retain their native
+    validation.  Custom prompters receive the shared attempt context, whose
+    types are re-exported for convenience.  [[#873], [#937], [#939]]
  -  Added support for prompt configurations derived from dependency sources.
     `prompt()` now also accepts a `derivePromptConfig()` result whose
     resolver returns any of this package's prompt configurations, exposed
     through the new `RuntimePromptConfig` union, so a later question can
     adapt its choices to earlier answers.  `derivePromptConfig()` and its
     types are re-exported for convenience.  [[#869], [#872]]
+
+[#873]: https://github.com/dahlia/optique/issues/873
+[#937]: https://github.com/dahlia/optique/issues/937
+[#939]: https://github.com/dahlia/optique/pull/939
 
 ### @optique/prompt
 
@@ -144,7 +153,6 @@ To be released.
     now runs before dependency replay, so it may be displayed before an
     earlier-declared non-source prompt.  [[#869], [#870], [#912]]
 
-[#873]: https://github.com/dahlia/optique/issues/873
 [#935]: https://github.com/dahlia/optique/issues/935
 [#938]: https://github.com/dahlia/optique/pull/938
 
@@ -2992,11 +3000,6 @@ interactive prompt fallback integration via Inquirer.js.  [[#87], [#137]]
     cleanly with `bindEnv()` and `bindConfig()`—the prompt is skipped
     whenever the CLI, environment variable, or config file supplies a value.
 
- -  Added `validate` support to `SelectConfig`, `RawlistConfig`,
-    `ExpandConfig`, and `CheckboxConfig` prompt configurations.  Return
-    `true` to accept, or a string error message to reject and re-prompt.
-    [[#620], [#625]]
-
 #### Prompt resolution and wrapper behavior
 
  -  *Behavioral change:* `prompt()` no longer re-validates prompted values
@@ -3068,9 +3071,7 @@ interactive prompt fallback integration via Inquirer.js.  [[#87], [#137]]
 [#612]: https://github.com/dahlia/optique/pull/612
 [#613]: https://github.com/dahlia/optique/pull/613
 [#615]: https://github.com/dahlia/optique/issues/615
-[#620]: https://github.com/dahlia/optique/issues/620
 [#621]: https://github.com/dahlia/optique/pull/621
-[#625]: https://github.com/dahlia/optique/pull/625
 
 ### @optique/logtape
 

--- a/changes.d/inquirer/runtime-prompt-skipping.md
+++ b/changes.d/inquirer/runtime-prompt-skipping.md
@@ -2,6 +2,6 @@
 links:
   '#882': https://github.com/dahlia/optique/issues/882
 ---
- -  Added conditional prompt skipping to Inquirer prompt configurations with
+ -  Added conditional prompt skipping to Inquirer.js prompt configurations with
     `when` and `otherwise`, allowing applications to avoid prompts whose
     runtime prerequisites are unavailable.  [[#882]]

--- a/changes.d/inquirer/shared-prompt-validation.md
+++ b/changes.d/inquirer/shared-prompt-validation.md
@@ -1,0 +1,11 @@
+---
+links:
+  '#873': https://github.com/dahlia/optique/issues/873
+  '#937': https://github.com/dahlia/optique/issues/937
+  '#939': https://github.com/dahlia/optique/pull/939
+---
+ -  Added shared validation, retry limits, and abort signals to `prompt()`.
+    Every Inquirer.js prompt type can now reject a returned answer and prompt
+    again, while `input`, `password`, and `editor` retain their native
+    validation.  Custom prompters receive the shared attempt context, whose
+    types are re-exported for convenience.  [[#873], [#937], [#939]]

--- a/docs/integrations/inquirer.md
+++ b/docs/integrations/inquirer.md
@@ -504,7 +504,8 @@ const useGitHubCli = prompt(fail<boolean>(), {
 The condition runs only when an actual parse reaches this fallback.  CLI
 values and configured sources take priority without running it, and Optique
 also skips it while generating help, version output, or shell completion.
-When `when` returns `false`, `otherwise` is returned without opening Inquirer.
+When `when` returns `false`, `otherwise` is returned without opening an
+Inquirer.js prompt.
 If the condition throws or rejects, the error propagates to the caller.
 
 
@@ -557,23 +558,79 @@ they came from the command line, a binding, or another prompt.  See the
 for declared defaults, failure behavior, and the runtime condition form.
 
 
-Testing
--------
+Shared validation, retries, and aborts
+--------------------------------------
 
-All prompt configuration types accept an optional `prompter` property for
-testing.  When provided, the function is called instead of launching an
-interactive Inquirer.js prompt:
+*Available since Optique 1.3.0.*
+
+Pass shared prompt options as the third argument to `prompt()` when a prompted
+value needs a recoverable check.  The validator may be synchronous or
+asynchronous.  Return `undefined` to accept the value, or a structured
+`Message` to show an explanation and open the prompt again:
 
 ~~~~ typescript twoslash
-import { parseAsync } from "@optique/core/parser";
+declare function canDeployTo(environment: string): Promise<boolean>;
+// ---cut-before---
+import { message } from "@optique/core/message";
 import { option } from "@optique/core/primitives";
 import { string } from "@optique/core/valueparser";
 import { prompt } from "@optique/inquirer";
 
+const environment = prompt(option("--environment", string()), {
+  type: "select",
+  message: "Choose the deployment environment:",
+  choices: ["development", "staging", "production"],
+}, {
+  maxAttempts: 3,
+  async validate(value) {
+    return await canDeployTo(value)
+      ? undefined
+      : message`Cannot deploy to ${value}.`;
+  },
+});
+~~~~
+
+This shared validator runs after Inquirer.js returns a value and works with
+every prompt type.  The `input`, `password`, and `editor` configs also retain
+their native `validate` callbacks.  Native validation keeps the same
+Inquirer.js prompt open, so rejected native submissions do not advance the
+shared attempt count.
+
+Before retrying a built-in Inquirer.js prompt, Optique writes the previous
+shared validation message to stderr.  A custom `prompter` receives that message
+in its attempt context and is responsible for displaying it.  `maxAttempts`
+must be a positive integer; when the limit is reached, the last validation
+message becomes the parse failure.  Omitting the limit allows retries until the
+answer passes or the prompt ends.
+
+Pass an `AbortSignal` as `signal` to stop an active prompt or validator.  The
+parse rejects with the signal's reason.  User cancellation, such as Ctrl+C,
+instead produces a `Prompt cancelled.` parse failure.  Unexpected errors from
+Inquirer.js, a custom prompter, or a shared validator propagate unchanged.
+
+
+Testing
+-------
+
+All prompt configuration types accept an optional `prompter` property for
+testing.  It receives the shared attempt context and runs instead of an
+interactive Inquirer.js prompt:
+
+~~~~ typescript twoslash
+import { parseAsync } from "@optique/core/parser";
+import { message } from "@optique/core/message";
+import { option } from "@optique/core/primitives";
+import { string } from "@optique/core/valueparser";
+import { prompt } from "@optique/inquirer";
+
+const answers = ["", "Alice"];
 const parser = prompt(option("--name", string()), {
   type: "input",
   message: "Enter your name:",
-  prompter: () => Promise.resolve("Alice"),  // used in tests
+  prompter: ({ attempt }) =>
+    Promise.resolve(answers[attempt - 1] ?? "Alice"),
+}, {
+  validate: (value) => value === "" ? message`Enter a name.` : undefined,
 });
 
 const result = await parseAsync(parser, []);
@@ -584,7 +641,7 @@ const result = await parseAsync(parser, []);
 API reference
 -------------
 
-### `prompt(parser, config)`
+### `prompt(parser, config, options?)`
 
 Wraps a parser with an Inquirer.js prompt fallback.
 
@@ -598,11 +655,16 @@ Parameters
         resolver may return any [`RuntimePromptConfig`] member; see the
         [*@optique/prompt* documentation](./prompt.md#derived-prompt-configurations)
         for the resolver contract.
+     -  `options`: Shared validation, retry-limit, and abort options.  See
+        [`PromptOptions<T>`](#promptoptionst).
 
 Returns
 :   A new parser with `mode: "async"` and Inquirer.js prompt fallback.
     The `usage` is wrapped in an `optional` term since the prompt handles
     the missing-value case.
+
+Throws
+:   `RangeError` when `options.maxAttempts` is not a positive integer.
 
 [`PromptConfig<T>`]: #promptconfigt
 [`RuntimePromptConfig`]: #runtimepromptconfig
@@ -642,6 +704,31 @@ parser's value type.  For example, do not return a `number` configuration for a
 parser that produces a string.  See
 [Prompt and inner parser independence](#prompt-and-inner-parser-independence).
 
+### `PromptValidator<T>`
+
+*Available since Optique 1.3.0.*
+
+Re-exported from *@optique/prompt*.  It validates a returned prompt value and
+returns `undefined` to accept it or a `Message` to retry.  See the
+[*@optique/prompt* API reference](./prompt.md#promptvalidatortvalue).
+
+### `PromptOptions<T>`
+
+*Available since Optique 1.3.0.*
+
+Re-exported from *@optique/prompt*.  It supplies the shared `validate`,
+`maxAttempts`, and `signal` options.  See the
+[*@optique/prompt* API reference](./prompt.md#promptoptionstvalue).
+
+### `PromptExecutionContext`
+
+*Available since Optique 1.3.0.*
+
+Re-exported from *@optique/prompt*.  A custom `prompter` receives the one-based
+attempt number, previous validation message, and optional abort signal through
+this context.  See the
+[*@optique/prompt* API reference](./prompt.md#promptexecutioncontext).
+
 ### `Choice`
 
 An object with `value`, optional `name`, `description`, `short`, and
@@ -672,9 +759,10 @@ value domain, making the prompted value incompatible with the inner
 parser's input path.  Treating the two paths independently avoids false
 rejections and keeps the architecture sound.
 
-As a consequence, any runtime validation you need on prompted values
-must be configured in the prompt config itself.  Some prompt types
-provide a `validate` option for this purpose.
+Use the shared `validate` option in the third argument to `prompt()` for
+recoverable checks on any prompted value.  The `input`, `password`, and
+`editor` configs also provide native `validate` callbacks for feedback within
+one Inquirer.js prompt.
 
 ### Matching constraints between CLI and prompt
 
@@ -733,17 +821,29 @@ prompt config.
     ~~~~
 
 `checkbox` with `multiple()` cardinality
-:   The `checkbox` prompt type does not currently support a `validate`
-    callback, so cardinality constraints from `multiple(..., { min, max })`
-    cannot be enforced at the prompt level.  This is a known limitation;
-    prompted checkbox values may violate the inner parser's cardinality
-    bounds.
+:   Use shared validation to mirror cardinality constraints from
+    `multiple(..., { min, max })`:
 
-> [!IMPORTANT]
-> `select`, `rawlist`, `expand`, and `checkbox` prompt types do not
-> expose a `validate` callback.  For these types, there is currently no
-> way to add custom runtime validation on prompted values.  This is a
-> known limitation that may be addressed in a future release.
+    ~~~~ typescript twoslash
+    import { message } from "@optique/core/message";
+    import { option } from "@optique/core/primitives";
+    import { multiple } from "@optique/core/modifiers";
+    import { string } from "@optique/core/valueparser";
+    import { prompt } from "@optique/inquirer";
+
+    const tags = prompt(
+      multiple(option("--tag", string()), { min: 2 }),
+      {
+        type: "checkbox",
+        message: "Select at least two tags:",
+        choices: ["typescript", "deno", "node", "bun"],
+      },
+      {
+        validate: (values) =>
+          values.length >= 2 ? undefined : message`Select at least two tags.`,
+      },
+    );
+    ~~~~
 
 
 Limitations
@@ -755,9 +855,11 @@ Limitations
  -  *No shell completion* — Interactive prompts do not contribute to shell
     tab-completion suggestions.  Only the wrapped inner parser's suggestions
     are used.
- -  *Per-occurrence caching* — A reached `prompt()` occurrence runs its
-    prompter at most once per parse.  Reusing one prompt parser at several
-    positions creates a separate occurrence at each position.
+ -  *Per-occurrence caching* — A reached `prompt()` occurrence completes once
+    per parse.  Shared validation may call Inquirer.js or a custom `prompter`
+    several times inside that completion, but only the terminal result is
+    cached.  Reusing one prompt parser at several positions creates a separate
+    occurrence at each position.
  -  *TTY required*: Inquirer.js requires an interactive terminal (TTY).
     In non-interactive environments (CI pipelines, piped input), prompts
     will error.  Use the `prompter` override for non-interactive testing.

--- a/docs/integrations/prompt.md
+++ b/docs/integrations/prompt.md
@@ -175,7 +175,7 @@ export const prompt = createPromptAdapter<TextConfig>({
 ~~~~
 
 Concrete integrations can keep their own naming conventions.  For example,
-*@optique/inquirer* uses Inquirer-style `input` and `checkbox` names, while
+*@optique/inquirer* uses Inquirer.js-style `input` and `checkbox` names, while
 *@optique/clack* uses Clack-style `text` and `multiselect` names.
 
 

--- a/packages/core/skills/optique/SKILL.md
+++ b/packages/core/skills/optique/SKILL.md
@@ -65,12 +65,12 @@ Core rules
     the wrapped parser separately when the CLI domain should change, and make
     it a dependency source only if another consumer needs its answer. Keep
     static prompt configs for everything else.
- -  For a custom adapter built with `createPromptAdapter()`, pass shared
-    validation options as the generated wrapper's third argument:
-    `{ validate, maxAttempts, signal }`. The validator receives the prompted
-    value and returns `undefined` to accept it or a structured `Message` to
-    retry; it may be synchronous or asynchronous. Attempt limits must be
-    positive integers and default to unlimited retries.
+ -  Pass `{ validate, maxAttempts, signal }` as a generated prompt wrapper's
+    third argument, including `prompt()` from *@optique/inquirer*. The validator
+    returns `undefined` to accept the prompted value or a structured `Message`
+    to retry, synchronously or asynchronously. Attempt limits must be positive
+    integers and default to unlimited retries. Inquirer.js selection prompts use
+    this shared validation rather than their prompt config.
  -  Implement a custom adapter's `execute(config, context)` so retries can show
     `context.previousValidationMessage`, and forward `context.signal` when the
     prompt library supports aborting active work. Adapter-native validation

--- a/packages/inquirer/src/index.test.ts
+++ b/packages/inquirer/src/index.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import process from "node:process";
 import * as fc from "fast-check";
 import { describe, it } from "node:test";
 import { type Annotations, getAnnotations } from "@optique/core/annotations";
@@ -12,7 +13,7 @@ import type {
 } from "@optique/core/context";
 import type { DocFragments } from "@optique/core/doc";
 import { runWith } from "@optique/core/facade";
-import { message } from "@optique/core/message";
+import { formatMessage, message } from "@optique/core/message";
 import {
   parseAsync,
   type Parser,
@@ -24,7 +25,14 @@ import { constant, fail, flag, option } from "@optique/core/primitives";
 import { map, multiple, optional, withDefault } from "@optique/core/modifiers";
 import { choice, integer, string } from "@optique/core/valueparser";
 import { bindEnv, bool, createEnvContext } from "@optique/env";
-import { derivePromptConfig, prompt, Separator } from "@optique/inquirer";
+import {
+  derivePromptConfig,
+  prompt,
+  type PromptExecutionContext,
+  type PromptOptions,
+  type PromptValidator,
+  Separator,
+} from "@optique/inquirer";
 import { bindConfig, createConfigContext } from "@optique/config";
 import { runAsync } from "@optique/run/run";
 
@@ -36,6 +44,45 @@ const propertyParameters = { numRuns: 120 } as const;
 const cliStringValueArbitrary = fc.string().map((value) => `value${value}`);
 
 let promptFunctionsOverrideQueue = Promise.resolve();
+
+interface Deferred<T> {
+  readonly promise: Promise<T>;
+  readonly resolve: (value: T) => void;
+  readonly reject: (reason?: unknown) => void;
+}
+
+interface InquirerPromptContext {
+  readonly signal?: AbortSignal;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+async function withCapturedStderr<T>(
+  callback: (chunks: string[]) => Promise<T>,
+  observeWrite?: (chunk: string) => void,
+): Promise<T> {
+  const chunks: string[] = [];
+  const originalWrite = process.stderr.write;
+  process.stderr.write = ((chunk: string | Uint8Array) => {
+    const text = String(chunk);
+    chunks.push(text);
+    observeWrite?.(text);
+    return true;
+  }) as typeof process.stderr.write;
+  try {
+    return await callback(chunks);
+  } finally {
+    process.stderr.write = originalWrite;
+  }
+}
 
 function isPhase2ContextRequest(
   request: unknown,
@@ -730,6 +777,386 @@ describe("prompt()", () => {
           return true;
         },
       );
+    });
+  });
+
+  describe("shared validation, retries, and aborts", {
+    concurrency: false,
+  }, () => {
+    async function assertSelectionPromptRetries<TValue, TState>(
+      promptName: "select" | "rawlist" | "expand" | "checkbox",
+      answers: readonly [TValue, TValue],
+      createParser: (
+        options: PromptOptions<TValue>,
+      ) => Parser<"async", TValue, TState>,
+    ): Promise<void> {
+      const validationMessage = message`That value is not available.`;
+      const events: string[] = [];
+      let promptCalls = 0;
+      let validationCalls = 0;
+
+      await withCapturedStderr(
+        async (chunks) => {
+          await withPromptFunctionsOverride(
+            {
+              [promptName]: () => {
+                promptCalls++;
+                events.push(`prompt:${promptCalls}`);
+                return Promise.resolve(answers[promptCalls - 1]);
+              },
+            },
+            async () => {
+              const parser = createParser({
+                async validate() {
+                  validationCalls++;
+                  events.push(`validate:${validationCalls}`);
+                  await Promise.resolve();
+                  return validationCalls === 1 ? validationMessage : undefined;
+                },
+              });
+
+              const result = await parseAsync(parser, []);
+
+              assert.ok(result.success);
+              assert.deepEqual(result.value, answers[1]);
+            },
+          );
+
+          assert.deepEqual(chunks, [formatMessage(validationMessage) + "\n"]);
+        },
+        () => events.push("stderr"),
+      );
+
+      assert.deepEqual(events, [
+        "prompt:1",
+        "validate:1",
+        "stderr",
+        "prompt:2",
+        "validate:2",
+      ]);
+    }
+
+    it("should infer shared validator values from the wrapped parser", () => {
+      const validator = ((value) =>
+        value.length > 0
+          ? undefined
+          : message`Enter a name.`) satisfies PromptValidator<string>;
+      const options = { validate: validator } satisfies PromptOptions<string>;
+      const parser = prompt(
+        option("--name", string()),
+        { type: "input", message: "Enter name:" },
+        options,
+      );
+
+      prompt(option("--name", string()), {
+        type: "input",
+        message: "Enter name:",
+      }, {
+        // @ts-expect-error The wrapped parser determines the validator value.
+        validate: (_value: number) =>
+          undefined,
+      });
+
+      assert.equal(parser.mode, "async");
+    });
+
+    it("should retry select prompts after shared validation", async () => {
+      await assertSelectionPromptRetries<string, undefined>(
+        "select",
+        ["development", "production"],
+        (options) =>
+          prompt(fail<string>(), {
+            type: "select",
+            message: "Choose environment:",
+            choices: ["development", "production"],
+          }, options),
+      );
+    });
+
+    it("should retry rawlist prompts after shared validation", async () => {
+      await assertSelectionPromptRetries<string, undefined>(
+        "rawlist",
+        ["json", "yaml"],
+        (options) =>
+          prompt(fail<string>(), {
+            type: "rawlist",
+            message: "Choose format:",
+            choices: ["json", "yaml"],
+          }, options),
+      );
+    });
+
+    it("should retry expand prompts after shared validation", async () => {
+      await assertSelectionPromptRetries<string, undefined>(
+        "expand",
+        ["skip", "overwrite"],
+        (options) =>
+          prompt(fail<string>(), {
+            type: "expand",
+            message: "Choose action:",
+            choices: [
+              { value: "skip", key: "s" },
+              { value: "overwrite", key: "o" },
+            ],
+          }, options),
+      );
+    });
+
+    it("should retry checkbox prompts after shared validation", async () => {
+      await assertSelectionPromptRetries<readonly string[], undefined>(
+        "checkbox",
+        [["typescript"], ["typescript", "deno"]],
+        (options) =>
+          prompt(fail<readonly string[]>(), {
+            type: "checkbox",
+            message: "Choose runtimes:",
+            choices: ["typescript", "deno"],
+          }, options),
+      );
+    });
+
+    it("should pass retry context to a custom prompter without writing", async () => {
+      const controller = new AbortController();
+      const validationMessage = message`Choose production.`;
+      const contexts: PromptExecutionContext[] = [];
+      const answers = ["development", "production"] as const;
+
+      await withCapturedStderr(async (chunks) => {
+        const parser = prompt(fail<string>(), {
+          type: "select",
+          message: "Choose environment:",
+          choices: answers,
+          prompter: (context) => {
+            contexts.push(context);
+            return Promise.resolve(answers[context.attempt - 1]);
+          },
+        }, {
+          signal: controller.signal,
+          validate(value) {
+            return value === "production" ? undefined : validationMessage;
+          },
+        });
+
+        const result = await parseAsync(parser, []);
+
+        assert.ok(result.success);
+        assert.equal(result.value, "production");
+        assert.deepEqual(chunks, []);
+      });
+
+      assert.deepEqual(contexts, [
+        { attempt: 1, signal: controller.signal },
+        {
+          attempt: 2,
+          previousValidationMessage: validationMessage,
+          signal: controller.signal,
+        },
+      ]);
+      assert.equal(contexts[1].previousValidationMessage, validationMessage);
+    });
+
+    it("should finish native validation within one shared attempt", async () => {
+      const events: string[] = [];
+      let promptCalls = 0;
+      let nativeValidationCalls = 0;
+      let sharedValidationCalls = 0;
+
+      await withPromptFunctionsOverride(
+        {
+          input: async (config: {
+            readonly validate?: (
+              value: string,
+            ) => boolean | string | Promise<boolean | string>;
+          }) => {
+            promptCalls++;
+            nativeValidationCalls++;
+            events.push("native:invalid");
+            assert.equal(
+              await config.validate?.(""),
+              "Name is required.",
+            );
+            nativeValidationCalls++;
+            events.push("native:valid");
+            assert.equal(await config.validate?.("Alice"), true);
+            return "Alice";
+          },
+        },
+        async () => {
+          const parser = prompt(fail<string>(), {
+            type: "input",
+            message: "Enter name:",
+            validate: (value) => value.length > 0 || "Name is required.",
+          }, {
+            validate(value) {
+              sharedValidationCalls++;
+              events.push("shared");
+              assert.equal(value, "Alice");
+              return undefined;
+            },
+          });
+
+          const result = await parseAsync(parser, []);
+
+          assert.ok(result.success);
+          assert.equal(result.value, "Alice");
+        },
+      );
+
+      assert.equal(promptCalls, 1);
+      assert.equal(nativeValidationCalls, 2);
+      assert.equal(sharedValidationCalls, 1);
+      assert.deepEqual(events, ["native:invalid", "native:valid", "shared"]);
+    });
+
+    it("should honor the shared maximum attempt limit", async () => {
+      const validationMessage = message`Production is required.`;
+      let promptCalls = 0;
+
+      await withCapturedStderr(async (chunks) => {
+        await withPromptFunctionsOverride(
+          {
+            select: () => {
+              promptCalls++;
+              return Promise.resolve("development");
+            },
+          },
+          async () => {
+            const parser = prompt(fail<string>(), {
+              type: "select",
+              message: "Choose environment:",
+              choices: ["development", "production"],
+            }, {
+              maxAttempts: 1,
+              validate: () => validationMessage,
+            });
+
+            const result = await parseAsync(parser, []);
+
+            assert.ok(!result.success);
+            assert.equal(result.error, validationMessage);
+          },
+        );
+
+        assert.deepEqual(chunks, []);
+      });
+
+      assert.equal(promptCalls, 1);
+    });
+
+    it("should treat user cancellation during a retry as terminal", async () => {
+      const validationMessage = message`Production is required.`;
+      let promptCalls = 0;
+      let validationCalls = 0;
+
+      await withCapturedStderr(async () => {
+        await withPromptFunctionsOverride(
+          {
+            select: () => {
+              promptCalls++;
+              if (promptCalls === 1) return Promise.resolve("development");
+              const error = new Error("User cancelled the prompt.");
+              error.name = "ExitPromptError";
+              throw error;
+            },
+          },
+          async () => {
+            const parser = prompt(fail<string>(), {
+              type: "select",
+              message: "Choose environment:",
+              choices: ["development", "production"],
+            }, {
+              validate() {
+                validationCalls++;
+                return validationMessage;
+              },
+            });
+
+            const result = await parseAsync(parser, []);
+
+            assert.ok(!result.success);
+            assert.equal(formatMessage(result.error), "Prompt cancelled.");
+          },
+        );
+      });
+
+      assert.equal(promptCalls, 2);
+      assert.equal(validationCalls, 1);
+    });
+
+    it("should reject a pre-aborted signal before invoking Inquirer.js", async () => {
+      const controller = new AbortController();
+      const reason = { code: "stopped" };
+      controller.abort(reason);
+
+      await withCapturedStderr(async (chunks) => {
+        await withPromptFunctionsOverride(
+          {
+            input: () => {
+              assert.fail("Inquirer.js should not be called.");
+            },
+          },
+          async () => {
+            const parser = prompt(fail<string>(), {
+              type: "input",
+              message: "Enter name:",
+            }, { signal: controller.signal });
+
+            await assert.rejects(
+              () => parseAsync(parser, []),
+              (error: unknown) => error === reason,
+            );
+          },
+        );
+
+        assert.deepEqual(chunks, []);
+      });
+    });
+
+    it("should reject with the signal reason during an active prompt", async () => {
+      const controller = new AbortController();
+      const reason = { code: "stopped" };
+      const started = deferred<void>();
+      const attempt = deferred<string>();
+      const contexts: (InquirerPromptContext | undefined)[] = [];
+
+      await withCapturedStderr(async (chunks) => {
+        await withPromptFunctionsOverride(
+          {
+            input: (
+              _config: Record<string, unknown>,
+              context?: InquirerPromptContext,
+            ) => {
+              contexts.push(context);
+              started.resolve(undefined);
+              return attempt.promise;
+            },
+          },
+          async () => {
+            const parser = prompt(fail<string>(), {
+              type: "input",
+              message: "Enter name:",
+            }, { signal: controller.signal });
+
+            const parsing = parseAsync(parser, []);
+            await started.promise;
+            controller.abort(reason);
+
+            await assert.rejects(
+              () => parsing,
+              (error: unknown) => error === reason,
+            );
+
+            const abortError = new Error("Prompt aborted.");
+            abortError.name = "AbortPromptError";
+            attempt.reject(abortError);
+            await Promise.resolve();
+          },
+        );
+
+        assert.deepEqual(chunks, []);
+      });
+
+      assert.deepEqual(contexts, [{ signal: controller.signal }]);
     });
   });
 
@@ -4049,44 +4476,75 @@ describe("prompt()", () => {
     );
 
     it("executes built-in prompt branches via prompt-function override", async () => {
-      const calls: Array<{ name: string; config: Record<string, unknown> }> =
-        [];
+      const controller = new AbortController();
+      const calls: Array<{
+        name: string;
+        config: Record<string, unknown>;
+        context?: InquirerPromptContext;
+      }> = [];
       await withPromptFunctionsOverride(
         {
-          confirm: (config: Record<string, unknown>) => {
-            calls.push({ name: "confirm", config });
+          confirm: (
+            config: Record<string, unknown>,
+            context?: InquirerPromptContext,
+          ) => {
+            calls.push({ name: "confirm", config, context });
             return true;
           },
-          number: (config: Record<string, unknown>) => {
-            calls.push({ name: "number", config });
+          number: (
+            config: Record<string, unknown>,
+            context?: InquirerPromptContext,
+          ) => {
+            calls.push({ name: "number", config, context });
             return 42;
           },
-          input: (config: Record<string, unknown>) => {
-            calls.push({ name: "input", config });
+          input: (
+            config: Record<string, unknown>,
+            context?: InquirerPromptContext,
+          ) => {
+            calls.push({ name: "input", config, context });
             return "hello";
           },
-          password: (config: Record<string, unknown>) => {
-            calls.push({ name: "password", config });
+          password: (
+            config: Record<string, unknown>,
+            context?: InquirerPromptContext,
+          ) => {
+            calls.push({ name: "password", config, context });
             return "secret";
           },
-          editor: (config: Record<string, unknown>) => {
-            calls.push({ name: "editor", config });
+          editor: (
+            config: Record<string, unknown>,
+            context?: InquirerPromptContext,
+          ) => {
+            calls.push({ name: "editor", config, context });
             return "edited";
           },
-          select: (config: Record<string, unknown>) => {
-            calls.push({ name: "select", config });
+          select: (
+            config: Record<string, unknown>,
+            context?: InquirerPromptContext,
+          ) => {
+            calls.push({ name: "select", config, context });
             return "green";
           },
-          rawlist: (config: Record<string, unknown>) => {
-            calls.push({ name: "rawlist", config });
+          rawlist: (
+            config: Record<string, unknown>,
+            context?: InquirerPromptContext,
+          ) => {
+            calls.push({ name: "rawlist", config, context });
             return "prod";
           },
-          expand: (config: Record<string, unknown>) => {
-            calls.push({ name: "expand", config });
+          expand: (
+            config: Record<string, unknown>,
+            context?: InquirerPromptContext,
+          ) => {
+            calls.push({ name: "expand", config, context });
             return "info";
           },
-          checkbox: (config: Record<string, unknown>) => {
-            calls.push({ name: "checkbox", config });
+          checkbox: (
+            config: Record<string, unknown>,
+            context?: InquirerPromptContext,
+          ) => {
+            calls.push({ name: "checkbox", config, context });
             return ["a", "c"];
           },
         },
@@ -4097,7 +4555,7 @@ describe("prompt()", () => {
                 type: "confirm",
                 message: "confirm?",
                 default: true,
-              }),
+              }, { signal: controller.signal }),
               [],
             )).success,
           );
@@ -4111,7 +4569,7 @@ describe("prompt()", () => {
                 min: 1,
                 max: 10,
                 step: 1,
-              }),
+              }, { signal: controller.signal }),
               [],
             )).success,
           );
@@ -4123,7 +4581,7 @@ describe("prompt()", () => {
                 message: "input?",
                 default: "x",
                 validate: (value) => value.length > 0,
-              }),
+              }, { signal: controller.signal }),
               [],
             )).success,
           );
@@ -4135,7 +4593,7 @@ describe("prompt()", () => {
                 message: "password?",
                 mask: true,
                 validate: (value) => value.length > 0,
-              }),
+              }, { signal: controller.signal }),
               [],
             )).success,
           );
@@ -4147,7 +4605,7 @@ describe("prompt()", () => {
                 message: "editor?",
                 default: "draft",
                 validate: (value) => value.length > 0,
-              }),
+              }, { signal: controller.signal }),
               [],
             )).success,
           );
@@ -4168,7 +4626,7 @@ describe("prompt()", () => {
                   },
                   { value: "blue", name: "Blue", disabled: "skip" },
                 ],
-              }),
+              }, { signal: controller.signal }),
               [],
             )).success,
           );
@@ -4183,7 +4641,7 @@ describe("prompt()", () => {
                   "dev",
                   { value: "prod", name: "Production" },
                 ],
-              }),
+              }, { signal: controller.signal }),
               [],
             )).success,
           );
@@ -4198,7 +4656,7 @@ describe("prompt()", () => {
                   { value: "debug", key: "d" },
                   { value: "info", key: "i", name: "Info" },
                 ],
-              }),
+              }, { signal: controller.signal }),
               [],
             )).success,
           );
@@ -4212,7 +4670,7 @@ describe("prompt()", () => {
                   "a",
                   { value: "c", name: "C", disabled: false },
                 ],
-              }),
+              }, { signal: controller.signal }),
               [],
             )).success,
           );
@@ -4229,14 +4687,23 @@ describe("prompt()", () => {
       assert.ok(names.includes("rawlist"));
       assert.ok(names.includes("expand"));
       assert.ok(names.includes("checkbox"));
+      assert.deepEqual(
+        calls.map((call) => call.context),
+        calls.map(() => ({ signal: controller.signal })),
+      );
     });
 
     it("covers prompt config spreads when optional fields are absent", async () => {
       const calls: Array<{ name: string; config: Record<string, unknown> }> =
         [];
+      let inquirerContext: InquirerPromptContext | undefined;
       await withPromptFunctionsOverride(
         {
-          confirm: (config: Record<string, unknown>) => {
+          confirm: (
+            config: Record<string, unknown>,
+            context?: InquirerPromptContext,
+          ) => {
+            inquirerContext = context;
             calls.push({ name: "confirm", config });
             return true;
           },
@@ -4343,6 +4810,7 @@ describe("prompt()", () => {
         !("name" in (((byName.get("select")?.choices as unknown[])?.[0] ??
           {}) as object)),
       );
+      assert.deepEqual(inquirerContext, {});
     });
 
     it("covers suggest() state unwrapping branches", async () => {

--- a/packages/inquirer/src/index.ts
+++ b/packages/inquirer/src/index.ts
@@ -4,6 +4,7 @@
  * @module
  * @since 1.0.0
  */
+import process from "node:process";
 import {
   checkbox,
   confirm,
@@ -17,13 +18,15 @@ import {
   Separator,
 } from "@inquirer/prompts";
 import type { FluentParser } from "@optique/core/fluent";
-import { message } from "@optique/core/message";
+import { formatMessage, message } from "@optique/core/message";
 import type { Mode, Parser } from "@optique/core/parser";
 import type { ValueParserResult } from "@optique/core/valueparser";
 import {
   createPromptAdapter,
   type DerivedPromptConfig,
   type PromptCondition,
+  type PromptExecutionContext,
+  type PromptOptions,
 } from "@optique/prompt";
 
 export { derivePromptConfig, isDerivedPromptConfig } from "@optique/prompt";
@@ -33,6 +36,9 @@ export type {
   DerivePromptConfigOptions,
   DerivePromptConfigsContext,
   DerivePromptConfigsOptions,
+  PromptExecutionContext,
+  PromptOptions,
+  PromptValidator,
 } from "@optique/prompt";
 
 // Re-export Separator for use in choice lists.
@@ -56,6 +62,10 @@ interface PromptFunctions {
   readonly rawlist: typeof rawlist;
   readonly expand: typeof expand;
   readonly checkbox: typeof checkbox;
+}
+
+interface InquirerPromptContext {
+  readonly signal?: AbortSignal;
 }
 
 const promptFunctionsOverrideSymbol = Symbol.for(
@@ -122,7 +132,7 @@ function getPromptFunctions(): PromptFunctions {
 }
 
 /**
- * Determines whether an error came from an interrupted Inquirer prompt.
+ * Determines whether an error came from an interrupted Inquirer.js prompt.
  */
 function isExitPromptError(error: unknown): boolean {
   return typeof error === "object" &&
@@ -214,8 +224,11 @@ export interface ConfirmConfig {
   readonly message: string;
   /** Default answer when the user just presses Enter. */
   readonly default?: boolean;
-  /** Override the prompt execution. Useful for testing. */
-  readonly prompter?: () => Promise<boolean>;
+  /**
+   * Override the prompt execution. Useful for testing.
+   * @since 1.3.0 The callback receives the current attempt context.
+   */
+  readonly prompter?: (context: PromptExecutionContext) => Promise<boolean>;
 }
 
 /**
@@ -235,8 +248,13 @@ export interface NumberPromptConfig {
   readonly max?: number;
   /** Granularity of valid values. Use `"any"` for arbitrary decimals. */
   readonly step?: number | "any";
-  /** Override the prompt execution. Useful for testing. */
-  readonly prompter?: () => Promise<number | undefined>;
+  /**
+   * Override the prompt execution. Useful for testing.
+   * @since 1.3.0 The callback receives the current attempt context.
+   */
+  readonly prompter?: (
+    context: PromptExecutionContext,
+  ) => Promise<number | undefined>;
 }
 
 /**
@@ -254,8 +272,11 @@ export interface InputConfig {
   readonly validate?: (
     value: string,
   ) => boolean | string | Promise<boolean | string>;
-  /** Override the prompt execution. Useful for testing. */
-  readonly prompter?: () => Promise<string>;
+  /**
+   * Override the prompt execution. Useful for testing.
+   * @since 1.3.0 The callback receives the current attempt context.
+   */
+  readonly prompter?: (context: PromptExecutionContext) => Promise<string>;
 }
 
 /**
@@ -273,8 +294,11 @@ export interface PasswordConfig {
   readonly validate?: (
     value: string,
   ) => boolean | string | Promise<boolean | string>;
-  /** Override the prompt execution. Useful for testing. */
-  readonly prompter?: () => Promise<string>;
+  /**
+   * Override the prompt execution. Useful for testing.
+   * @since 1.3.0 The callback receives the current attempt context.
+   */
+  readonly prompter?: (context: PromptExecutionContext) => Promise<string>;
 }
 
 /**
@@ -292,8 +316,11 @@ export interface EditorConfig {
   readonly validate?: (
     value: string,
   ) => boolean | string | Promise<boolean | string>;
-  /** Override the prompt execution. Useful for testing. */
-  readonly prompter?: () => Promise<string>;
+  /**
+   * Override the prompt execution. Useful for testing.
+   * @since 1.3.0 The callback receives the current attempt context.
+   */
+  readonly prompter?: (context: PromptExecutionContext) => Promise<string>;
 }
 
 /**
@@ -309,8 +336,11 @@ export interface SelectConfig {
   readonly choices: readonly (string | Choice | Separator)[];
   /** Initially highlighted choice value. */
   readonly default?: string;
-  /** Override the prompt execution. Useful for testing. */
-  readonly prompter?: () => Promise<string>;
+  /**
+   * Override the prompt execution. Useful for testing.
+   * @since 1.3.0 The callback receives the current attempt context.
+   */
+  readonly prompter?: (context: PromptExecutionContext) => Promise<string>;
 }
 
 /**
@@ -326,8 +356,11 @@ export interface RawlistConfig {
   readonly choices: readonly (string | Choice)[];
   /** Pre-selected choice value. */
   readonly default?: string;
-  /** Override the prompt execution. Useful for testing. */
-  readonly prompter?: () => Promise<string>;
+  /**
+   * Override the prompt execution. Useful for testing.
+   * @since 1.3.0 The callback receives the current attempt context.
+   */
+  readonly prompter?: (context: PromptExecutionContext) => Promise<string>;
 }
 
 /**
@@ -343,8 +376,11 @@ export interface ExpandConfig {
   readonly choices: readonly ExpandChoice[];
   /** Default choice key. */
   readonly default?: string;
-  /** Override the prompt execution. Useful for testing. */
-  readonly prompter?: () => Promise<string>;
+  /**
+   * Override the prompt execution. Useful for testing.
+   * @since 1.3.0 The callback receives the current attempt context.
+   */
+  readonly prompter?: (context: PromptExecutionContext) => Promise<string>;
 }
 
 /**
@@ -358,8 +394,13 @@ export interface CheckboxConfig {
   readonly message: string;
   /** Available choices. */
   readonly choices: readonly (string | CheckboxChoice | Separator)[];
-  /** Override the prompt execution. Useful for testing. */
-  readonly prompter?: () => Promise<readonly string[]>;
+  /**
+   * Override the prompt execution. Useful for testing.
+   * @since 1.3.0 The callback receives the current attempt context.
+   */
+  readonly prompter?: (
+    context: PromptExecutionContext,
+  ) => Promise<readonly string[]>;
 }
 
 /**
@@ -427,28 +468,34 @@ const validPromptTypes: ReadonlySet<string> = new Set([
  *
  * When the inner parser finds a value in the CLI arguments, that value is used
  * directly.  When no CLI value is found, an interactive prompt is shown to the
- * user.
+ * user.  If the supplied signal is aborted, parsing rejects with the signal's
+ * reason.
  *
  * @param parser Inner parser that reads CLI values.
  * @param config Type-safe Inquirer.js prompt configuration, or a
  *               configuration derived from dependency sources via
  *               `derivePromptConfig()`.
+ * @param options Shared validation, retry, and abort options for the
+ *                interactive fallback.
  * @returns A parser with interactive prompt fallback, always in async mode.
+ * @throws {RangeError} If `options.maxAttempts` is not a positive integer.
  * @throws {Error} If prompt execution fails with an unexpected error or if the
  *                 inner parser throws while parsing or completing.
  * @since 1.0.0
+ * @since 1.3.0 Added the `options` parameter.
  */
 export function prompt<M extends Mode, TValue, TState>(
   parser: Parser<M, TValue, TState>,
   config:
     | PromptConfig<TValue>
     | DerivedPromptConfig<RuntimePromptConfig, NoInfer<TValue>>,
+  options?: PromptOptions<NoInfer<TValue>>,
 ): FluentParser<"async", TValue, TState> {
   const promptWithAdapter = createPromptAdapter<RuntimePromptConfig>({
     execute: executePromptRaw,
     getDefaultValue: getConfigDefault,
   });
-  return promptWithAdapter(parser, config);
+  return promptWithAdapter(parser, config, options);
 }
 
 function getConfigDefault(config: unknown): unknown {
@@ -460,6 +507,7 @@ function getConfigDefault(config: unknown): unknown {
 
 async function executePromptRaw<TValue>(
   config: RuntimePromptConfig,
+  context: PromptExecutionContext,
 ): Promise<ValueParserResult<TValue>> {
   const cfg = config;
   const prompts = getPromptFunctions();
@@ -471,12 +519,21 @@ async function executePromptRaw<TValue>(
     }
 
     if ("prompter" in cfg && cfg.prompter != null) {
-      const value = await cfg.prompter();
+      const value = await cfg.prompter(context);
       if (cfg.type === "number" && value === undefined) {
         return { success: false, error: message`No number provided.` };
       }
       return { success: true, value: value as TValue };
     }
+
+    if (context.previousValidationMessage !== undefined) {
+      process.stderr.write(
+        formatMessage(context.previousValidationMessage) + "\n",
+      );
+    }
+    const inquirerContext: InquirerPromptContext = {
+      ...(context.signal === undefined ? {} : { signal: context.signal }),
+    };
 
     switch (cfg.type) {
       case "confirm":
@@ -485,7 +542,7 @@ async function executePromptRaw<TValue>(
           value: await prompts.confirm({
             message: cfg.message,
             ...(cfg.default !== undefined ? { default: cfg.default } : {}),
-          }) as TValue,
+          }, inquirerContext) as TValue,
         };
 
       case "number": {
@@ -495,7 +552,7 @@ async function executePromptRaw<TValue>(
           ...(cfg.min !== undefined ? { min: cfg.min } : {}),
           ...(cfg.max !== undefined ? { max: cfg.max } : {}),
           ...(cfg.step !== undefined ? { step: cfg.step } : {}),
-        });
+        }, inquirerContext);
         if (numResult === undefined) {
           return { success: false, error: message`No number provided.` };
         }
@@ -509,7 +566,7 @@ async function executePromptRaw<TValue>(
             message: cfg.message,
             ...(cfg.default !== undefined ? { default: cfg.default } : {}),
             ...(cfg.validate !== undefined ? { validate: cfg.validate } : {}),
-          }) as TValue,
+          }, inquirerContext) as TValue,
         };
 
       case "password":
@@ -519,7 +576,7 @@ async function executePromptRaw<TValue>(
             message: cfg.message,
             ...(cfg.mask !== undefined ? { mask: cfg.mask } : {}),
             ...(cfg.validate !== undefined ? { validate: cfg.validate } : {}),
-          }) as TValue,
+          }, inquirerContext) as TValue,
         };
 
       case "editor":
@@ -529,7 +586,7 @@ async function executePromptRaw<TValue>(
             message: cfg.message,
             ...(cfg.default !== undefined ? { default: cfg.default } : {}),
             ...(cfg.validate !== undefined ? { validate: cfg.validate } : {}),
-          }) as TValue,
+          }, inquirerContext) as TValue,
         };
 
       case "select":
@@ -539,7 +596,7 @@ async function executePromptRaw<TValue>(
             message: cfg.message,
             choices: normalizeChoices(cfg.choices),
             ...(cfg.default !== undefined ? { default: cfg.default } : {}),
-          }) as TValue,
+          }, inquirerContext) as TValue,
         };
 
       case "rawlist":
@@ -549,21 +606,28 @@ async function executePromptRaw<TValue>(
             message: cfg.message,
             choices: normalizeChoices(cfg.choices),
             ...(cfg.default !== undefined ? { default: cfg.default } : {}),
-          }) as TValue,
+          }, inquirerContext) as TValue,
         };
 
       case "expand":
         return {
           success: true,
-          value: await (prompts.expand as (config: {
-            message: string;
-            choices: readonly { value: string; name?: string; key: string }[];
-            default?: string;
-          }) => Promise<string>)({
+          value: await (prompts.expand as (
+            config: {
+              message: string;
+              choices: readonly {
+                value: string;
+                name?: string;
+                key: string;
+              }[];
+              default?: string;
+            },
+            context?: InquirerPromptContext,
+          ) => Promise<string>)({
             message: cfg.message,
             choices: cfg.choices,
             ...(cfg.default !== undefined ? { default: cfg.default } : {}),
-          }) as TValue,
+          }, inquirerContext) as TValue,
         };
 
       case "checkbox":
@@ -572,13 +636,15 @@ async function executePromptRaw<TValue>(
           value: await prompts.checkbox({
             message: cfg.message,
             choices: normalizeChoices(cfg.choices),
-          }) as TValue,
+          }, inquirerContext) as TValue,
         };
     }
   } catch (error) {
     if (isExitPromptError(error)) {
       return { success: false, error: message`Prompt cancelled.` };
     }
+    // Inquirer.js uses AbortPromptError for an AbortSignal.  The shared adapter
+    // race propagates signal.reason, so do not treat it as user cancellation.
     throw error;
   }
 }


### PR DESCRIPTION
*@optique/inquirer* previously relied on Inquirer.js's native validation, which left selection prompts without an equivalent way to reject answers. It also could not stop an active prompt through the shared prompt contract.

The adapter now applies shared validation after any Inquirer.js prompt resolves and forwards its `AbortSignal` while the prompt is active. Native validation for `input`, `password`, and `editor` stays within one attempt. Built-in retries show the validation message, while custom prompters receive `PromptExecutionContext` and retain control of presentation.

The documentation and Agent Skill explain this boundary. The changelog also removes the stale claim that selection configs shipped native `validate` hooks.

Closes #937. Part of #873. Motivated by fedify-dev/fedify#943.
