### PR TITLE
Set up `@optique/testing` and its shared contracts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -163,6 +163,15 @@ To be released.
 [#935]: https://github.com/dahlia/optique/issues/935
 [#938]: https://github.com/dahlia/optique/pull/938
 
+### @optique/testing
+
+ -  Added the `@optique/testing` package with a shared `CapturedOutput` type
+    and reserved entry points for parser, runner, command discovery, and
+    subprocess testing.  [[#891], [#942]]
+
+[#891]: https://github.com/dahlia/optique/issues/891
+[#942]: https://github.com/dahlia/optique/pull/942
+
 
 Version 1.2.5
 -------------

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,6 +160,10 @@ Architecture
     as a value parser.
  -  *@optique/inquirer* (*packages/inquirer/*): Inquirer.js prompt integration.
     Provides `prompt()` for interactive fallback using Inquirer.js prompts.
+ -  *@optique/testing* (*packages/testing/*): Layered testing support.
+    Reserves `@optique/testing/parser`, `/run`, `/discover`, and `/cli` for
+    helpers that exercise a CLI at a chosen execution boundary, and holds the
+    contracts shared across them.
 
 ### Dual publishing
 
@@ -191,6 +195,10 @@ When adding a new package to the monorepo, update the following files:
     matching role group (Foundation, Value parsers, Value sources, or
     Surfaces & tooling) so the package shows up in the landing page's
     ecosystem grid
+ -  *docs/.vitepress/config.mts*: Add the package to the `REFERENCES` group, and
+    to `CONCEPTS` or `INTEGRATIONS` if it ships a guide page
+ -  *packages/core/skills/optique/SKILL.md*: Add the package to the integration
+    package table
 
 ### Keeping the landing page in sync
 

--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ The following is a list of the available packages:
 | [@optique/zod](/packages/zod/)                           | [JSR][jsr:@optique/zod]              | [npm][npm:@optique/zod]              | [Zod] schema integration for validation     |
 | [@optique/inquirer](/packages/inquirer/)                 | [JSR][jsr:@optique/inquirer]         | [npm][npm:@optique/inquirer]         | [Inquirer.js] prompt support                |
 | [@optique/prompt](/packages/prompt/)                     | [JSR][jsr:@optique/prompt]           | [npm][npm:@optique/prompt]           | Generic prompt adapter foundation           |
+| [@optique/testing](/packages/testing/)                   | [JSR][jsr:@optique/testing]          | [npm][npm:@optique/testing]          | Layered testing support for CLIs            |
 
 [jsr:@optique/core]: https://jsr.io/@optique/core
 [npm:@optique/core]: https://www.npmjs.com/package/@optique/core
@@ -241,6 +242,8 @@ The following is a list of the available packages:
 [Inquirer.js]: https://github.com/SBoudrias/Inquirer.js
 [jsr:@optique/prompt]: https://jsr.io/@optique/prompt
 [npm:@optique/prompt]: https://www.npmjs.com/package/@optique/prompt
+[jsr:@optique/testing]: https://jsr.io/@optique/testing
+[npm:@optique/testing]: https://www.npmjs.com/package/@optique/testing
 
 
 Contributing

--- a/changes.d/testing/testing-package.md
+++ b/changes.d/testing/testing-package.md
@@ -1,0 +1,8 @@
+---
+links:
+  '#891': https://github.com/dahlia/optique/issues/891
+  '#942': https://github.com/dahlia/optique/pull/942
+---
+ -  Added the `@optique/testing` package with a shared `CapturedOutput` type
+    and reserved entry points for parser, runner, command discovery, and
+    subprocess testing.  [[#891], [#942]]

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -70,6 +70,7 @@ const CONCEPTS = {
     { text: "Messages", link: "/concepts/messages" },
     { text: "Runners and execution", link: "/concepts/runners" },
     { text: "Runtime context extension", link: "/concepts/extend" },
+    { text: "Testing", link: "/concepts/testing" },
   ],
 };
 
@@ -121,6 +122,7 @@ const REFERENCES = {
     { text: "@optique/temporal", link: "https://jsr.io/@optique/temporal/doc" },
     { text: "@optique/valibot", link: "https://jsr.io/@optique/valibot/doc" },
     { text: "@optique/zod", link: "https://jsr.io/@optique/zod/doc" },
+    { text: "@optique/testing", link: "https://jsr.io/@optique/testing/doc" },
   ],
 };
 

--- a/docs/.vitepress/theme/components/PackageGrid.vue
+++ b/docs/.vitepress/theme/components/PackageGrid.vue
@@ -39,6 +39,7 @@ const groups = [
       { name: "@optique/discover", desc: "File-based command discovery and dispatch.", link: "/concepts/discover" },
       { name: "@optique/man", desc: "Unix man pages from parsers.", link: "/concepts/man" },
       { name: "@optique/logtape", desc: "Log-level options for LogTape.", link: "/integrations/logtape" },
+      { name: "@optique/testing", desc: "Shared contracts for layered CLI testing.", link: "/concepts/testing" },
     ],
   },
 ];

--- a/docs/concepts/testing.md
+++ b/docs/concepts/testing.md
@@ -1,0 +1,105 @@
+---
+description: >-
+  Choose the execution boundary a CLI test should exercise, and understand what
+  each layer of @optique/testing does and does not run.
+---
+
+Testing
+=======
+
+An Optique application is testable at several points, and the useful question
+is rarely “how do I test my CLI?” but “which part of it do I want to run?”
+A parser can be checked without rendering help or touching a process.  A runner
+can be checked without executing the code that consumes the parsed value.
+Neither of those observes what a command handler prints through `console.log()`.
+
+The *@optique/testing* package draws those boundaries as separate entry points,
+so the scope of a test is visible from its import:
+
+~~~~ typescript
+import { /* ... */ } from "@optique/testing/parser";
+import { /* ... */ } from "@optique/testing/run";
+import { /* ... */ } from "@optique/testing/discover";
+import { /* ... */ } from "@optique/testing/cli";
+~~~~
+
+> [!NOTE]
+> The package currently ships the shared contracts below and reserves the four
+> entry points.  The helpers for each layer are still landing; follow
+> [issue #890] for progress.
+
+[issue #890]: https://github.com/dahlia/optique/issues/890
+
+
+Execution boundaries
+--------------------
+
+Each layer runs strictly more of the application than the one above it:
+
+| Layer                       | Runs                                                                     | Does not run                                                     |
+| --------------------------- | ------------------------------------------------------------------------ | ---------------------------------------------------------------- |
+| *@optique/testing/parser*   | The parser, over a complete argument list                                | Help rendering, output, exits, command handlers                  |
+| *@optique/testing/run*      | The above, plus help, version, completion, and parse-error output        | The code that consumes the parsed value                          |
+| *@optique/testing/discover* | The above, plus command discovery, lifecycle hooks, and handler dispatch | Nothing—but writes that bypass Optique's handlers escape capture |
+| *@optique/testing/cli*      | The entire process                                                       | —                                                                |
+
+The gap between the last two rows is the one that catches people out.  The
+in-process layers capture output because *@optique/run* accepts injected
+`stdout` and `stderr` callbacks, and Optique routes help, version, completion,
+and parse errors through them.  A command handler that calls `console.log()`,
+[`print()`](./runners.md), or `process.stdout.write()` writes past those
+callbacks and is invisible to a `runProgram()` capture.  Asserting on that
+output requires a child process.
+
+
+Choosing a layer
+----------------
+
+Prefer the narrowest layer that still exercises what you are asserting about.
+
+`@optique/testing/parser`
+:   Grammar questions.  Does this option accept that value, does a bad value
+    produce the error you intended, does `or()` pick the branch you expect?
+    Nothing is rendered and nothing exits, so the assertions are about values
+    and structured errors rather than text.
+
+`@optique/testing/run`
+:   Runner behavior.  Does `--help` print the usage you expect, does an unknown
+    option exit with the code you configured, does the parser return the value
+    your application will receive?
+
+`@optique/testing/discover`
+:   Dispatch.  Does the right command module get selected, do program hooks run
+    in order, does a failing handler propagate its error?
+
+`@optique/testing/cli`
+:   The application as users experience it.  This is also the only layer that
+    sees the working directory, the environment, stdin, and the exit code of a
+    real process, and the only one that needs the entry point to be runnable.
+
+These layers are complements, not alternatives.  A parser test that runs in
+milliseconds is a poor substitute for one end-to-end check that the binary
+starts at all, and the reverse is equally true.
+
+
+Shared contracts
+----------------
+
+The package root holds only the contracts that mean the same thing at more than
+one boundary.  Today that is `CapturedOutput`, the pair of captured streams:
+
+~~~~ typescript twoslash
+import type { CapturedOutput } from "@optique/testing";
+
+function assertQuiet(output: CapturedOutput): void {
+  if (output.stderr !== "") throw new Error(output.stderr);
+}
+~~~~
+
+The two streams stay separate and their text is preserved exactly, including
+trailing newlines, so a test can assert which stream a message reached.
+
+Results that differ by layer stay with the layer that produces them.  A parse
+failure, an intentional runner exit, and a terminating signal are not the same
+kind of outcome, and flattening them into one result shape would hide the
+distinction that made these layers worth separating.

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,6 +15,7 @@
     "@optique/run": "workspace:",
     "@optique/standard-schema": "workspace:",
     "@optique/temporal": "workspace:",
+    "@optique/testing": "workspace:",
     "@optique/valibot": "workspace:",
     "@optique/zod": "workspace:",
     "@optique/inquirer": "workspace:",

--- a/packages/core/skills/optique/SKILL.md
+++ b/packages/core/skills/optique/SKILL.md
@@ -245,8 +245,7 @@ Common mistakes checklist
  -  Do not expect `multiple(p)` to fail when absent; it returns `[]`. Wrap with
     `nonEmpty()` when at least one value is required.
  -  Do not confuse free-order parsing with `seq()`. Most constructs let child
-    parsers compete by priority; use `seq()` only when the grammar is truly
-    ordered.
+    parsers compete by priority; use `seq()` only for truly ordered grammars.
  -  Do not concatenate plain strings for errors or descriptions. Use structured
     `message` values.
  -  Do not forget to register source contexts when using `bindEnv()`,
@@ -297,3 +296,4 @@ Integration packages
 | `@optique/logtape`          | LogTape levels and formatter/output options | <https://optique.dev/integrations/logtape.md>         |
 | `@optique/man`              | Man page generation                         | <https://optique.dev/concepts/man.md>                 |
 | `@optique/discover`         | File-based command discovery                | <https://optique.dev/concepts/discover.md>            |
+| `@optique/testing`          | Layered CLI testing at a chosen boundary    | <https://optique.dev/concepts/testing.md>             |

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -1,0 +1,42 @@
+@optique/testing
+================
+
+Testing support for [Optique] command-line interfaces.
+
+An Optique application can be exercised at four distinct execution boundaries,
+and this package gives each one its own entry point, so the scope of a test is
+visible from its import:
+
+ -  *@optique/testing/parser*: a parser on its own, without help rendering,
+    process integration, or command dispatch.
+ -  *@optique/testing/run*: what `run()` and `runAsync()` write through their
+    injected output callbacks, plus intentional exits.
+ -  *@optique/testing/discover*: a `runProgram()` invocation, including command
+    discovery and handler dispatch.
+ -  *@optique/testing/cli*: a real CLI entry point in a child process.
+
+The package root holds only the contracts that mean the same thing at more than
+one boundary.  It depends on no test framework and no assertion library.
+
+[Optique]: https://optique.dev/
+
+
+Installation
+------------
+
+~~~~ bash
+deno add jsr:@optique/testing
+npm add @optique/testing
+pnpm add @optique/testing
+yarn add @optique/testing
+bun add @optique/testing
+~~~~
+
+
+Documentation
+-------------
+
+For full documentation, visit the [testing guide], which explains what each
+layer does and does not execute, and how to choose between them.
+
+[testing guide]: https://optique.dev/concepts/testing

--- a/packages/testing/deno.json
+++ b/packages/testing/deno.json
@@ -1,0 +1,40 @@
+{
+  "name": "@optique/testing",
+  "version": "1.3.0",
+  "license": "MIT",
+  "exports": {
+    ".": "./src/index.ts",
+    "./cli": "./src/cli.ts",
+    "./discover": "./src/discover.ts",
+    "./parser": "./src/parser.ts",
+    "./run": "./src/run.ts"
+  },
+  "exclude": [
+    "dist/",
+    "node_modules",
+    "tsdown.config.ts"
+  ],
+  "tasks": {
+    "build": "pnpm build",
+    "test": "deno test --allow-read",
+    "test:node": {
+      "dependencies": [
+        "build"
+      ],
+      "command": "node --test"
+    },
+    "test:bun": {
+      "dependencies": [
+        "build"
+      ],
+      "command": "bun test"
+    },
+    "test-all": {
+      "dependencies": [
+        "test",
+        "test:node",
+        "test:bun"
+      ]
+    }
+  }
+}

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,0 +1,102 @@
+{
+  "name": "@optique/testing",
+  "version": "1.3.0",
+  "description": "Testing support for Optique command-line interfaces",
+  "keywords": [
+    "CLI",
+    "command-line",
+    "commandline",
+    "parser",
+    "testing",
+    "subprocess"
+  ],
+  "license": "MIT",
+  "author": {
+    "name": "Hong Minhee",
+    "email": "hong@minhee.org",
+    "url": "https://hongminhee.org/"
+  },
+  "homepage": "https://optique.dev/",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dahlia/optique.git",
+    "directory": "packages/testing/"
+  },
+  "bugs": {
+    "url": "https://github.com/dahlia/optique/issues"
+  },
+  "funding": [
+    "https://github.com/sponsors/dahlia"
+  ],
+  "engines": {
+    "node": ">=20.0.0",
+    "bun": ">=1.2.0",
+    "deno": ">=2.3.0"
+  },
+  "files": [
+    "dist/",
+    "package.json",
+    "README.md"
+  ],
+  "type": "module",
+  "module": "./dist/index.js",
+  "main": "./dist/index.cjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": {
+        "import": "./dist/index.d.ts",
+        "require": "./dist/index.d.cts"
+      },
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./cli": {
+      "types": {
+        "import": "./dist/cli.d.ts",
+        "require": "./dist/cli.d.cts"
+      },
+      "import": "./dist/cli.js",
+      "require": "./dist/cli.cjs"
+    },
+    "./discover": {
+      "types": {
+        "import": "./dist/discover.d.ts",
+        "require": "./dist/discover.d.cts"
+      },
+      "import": "./dist/discover.js",
+      "require": "./dist/discover.cjs"
+    },
+    "./parser": {
+      "types": {
+        "import": "./dist/parser.d.ts",
+        "require": "./dist/parser.d.cts"
+      },
+      "import": "./dist/parser.js",
+      "require": "./dist/parser.cjs"
+    },
+    "./run": {
+      "types": {
+        "import": "./dist/run.d.ts",
+        "require": "./dist/run.d.cts"
+      },
+      "import": "./dist/run.js",
+      "require": "./dist/run.cjs"
+    }
+  },
+  "sideEffects": false,
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "tsdown": "catalog:",
+    "typescript": "catalog:"
+  },
+  "scripts": {
+    "build": "tsdown",
+    "prepack": "tsdown",
+    "prepublish": "tsdown",
+    "test": "node --test",
+    "test:bun": "bun test",
+    "test:deno": "deno test --allow-read",
+    "test-all": "tsdown && node --test && bun test && deno test --allow-read"
+  }
+}

--- a/packages/testing/src/cli.ts
+++ b/packages/testing/src/cli.ts
@@ -1,0 +1,16 @@
+/**
+ * Reserved for helpers that invoke a CLI entry point in a child process.
+ *
+ * This layer will execute the whole application, so it observes everything the
+ * process writes—including output the in-process layers cannot see—plus its
+ * exit code or terminating signal.  In exchange it needs a runnable entry
+ * point, permission to start a process, and whatever build step that entry
+ * point depends on.
+ *
+ * The helpers themselves are still landing; see
+ * {@link https://github.com/dahlia/optique/issues/890}.
+ *
+ * @module
+ * @since 1.3.0
+ */
+export {};

--- a/packages/testing/src/discover.ts
+++ b/packages/testing/src/discover.ts
@@ -1,0 +1,16 @@
+/**
+ * Reserved for helpers that capture `runProgram()` executions.
+ *
+ * This layer will add command discovery, lifecycle hooks, and handler dispatch
+ * to what `@optique/testing/run` covers, so a test can assert on which command
+ * ran.  Because a handler runs for real, output it writes outside Optique's
+ * injected handlers still escapes capture, and an error it throws still
+ * propagates to the caller.
+ *
+ * The helpers themselves are still landing; see
+ * {@link https://github.com/dahlia/optique/issues/890}.
+ *
+ * @module
+ * @since 1.3.0
+ */
+export {};

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -1,0 +1,45 @@
+/**
+ * Testing support for Optique command-line interfaces.
+ *
+ * An Optique application can be exercised at four distinct execution
+ * boundaries, and this package gives each one its own entry point:
+ *
+ * - `@optique/testing/parser` runs a parser against an argument list without
+ *   help rendering, process integration, or command dispatch.
+ * - `@optique/testing/run` captures what `run()` and `runAsync()` write
+ *   through their injected output callbacks, along with intentional exits.
+ * - `@optique/testing/discover` captures a `runProgram()` invocation,
+ *   including command discovery and handler dispatch.
+ * - `@optique/testing/cli` invokes a real CLI entry point in a child process.
+ *
+ * This module holds only the contracts that mean the same thing at more than
+ * one of those boundaries.  Results that differ by layer—parsed values,
+ * intentional exits, terminating signals—belong to the subpath that produces
+ * them.
+ *
+ * @module
+ * @since 1.3.0
+ */
+
+/**
+ * Text captured from a program's standard output and standard error streams.
+ *
+ * The two streams are kept apart and their text is preserved exactly, so a
+ * test can assert on trailing newlines and on which stream a message reached.
+ * Each layer documents how it fills these fields: the in-process layers
+ * accumulate the text their injected writers receive, while the subprocess
+ * layer decodes whatever the child actually wrote.
+ *
+ * @since 1.3.0
+ */
+export interface CapturedOutput {
+  /**
+   * The text written to standard output.  Empty when nothing was written.
+   */
+  readonly stdout: string;
+
+  /**
+   * The text written to standard error.  Empty when nothing was written.
+   */
+  readonly stderr: string;
+}

--- a/packages/testing/src/parser.ts
+++ b/packages/testing/src/parser.ts
@@ -1,0 +1,15 @@
+/**
+ * Reserved for helpers that exercise a parser on its own.
+ *
+ * This layer will drive Optique's parsing protocol over a complete argument
+ * list and report the parsed value or a structured parse error.  It renders no
+ * help, writes to no stream, dispatches no command handler, and never exits,
+ * so it observes neither standard output nor standard error.
+ *
+ * The helpers themselves are still landing; see
+ * {@link https://github.com/dahlia/optique/issues/890}.
+ *
+ * @module
+ * @since 1.3.0
+ */
+export {};

--- a/packages/testing/src/public-api.test.ts
+++ b/packages/testing/src/public-api.test.ts
@@ -124,16 +124,19 @@ describe("public surface", () => {
     assert.equal(captured.stderr, "");
   });
 
-  it("should resolve every reserved subpath", async () => {
-    const root = await import("@optique/testing");
-    await import("@optique/testing/cli");
-    await import("@optique/testing/discover");
-    await import("@optique/testing/parser");
-    await import("@optique/testing/run");
-
-    // The root is limited to types shared across layers, so it contributes no
-    // runtime exports.  Test functions belong to the layer subpaths instead.
-    assert.deepEqual(Object.keys(root), []);
+  it("should resolve every reserved subpath without runtime exports", async () => {
+    // The root is limited to types shared across layers, and the four layer
+    // subpaths are reserved but not yet implemented, so none of them
+    // contributes a runtime export.  A subpath that starts exporting a helper
+    // has to say so here.
+    assert.deepEqual(Object.keys(await import("@optique/testing")), []);
+    assert.deepEqual(Object.keys(await import("@optique/testing/cli")), []);
+    assert.deepEqual(
+      Object.keys(await import("@optique/testing/discover")),
+      [],
+    );
+    assert.deepEqual(Object.keys(await import("@optique/testing/parser")), []);
+    assert.deepEqual(Object.keys(await import("@optique/testing/run")), []);
   });
 });
 
@@ -161,10 +164,12 @@ describe("npm build output", () => {
 
     const require = createRequire(import.meta.url);
 
-    assert.equal(typeof require("@optique/testing"), "object");
-    require("@optique/testing/cli");
-    require("@optique/testing/discover");
-    require("@optique/testing/parser");
-    require("@optique/testing/run");
+    // The CommonJS surface has to stay empty for the same reason the ESM one
+    // does, so that the two cannot drift apart unnoticed.
+    assert.deepEqual(Object.keys(require("@optique/testing")), []);
+    assert.deepEqual(Object.keys(require("@optique/testing/cli")), []);
+    assert.deepEqual(Object.keys(require("@optique/testing/discover")), []);
+    assert.deepEqual(Object.keys(require("@optique/testing/parser")), []);
+    assert.deepEqual(Object.keys(require("@optique/testing/run")), []);
   });
 });

--- a/packages/testing/src/public-api.test.ts
+++ b/packages/testing/src/public-api.test.ts
@@ -1,0 +1,170 @@
+import type { CapturedOutput } from "@optique/testing";
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { describe, it } from "node:test";
+
+/**
+ * The subpaths this package reserves, as they appear in `deno.json` and in
+ * `package.json`.  Every other assertion in this file is derived from it.
+ */
+const SUBPATHS = [".", "./cli", "./discover", "./parser", "./run"] as const;
+
+/**
+ * The `dist/` basename backing each subpath.
+ */
+const DIST_BASENAMES: Record<string, string> = {
+  ".": "index",
+  "./cli": "cli",
+  "./discover": "discover",
+  "./parser": "parser",
+  "./run": "run",
+};
+
+const isDeno = "Deno" in globalThis;
+
+function readJson(relativePath: string): Record<string, unknown> {
+  return JSON.parse(
+    readFileSync(new URL(relativePath, import.meta.url), "utf8"),
+  ) as Record<string, unknown>;
+}
+
+function readTsdownEntries(): string[] {
+  const config = readFileSync(
+    new URL("../tsdown.config.ts", import.meta.url),
+    "utf8",
+  );
+  return [...config.matchAll(/"(src\/[^"]+\.ts)"/g)]
+    .map((match) => match[1])
+    .sort();
+}
+
+function distPath(fileName: string): URL {
+  return new URL(`../dist/${fileName}`, import.meta.url);
+}
+
+describe("package manifests", () => {
+  it("should expose the same subpaths to JSR and npm", () => {
+    const packageJson = readJson("../package.json");
+    const denoJson = readJson("../deno.json");
+    const expected = [...SUBPATHS].sort();
+
+    assert.deepEqual(
+      Object.keys(packageJson.exports as Record<string, unknown>).sort(),
+      expected,
+    );
+    assert.deepEqual(
+      Object.keys(denoJson.exports as Record<string, unknown>).sort(),
+      expected,
+    );
+  });
+
+  it("should build every subpath it exports", () => {
+    assert.deepEqual(
+      readTsdownEntries(),
+      [...SUBPATHS]
+        .map((subpath) => `src/${DIST_BASENAMES[subpath]}.ts`)
+        .sort(),
+    );
+  });
+
+  it("should point each JSR export at its source module", () => {
+    const denoExports = readJson("../deno.json").exports as Record<
+      string,
+      string
+    >;
+
+    for (const subpath of SUBPATHS) {
+      const source = denoExports[subpath];
+      assert.equal(source, `./src/${DIST_BASENAMES[subpath]}.ts`);
+      assert.ok(
+        existsSync(new URL(source, new URL("../", import.meta.url))),
+        `Missing source module for ${subpath}: ${source}`,
+      );
+    }
+  });
+
+  it("should point each npm condition at the matching build output", () => {
+    const packageExports = readJson("../package.json").exports as Record<
+      string,
+      Record<string, unknown>
+    >;
+
+    for (const subpath of SUBPATHS) {
+      const basename = DIST_BASENAMES[subpath];
+      assert.deepEqual(packageExports[subpath], {
+        types: {
+          import: `./dist/${basename}.d.ts`,
+          require: `./dist/${basename}.d.cts`,
+        },
+        import: `./dist/${basename}.js`,
+        require: `./dist/${basename}.cjs`,
+      });
+    }
+  });
+
+  it("should keep the legacy root fields aligned with the root export", () => {
+    const packageJson = readJson("../package.json");
+
+    assert.equal(packageJson.module, "./dist/index.js");
+    assert.equal(packageJson.main, "./dist/index.cjs");
+    assert.equal(packageJson.types, "./dist/index.d.ts");
+    assert.equal(packageJson.sideEffects, false);
+  });
+});
+
+describe("public surface", () => {
+  it("should describe captured output", () => {
+    const captured = {
+      stdout: "Usage: app [options]\n",
+      stderr: "",
+    } satisfies CapturedOutput;
+
+    assert.equal(captured.stdout, "Usage: app [options]\n");
+    assert.equal(captured.stderr, "");
+  });
+
+  it("should resolve every reserved subpath", async () => {
+    const root = await import("@optique/testing");
+    await import("@optique/testing/cli");
+    await import("@optique/testing/discover");
+    await import("@optique/testing/parser");
+    await import("@optique/testing/run");
+
+    // The root is limited to types shared across layers, so it contributes no
+    // runtime exports.  Test functions belong to the layer subpaths instead.
+    assert.deepEqual(Object.keys(root), []);
+  });
+});
+
+describe("npm build output", () => {
+  it("should emit every artifact the export map promises", {
+    skip: isDeno,
+  }, () => {
+    // Bun ignores the `skip` option, so bail out explicitly as well.
+    if (isDeno) return;
+
+    for (const subpath of SUBPATHS) {
+      const basename = DIST_BASENAMES[subpath];
+      for (const extension of ["js", "cjs", "d.ts", "d.cts"]) {
+        const fileName = `${basename}.${extension}`;
+        assert.ok(
+          existsSync(distPath(fileName)),
+          `Missing build output: dist/${fileName}`,
+        );
+      }
+    }
+  });
+
+  it("should be requirable from CommonJS", { skip: isDeno }, () => {
+    if (isDeno) return;
+
+    const require = createRequire(import.meta.url);
+
+    assert.equal(typeof require("@optique/testing"), "object");
+    require("@optique/testing/cli");
+    require("@optique/testing/discover");
+    require("@optique/testing/parser");
+    require("@optique/testing/run");
+  });
+});

--- a/packages/testing/src/run.ts
+++ b/packages/testing/src/run.ts
@@ -1,0 +1,17 @@
+/**
+ * Reserved for helpers that capture `run()` and `runAsync()` executions.
+ *
+ * This layer will run a parser or `Program` through `@optique/run` with its
+ * output and exit handlers injected, so help, version, completion, and
+ * parse-error output become a captured result instead of process output.  It
+ * does not run the application code that consumes the parsed value, and it
+ * cannot see writes that bypass those handlers, such as `console.log()`,
+ * `print()`, or direct writes to a process stream.
+ *
+ * The helpers themselves are still landing; see
+ * {@link https://github.com/dahlia/optique/issues/890}.
+ *
+ * @module
+ * @since 1.3.0
+ */
+export {};

--- a/packages/testing/tsdown.config.ts
+++ b/packages/testing/tsdown.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+  entry: [
+    "src/cli.ts",
+    "src/discover.ts",
+    "src/index.ts",
+    "src/parser.ts",
+    "src/run.ts",
+  ],
+  dts: true,
+  format: ["esm", "cjs"],
+  platform: "neutral",
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ importers:
       '@optique/temporal':
         specifier: 'workspace:'
         version: link:../packages/temporal
+      '@optique/testing':
+        specifier: 'workspace:'
+        version: link:../packages/testing
       '@optique/valibot':
         specifier: 'workspace:'
         version: link:../packages/valibot
@@ -116,7 +119,7 @@ importers:
         version: link:../packages/zod
       '@shikijs/vitepress-twoslash':
         specifier: ^3.20.0
-        version: 3.20.0(typescript@5.8.3)
+        version: 3.20.0(supports-color@10.2.2)(typescript@5.8.3)
       '@standard-schema/spec':
         specifier: 'catalog:'
         version: 1.1.0
@@ -149,10 +152,10 @@ importers:
         version: 2.0.0-alpha.17(@types/node@20.19.41)(jiti@2.5.1)(postcss@8.5.15)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.2)
       vitepress-plugin-group-icons:
         specifier: ^1.6.3
-        version: 1.6.3(markdown-it@14.1.0)(vite@7.3.5(patch_hash=c93908c36d57e15b6a2d0014f356e0ddcb021ece7c4436f9145cc52acb6dcb49)(@types/node@20.19.41)(jiti@2.5.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 1.6.3(markdown-it@14.1.0)(supports-color@10.2.2)(vite@7.3.5(patch_hash=c93908c36d57e15b6a2d0014f356e0ddcb021ece7c4436f9145cc52acb6dcb49)(@types/node@20.19.41)(jiti@2.5.1)(tsx@4.21.0)(yaml@2.8.2))
       vitepress-plugin-llms:
         specifier: ^1.7.3
-        version: 1.7.3
+        version: 1.7.3(supports-color@10.2.2)
       vitepress-plugin-mermaid:
         specifier: ^2.0.17
         version: 2.0.17(mermaid@11.16.0)(vitepress@2.0.0-alpha.17(@types/node@20.19.41)(jiti@2.5.1)(postcss@8.5.15)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.2))
@@ -177,7 +180,7 @@ importers:
         version: 24.12.4
       tsdown:
         specifier: 'catalog:'
-        version: 0.13.0(typescript@5.8.3)
+        version: 0.13.0(supports-color@10.2.2)(typescript@5.8.3)
       typescript:
         specifier: 'catalog:'
         version: 5.8.3
@@ -208,7 +211,7 @@ importers:
         version: 4.7.0
       tsdown:
         specifier: 'catalog:'
-        version: 0.13.0(typescript@5.8.3)
+        version: 0.13.0(supports-color@10.2.2)(typescript@5.8.3)
       typescript:
         specifier: 'catalog:'
         version: 5.8.3
@@ -233,7 +236,7 @@ importers:
         version: 4.7.0
       tsdown:
         specifier: 'catalog:'
-        version: 0.13.0(typescript@5.8.3)
+        version: 0.13.0(supports-color@10.2.2)(typescript@5.8.3)
       typescript:
         specifier: 'catalog:'
         version: 5.8.3
@@ -254,7 +257,7 @@ importers:
         version: 4.7.0
       tsdown:
         specifier: 'catalog:'
-        version: 0.13.0(typescript@5.8.3)
+        version: 0.13.0(supports-color@10.2.2)(typescript@5.8.3)
       typescript:
         specifier: 'catalog:'
         version: 5.8.3
@@ -282,7 +285,7 @@ importers:
         version: 4.7.0
       tsdown:
         specifier: 'catalog:'
-        version: 0.13.0(typescript@5.8.3)
+        version: 0.13.0(supports-color@10.2.2)(typescript@5.8.3)
       typescript:
         specifier: 'catalog:'
         version: 5.8.3
@@ -301,7 +304,7 @@ importers:
         version: 24.12.4
       tsdown:
         specifier: 'catalog:'
-        version: 0.13.0(typescript@5.8.3)
+        version: 0.13.0(supports-color@10.2.2)(typescript@5.8.3)
       typescript:
         specifier: 'catalog:'
         version: 5.8.3
@@ -323,7 +326,7 @@ importers:
         version: 4.7.0
       tsdown:
         specifier: 'catalog:'
-        version: 0.13.0(typescript@5.8.3)
+        version: 0.13.0(supports-color@10.2.2)(typescript@5.8.3)
       typescript:
         specifier: 'catalog:'
         version: 5.8.3
@@ -345,7 +348,7 @@ importers:
         version: 24.12.4
       tsdown:
         specifier: 'catalog:'
-        version: 0.13.0(typescript@5.8.3)
+        version: 0.13.0(supports-color@10.2.2)(typescript@5.8.3)
       typescript:
         specifier: 'catalog:'
         version: 5.8.3
@@ -379,7 +382,7 @@ importers:
         version: 4.7.0
       tsdown:
         specifier: 'catalog:'
-        version: 0.13.0(typescript@5.8.3)
+        version: 0.13.0(supports-color@10.2.2)(typescript@5.8.3)
       typescript:
         specifier: 'catalog:'
         version: 5.8.3
@@ -401,7 +404,7 @@ importers:
         version: 24.12.4
       tsdown:
         specifier: 'catalog:'
-        version: 0.13.0(typescript@5.8.3)
+        version: 0.13.0(supports-color@10.2.2)(typescript@5.8.3)
       typescript:
         specifier: 'catalog:'
         version: 5.8.3
@@ -420,7 +423,7 @@ importers:
         version: 24.12.4
       tsdown:
         specifier: 'catalog:'
-        version: 0.13.0(typescript@5.8.3)
+        version: 0.13.0(supports-color@10.2.2)(typescript@5.8.3)
       tsx:
         specifier: 'catalog:'
         version: 4.21.0
@@ -451,7 +454,7 @@ importers:
         version: 4.7.0
       tsdown:
         specifier: 'catalog:'
-        version: 0.13.0(typescript@5.8.3)
+        version: 0.13.0(supports-color@10.2.2)(typescript@5.8.3)
       typescript:
         specifier: 'catalog:'
         version: 5.8.3
@@ -476,7 +479,7 @@ importers:
         version: 4.7.0
       tsdown:
         specifier: 'catalog:'
-        version: 0.13.0(typescript@5.8.3)
+        version: 0.13.0(supports-color@10.2.2)(typescript@5.8.3)
       typescript:
         specifier: 'catalog:'
         version: 5.8.3
@@ -495,7 +498,7 @@ importers:
         version: 24.12.4
       tsdown:
         specifier: 'catalog:'
-        version: 0.13.0(typescript@5.8.3)
+        version: 0.13.0(supports-color@10.2.2)(typescript@5.8.3)
       typescript:
         specifier: 'catalog:'
         version: 5.8.3
@@ -514,7 +517,19 @@ importers:
         version: 24.12.4
       tsdown:
         specifier: 'catalog:'
-        version: 0.13.0(typescript@5.8.3)
+        version: 0.13.0(supports-color@10.2.2)(typescript@5.8.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.8.3
+
+  packages/testing:
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.12.4
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.13.0(supports-color@10.2.2)(typescript@5.8.3)
       typescript:
         specifier: 'catalog:'
         version: 5.8.3
@@ -530,7 +545,7 @@ importers:
         version: 24.12.4
       tsdown:
         specifier: 'catalog:'
-        version: 0.13.0(typescript@5.8.3)
+        version: 0.13.0(supports-color@10.2.2)(typescript@5.8.3)
       typescript:
         specifier: 'catalog:'
         version: 5.8.3
@@ -549,7 +564,7 @@ importers:
         version: 24.12.4
       tsdown:
         specifier: 'catalog:'
-        version: 0.13.0(typescript@5.8.3)
+        version: 0.13.0(supports-color@10.2.2)(typescript@5.8.3)
       typescript:
         specifier: 'catalog:'
         version: 5.8.3
@@ -3425,12 +3440,12 @@ snapshots:
 
   '@iconify/types@2.0.0': {}
 
-  '@iconify/utils@3.0.1':
+  '@iconify/utils@3.0.1(supports-color@10.2.2)':
     dependencies:
       '@antfu/install-pkg': 1.1.0
       '@antfu/utils': 9.2.0
       '@iconify/types': 2.0.0
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@10.2.2)
       globals: 15.15.0
       kolorist: 1.8.0
       local-pkg: 1.1.2
@@ -3901,11 +3916,11 @@ snapshots:
       '@shikijs/core': 3.23.0
       '@shikijs/types': 3.23.0
 
-  '@shikijs/twoslash@3.20.0(typescript@5.8.3)':
+  '@shikijs/twoslash@3.20.0(supports-color@10.2.2)(typescript@5.8.3)':
     dependencies:
       '@shikijs/core': 3.20.0
       '@shikijs/types': 3.20.0
-      twoslash: 0.3.4(typescript@5.8.3)
+      twoslash: 0.3.4(supports-color@10.2.2)(typescript@5.8.3)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
@@ -3920,20 +3935,20 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
-  '@shikijs/vitepress-twoslash@3.20.0(typescript@5.8.3)':
+  '@shikijs/vitepress-twoslash@3.20.0(supports-color@10.2.2)(typescript@5.8.3)':
     dependencies:
-      '@shikijs/twoslash': 3.20.0(typescript@5.8.3)
+      '@shikijs/twoslash': 3.20.0(supports-color@10.2.2)(typescript@5.8.3)
       floating-vue: 5.2.2(vue@3.5.38(typescript@5.8.3))
       lz-string: 1.5.0
       magic-string: 0.30.21
       markdown-it: 14.1.0
-      mdast-util-from-markdown: 2.0.2
-      mdast-util-gfm: 3.1.0
+      mdast-util-from-markdown: 2.0.2(supports-color@10.2.2)
+      mdast-util-gfm: 3.1.0(supports-color@10.2.2)
       mdast-util-to-hast: 13.2.1
       ohash: 2.0.11
       shiki: 3.20.0
-      twoslash: 0.3.4(typescript@5.8.3)
-      twoslash-vue: 0.3.4(typescript@5.8.3)
+      twoslash: 0.3.4(supports-color@10.2.2)(typescript@5.8.3)
+      twoslash-vue: 0.3.4(supports-color@10.2.2)(typescript@5.8.3)
       vue: 3.5.38(typescript@5.8.3)
     transitivePeerDependencies:
       - '@nuxt/kit'
@@ -4112,9 +4127,9 @@ snapshots:
 
   '@types/web-bluetooth@0.0.21': {}
 
-  '@typescript/vfs@1.6.1(typescript@5.8.3)':
+  '@typescript/vfs@1.6.1(supports-color@10.2.2)(typescript@5.8.3)':
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@10.2.2)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
@@ -4572,9 +4587,11 @@ snapshots:
 
   de-indent@1.0.2: {}
 
-  debug@4.4.1:
+  debug@4.4.1(supports-color@10.2.2):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 10.2.2
 
   decode-named-character-reference@1.2.0:
     dependencies:
@@ -4977,14 +4994,14 @@ snapshots:
       unist-util-is: 6.0.0
       unist-util-visit-parents: 6.0.1
 
-  mdast-util-from-markdown@2.0.2:
+  mdast-util-from-markdown@2.0.2(supports-color@10.2.2):
     dependencies:
       '@types/mdast': 4.0.4
       '@types/unist': 3.0.3
       decode-named-character-reference: 1.2.0
       devlop: 1.1.0
       mdast-util-to-string: 4.0.0
-      micromark: 4.0.2
+      micromark: 4.0.2(supports-color@10.2.2)
       micromark-util-decode-numeric-character-reference: 2.0.2
       micromark-util-decode-string: 2.0.1
       micromark-util-normalize-identifier: 2.0.1
@@ -4994,12 +5011,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-frontmatter@2.0.1:
+  mdast-util-frontmatter@2.0.1(supports-color@10.2.2):
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       escape-string-regexp: 5.0.0
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.2(supports-color@10.2.2)
       mdast-util-to-markdown: 2.1.2
       micromark-extension-frontmatter: 2.0.0
     transitivePeerDependencies:
@@ -5013,51 +5030,51 @@ snapshots:
       mdast-util-find-and-replace: 3.0.2
       micromark-util-character: 2.1.1
 
-  mdast-util-gfm-footnote@2.1.0:
+  mdast-util-gfm-footnote@2.1.0(supports-color@10.2.2):
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.2(supports-color@10.2.2)
       mdast-util-to-markdown: 2.1.2
       micromark-util-normalize-identifier: 2.0.1
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-strikethrough@2.0.0:
+  mdast-util-gfm-strikethrough@2.0.0(supports-color@10.2.2):
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.2(supports-color@10.2.2)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-table@2.0.0:
+  mdast-util-gfm-table@2.0.0(supports-color@10.2.2):
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       markdown-table: 3.0.4
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.2(supports-color@10.2.2)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-task-list-item@2.0.0:
+  mdast-util-gfm-task-list-item@2.0.0(supports-color@10.2.2):
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.2(supports-color@10.2.2)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm@3.1.0:
+  mdast-util-gfm@3.1.0(supports-color@10.2.2):
     dependencies:
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.2(supports-color@10.2.2)
       mdast-util-gfm-autolink-literal: 2.0.1
-      mdast-util-gfm-footnote: 2.1.0
-      mdast-util-gfm-strikethrough: 2.0.0
-      mdast-util-gfm-table: 2.0.0
-      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-gfm-footnote: 2.1.0(supports-color@10.2.2)
+      mdast-util-gfm-strikethrough: 2.0.0(supports-color@10.2.2)
+      mdast-util-gfm-table: 2.0.0(supports-color@10.2.2)
+      mdast-util-gfm-task-list-item: 2.0.0(supports-color@10.2.2)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -5239,10 +5256,10 @@ snapshots:
 
   micromark-util-types@2.0.2: {}
 
-  micromark@4.0.2:
+  micromark@4.0.2(supports-color@10.2.2):
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@10.2.2)
       decode-named-character-reference: 1.2.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -5404,19 +5421,19 @@ snapshots:
     dependencies:
       regex-utilities: 2.3.0
 
