### PR TITLE
Add shared validation to Clack prompts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -97,6 +97,10 @@ To be released.
  -  Added conditional prompt skipping to Clack prompt configurations with
     `when` and `otherwise`, allowing applications to avoid prompts whose
     runtime prerequisites are unavailable.  [[#882]]
+ -  Added shared validation, retry limits, and abort handling to `prompt()`
+    for every Clack prompt type, including selection prompts.  Custom
+    `prompter` callbacks now receive the attempt number, previous validation
+    message, and signal.  [[#873], [#936], [#940]]
  -  Added support for prompt configurations derived from dependency sources.
     `prompt()` now also accepts a `derivePromptConfig()` result whose
     resolver returns any of this package's prompt configurations, exposed
@@ -104,7 +108,10 @@ To be released.
     adapt its options to earlier answers.  `derivePromptConfig()` and its
     types are re-exported for convenience.  [[#869], [#872]]
 
+[#873]: https://github.com/dahlia/optique/issues/873
 [#882]: https://github.com/dahlia/optique/issues/882
+[#936]: https://github.com/dahlia/optique/issues/936
+[#940]: https://github.com/dahlia/optique/pull/940
 
 ### @optique/inquirer
 
@@ -123,7 +130,6 @@ To be released.
     adapt its choices to earlier answers.  `derivePromptConfig()` and its
     types are re-exported for convenience.  [[#869], [#872]]
 
-[#873]: https://github.com/dahlia/optique/issues/873
 [#937]: https://github.com/dahlia/optique/issues/937
 [#939]: https://github.com/dahlia/optique/pull/939
 

--- a/changes.d/clack/shared-prompt-validation.md
+++ b/changes.d/clack/shared-prompt-validation.md
@@ -1,0 +1,10 @@
+---
+links:
+  '#873': https://github.com/dahlia/optique/issues/873
+  '#936': https://github.com/dahlia/optique/issues/936
+  '#940': https://github.com/dahlia/optique/pull/940
+---
+ -  Added shared validation, retry limits, and abort handling to `prompt()`
+    for every Clack prompt type, including selection prompts.  Custom
+    `prompter` callbacks now receive the attempt number, previous validation
+    message, and signal.  [[#873], [#936], [#940]]

--- a/docs/integrations/clack.md
+++ b/docs/integrations/clack.md
@@ -612,7 +612,7 @@ re-exported from *@optique/prompt* for callers that need to name these types.
 
 [`PromptConfig<T>`]: #promptconfigt
 [`RuntimePromptConfig`]: #runtimepromptconfig
-[`PromptOptions<T>`]: ./prompt.md#promptoptions-tvalue
+[`PromptOptions<T>`]: ./prompt.md#promptoptionstvalue
 
 ### `PromptConfig<T>`
 

--- a/docs/integrations/clack.md
+++ b/docs/integrations/clack.md
@@ -468,10 +468,14 @@ const environment = prompt(option("--environment", string()), {
 
 The validator may be synchronous or asynchronous.  When it rejects a value,
 the prompt runs again and Clack displays the preceding validation message
-before opening the next prompt.  `maxAttempts` limits the number of Clack
-executions in that completion and must be a positive integer.  It defaults to
-unlimited retries; when the limit is exhausted, parsing fails with the last
-validation message.
+before opening the next prompt.  A failed adapter result ends parsing with that
+failure.  If the adapter or shared validator throws or rejects, the exception
+propagates unchanged and no retry runs.
+
+Each built-in Clack prompt execution or custom `prompter` invocation is one
+shared attempt.  `maxAttempts` limits these adapter executions in a completion
+and must be a positive integer.  It defaults to unlimited retries; when the
+limit is exhausted, parsing fails with the last validation message.
 
 Configuration-level `validate` fields on `text`, `password`, and `number` are
 native Clack validation.  They run within one Clack execution and can reject
@@ -597,10 +601,11 @@ Parameters
         resolver may return any [`RuntimePromptConfig`] member; see the
         [*@optique/prompt* documentation](./prompt.md#derived-prompt-configurations)
         for the resolver contract.
-     -  `options`: Optional shared [`PromptOptions<T>`] with `validate`,
-        `maxAttempts`, and `signal`.  These options apply after the adapter
-        returns a prompted value, independently of config-level native
-        validation.
+     -  `options`: Optional shared [`PromptOptions<T>`].  `validate` runs after
+        each successful adapter execution, independently of config-level native
+        validation.  `maxAttempts` limits adapter executions, including custom
+        `prompter` invocations.  `signal` can stop an active adapter execution
+        or validator.
 
 Returns
 :   A new parser with `mode: "async"` and Clack prompt fallback.  The `usage`

--- a/docs/integrations/clack.md
+++ b/docs/integrations/clack.md
@@ -435,14 +435,67 @@ When `when` returns `false`, `otherwise` is returned without opening Clack.  If
 the condition throws or rejects, the error propagates to the caller.
 
 
+Shared validation, retries, and cancellation
+--------------------------------------------
+
+*This API is available since Optique 1.3.0.*
+
+Pass a third options argument to `prompt()` to validate any value returned by
+Clack, including `select` and `multiselect` results.  The validator returns a
+structured [`Message`](../concepts/messages.md) to reject the value, or
+`undefined` to accept it:
+
+~~~~ typescript twoslash
+import { message } from "@optique/core/message";
+import { option } from "@optique/core/primitives";
+import { string } from "@optique/core/valueparser";
+import { prompt } from "@optique/clack";
+
+const environment = prompt(option("--environment", string()), {
+  type: "select",
+  message: "Choose the deployment environment:",
+  options: ["development", "production"],
+}, {
+  validate: async (value) => {
+    await Promise.resolve();
+    return value === "production"
+      ? undefined
+      : message`Production access is required.`;
+  },
+  maxAttempts: 3,
+});
+~~~~
+
+The validator may be synchronous or asynchronous.  When it rejects a value,
+the prompt runs again and Clack displays the preceding validation message
+before opening the next prompt.  `maxAttempts` limits the number of Clack
+executions in that completion and must be a positive integer.  It defaults to
+unlimited retries; when the limit is exhausted, parsing fails with the last
+validation message.
+
+Configuration-level `validate` fields on `text`, `password`, and `number` are
+native Clack validation.  They run within one Clack execution and can reject
+several submissions without consuming another shared attempt.  The third
+argument's shared validator runs once after Clack returns a value.
+
+Pass an `AbortSignal` as `signal` to stop an active prompt or validator.  An
+abort rejects parsing with the signal's exact `reason`; it is not converted to
+a `Prompt cancelled.` failure.  CLI values, configured sources, and skipped
+runtime conditions do not consult these shared options because no prompt
+attempt runs.
+
+
 Testing
 -------
 
 All prompt configuration types accept an optional `prompter` property for
 testing.  When provided, the function is called instead of launching an
-interactive Clack prompt:
+interactive Clack prompt.  It receives the one-based `attempt`, the
+`previousValidationMessage` from the preceding shared validation failure, and
+the shared `signal`:
 
 ~~~~ typescript twoslash
+import { message } from "@optique/core/message";
 import { parseAsync } from "@optique/core/parser";
 import { option } from "@optique/core/primitives";
 import { string } from "@optique/core/valueparser";
@@ -451,19 +504,30 @@ import { prompt } from "@optique/clack";
 const parser = prompt(option("--name", string()), {
   type: "text",
   message: "Enter your name:",
-  prompter: () => Promise.resolve("Alice"),  // used in tests
+  prompter: ({ attempt }) =>
+    Promise.resolve(attempt === 1 ? "taken" : "Alice"),
+}, {
+  validate: (value) => value === "taken"
+    ? message`That name is already taken.`
+    : undefined,
 });
 
 const result = await parseAsync(parser, []);
 // result.value === "Alice"
 ~~~~
 
+A custom `prompter` replaces the Clack UI completely, so the adapter does not
+log `previousValidationMessage` automatically.  The function can inspect or
+display that message itself.  Each invocation is one shared attempt.
+
 
 Cancellation
 ------------
 
 When Clack reports cancellation through `isCancel()`, *@optique/clack* returns
-a parse failure with the message `Prompt cancelled.` instead of throwing.
+a parse failure with the message `Prompt cancelled.` instead of throwing.  If
+an `AbortSignal` caused Clack to cancel while closing its UI, parsing instead
+rejects with that signal's exact reason.
 
 
 Dependency-derived configurations
@@ -519,7 +583,7 @@ for declared defaults, failure behavior, and the runtime condition form.
 API reference
 -------------
 
-### `prompt(parser, config)`
+### `prompt(parser, config, options?)`
 
 Wraps a parser with a Clack prompt fallback.
 
@@ -533,14 +597,22 @@ Parameters
         resolver may return any [`RuntimePromptConfig`] member; see the
         [*@optique/prompt* documentation](./prompt.md#derived-prompt-configurations)
         for the resolver contract.
+     -  `options`: Optional shared [`PromptOptions<T>`] with `validate`,
+        `maxAttempts`, and `signal`.  These options apply after the adapter
+        returns a prompted value, independently of config-level native
+        validation.
 
 Returns
 :   A new parser with `mode: "async"` and Clack prompt fallback.  The `usage`
     is wrapped in an `optional` term since the prompt handles the
     missing-value case.
 
+`PromptOptions`, `PromptValidator`, and `PromptExecutionContext` are
+re-exported from *@optique/prompt* for callers that need to name these types.
+
 [`PromptConfig<T>`]: #promptconfigt
 [`RuntimePromptConfig`]: #runtimepromptconfig
+[`PromptOptions<T>`]: ./prompt.md#promptoptions-tvalue
 
 ### `PromptConfig<T>`
 
@@ -597,9 +669,10 @@ value domain, making the prompted value incompatible with the inner
 parser's input path.  Treating the two paths independently avoids false
 rejections and keeps the architecture sound.
 
-As a consequence, any runtime validation you need on prompted values
-must be configured in the prompt config itself.  Some prompt types
-provide a `validate` option for this purpose.
+As a consequence, runtime constraints that should apply to both paths must be
+declared for each path.  Use config-level native validation when the prompt
+type supports it, and use the third argument's shared `validate` option for
+validation after any prompt type returns a value.
 
 ### Matching constraints between CLI and prompt
 
@@ -643,8 +716,8 @@ prompt config.
 
 `select` with `choice()` values
 :   Keep the prompt `options` array consistent with the inner parser's
-    `choice()` domain.  Ensuring this consistency is the caller's
-    responsibility.
+    `choice()` domain.  Shared validation can additionally reject a selected
+    value at runtime.
 
     ~~~~ typescript twoslash
     import { option } from "@optique/core/primitives";
@@ -659,16 +732,13 @@ prompt config.
     ~~~~
 
 `multiselect` with `multiple()` cardinality
-:   The `required` option can require at least one selected value.  Clack's
-    `multiselect` prompt does not expose a custom `validate` callback here,
-    so constraints such as `max` or `min` greater than `1` from `multiple()`
-    cannot be enforced at the prompt level.
+:   The native `required` option can require at least one selected value.  Use
+    shared validation for other constraints such as a maximum or a minimum
+    greater than one.
 
 > [!IMPORTANT]
-> `select` and `multiselect` prompt types do not expose a `validate`
-> callback.  For these types, there is currently no way to add custom runtime
-> validation on prompted values other than disabling individual options or,
-> for `multiselect`, setting `required`.
+> Shared validation applies only to prompted values.  It does not re-run the
+> wrapped parser's value parser, modifiers, or mappings.
 
 
 Limitations
@@ -681,8 +751,10 @@ Limitations
     tab-completion suggestions.  Only the wrapped inner parser's suggestions
     are used.
  -  *Per-occurrence caching* — A reached `prompt()` occurrence runs its
-    prompter at most once per parse.  Reusing one prompt parser at several
-    positions creates a separate occurrence at each position.
+    prompter once per shared attempt, so validation can invoke it several
+    times.  The terminal result is still cached across internal completion
+    passes.  Reusing one prompt parser at several positions creates a separate
+    occurrence at each position.
  -  *TTY required*: Clack requires an interactive terminal (TTY).  In
     non-interactive environments (CI pipelines, piped input), prompts may
     error.  Use the `prompter` override for non-interactive testing.

--- a/packages/clack/src/index.test.ts
+++ b/packages/clack/src/index.test.ts
@@ -1,20 +1,43 @@
 import assert from "node:assert/strict";
+import { getEventListeners } from "node:events";
 import { describe, it } from "node:test";
 import { object } from "@optique/core/constructs";
 import { dependency } from "@optique/core/dependency";
-import { message } from "@optique/core/message";
+import { formatMessage, message } from "@optique/core/message";
 import { multiple } from "@optique/core/modifiers";
 import { parseAsync } from "@optique/core/parser";
 import { fail, flag, option } from "@optique/core/primitives";
 import { choice, integer, string } from "@optique/core/valueparser";
 import { bindEnv, createEnvContext } from "@optique/env";
-import { derivePromptConfig, prompt } from "@optique/clack";
+import {
+  derivePromptConfig,
+  prompt,
+  type PromptExecutionContext,
+  type PromptOptions,
+  type PromptValidator,
+} from "@optique/clack";
 
 const promptFunctionsOverrideSymbol = Symbol.for(
   "@optique/clack/prompt-functions",
 );
 
 let promptFunctionsOverrideQueue = Promise.resolve();
+
+function deferred<T>(): {
+  readonly promise: Promise<T>;
+  readonly resolve: (value: T) => void;
+} {
+  let resolve: ((value: T) => void) | undefined;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return {
+    promise,
+    resolve(value) {
+      resolve?.(value);
+    },
+  };
+}
 
 async function withPromptFunctionsOverride<T>(
   override: Record<string, unknown>,
@@ -200,6 +223,7 @@ describe("prompt()", () => {
   });
 
   it("rejects missing required multiselect prompt values", async () => {
+    let validationCalls = 0;
     await withPromptFunctionsOverride({
       multiselect: () => Promise.resolve(undefined),
     }, async () => {
@@ -208,13 +232,450 @@ describe("prompt()", () => {
         message: "Tags:",
         options: ["a", "b", "c"],
         required: true,
+      }, {
+        validate() {
+          validationCalls++;
+          return undefined;
+        },
       });
 
       const result = await parseAsync(parser, []);
 
       assert.ok(!result.success);
       assert.deepEqual(result.error, message`No option selected.`);
+      assert.equal(validationCalls, 0);
     });
+  });
+
+  it("retries shared select validation with execution context", async () => {
+    const controller = new AbortController();
+    const verdict = message`Production is required.`;
+    const answers = ["dev", "prod"] as const;
+    const contexts: PromptExecutionContext[] = [];
+    const validated: string[] = [];
+    let logCalls = 0;
+    const validator = (async (value) => {
+      await Promise.resolve();
+      validated.push(value);
+      return value === "prod" ? undefined : verdict;
+    }) satisfies PromptValidator<string>;
+    const options = {
+      signal: controller.signal,
+      validate: validator,
+    } satisfies PromptOptions<string>;
+
+    await withPromptFunctionsOverride({
+      logError: () => {
+        logCalls++;
+      },
+    }, async () => {
+      const parser = prompt(option("--env", string()), {
+        type: "select",
+        message: "Environment:",
+        options: ["dev", "prod"],
+        prompter(context) {
+          contexts.push(context);
+          return Promise.resolve(answers[context.attempt - 1]);
+        },
+      }, options);
+
+      const result = await parseAsync(parser, []);
+
+      assert.ok(result.success);
+      assert.equal(result.value, "prod");
+      assert.deepEqual(validated, ["dev", "prod"]);
+      assert.equal(contexts.length, 2);
+      assert.equal(contexts[0].attempt, 1);
+      assert.equal(contexts[0].previousValidationMessage, undefined);
+      assert.equal(contexts[0].signal, controller.signal);
+      assert.equal(contexts[1].attempt, 2);
+      assert.equal(contexts[1].previousValidationMessage, verdict);
+      assert.equal(contexts[1].signal, controller.signal);
+      assert.equal(logCalls, 0);
+    });
+  });
+
+  it("retries shared multiselect validation", async () => {
+    const answers = [["api"], ["api", "web"]] as const;
+    const attempts: number[] = [];
+    const parser = prompt(multiple(option("--tag", string())), {
+      type: "multiselect",
+      message: "Tags:",
+      options: ["api", "web"],
+      prompter(context) {
+        attempts.push(context.attempt);
+        return Promise.resolve(answers[context.attempt - 1]);
+      },
+    }, {
+      validate: (values) =>
+        values.length > 1 ? undefined : message`Select another tag.`,
+    });
+
+    const result = await parseAsync(parser, []);
+
+    assert.ok(result.success);
+    assert.deepEqual(result.value, ["api", "web"]);
+    assert.deepEqual(attempts, [1, 2]);
+  });
+
+  it("returns the last shared validation message at the attempt limit", async () => {
+    const verdicts = [message`Try another name.`, message`Still unavailable.`];
+    let promptCalls = 0;
+    const parser = prompt(option("--name", string()), {
+      type: "text",
+      message: "Name:",
+      prompter: () => {
+        promptCalls++;
+        return Promise.resolve("taken");
+      },
+    }, {
+      maxAttempts: 2,
+      validate: () => verdicts[promptCalls - 1],
+    });
+
+    const result = await parseAsync(parser, []);
+
+    assert.ok(!result.success);
+    assert.equal(result.error, verdicts[1]);
+    assert.equal(promptCalls, 2);
+  });
+
+  it("rejects invalid shared attempt limits at construction", () => {
+    assert.throws(
+      () =>
+        prompt(option("--name", string()), {
+          type: "text",
+          message: "Name:",
+        }, { maxAttempts: 0 }),
+      {
+        name: "RangeError",
+        message: "maxAttempts must be an integer greater than or equal to 1.",
+      },
+    );
+  });
+
+  it("shows the preceding validation message before a real retry", async () => {
+    const verdict = message`Choose a longer name.`;
+    const answers = ["a", "alice"];
+    const order: string[] = [];
+
+    await withPromptFunctionsOverride({
+      text: () => {
+        order.push("prompt");
+        return Promise.resolve(answers.shift());
+      },
+      logError: (value: string) => {
+        order.push(`error:${value}`);
+      },
+    }, async () => {
+      const parser = prompt(option("--name", string()), {
+        type: "text",
+        message: "Name:",
+      }, {
+        validate: (value) => value.length > 1 ? undefined : verdict,
+      });
+
+      const result = await parseAsync(parser, []);
+
+      assert.ok(result.success);
+      assert.equal(result.value, "alice");
+      assert.deepEqual(order, [
+        "prompt",
+        `error:${formatMessage(verdict)}`,
+        "prompt",
+      ]);
+    });
+  });
+
+  it("forwards shared signals through every real Clack prompt", async () => {
+    const controller = new AbortController();
+    const receivedSignals: (AbortSignal | undefined)[] = [];
+    const validated: unknown[] = [];
+    const textNativeValidate = (value: string) =>
+      value.length > 0 ? undefined : "Required.";
+    const passwordNativeValidate = (value: string) =>
+      value.length > 0 ? undefined : "Required.";
+    const numberNativeValues: number[] = [];
+
+    await withPromptFunctionsOverride({
+      text: async (config: {
+        readonly message: string;
+        readonly signal?: AbortSignal;
+        readonly validate?: (
+          value: string,
+        ) => string | void | Promise<string | void>;
+      }) => {
+        receivedSignals.push(config.signal);
+        if (config.message === "Port:") {
+          assert.notEqual(config.validate, textNativeValidate);
+          assert.equal(await config.validate?.("42"), undefined);
+          return "42";
+        }
+        assert.equal(config.validate, textNativeValidate);
+        return "Alice";
+      },
+      password: (config: {
+        readonly signal?: AbortSignal;
+        readonly validate?: (
+          value: string,
+        ) => string | void | Promise<string | void>;
+      }) => {
+        receivedSignals.push(config.signal);
+        assert.equal(config.validate, passwordNativeValidate);
+        return Promise.resolve("secret");
+      },
+      confirm: (config: { readonly signal?: AbortSignal }) => {
+        receivedSignals.push(config.signal);
+        return Promise.resolve(true);
+      },
+      select: (config: { readonly signal?: AbortSignal }) => {
+        receivedSignals.push(config.signal);
+        return Promise.resolve("prod");
+      },
+      multiselect: (config: {
+        readonly signal?: AbortSignal;
+        readonly required?: boolean;
+      }) => {
+        receivedSignals.push(config.signal);
+        assert.ok(config.required);
+        return Promise.resolve(["api"]);
+      },
+    }, async () => {
+      const parser = object({
+        name: prompt(option("--name", string()), {
+          type: "text",
+          message: "Name:",
+          validate: textNativeValidate,
+        }, {
+          signal: controller.signal,
+          validate: (value) => {
+            validated.push(value);
+            return undefined;
+          },
+        }),
+        password: prompt(option("--password", string()), {
+          type: "password",
+          message: "Password:",
+          validate: passwordNativeValidate,
+        }, {
+          signal: controller.signal,
+          validate: (value) => {
+            validated.push(value);
+            return undefined;
+          },
+        }),
+        confirmed: prompt(flag("--confirm"), {
+          type: "confirm",
+          message: "Confirm?",
+        }, {
+          signal: controller.signal,
+          validate: (value) => {
+            validated.push(value);
+            return undefined;
+          },
+        }),
+        port: prompt(option("--port", integer()), {
+          type: "number",
+          message: "Port:",
+          validate: (value) => {
+            numberNativeValues.push(value);
+            return undefined;
+          },
+        }, {
+          signal: controller.signal,
+          validate: (value) => {
+            validated.push(value);
+            return undefined;
+          },
+        }),
+        environment: prompt(option("--environment", string()), {
+          type: "select",
+          message: "Environment:",
+          options: ["dev", "prod"],
+        }, {
+          signal: controller.signal,
+          validate: (value) => {
+            validated.push(value);
+            return undefined;
+          },
+        }),
+        tags: prompt(multiple(option("--tag", string())), {
+          type: "multiselect",
+          message: "Tags:",
+          options: ["api", "web"],
+          required: true,
+        }, {
+          signal: controller.signal,
+          validate: (value) => {
+            validated.push(value);
+            return undefined;
+          },
+        }),
+      });
+
+      const result = await parseAsync(parser, []);
+
+      assert.ok(result.success);
+      assert.deepEqual(result.value, {
+        name: "Alice",
+        password: "secret",
+        confirmed: true,
+        port: 42,
+        environment: "prod",
+        tags: ["api"],
+      });
+      assert.equal(receivedSignals.length, 6);
+      for (let index = 0; index < receivedSignals.length; index++) {
+        const signal = receivedSignals[index];
+        assert.ok(signal instanceof AbortSignal);
+        assert.notEqual(signal, controller.signal);
+        assert.ok(!signal.aborted);
+        assert.ok(!receivedSignals.slice(0, index).includes(signal));
+      }
+      assert.equal(getEventListeners(controller.signal, "abort").length, 0);
+      assert.deepEqual(numberNativeValues, [42]);
+      assert.deepEqual(validated, [
+        "Alice",
+        "secret",
+        true,
+        42,
+        "prod",
+        ["api"],
+      ]);
+    });
+  });
+
+  it("keeps native number retries inside one shared attempt", async () => {
+    const order: string[] = [];
+
+    await withPromptFunctionsOverride({
+      text: async (config: {
+        readonly validate?: (
+          value: string,
+        ) => string | void | Promise<string | void>;
+      }) => {
+        order.push("native");
+        assert.equal(await config.validate?.("3"), "Must be at least 4.");
+        order.push("native");
+        assert.equal(await config.validate?.("5"), undefined);
+        return "5";
+      },
+    }, async () => {
+      const parser = prompt(option("--port", integer()), {
+        type: "number",
+        message: "Port:",
+        min: 4,
+      }, {
+        validate: (value) => {
+          order.push("shared");
+          assert.equal(value, 5);
+          return undefined;
+        },
+      });
+
+      const result = await parseAsync(parser, []);
+
+      assert.ok(result.success);
+      assert.equal(result.value, 5);
+      assert.deepEqual(order, ["native", "native", "shared"]);
+    });
+  });
+
+  it("propagates a pre-aborted shared signal without starting work", async () => {
+    const controller = new AbortController();
+    const reason = { code: "stopped" };
+    controller.abort(reason);
+    let promptCalls = 0;
+    let validationCalls = 0;
+    let logCalls = 0;
+
+    await withPromptFunctionsOverride({
+      text: () => {
+        promptCalls++;
+        return Promise.resolve("Alice");
+      },
+      logError: () => {
+        logCalls++;
+      },
+    }, async () => {
+      const parser = prompt(option("--name", string()), {
+        type: "text",
+        message: "Name:",
+      }, {
+        signal: controller.signal,
+        validate: () => {
+          validationCalls++;
+          return undefined;
+        },
+      });
+
+      await assert.rejects(
+        () => parseAsync(parser, []),
+        (error: unknown) => error === reason,
+      );
+      assert.equal(promptCalls, 0);
+      assert.equal(validationCalls, 0);
+      assert.equal(logCalls, 0);
+    });
+  });
+
+  it("propagates the abort reason when an active Clack prompt cancels", async () => {
+    const controller = new AbortController();
+    const reason = { code: "stopped" };
+    const started = deferred<void>();
+    const cancel = Symbol.for("clack:cancel");
+
+    await withPromptFunctionsOverride({
+      text: (config: { readonly signal?: AbortSignal }) => {
+        assert.ok(config.signal instanceof AbortSignal);
+        assert.notEqual(config.signal, controller.signal);
+        started.resolve();
+        return new Promise((resolve) => {
+          config.signal?.addEventListener("abort", () => resolve(cancel), {
+            once: true,
+          });
+        });
+      },
+      isCancel: (value: unknown) => value === cancel,
+    }, async () => {
+      const parser = prompt(option("--name", string()), {
+        type: "text",
+        message: "Name:",
+      }, { signal: controller.signal });
+
+      const parsing = parseAsync(parser, []);
+      await started.promise;
+      controller.abort(reason);
+
+      await assert.rejects(
+        () => parsing,
+        (error: unknown) => error === reason,
+      );
+    });
+  });
+
+  it("propagates a prompter error during a shared retry", async () => {
+    const error = new Error("Prompt failed.");
+    let validationCalls = 0;
+    const parser = prompt(option("--name", string()), {
+      type: "text",
+      message: "Name:",
+      prompter(context) {
+        if (context.attempt > 1) return Promise.reject(error);
+        return Promise.resolve("taken");
+      },
+    }, {
+      validate: () => {
+        validationCalls++;
+        return message`Try another name.`;
+      },
+    });
+
+    await assert.rejects(
+      () => parseAsync(parser, []),
+      (thrown: unknown) => thrown === error,
+    );
+    assert.equal(validationCalls, 1);
   });
 
   it("supports prompt-only values with fail()", async () => {
@@ -287,15 +748,20 @@ describe("prompt()", () => {
     assert.deepEqual(order, ["name", "port"]);
   });
 
-  it("converts Clack cancellation into a parse failure", async () => {
+  it("converts Clack cancellation with an active signal into a parse failure", async () => {
+    const controller = new AbortController();
     await withPromptFunctionsOverride({
-      text: () => Promise.resolve(Symbol.for("clack:cancel")),
+      text: (config: { readonly signal?: AbortSignal }) => {
+        assert.ok(config.signal instanceof AbortSignal);
+        assert.ok(!config.signal.aborted);
+        return Promise.resolve(Symbol.for("clack:cancel"));
+      },
       isCancel: (value: unknown) => value === Symbol.for("clack:cancel"),
     }, async () => {
       const parser = prompt(option("--name", string()), {
         type: "text",
         message: "Name:",
-      });
+      }, { signal: controller.signal });
 
       const result = await parseAsync(parser, []);
 

--- a/packages/clack/src/index.ts
+++ b/packages/clack/src/index.ts
@@ -7,19 +7,22 @@
 import {
   confirm,
   isCancel,
+  log,
   multiselect,
   password,
   select,
   text,
 } from "@clack/prompts";
 import type { FluentParser } from "@optique/core/fluent";
-import { message } from "@optique/core/message";
+import { formatMessage, message } from "@optique/core/message";
 import type { Mode, Parser } from "@optique/core/parser";
 import type { ValueParserResult } from "@optique/core/valueparser";
 import {
   createPromptAdapter,
   type DerivedPromptConfig,
   type PromptCondition,
+  type PromptExecutionContext,
+  type PromptOptions,
 } from "@optique/prompt";
 
 export { derivePromptConfig, isDerivedPromptConfig } from "@optique/prompt";
@@ -29,6 +32,9 @@ export type {
   DerivePromptConfigOptions,
   DerivePromptConfigsContext,
   DerivePromptConfigsOptions,
+  PromptExecutionContext,
+  PromptOptions,
+  PromptValidator,
 } from "@optique/prompt";
 
 /**
@@ -46,6 +52,7 @@ interface PromptFunctions {
   readonly select: typeof select;
   readonly multiselect: typeof multiselect;
   readonly isCancel: typeof isCancel;
+  readonly logError: (value: string) => void;
 }
 
 const promptFunctionsOverrideSymbol = Symbol.for(
@@ -59,6 +66,7 @@ const defaultPromptFunctions: PromptFunctions = {
   select,
   multiselect,
   isCancel,
+  logError: (value) => log.error(value),
 };
 
 function promptFunctionKeys(): readonly (keyof PromptFunctions)[] {
@@ -146,8 +154,11 @@ export interface TextConfig {
   readonly validate?: (
     value: string,
   ) => string | void | Promise<string | void>;
-  /** Override the prompt execution. Useful for testing. */
-  readonly prompter?: () => Promise<string>;
+  /**
+   * Overrides prompt execution. Useful for testing.
+   * @since 1.3.0 Added the execution context parameter.
+   */
+  readonly prompter?: (context: PromptExecutionContext) => Promise<string>;
 }
 
 /**
@@ -165,8 +176,11 @@ export interface PasswordConfig {
   readonly validate?: (
     value: string,
   ) => string | void | Promise<string | void>;
-  /** Override the prompt execution. Useful for testing. */
-  readonly prompter?: () => Promise<string>;
+  /**
+   * Overrides prompt execution. Useful for testing.
+   * @since 1.3.0 Added the execution context parameter.
+   */
+  readonly prompter?: (context: PromptExecutionContext) => Promise<string>;
 }
 
 /**
@@ -180,8 +194,11 @@ export interface ConfirmConfig {
   readonly message: string;
   /** Initial Boolean value. */
   readonly initialValue?: boolean;
-  /** Override the prompt execution. Useful for testing. */
-  readonly prompter?: () => Promise<boolean>;
+  /**
+   * Overrides prompt execution. Useful for testing.
+   * @since 1.3.0 Added the execution context parameter.
+   */
+  readonly prompter?: (context: PromptExecutionContext) => Promise<boolean>;
 }
 
 /**
@@ -208,8 +225,13 @@ export interface NumberPromptConfig {
   readonly validate?: (
     value: number,
   ) => string | void | Promise<string | void>;
-  /** Override the prompt execution. Useful for testing. */
-  readonly prompter?: () => Promise<number | undefined>;
+  /**
+   * Overrides prompt execution. Useful for testing.
+   * @since 1.3.0 Added the execution context parameter.
+   */
+  readonly prompter?: (
+    context: PromptExecutionContext,
+  ) => Promise<number | undefined>;
 }
 
 /**
@@ -225,8 +247,11 @@ export interface SelectConfig {
   readonly options: readonly (string | Option)[];
   /** Initially selected option value. */
   readonly initialValue?: string;
-  /** Override the prompt execution. Useful for testing. */
-  readonly prompter?: () => Promise<string>;
+  /**
+   * Overrides prompt execution. Useful for testing.
+   * @since 1.3.0 Added the execution context parameter.
+   */
+  readonly prompter?: (context: PromptExecutionContext) => Promise<string>;
 }
 
 /**
@@ -242,8 +267,13 @@ export interface MultiselectConfig {
   readonly options: readonly (string | Option)[];
   /** Whether at least one option must be selected. */
   readonly required?: boolean;
-  /** Override the prompt execution. Useful for testing. */
-  readonly prompter?: () => Promise<readonly string[]>;
+  /**
+   * Overrides prompt execution. Useful for testing.
+   * @since 1.3.0 Added the execution context parameter.
+   */
+  readonly prompter?: (
+    context: PromptExecutionContext,
+  ) => Promise<readonly string[]>;
 }
 
 /**
@@ -288,6 +318,7 @@ export type RuntimePromptConfig =
 
 type ClackText = (config: {
   readonly message: string;
+  readonly signal?: AbortSignal;
   readonly placeholder?: string;
   readonly initialValue?: string;
   readonly validate?: (
@@ -297,6 +328,7 @@ type ClackText = (config: {
 
 type ClackPassword = (config: {
   readonly message: string;
+  readonly signal?: AbortSignal;
   readonly mask?: string;
   readonly validate?: (
     value: string,
@@ -305,17 +337,20 @@ type ClackPassword = (config: {
 
 type ClackConfirm = (config: {
   readonly message: string;
+  readonly signal?: AbortSignal;
   readonly initialValue?: boolean;
 }) => Promise<unknown>;
 
 type ClackSelect = (config: {
   readonly message: string;
+  readonly signal?: AbortSignal;
   readonly options: readonly Option[];
   readonly initialValue?: string;
 }) => Promise<unknown>;
 
 type ClackMultiselect = (config: {
   readonly message: string;
+  readonly signal?: AbortSignal;
   readonly options: readonly Option[];
   readonly required?: boolean;
 }) => Promise<unknown>;
@@ -326,22 +361,26 @@ type ClackMultiselect = (config: {
  * @param parser Inner parser that reads CLI values.
  * @param config Type-safe Clack prompt configuration, or a configuration
  *               derived from dependency sources via `derivePromptConfig()`.
+ * @param options Shared validation, retry, and cancellation options.
  * @returns A parser with interactive prompt fallback, always in async mode.
+ * @throws {RangeError} If `maxAttempts` is not a positive integer.
  * @throws {Error} If prompt execution fails with an unexpected error or if the
  *                 inner parser throws while parsing or completing.
  * @since 1.2.0
+ * @since 1.3.0 Added shared options and the prompter context.
  */
 export function prompt<M extends Mode, TValue, TState>(
   parser: Parser<M, TValue, TState>,
   config:
     | PromptConfig<TValue>
     | DerivedPromptConfig<RuntimePromptConfig, NoInfer<TValue>>,
+  options?: PromptOptions<NoInfer<TValue>>,
 ): FluentParser<"async", TValue, TState> {
   const promptWithAdapter = createPromptAdapter<RuntimePromptConfig>({
     execute: executePromptRaw,
     getDefaultValue: getConfigDefault,
   });
-  return promptWithAdapter(parser, config);
+  return promptWithAdapter(parser, config, options);
 }
 
 function getConfigDefault(config: unknown): unknown {
@@ -355,6 +394,7 @@ function getConfigDefault(config: unknown): unknown {
 
 async function executePromptRaw<TValue>(
   config: RuntimePromptConfig,
+  context: PromptExecutionContext,
 ): Promise<ValueParserResult<TValue>> {
   const cfg = config;
   const type = cfg.type;
@@ -363,22 +403,18 @@ async function executePromptRaw<TValue>(
   }
   const prompts = getPromptFunctions();
 
+  let result: unknown;
   if ("prompter" in cfg && cfg.prompter != null) {
-    const value = await cfg.prompter();
-    if (prompts.isCancel(value)) {
-      return { success: false, error: message`Prompt cancelled.` };
+    result = await cfg.prompter(context);
+  } else {
+    if (context.previousValidationMessage !== undefined) {
+      prompts.logError(formatMessage(context.previousValidationMessage));
     }
-    if (cfg.type === "number") {
-      return normalizeNumberResult(value);
-    }
-    if (cfg.type === "multiselect") {
-      return normalizeMultiselectResult(value, cfg);
-    }
-    return { success: true, value: value as TValue };
+    result = await executeClackPromptWithSignal(cfg, prompts, context.signal);
   }
 
-  const result = await executeClackPrompt(cfg, prompts);
   if (prompts.isCancel(result)) {
+    if (context.signal?.aborted === true) throw context.signal.reason;
     return { success: false, error: message`Prompt cancelled.` };
   }
   if (cfg.type === "number") {
@@ -390,6 +426,27 @@ async function executePromptRaw<TValue>(
   return { success: true, value: result as TValue };
 }
 
+async function executeClackPromptWithSignal(
+  cfg: RuntimePromptConfig,
+  prompts: PromptFunctions,
+  signal: AbortSignal | undefined,
+): Promise<unknown> {
+  if (signal === undefined) return await executeClackPrompt(cfg, prompts);
+
+  const controller = new AbortController();
+  const abort = () => controller.abort(signal.reason);
+  if (signal.aborted) {
+    abort();
+  } else {
+    signal.addEventListener("abort", abort, { once: true });
+  }
+  try {
+    return await executeClackPrompt(cfg, prompts, controller.signal);
+  } finally {
+    signal.removeEventListener("abort", abort);
+  }
+}
+
 function isPromptType(value: unknown): value is RuntimePromptConfig["type"] {
   return value === "text" || value === "password" || value === "confirm" ||
     value === "number" || value === "select" || value === "multiselect";
@@ -398,11 +455,13 @@ function isPromptType(value: unknown): value is RuntimePromptConfig["type"] {
 function executeClackPrompt(
   cfg: RuntimePromptConfig,
   prompts: PromptFunctions,
+  signal?: AbortSignal,
 ): Promise<unknown> {
   switch (cfg.type) {
     case "text":
       return (prompts.text as ClackText)({
         message: cfg.message,
+        ...(signal === undefined ? {} : { signal }),
         ...(cfg.placeholder !== undefined
           ? { placeholder: cfg.placeholder }
           : {}),
@@ -415,6 +474,7 @@ function executeClackPrompt(
     case "password":
       return (prompts.password as ClackPassword)({
         message: cfg.message,
+        ...(signal === undefined ? {} : { signal }),
         ...(cfg.mask !== undefined ? { mask: cfg.mask } : {}),
         ...(cfg.validate !== undefined ? { validate: cfg.validate } : {}),
       });
@@ -422,6 +482,7 @@ function executeClackPrompt(
     case "confirm":
       return (prompts.confirm as ClackConfirm)({
         message: cfg.message,
+        ...(signal === undefined ? {} : { signal }),
         ...(cfg.initialValue !== undefined
           ? { initialValue: cfg.initialValue }
           : {}),
@@ -430,6 +491,7 @@ function executeClackPrompt(
     case "number":
       return (prompts.text as ClackText)({
         message: cfg.message,
+        ...(signal === undefined ? {} : { signal }),
         ...(cfg.placeholder !== undefined
           ? { placeholder: cfg.placeholder }
           : {}),
@@ -452,6 +514,7 @@ function executeClackPrompt(
     case "select":
       return (prompts.select as ClackSelect)({
         message: cfg.message,
+        ...(signal === undefined ? {} : { signal }),
         options: normalizeOptions(cfg.options),
         ...(cfg.initialValue !== undefined
           ? { initialValue: cfg.initialValue }
@@ -461,6 +524,7 @@ function executeClackPrompt(
     case "multiselect":
       return (prompts.multiselect as ClackMultiselect)({
         message: cfg.message,
+        ...(signal === undefined ? {} : { signal }),
         options: normalizeOptions(cfg.options),
         ...(cfg.required !== undefined ? { required: cfg.required } : {}),
       });

--- a/packages/core/skills/optique/SKILL.md
+++ b/packages/core/skills/optique/SKILL.md
@@ -70,7 +70,7 @@ Core rules
     *@optique/clack*. The validator returns `undefined` to accept the prompted
     value or a structured `Message` to retry, synchronously or asynchronously.
     Attempt limits must be positive integers and default to unlimited retries.
-    Selection prompts use shared validation instead of a prompt config.
+    Selection prompts keep their config and use the shared `validate` option.
  -  Implement a custom adapter's `execute(config, context)` so retries can show
     `context.previousValidationMessage`, and forward `context.signal` when the
     prompt library supports aborting active work. Adapter-native validation

--- a/packages/core/skills/optique/SKILL.md
+++ b/packages/core/skills/optique/SKILL.md
@@ -66,11 +66,11 @@ Core rules
     it a dependency source only if another consumer needs its answer. Keep
     static prompt configs for everything else.
  -  Pass `{ validate, maxAttempts, signal }` as a generated prompt wrapper's
-    third argument, including `prompt()` from *@optique/inquirer*. The validator
-    returns `undefined` to accept the prompted value or a structured `Message`
-    to retry, synchronously or asynchronously. Attempt limits must be positive
-    integers and default to unlimited retries. Inquirer.js selection prompts use
-    this shared validation rather than their prompt config.
+    third argument, including `prompt()` from *@optique/inquirer* and
+    *@optique/clack*. The validator returns `undefined` to accept the prompted
+    value or a structured `Message` to retry, synchronously or asynchronously.
+    Attempt limits must be positive integers and default to unlimited retries.
+    Selection prompts use shared validation instead of a prompt config.
  -  Implement a custom adapter's `execute(config, context)` so retries can show
     `context.previousValidationMessage`, and forward `context.signal` when the
     prompt library supports aborting active work. Adapter-native validation


### PR DESCRIPTION
Closes #936.  Part of #873.


Why
---

*@optique/clack* should honor the recovery contract defined by *@optique/prompt*.  Without it, selection prompts cannot reject a returned value and ask again, leaving callers to rebuild retry and cancellation loops around the parser.


How
---

`prompt()` keeps shared validation in its third argument, separate from Clack's native validation.  Each returned value is checked before completion caching or dependency publication.  A rejection starts another adapter attempt with its message, while `maxAttempts` turns the last rejection into a normal parse failure.

Abort signals pass through a short-lived controller.  This stops active prompt or validator work with the caller's reason without retaining listeners after completion.  Custom `prompter` callbacks receive the same attempt context, so the contract remains testable without a TTY.
