### PR TITLE
Align the shared prompt validation documentation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -100,7 +100,8 @@ To be released.
  -  Added shared validation, retry limits, and abort handling to `prompt()`
     for every Clack prompt type, including selection prompts.  Custom
     `prompter` callbacks now receive the attempt number, previous validation
-    message, and signal.  [[#873], [#936], [#940]]
+    message, and signal, whose types are re-exported for convenience.
+    [[#873], [#936], [#940]]
  -  Added support for prompt configurations derived from dependency sources.
     `prompt()` now also accepts a `derivePromptConfig()` result whose
     resolver returns any of this package's prompt configurations, exposed

--- a/changes.d/clack/shared-prompt-validation.md
+++ b/changes.d/clack/shared-prompt-validation.md
@@ -7,4 +7,5 @@ links:
  -  Added shared validation, retry limits, and abort handling to `prompt()`
     for every Clack prompt type, including selection prompts.  Custom
     `prompter` callbacks now receive the attempt number, previous validation
-    message, and signal.  [[#873], [#936], [#940]]
+    message, and signal, whose types are re-exported for convenience.
+    [[#873], [#936], [#940]]

--- a/docs/integrations/clack.md
+++ b/docs/integrations/clack.md
@@ -435,8 +435,8 @@ When `when` returns `false`, `otherwise` is returned without opening Clack.  If
 the condition throws or rejects, the error propagates to the caller.
 
 
-Shared validation, retries, and cancellation
---------------------------------------------
+Shared validation, retries, and aborts
+--------------------------------------
 
 *This API is available since Optique 1.3.0.*
 
@@ -612,12 +612,12 @@ Returns
     is wrapped in an `optional` term since the prompt handles the
     missing-value case.
 
-`PromptOptions`, `PromptValidator`, and `PromptExecutionContext` are
-re-exported from *@optique/prompt* for callers that need to name these types.
+Throws
+:   `RangeError` when `options.maxAttempts` is not a positive integer.
 
 [`PromptConfig<T>`]: #promptconfigt
 [`RuntimePromptConfig`]: #runtimepromptconfig
-[`PromptOptions<T>`]: ./prompt.md#promptoptionstvalue
+[`PromptOptions<T>`]: #promptoptionst
 
 ### `PromptConfig<T>`
 
@@ -653,6 +653,31 @@ The resolver must therefore return a prompt kind whose result has the wrapped
 parser's value type.  For example, do not return a `number` configuration for a
 parser that produces a string.  See
 [Prompt and inner parser independence](#prompt-and-inner-parser-independence).
+
+### `PromptValidator<T>`
+
+*Available since Optique 1.3.0.*
+
+Re-exported from *@optique/prompt*.  It validates a returned prompt value and
+returns `undefined` to accept it or a `Message` to retry.  See the
+[*@optique/prompt* API reference](./prompt.md#promptvalidatortvalue).
+
+### `PromptOptions<T>`
+
+*Available since Optique 1.3.0.*
+
+Re-exported from *@optique/prompt*.  It supplies the shared `validate`,
+`maxAttempts`, and `signal` options.  See the
+[*@optique/prompt* API reference](./prompt.md#promptoptionstvalue).
+
+### `PromptExecutionContext`
+
+*Available since Optique 1.3.0.*
+
+Re-exported from *@optique/prompt*.  A custom `prompter` receives the one-based
+attempt number, previous validation message, and optional abort signal through
+this context.  See the
+[*@optique/prompt* API reference](./prompt.md#promptexecutioncontext).
 
 ### `Option`
 

--- a/docs/integrations/inquirer.md
+++ b/docs/integrations/inquirer.md
@@ -561,7 +561,7 @@ for declared defaults, failure behavior, and the runtime condition form.
 Shared validation, retries, and aborts
 --------------------------------------
 
-*Available since Optique 1.3.0.*
+*This API is available since Optique 1.3.0.*
 
 Pass shared prompt options as the third argument to `prompt()` when a prompted
 value needs a recoverable check.  The validator may be synchronous or
@@ -844,6 +844,10 @@ prompt config.
       },
     );
     ~~~~
+
+> [!IMPORTANT]
+> Shared validation applies only to prompted values.  It does not re-run the
+> wrapped parser's value parser, modifiers, or mappings.
 
 
 Limitations

--- a/docs/integrations/prompt.md
+++ b/docs/integrations/prompt.md
@@ -423,6 +423,10 @@ or derived configuration resolution.  If it aborts while a resolver is
 pending, the reason is observed immediately after the resolver settles and
 before an adapter starts.
 
+> [!IMPORTANT]
+> Shared validation applies only to prompted values.  It does not re-run the
+> wrapped parser's value parser, modifiers, or mappings.
+
 ### Missing values run the adapter
 
 If the inner parser does not consume CLI tokens and no source binding supplies

--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -311,12 +311,13 @@ A few more points worth knowing:
     domain should change, and wrap it with `dependency()` only when its result
     must feed another consumer.
  -  *Prompted values are not re-validated by the inner parser.* A check that
-    can only run after the answer arrives—whether a package manager is
-    installed, whether a store suits the chosen runtime—belongs in the
+    can only run after the answer arrives, such as whether a package manager
+    is installed or whether a store suits the chosen runtime, belongs in the
     [shared `validate`](./integrations/prompt.md#shared-validation-and-retries)
     option of the prompt wrapper's third argument. It receives the value the
     prompt produced rather than raw command-line input, and rejecting it asks
-    the same question again instead of failing the parse.
+    the same question again as long as attempts remain. Set `maxAttempts` to
+    bound that loop; the last rejection then becomes the parse failure.
  -  *For config-only or environment-only values, wrap `fail()`, not
     `constant()`.* `constant()` always succeeds, so `bindConfig()` treats it as
     a value the user supplied and skips the file lookup entirely. `fail()`

--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -310,6 +310,13 @@ A few more points worth knowing:
     parser's CLI constraints. Derive the inner parser as well when the CLI
     domain should change, and wrap it with `dependency()` only when its result
     must feed another consumer.
+ -  *Prompted values are not re-validated by the inner parser.* A check that
+    can only run after the answer arrives—whether a package manager is
+    installed, whether a store suits the chosen runtime—belongs in the
+    [shared `validate`](./integrations/prompt.md#shared-validation-and-retries)
+    option of the prompt wrapper's third argument. It receives the value the
+    prompt produced rather than raw command-line input, and rejecting it asks
+    the same question again instead of failing the parse.
  -  *For config-only or environment-only values, wrap `fail()`, not
     `constant()`.* `constant()` always succeeds, so `bindConfig()` treats it as
     a value the user supplied and skips the file lookup entirely. `fail()`

--- a/packages/clack/README.md
+++ b/packages/clack/README.md
@@ -26,8 +26,9 @@ Documentation
 -------------
 
 For full documentation, visit <https://optique.dev/integrations/clack>.
-The guide includes dependency-derived prompt options with
-`derivePromptConfig()`.
+The guide covers dependency-derived prompt options with
+`derivePromptConfig()`, along with shared validation, retry limits, and
+abort signals.
 
 
 Quick start

--- a/packages/inquirer/README.md
+++ b/packages/inquirer/README.md
@@ -66,6 +66,8 @@ Features
     prompt fires only when no higher-priority source supplies a value
  -  *Dependency-derived configurations* with `derivePromptConfig()` — later
     questions can adapt to values supplied by CLI input, bindings, or prompts
+ -  *Shared validation and retries* — reject a prompted answer with a message
+    and ask again, with an optional attempt limit and an `AbortSignal`
  -  *Prompt-only values* via `prompt(fail<T>(), …)` when a value should not
     be exposed as a CLI option
  -  *TTY-free testing* via the `prompter` escape hatch on every config type


### PR DESCRIPTION
#873 cannot close until the cross-adapter tests, integration guides, and changelog describe the same observable behavior.  The implementations landed in #938, #939, and #940, but the three guides were written at different times, so each ended up correct about a different subset.

Every divergence turned out to be drafting rather than behavior, so each fix takes whichever guide was already right.

The Clack guide was missing API entries for `PromptValidator`, `PromptOptions`, and `PromptExecutionContext`, which the package re-exports, and the `RangeError` that its `prompt()` throws for an invalid `maxAttempts`; the Inquirer.js guide documents both.  Only the Clack guide warned that shared validation never re-runs the wrapped parser, which is the misconception behind #392 and #615, so that warning now appears on the Inquirer.js page, where #620 sends readers, and on the adapter-neutral page.  I settled on “Shared validation, retries, and aborts” for both section titles, because Clack's “cancellation” collided with its own section on user cancellation a few paragraphs down.

*docs/pitfalls.md* already warns that fallback values are re-validated by the inner parser.  Prompted values are not, and the contrast is worth stating next to it.

Both package *README.md* files still described the pre-1.3.0 feature set, and the Clack changelog fragment omitted its new re-exports while the Inquirer.js one listed them.