-  remark-frontmatter@5.0.0:
+  remark-frontmatter@5.0.0(supports-color@10.2.2):
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-frontmatter: 2.0.1
+      mdast-util-frontmatter: 2.0.1(supports-color@10.2.2)
       micromark-extension-frontmatter: 2.0.0
       unified: 11.0.5
     transitivePeerDependencies:
       - supports-color
 
-  remark-parse@11.0.0:
+  remark-parse@11.0.0(supports-color@10.2.2):
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.2(supports-color@10.2.2)
       micromark-util-types: 2.0.2
       unified: 11.0.5
     transitivePeerDependencies:
@@ -5428,10 +5445,10 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
-  remark@15.0.1:
+  remark@15.0.1(supports-color@10.2.2):
     dependencies:
       '@types/mdast': 4.0.4
-      remark-parse: 11.0.0
+      remark-parse: 11.0.0(supports-color@10.2.2)
       remark-stringify: 11.0.0
       unified: 11.0.5
     transitivePeerDependencies:
@@ -5445,14 +5462,14 @@ snapshots:
 
   robust-predicates@3.0.3: {}
 
-  rolldown-plugin-dts@0.14.1(rolldown@1.0.0-beta.29)(typescript@5.8.3):
+  rolldown-plugin-dts@0.14.1(rolldown@1.0.0-beta.29)(supports-color@10.2.2)(typescript@5.8.3):
     dependencies:
       '@babel/generator': 7.28.0
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
       ast-kit: 2.1.1
       birpc: 2.9.0
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@10.2.2)
       dts-resolver: 2.1.1
       get-tsconfig: 4.10.1
       rolldown: 1.0.0-beta.29
@@ -5670,17 +5687,17 @@ snapshots:
 
   ts-dedent@2.3.0: {}
 
-  tsdown@0.13.0(typescript@5.8.3):
+  tsdown@0.13.0(supports-color@10.2.2)(typescript@5.8.3):
     dependencies:
       ansis: 4.1.0
       cac: 6.7.14
       chokidar: 4.0.3
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@10.2.2)
       diff: 8.0.2
       empathic: 2.0.0
       hookable: 5.5.3
       rolldown: 1.0.0-beta.29
-      rolldown-plugin-dts: 0.14.1(rolldown@1.0.0-beta.29)(typescript@5.8.3)
+      rolldown-plugin-dts: 0.14.1(rolldown@1.0.0-beta.29)(supports-color@10.2.2)(typescript@5.8.3)
       semver: 7.8.0
       tinyexec: 1.0.1
       tinyglobby: 0.2.15
@@ -5705,18 +5722,18 @@ snapshots:
 
   twoslash-protocol@0.3.4: {}
 
-  twoslash-vue@0.3.4(typescript@5.8.3):
+  twoslash-vue@0.3.4(supports-color@10.2.2)(typescript@5.8.3):
     dependencies:
       '@vue/language-core': 3.0.5(typescript@5.8.3)
-      twoslash: 0.3.4(typescript@5.8.3)
+      twoslash: 0.3.4(supports-color@10.2.2)(typescript@5.8.3)
       twoslash-protocol: 0.3.4
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
-  twoslash@0.3.4(typescript@5.8.3):
+  twoslash@0.3.4(supports-color@10.2.2)(typescript@5.8.3):
     dependencies:
-      '@typescript/vfs': 1.6.1(typescript@5.8.3)
+      '@typescript/vfs': 1.6.1(supports-color@10.2.2)(typescript@5.8.3)
       twoslash-protocol: 0.3.4
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -5821,17 +5838,17 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.2
 
-  vitepress-plugin-group-icons@1.6.3(markdown-it@14.1.0)(vite@7.3.5(patch_hash=c93908c36d57e15b6a2d0014f356e0ddcb021ece7c4436f9145cc52acb6dcb49)(@types/node@20.19.41)(jiti@2.5.1)(tsx@4.21.0)(yaml@2.8.2)):
+  vitepress-plugin-group-icons@1.6.3(markdown-it@14.1.0)(supports-color@10.2.2)(vite@7.3.5(patch_hash=c93908c36d57e15b6a2d0014f356e0ddcb021ece7c4436f9145cc52acb6dcb49)(@types/node@20.19.41)(jiti@2.5.1)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@iconify-json/logos': 1.2.9
       '@iconify-json/vscode-icons': 1.2.29
-      '@iconify/utils': 3.0.1
+      '@iconify/utils': 3.0.1(supports-color@10.2.2)
       markdown-it: 14.1.0
       vite: 7.3.5(patch_hash=c93908c36d57e15b6a2d0014f356e0ddcb021ece7c4436f9145cc52acb6dcb49)(@types/node@20.19.41)(jiti@2.5.1)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
-  vitepress-plugin-llms@1.7.3:
+  vitepress-plugin-llms@1.7.3(supports-color@10.2.2):
     dependencies:
       byte-size: 9.0.1
       gray-matter: 4.0.3
@@ -5841,8 +5858,8 @@ snapshots:
       minimatch: 10.0.3
       path-to-regexp: 8.2.0
       picocolors: 1.1.1
-      remark: 15.0.1
-      remark-frontmatter: 5.0.0
+      remark: 15.0.1(supports-color@10.2.2)
+      remark-frontmatter: 5.0.0(supports-color@10.2.2)
       tokenx: 1.1.0
       unist-util-remove: 4.0.0
       unist-util-visit: 5.0.0

--- a/sacho.toml
+++ b/sacho.toml
@@ -97,3 +97,8 @@ paths = ["packages/inquirer/**"]
 id = "@optique/prompt"
 directory = "prompt"
 paths = ["packages/prompt/**"]
+
+[[sections]]
+id = "@optique/testing"
+directory = "testing"
+paths = ["packages/testing/**"]


### PR DESCRIPTION
Closes https://github.com/dahlia/optique/issues/891. Part of https://github.com/dahlia/optique/issues/890.

Scaffolding only. The four layer subpaths are reserved but export nothing yet; #892, #893, #887, and #894 track the helpers.

`CapturedOutput` is the only root type, because captured stdout and stderr are the only thing that means the same at more than one boundary. Exit results are not: the runner layer has to tell a returned value apart from an intercepted exit, the parser layer never exits at all, and an in-process exit code is not a subprocess signal. Those types will stay with the subpaths that produce them. There is no runtime Optique dependency yet either, since no public module imports one.

*packages/testing/src/public-api.test.ts* derives its manifest and build assertions from a single list of the five subpaths, so a JSR and npm desync fails instead of going unnoticed. Its artifact and CommonJS checks skip under Deno rather than when *dist/* is missing: keying off *dist/* would let a missing artifact disable the assertion meant to catch it. Node.js and Bun build first, so they always run.

No helper API exists yet, so *docs/concepts/testing.md* documents the execution boundaries instead. The part worth the space is the gap between the `discover` and `cli` layers: a handler that writes through `console.log()` or `print()` bypasses the injected callbacks, so only a subprocess can see it.

Adding the package row to *SKILL.md* would have tripped the line cap its own test enforces, so the `seq()` pitfall bullet is a line shorter now. The new-package checklist in *CONTRIBUTING.md* gained *docs/.vitepress/config.mts* and *SKILL.md*, which it had not named.
