### PR TITLE
Share whole-argument parsing with test helpers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@ To be released.
 
 ### @optique/core
 
+ -  Added `parseDetailed()` to preserve remaining arguments and the matched
+    command path on structured parse failures.  [[#890], [#892], [#943]]
  -  Added `regExp()` for compiling command-line values into `RegExp` objects
     with fixed flags and customizable parse errors.  [[#906], [#909]]
  -  Added `termWidth: "auto"` to `formatDocPage()` for aligning descriptions
@@ -58,6 +60,8 @@ To be released.
 [#871]: https://github.com/dahlia/optique/issues/871
 [#872]: https://github.com/dahlia/optique/issues/872
 [#879]: https://github.com/dahlia/optique/issues/879
+[#890]: https://github.com/dahlia/optique/issues/890
+[#892]: https://github.com/dahlia/optique/issues/892
 [#904]: https://github.com/dahlia/optique/issues/904
 [#906]: https://github.com/dahlia/optique/issues/906
 [#909]: https://github.com/dahlia/optique/pull/909
@@ -76,6 +80,7 @@ To be released.
 [#929]: https://github.com/dahlia/optique/issues/929
 [#931]: https://github.com/dahlia/optique/pull/931
 [#932]: https://github.com/dahlia/optique/pull/932
+[#943]: https://github.com/dahlia/optique/pull/943
 
 ### @optique/run
 
@@ -166,8 +171,11 @@ To be released.
 ### @optique/testing
 
  -  Added the `@optique/testing` package with a shared `CapturedOutput` type
-    and reserved entry points for parser, runner, command discovery, and
-    subprocess testing.  [[#891], [#942]]
+    and layered entry points for parser, runner, command discovery, and
+    subprocess testing.  The parser entry point can run a complete argument
+    list and report an inferred value or a structured failure with remaining
+    arguments and the matched command path.
+    [[#890], [#891], [#892], [#942], [#943]]
 
 [#891]: https://github.com/dahlia/optique/issues/891
 [#942]: https://github.com/dahlia/optique/pull/942

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,16 +95,23 @@ Always prefer the latest stable version unless there is a specific reason
 to use an older version.
 
 > [!IMPORTANT]
-> Because this project supports both Deno and Node.js/Bun, dependencies must
-> be added to *both* configuration files:
+> Because this project supports both Deno and Node.js/Bun, third-party
+> dependencies must be added to *both* configuration files:
 >
 >  -  *deno.json*: Add to the `imports` field (for Deno)
 >  -  *package.json*: Add to `dependencies` or `devDependencies` (for
 >     Node.js/Bun)
 >
-> For workspace packages, use the pnpm catalog (*pnpm-workspace.yaml*) to manage
-> versions centrally.  In *package.json*, reference catalog versions with
-> `"catalog:"` instead of hardcoding version numbers.
+> Dependencies on another Optique workspace package are different.  Declare
+> them only in the consuming package's *package.json*, using the `workspace:`
+> protocol.  Do not add a *deno.json* import that points to a sibling package
+> through a `../` path.  Deno resolves workspace members locally and rewrites
+> workspace references when publishing to JSR.
+>
+> For third-party versions shared across workspace packages, use the pnpm
+> catalog (*pnpm-workspace.yaml*) to manage versions centrally.  In
+> *package.json*, reference catalog versions with `"catalog:"` instead of
+> hardcoding version numbers.
 >
 > Forgetting to add a dependency to *package.json* will cause Node.js and Bun
 > tests to fail with `ERR_MODULE_NOT_FOUND`, even if Deno tests pass.

--- a/changes.d/core/detailed-parse-results.md
+++ b/changes.d/core/detailed-parse-results.md
@@ -1,0 +1,8 @@
+---
+links:
+  '#890': https://github.com/dahlia/optique/issues/890
+  '#892': https://github.com/dahlia/optique/issues/892
+  '#943': https://github.com/dahlia/optique/pull/943
+---
+ -  Added `parseDetailed()` to preserve remaining arguments and the matched
+    command path on structured parse failures.  [[#890], [#892], [#943]]

--- a/changes.d/testing/testing-package.md
+++ b/changes.d/testing/testing-package.md
@@ -1,8 +1,14 @@
 ---
 links:
+  '#890': https://github.com/dahlia/optique/issues/890
   '#891': https://github.com/dahlia/optique/issues/891
+  '#892': https://github.com/dahlia/optique/issues/892
   '#942': https://github.com/dahlia/optique/pull/942
+  '#943': https://github.com/dahlia/optique/pull/943
 ---
  -  Added the `@optique/testing` package with a shared `CapturedOutput` type
-    and reserved entry points for parser, runner, command discovery, and
-    subprocess testing.  [[#891], [#942]]
+    and layered entry points for parser, runner, command discovery, and
+    subprocess testing.  The parser entry point can run a complete argument
+    list and report an inferred value or a structured failure with remaining
+    arguments and the matched command path.
+    [[#890], [#891], [#892], [#942], [#943]]

--- a/docs/concepts/runners.md
+++ b/docs/concepts/runners.md
@@ -152,6 +152,12 @@ Use `parse()` when you need complete control over error handling, want to
 integrate parsing into a larger application flow, or need to handle multiple
 parsing attempts.
 
+When the caller also needs to know where a failure occurred, use
+`parseDetailed()`.  It runs the same parse and completion phases as `parse()`,
+but its failure result also contains `remainingArgs` and the canonical
+`commandPath`.  Parser-focused tests can use the corresponding `parseArgs()`
+and `parseArgsSync()` helpers from *@optique/testing/parser*.
+
 
 Mid-level execution with `@optique/core/facade`
 -----------------------------------------------

--- a/docs/concepts/testing.md
+++ b/docs/concepts/testing.md
@@ -23,10 +23,8 @@ import { /* ... */ } from "@optique/testing/discover";
 import { /* ... */ } from "@optique/testing/cli";
 ~~~~
 
-> [!NOTE]
-> The package currently ships the shared contracts below and reserves the four
-> entry points.  The helpers for each layer are still landing; follow
-> [issue #890] for progress.
+The parser helpers are available now.  The runner, discovery, and child-process
+helpers remain reserved while their respective parts of [issue #890] land.
 
 [issue #890]: https://github.com/dahlia/optique/issues/890
 
@@ -80,6 +78,43 @@ Prefer the narrowest layer that still exercises what you are asserting about.
 These layers are complements, not alternatives.  A parser test that runs in
 milliseconds is a poor substitute for one end-to-end check that the binary
 starts at all, and the reverse is equally true.
+
+
+Testing a parser
+----------------
+
+Use `parseArgsSync()` with a synchronous parser, or `parseArgs()` when the
+parser may be asynchronous.  The latter always returns a promise, including
+when given a synchronous parser.
+
+~~~~ typescript twoslash
+import { command, option } from "@optique/core/primitives";
+import { parseArgsSync } from "@optique/testing/parser";
+
+const parser = command("serve", option("--watch"));
+const result = parseArgsSync(parser, ["serve", "--watch"]);
+//    ^?
+
+if (result.success) {
+  result.value; // boolean
+} else {
+  result.error;
+  result.remainingArgs;
+  result.commandPath;
+}
+~~~~
+
+A failure reports the argument suffix that remained where parsing stopped.
+`commandPath` contains the canonical names of commands matched before that
+point, even when the input used a command alias.  Completion-time failures have
+an empty `remainingArgs` array because the complete argument list was already
+consumed.
+
+Both helpers accept the same `ParseOptions` as the core parsing APIs, including
+annotations.  They return parser failures as values, but exceptions thrown by
+the parser still propagate.  `parseArgs()` likewise preserves promise
+rejections.  Neither helper renders help, interprets `--help`/`--version`,
+writes output, exits, or dispatches a command handler.
 
 
 Shared contracts

--- a/packages/core/skills/optique/SKILL.md
+++ b/packages/core/skills/optique/SKILL.md
@@ -22,11 +22,11 @@ they cover the parts agents most often get wrong.
 Core rules
 ----------
 
- -  Use `run()` from *@optique/run* for real CLI applications. It reads
-    `process.argv`/`Deno.args`, handles help, version output, errors, exit
-    codes, colors, terminal width, and shell completion. Use `parse()` from
-    `@optique/core/parser` or `runParser()` from `@optique/core/facade` when
-    embedding Optique in tests, libraries, tools, or custom runtimes.
+ -  Use `run()` from *@optique/run* for applications; use `parse()` or
+    `runParser()` for embedded and custom runtimes.
+ -  In parser-focused tests, use `parseArgs()` or `parseArgsSync()` from
+    *@optique/testing/parser* for inferred values and detailed failures without
+    running help, output, exits, or command handlers.
  -  Compose parsers with `object()`, `tuple()`, `seq()`, `or()`, `merge()`, and
     modifiers. Do not write imperative `if`/`else` argument scanners around
     Optique parsers.

--- a/packages/core/src/facade.ts
+++ b/packages/core/src/facade.ts
@@ -47,7 +47,12 @@ import {
   type ParserResult,
   type Suggestion,
 } from "./parser.ts";
-import { createEffectfulCompletionSession } from "./internal/parser.ts";
+import {
+  attemptParseAsync,
+  attemptParseSync,
+  createEffectfulCompletionSession,
+  type ParseAttempt,
+} from "./internal/parser.ts";
 import { dispatchByMode } from "./internal/mode-dispatch.ts";
 import {
   collectExplicitSourceValues,
@@ -68,12 +73,7 @@ import {
   type Usage,
 } from "./usage.ts";
 import { type DeferredMap, string } from "./valueparser.ts";
-import {
-  type Annotations,
-  injectAnnotations,
-  isInjectedAnnotationWrapper,
-  unwrapInjectedAnnotationWrapper,
-} from "./internal/annotations.ts";
+import { type Annotations, injectAnnotations } from "./internal/annotations.ts";
 import {
   allowDuplicateLeadingCommandNamesKey,
   hiddenCommandAliasesKey,
@@ -275,50 +275,6 @@ function isBufferUnchanged(
   );
 }
 
-function getFailureProgress(
-  args: readonly string[],
-  buffer: readonly string[],
-  consumedInStep: number,
-): {
-  readonly remainingArgs: readonly string[];
-  readonly consumedCount: number;
-} {
-  return {
-    remainingArgs: buffer.slice(consumedInStep),
-    consumedCount: args.length - buffer.length + consumedInStep,
-  };
-}
-
-type ParseAttempt<T> =
-  | {
-    readonly kind: "success";
-    readonly value: T;
-  }
-  | {
-    readonly kind: "failure";
-    readonly error: Message;
-    readonly remainingArgs: readonly string[];
-    readonly consumedCount: number;
-    readonly optionsTerminated: boolean;
-    readonly commandPath: readonly string[];
-  };
-
-function createParseExec(
-  parser: Parser<Mode, unknown, unknown>,
-): ExecutionContext {
-  return {
-    usage: parser.usage,
-    phase: "parse",
-    path: [],
-    commandPath: [],
-    trace: createInputTrace(),
-  };
-}
-
-function getCommandPath(exec: ExecutionContext | undefined): readonly string[] {
-  return exec?.commandPath ?? [];
-}
-
 // Module-private options key carrying the run-scoped effectful completion
 // session from runWith() into the final runParser() pass without widening
 // the public RunOptions surface.
@@ -368,216 +324,6 @@ function createRunWithSessions(): {
   return { seedSession, finalSession };
 }
 
-function createCompleteExec(
-  exec: ExecutionContext,
-  context: {
-    readonly exec?: ExecutionContext;
-    readonly trace?: ReturnType<typeof createInputTrace>;
-  },
-  session?: EffectfulCompletionSession,
-): ExecutionContext {
-  const runtime = createDependencyRuntimeContext();
-  return {
-    ...exec,
-    phase: "complete",
-    dependencyRuntime: runtime,
-    dependencyRegistry: runtime.registry,
-    commandPath: getCommandPath(context.exec) ?? exec.commandPath,
-    trace: context.exec?.trace ?? context.trace ?? exec.trace,
-    effectfulCompletionSession: session ?? createEffectfulCompletionSession(),
-  };
-}
-
-function attemptParseSync<T>(
-  parser: Parser<"sync", T, unknown>,
-  args: readonly string[],
-): ParseAttempt<T>;
-function attemptParseSync(
-  parser: Parser<"sync", unknown, unknown>,
-  args: readonly string[],
-  mode: "parse-only",
-): ParseAttempt<undefined>;
-function attemptParseSync<T>(
-  parser: Parser<"sync", T, unknown>,
-  args: readonly string[],
-  mode: "complete",
-  session?: EffectfulCompletionSession,
-): ParseAttempt<T>;
-function attemptParseSync<T>(
-  parser: Parser<"sync", T, unknown>,
-  args: readonly string[],
-  mode: "complete" | "parse-only" = "complete",
-  session?: EffectfulCompletionSession,
-): ParseAttempt<T | undefined> {
-  const shouldUnwrapAnnotatedValue = isInjectedAnnotationWrapper(
-    parser.initialState,
-  );
-  const exec = createParseExec(parser);
-  let context: ParserContext<unknown> = createParserContext(
-    { buffer: args, state: parser.initialState, optionsTerminated: false },
-    exec,
-  );
-
-  do {
-    const result = parser.parse(context);
-    if (!result.success) {
-      const progress = getFailureProgress(
-        args,
-        context.buffer,
-        result.consumed,
-      );
-      return {
-        kind: "failure",
-        error: result.error,
-        remainingArgs: progress.remainingArgs,
-        consumedCount: progress.consumedCount,
-        optionsTerminated: context.optionsTerminated,
-        commandPath: getCommandPath(context.exec),
-      };
-    }
-    const previousBuffer = context.buffer;
-    context = result.next;
-    if (isBufferUnchanged(previousBuffer, context.buffer)) {
-      const progress = getFailureProgress(
-        args,
-        previousBuffer,
-        result.consumed.length,
-      );
-      return {
-        kind: "failure",
-        error: message`Unexpected option or argument: ${context.buffer[0]}.`,
-        remainingArgs: progress.remainingArgs,
-        consumedCount: progress.consumedCount,
-        optionsTerminated: context.optionsTerminated,
-        commandPath: getCommandPath(context.exec),
-      };
-    }
-  } while (context.buffer.length > 0);
-
-  if (mode === "parse-only") {
-    return {
-      kind: "success",
-      value: undefined,
-    };
-  }
-
-  const endResult = parser.complete(
-    context.state,
-    createCompleteExec(exec, context, session),
-  );
-  if (!endResult.success) {
-    return {
-      kind: "failure",
-      error: endResult.error,
-      remainingArgs: [],
-      consumedCount: args.length,
-      optionsTerminated: context.optionsTerminated,
-      commandPath: getCommandPath(context.exec),
-    };
-  }
-  return {
-    kind: "success",
-    value: shouldUnwrapAnnotatedValue
-      ? unwrapInjectedAnnotationWrapper(endResult.value)
-      : endResult.value,
-  };
-}
-
-async function attemptParseAsync<T>(
-  parser: Parser<Mode, T, unknown>,
-  args: readonly string[],
-): Promise<ParseAttempt<T>>;
-async function attemptParseAsync(
-  parser: Parser<Mode, unknown, unknown>,
-  args: readonly string[],
-  mode: "parse-only",
-): Promise<ParseAttempt<undefined>>;
-async function attemptParseAsync<T>(
-  parser: Parser<Mode, T, unknown>,
-  args: readonly string[],
-  mode: "complete",
-  session?: EffectfulCompletionSession,
-): Promise<ParseAttempt<T>>;
-async function attemptParseAsync<T>(
-  parser: Parser<Mode, T, unknown>,
-  args: readonly string[],
-  mode: "complete" | "parse-only" = "complete",
-  session?: EffectfulCompletionSession,
-): Promise<ParseAttempt<T | undefined>> {
-  const shouldUnwrapAnnotatedValue = isInjectedAnnotationWrapper(
-    parser.initialState,
-  );
-  const exec = createParseExec(parser);
-  let context: ParserContext<unknown> = createParserContext(
-    { buffer: args, state: parser.initialState, optionsTerminated: false },
-    exec,
-  );
-
-  do {
-    const result = await parser.parse(context);
-    if (!result.success) {
-      const progress = getFailureProgress(
-        args,
-        context.buffer,
-        result.consumed,
-      );
-      return {
-        kind: "failure",
-        error: result.error,
-        remainingArgs: progress.remainingArgs,
-        consumedCount: progress.consumedCount,
-        optionsTerminated: context.optionsTerminated,
-        commandPath: getCommandPath(context.exec),
-      };
-    }
-    const previousBuffer = context.buffer;
-    context = result.next;
-    if (isBufferUnchanged(previousBuffer, context.buffer)) {
-      const progress = getFailureProgress(
-        args,
-        previousBuffer,
-        result.consumed.length,
-      );
-      return {
-        kind: "failure",
-        error: message`Unexpected option or argument: ${context.buffer[0]}.`,
-        remainingArgs: progress.remainingArgs,
-        consumedCount: progress.consumedCount,
-        optionsTerminated: context.optionsTerminated,
-        commandPath: getCommandPath(context.exec),
-      };
-    }
-  } while (context.buffer.length > 0);
-
-  if (mode === "parse-only") {
-    return {
-      kind: "success",
-      value: undefined,
-    };
-  }
-
-  const endResult = await parser.complete(
-    context.state,
-    createCompleteExec(exec, context, session),
-  );
-  if (!endResult.success) {
-    return {
-      kind: "failure",
-      error: endResult.error,
-      remainingArgs: [],
-      consumedCount: args.length,
-      optionsTerminated: context.optionsTerminated,
-      commandPath: getCommandPath(context.exec),
-    };
-  }
-  return {
-    kind: "success",
-    value: shouldUnwrapAnnotatedValue
-      ? unwrapInjectedAnnotationWrapper(endResult.value)
-      : endResult.value,
-  };
-}
-
 function createPhase2SeedExec(
   parser: Parser<Mode, unknown, unknown>,
   context: {
@@ -599,7 +345,7 @@ function createPhase2SeedExec(
     phase: "complete",
     dependencyRuntime: runtime,
     dependencyRegistry: runtime.registry,
-    commandPath: getCommandPath(context.exec),
+    commandPath: context.exec?.commandPath ?? [],
     trace: context.exec?.trace ?? context.trace ?? exec.trace,
     effectfulCompletionSession: session ?? createEffectfulCompletionSession(),
   };
@@ -3146,11 +2892,13 @@ export function runParser<
       const attempted = attemptParseSync(
         parser as Parser<"sync", unknown, unknown>,
         args,
-        "complete",
-        getEffectfulSessionOption(options),
+        {
+          mode: "complete",
+          session: getEffectfulSessionOption(options),
+        },
       );
       const classified: ParsedResult = attempted.kind === "success"
-        ? { type: "success", value: attempted.value }
+        ? { type: "success", value: attempted.result.value }
         : classifyParseFailure(
           attempted,
           helpOptionConfig ? [...helpOptionNames] : [],
@@ -3170,11 +2918,13 @@ export function runParser<
       const attempted = await attemptParseAsync(
         parser,
         args,
-        "complete",
-        getEffectfulSessionOption(options),
+        {
+          mode: "complete",
+          session: getEffectfulSessionOption(options),
+        },
       );
       const classified: ParsedResult = attempted.kind === "success"
-        ? { type: "success", value: attempted.value }
+        ? { type: "success", value: attempted.result.value }
         : classifyParseFailure(
           attempted,
           helpOptionConfig ? [...helpOptionNames] : [],
@@ -3399,7 +3149,7 @@ function needsEarlyExitSync<THelp, TError>(
   args: readonly string[],
   options: RunWithOptions<THelp, TError>,
 ): boolean {
-  const attempted = attemptParseSync(parser, args, "parse-only");
+  const attempted = attemptParseSync(parser, args, { mode: "parse-only" });
   if (attempted.kind === "success") return false;
   return isMetaEarlyExit(classifyEarlyExitFailure(attempted, options));
 }
@@ -3412,7 +3162,9 @@ async function needsEarlyExitAsync<THelp, TError>(
   args: readonly string[],
   options: RunWithOptions<THelp, TError>,
 ): Promise<boolean> {
-  const attempted = await attemptParseAsync(parser, args, "parse-only");
+  const attempted = await attemptParseAsync(parser, args, {
+    mode: "parse-only",
+  });
   if (attempted.kind === "success") return false;
   return isMetaEarlyExit(classifyEarlyExitFailure(attempted, options));
 }

--- a/packages/core/src/internal/mode-dispatch.test.ts
+++ b/packages/core/src/internal/mode-dispatch.test.ts
@@ -1,7 +1,26 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { wrapIterableForMode } from "./mode-dispatch.ts";
+import { constant } from "../primitives.ts";
+import { dispatchParserByMode, wrapIterableForMode } from "./mode-dispatch.ts";
+
+describe("dispatchParserByMode()", () => {
+  it("should narrow the parser type for each branch", () => {
+    const result = dispatchParserByMode(
+      constant("ok"),
+      (parser) => {
+        const mode: "sync" = parser.mode;
+        return mode;
+      },
+      (parser) => {
+        const mode: "async" = parser.mode;
+        return Promise.resolve(mode);
+      },
+    );
+
+    assert.equal(result, "sync");
+  });
+});
 
 describe("wrapIterableForMode", () => {
   it("should reject non-object sync values without in-operator errors", () => {

--- a/packages/core/src/internal/mode-dispatch.ts
+++ b/packages/core/src/internal/mode-dispatch.ts
@@ -10,7 +10,7 @@
  * @since 0.10.0
  */
 
-import type { Mode, ModeIterable, ModeValue } from "../parser.ts";
+import type { Mode, ModeIterable, ModeValue, Parser } from "../parser.ts";
 
 /**
  * Dispatches to sync or async implementation based on mode.
@@ -34,6 +34,33 @@ export function dispatchByMode<M extends Mode, T>(
     return asyncFn() as ModeValue<M, T>;
   }
   return syncFn() as ModeValue<M, T>;
+}
+
+/**
+ * Dispatches a parser to a callback narrowed to its runtime mode.
+ *
+ * TypeScript cannot narrow the generic mode parameter of a {@link Parser}
+ * from its `mode` property.  This helper keeps the necessary parser assertions
+ * at the mode-dispatch boundary while giving each callback a precise parser
+ * type.
+ *
+ * @param parser The parser whose mode selects the callback.
+ * @param syncFn Function to call with a synchronous parser.
+ * @param asyncFn Function to call with an asynchronous parser.
+ * @returns The callback result with the parser's mode wrapping.
+ * @internal
+ * @since 1.3.0
+ */
+export function dispatchParserByMode<M extends Mode, T, S, R>(
+  parser: Parser<M, T, S>,
+  syncFn: (parser: Parser<"sync", T, S>) => R,
+  asyncFn: (parser: Parser<"async", T, S>) => Promise<R>,
+): ModeValue<M, R> {
+  return dispatchByMode(
+    parser.mode,
+    () => syncFn(parser as Parser<"sync", T, S>),
+    () => asyncFn(parser as Parser<"async", T, S>),
+  );
 }
 
 /**

--- a/packages/core/src/internal/parser.ts
+++ b/packages/core/src/internal/parser.ts
@@ -23,7 +23,7 @@ import {
   type ParseOptions,
   unwrapInjectedAnnotationWrapper,
 } from "./annotations.ts";
-import { dispatchByMode } from "./mode-dispatch.ts";
+import { dispatchByMode, dispatchParserByMode } from "./mode-dispatch.ts";
 import type { ParserDependencyMetadata } from "../dependency-metadata.ts";
 import {
   collectExplicitSourceValues,
@@ -1466,11 +1466,11 @@ export function parseDetailed<M extends Mode, T>(
   args: readonly string[],
   options?: ParseOptions,
 ): ModeValue<M, DetailedParseResult<T>> {
-  return dispatchByMode(
-    parser.mode,
-    () => {
+  return dispatchParserByMode(
+    parser,
+    (parser) => {
       const attempted = attemptParseSync(
-        parser as Parser<"sync", T, unknown>,
+        parser,
         args,
         { parseOptions: options },
       );
@@ -1481,7 +1481,7 @@ export function parseDetailed<M extends Mode, T>(
         commandPath: attempted.commandPath,
       };
     },
-    async () => {
+    async (parser) => {
       const attempted = await attemptParseAsync(parser, args, {
         parseOptions: options,
       });

--- a/packages/core/src/internal/parser.ts
+++ b/packages/core/src/internal/parser.ts
@@ -1049,11 +1049,317 @@ export type Result<T> =
     readonly error: Message;
   };
 
+/**
+ * The result of a whole parser operation with failure progress preserved.
+ *
+ * Successful results have the same shape as {@link Result}.  Failures also
+ * identify the unconsumed argument suffix and the canonical command path
+ * matched before the failure.
+ *
+ * @template T The type of the value produced by the parser.
+ * @since 1.3.0
+ */
+export type DetailedParseResult<T> =
+  | Extract<Result<T>, { readonly success: true }>
+  | {
+    /** Indicates that the parsing operation failed. */
+    readonly success: false;
+    /** The error message describing why parsing failed. */
+    readonly error: Message;
+    /** The arguments that remained at the point of failure. */
+    readonly remainingArgs: readonly string[];
+    /** The canonical names of commands matched before the failure. */
+    readonly commandPath: readonly string[];
+  };
+
+/** @internal */
+export type ParseAttempt<T> =
+  | {
+    readonly kind: "success";
+    readonly result: Extract<Result<T>, { readonly success: true }>;
+  }
+  | {
+    readonly kind: "failure";
+    readonly error: Message;
+    readonly remainingArgs: readonly string[];
+    readonly consumedCount: number;
+    readonly optionsTerminated: boolean;
+    readonly commandPath: readonly string[];
+  };
+
+interface ParseAttemptOptions {
+  readonly mode?: "complete" | "parse-only";
+  readonly session?: EffectfulCompletionSession;
+  readonly parseOptions?: ParseOptions;
+}
+
 function injectAnnotationsIntoState<TState>(
   state: TState,
   options?: ParseOptions,
 ): TState {
   return injectAnnotations(state, options?.annotations);
+}
+
+function getFailureProgress(
+  args: readonly string[],
+  buffer: readonly string[],
+  consumedInStep: number,
+): {
+  readonly remainingArgs: readonly string[];
+  readonly consumedCount: number;
+} {
+  return {
+    remainingArgs: buffer.slice(consumedInStep),
+    consumedCount: args.length - buffer.length + consumedInStep,
+  };
+}
+
+function createParseExec(
+  parser: Parser<Mode, unknown, unknown>,
+): ExecutionContext {
+  return {
+    usage: parser.usage,
+    phase: "parse",
+    path: [],
+    commandPath: [],
+    trace: createInputTrace(),
+  };
+}
+
+function getCommandPath(exec: ExecutionContext | undefined): readonly string[] {
+  return [...(exec?.commandPath ?? [])];
+}
+
+function createCompleteExec(
+  exec: ExecutionContext,
+  context: {
+    readonly exec?: ExecutionContext;
+    readonly trace?: InputTrace;
+  },
+  session?: EffectfulCompletionSession,
+): ExecutionContext {
+  const runtime = createDependencyRuntimeContext();
+  return {
+    ...exec,
+    phase: "complete",
+    dependencyRuntime: runtime,
+    dependencyRegistry: runtime.registry,
+    commandPath: context.exec?.commandPath ?? exec.commandPath,
+    trace: context.exec?.trace ?? context.trace ?? exec.trace,
+    effectfulCompletionSession: session ?? createEffectfulCompletionSession(),
+  };
+}
+
+/** @internal */
+export function attemptParseSync<T>(
+  parser: Parser<"sync", T, unknown>,
+  args: readonly string[],
+  options?: ParseAttemptOptions,
+): ParseAttempt<T>;
+/** @internal */
+export function attemptParseSync(
+  parser: Parser<"sync", unknown, unknown>,
+  args: readonly string[],
+  options: ParseAttemptOptions & { readonly mode: "parse-only" },
+): ParseAttempt<undefined>;
+export function attemptParseSync<T>(
+  parser: Parser<"sync", T, unknown>,
+  args: readonly string[],
+  options: ParseAttemptOptions = {},
+): ParseAttempt<T | undefined> {
+  const initialState = injectAnnotationsIntoState(
+    parser.initialState,
+    options.parseOptions,
+  );
+  const shouldUnwrapAnnotatedValue =
+    hasMeaningfulAnnotations(options.parseOptions?.annotations) ||
+    isInjectedAnnotationWrapper(parser.initialState);
+  const exec = createParseExec(parser);
+  let context: ParserContext<unknown> = createParserContext(
+    {
+      buffer: [...args],
+      state: initialState,
+      optionsTerminated: false,
+    },
+    exec,
+  );
+
+  do {
+    const result = parser.parse(context);
+    if (!result.success) {
+      const progress = getFailureProgress(
+        args,
+        context.buffer,
+        result.consumed,
+      );
+      return {
+        kind: "failure",
+        error: result.error,
+        remainingArgs: progress.remainingArgs,
+        consumedCount: progress.consumedCount,
+        optionsTerminated: context.optionsTerminated,
+        commandPath: getCommandPath(context.exec),
+      };
+    }
+    const previousBuffer = context.buffer;
+    context = result.next;
+    if (isBufferUnchanged(previousBuffer, context.buffer)) {
+      const progress = getFailureProgress(
+        args,
+        previousBuffer,
+        result.consumed.length,
+      );
+      return {
+        kind: "failure",
+        error: message`Unexpected option or argument: ${context.buffer[0]}.`,
+        remainingArgs: progress.remainingArgs,
+        consumedCount: progress.consumedCount,
+        optionsTerminated: context.optionsTerminated,
+        commandPath: getCommandPath(context.exec),
+      };
+    }
+  } while (context.buffer.length > 0);
+
+  if (options.mode === "parse-only") {
+    return {
+      kind: "success",
+      result: { success: true, value: undefined },
+    };
+  }
+
+  const endResult = parser.complete(
+    context.state,
+    createCompleteExec(exec, context, options.session),
+  );
+  if (!endResult.success) {
+    return {
+      kind: "failure",
+      error: endResult.error,
+      remainingArgs: [],
+      consumedCount: args.length,
+      optionsTerminated: context.optionsTerminated,
+      commandPath: getCommandPath(context.exec),
+    };
+  }
+  return {
+    kind: "success",
+    result: {
+      success: true,
+      value: shouldUnwrapAnnotatedValue
+        ? unwrapInjectedAnnotationWrapper(endResult.value)
+        : endResult.value,
+      ...(endResult.deferred ? { deferred: true as const } : {}),
+      ...(endResult.deferredKeys
+        ? { deferredKeys: endResult.deferredKeys }
+        : {}),
+    },
+  };
+}
+
+/** @internal */
+export async function attemptParseAsync<T>(
+  parser: Parser<Mode, T, unknown>,
+  args: readonly string[],
+  options?: ParseAttemptOptions,
+): Promise<ParseAttempt<T>>;
+/** @internal */
+export async function attemptParseAsync(
+  parser: Parser<Mode, unknown, unknown>,
+  args: readonly string[],
+  options: ParseAttemptOptions & { readonly mode: "parse-only" },
+): Promise<ParseAttempt<undefined>>;
+export async function attemptParseAsync<T>(
+  parser: Parser<Mode, T, unknown>,
+  args: readonly string[],
+  options: ParseAttemptOptions = {},
+): Promise<ParseAttempt<T | undefined>> {
+  const initialState = injectAnnotationsIntoState(
+    parser.initialState,
+    options.parseOptions,
+  );
+  const shouldUnwrapAnnotatedValue =
+    hasMeaningfulAnnotations(options.parseOptions?.annotations) ||
+    isInjectedAnnotationWrapper(parser.initialState);
+  const exec = createParseExec(parser);
+  let context: ParserContext<unknown> = createParserContext(
+    {
+      buffer: [...args],
+      state: initialState,
+      optionsTerminated: false,
+    },
+    exec,
+  );
+
+  do {
+    const result = await parser.parse(context);
+    if (!result.success) {
+      const progress = getFailureProgress(
+        args,
+        context.buffer,
+        result.consumed,
+      );
+      return {
+        kind: "failure",
+        error: result.error,
+        remainingArgs: progress.remainingArgs,
+        consumedCount: progress.consumedCount,
+        optionsTerminated: context.optionsTerminated,
+        commandPath: getCommandPath(context.exec),
+      };
+    }
+    const previousBuffer = context.buffer;
+    context = result.next;
+    if (isBufferUnchanged(previousBuffer, context.buffer)) {
+      const progress = getFailureProgress(
+        args,
+        previousBuffer,
+        result.consumed.length,
+      );
+      return {
+        kind: "failure",
+        error: message`Unexpected option or argument: ${context.buffer[0]}.`,
+        remainingArgs: progress.remainingArgs,
+        consumedCount: progress.consumedCount,
+        optionsTerminated: context.optionsTerminated,
+        commandPath: getCommandPath(context.exec),
+      };
+    }
+  } while (context.buffer.length > 0);
+
+  if (options.mode === "parse-only") {
+    return {
+      kind: "success",
+      result: { success: true, value: undefined },
+    };
+  }
+
+  const endResult = await parser.complete(
+    context.state,
+    createCompleteExec(exec, context, options.session),
+  );
+  if (!endResult.success) {
+    return {
+      kind: "failure",
+      error: endResult.error,
+      remainingArgs: [],
+      consumedCount: args.length,
+      optionsTerminated: context.optionsTerminated,
+      commandPath: getCommandPath(context.exec),
+    };
+  }
+  return {
+    kind: "success",
+    result: {
+      success: true,
+      value: shouldUnwrapAnnotatedValue
+        ? unwrapInjectedAnnotationWrapper(endResult.value)
+        : endResult.value,
+      ...(endResult.deferred ? { deferred: true as const } : {}),
+      ...(endResult.deferredKeys
+        ? { deferredKeys: endResult.deferredKeys }
+        : {}),
+    },
+  };
 }
 
 /**
@@ -1085,58 +1391,10 @@ export function parseSync<T>(
   args: readonly string[],
   options?: ParseOptions,
 ): Result<T> {
-  const initialState = injectAnnotationsIntoState(parser.initialState, options);
-  const shouldUnwrapAnnotatedValue =
-    hasMeaningfulAnnotations(options?.annotations) ||
-    isInjectedAnnotationWrapper(parser.initialState);
-
-  const exec: ExecutionContext = {
-    usage: parser.usage,
-    phase: "parse",
-    path: [],
-    trace: createInputTrace(),
-  };
-  let context: ParserContext<unknown> = createParserContext(
-    { buffer: args, state: initialState, optionsTerminated: false },
-    exec,
-  );
-  do {
-    const result = parser.parse(context);
-    if (!result.success) {
-      return { success: false, error: result.error };
-    }
-    const previousBuffer = context.buffer;
-    context = result.next;
-    if (isBufferUnchanged(previousBuffer, context.buffer)) {
-      return {
-        success: false,
-        error: message`Unexpected option or argument: ${context.buffer[0]}.`,
-      };
-    }
-  } while (context.buffer.length > 0);
-  const runtime = createDependencyRuntimeContext();
-  const completeExec: ExecutionContext = {
-    ...exec,
-    phase: "complete",
-    dependencyRuntime: runtime,
-    dependencyRegistry: runtime.registry,
-    commandPath: context.exec?.commandPath ?? exec.commandPath,
-    trace: context.exec?.trace ?? context.trace ?? exec.trace,
-    effectfulCompletionSession: createEffectfulCompletionSession(),
-  };
-  const endResult = parser.complete(context.state, completeExec);
-  return endResult.success
-    ? {
-      success: true,
-      value: shouldUnwrapAnnotatedValue
-        ? unwrapInjectedAnnotationWrapper(endResult.value)
-        : endResult.value,
-      ...(endResult.deferred ? { deferred: true as const } : {}),
-      ...(endResult.deferredKeys
-        ? { deferredKeys: endResult.deferredKeys }
-        : {}),
-    }
-    : { success: false, error: endResult.error };
+  const attempted = attemptParseSync(parser, args, { parseOptions: options });
+  return attempted.kind === "success"
+    ? attempted.result
+    : { success: false, error: attempted.error };
 }
 
 /**
@@ -1178,58 +1436,63 @@ export async function parseAsync<T>(
   args: readonly string[],
   options?: ParseOptions,
 ): Promise<Result<T>> {
-  const initialState = injectAnnotationsIntoState(parser.initialState, options);
-  const shouldUnwrapAnnotatedValue =
-    hasMeaningfulAnnotations(options?.annotations) ||
-    isInjectedAnnotationWrapper(parser.initialState);
+  const attempted = await attemptParseAsync(parser, args, {
+    parseOptions: options,
+  });
+  return attempted.kind === "success"
+    ? attempted.result
+    : { success: false, error: attempted.error };
+}
 
-  const exec: ExecutionContext = {
-    usage: parser.usage,
-    phase: "parse",
-    path: [],
-    trace: createInputTrace(),
-  };
-  let context: ParserContext<unknown> = createParserContext(
-    { buffer: args, state: initialState, optionsTerminated: false },
-    exec,
-  );
-  do {
-    const result = await parser.parse(context);
-    if (!result.success) {
-      return { success: false, error: result.error };
-    }
-    const previousBuffer = context.buffer;
-    context = result.next;
-    if (isBufferUnchanged(previousBuffer, context.buffer)) {
-      return {
-        success: false,
-        error: message`Unexpected option or argument: ${context.buffer[0]}.`,
+/**
+ * Parses a complete argument list while preserving failure progress.
+ *
+ * The return mode follows the parser: synchronous parsers return immediately,
+ * while asynchronous parsers return a promise.  Use this lower-level API when
+ * a caller needs the unconsumed argument suffix or matched command path.
+ *
+ * @template M The execution mode of the parser.
+ * @template T The type of the value produced by the parser.
+ * @param parser The parser to run.
+ * @param args The complete argument list to parse.
+ * @param options Optional parsing annotations.
+ * @returns A detailed success or failure result in the parser's mode.
+ * @throws {TypeError} When a synchronous dependency source extractor returns a
+ *         thenable during completion-time dependency seeding.
+ * @since 1.3.0
+ */
+export function parseDetailed<M extends Mode, T>(
+  parser: Parser<M, T, unknown>,
+  args: readonly string[],
+  options?: ParseOptions,
+): ModeValue<M, DetailedParseResult<T>> {
+  return dispatchByMode(
+    parser.mode,
+    () => {
+      const attempted = attemptParseSync(
+        parser as Parser<"sync", T, unknown>,
+        args,
+        { parseOptions: options },
+      );
+      return attempted.kind === "success" ? attempted.result : {
+        success: false as const,
+        error: attempted.error,
+        remainingArgs: attempted.remainingArgs,
+        commandPath: attempted.commandPath,
       };
-    }
-  } while (context.buffer.length > 0);
-  const runtime = createDependencyRuntimeContext();
-  const completeExec: ExecutionContext = {
-    ...exec,
-    phase: "complete",
-    dependencyRuntime: runtime,
-    dependencyRegistry: runtime.registry,
-    commandPath: context.exec?.commandPath ?? exec.commandPath,
-    trace: context.exec?.trace ?? context.trace ?? exec.trace,
-    effectfulCompletionSession: createEffectfulCompletionSession(),
-  };
-  const endResult = await parser.complete(context.state, completeExec);
-  return endResult.success
-    ? {
-      success: true,
-      value: shouldUnwrapAnnotatedValue
-        ? unwrapInjectedAnnotationWrapper(endResult.value)
-        : endResult.value,
-      ...(endResult.deferred ? { deferred: true as const } : {}),
-      ...(endResult.deferredKeys
-        ? { deferredKeys: endResult.deferredKeys }
-        : {}),
-    }
-    : { success: false, error: endResult.error };
+    },
+    async () => {
+      const attempted = await attemptParseAsync(parser, args, {
+        parseOptions: options,
+      });
+      return attempted.kind === "success" ? attempted.result : {
+        success: false as const,
+        error: attempted.error,
+        remainingArgs: attempted.remainingArgs,
+        commandPath: attempted.commandPath,
+      };
+    },
+  );
 }
 
 /**

--- a/packages/core/src/parser.test.ts
+++ b/packages/core/src/parser.test.ts
@@ -21,6 +21,7 @@ import {
   getDocPageSync,
   parse,
   parseAsync,
+  parseDetailed,
   type Parser,
   parseSync,
   suggestAsync,
@@ -102,6 +103,79 @@ function createIssue184SuggestionParsers() {
 }
 
 describe("parse", () => {
+  it("should preserve failure progress in parseDetailed()", () => {
+    const parser = command("serve", option("--port"));
+    const result = parseDetailed(parser, ["serve", "--unknown"]);
+
+    assert.ok(!result.success);
+    if (!result.success) {
+      assert.deepEqual(result.remainingArgs, ["--unknown"]);
+      assert.deepEqual(result.commandPath, ["serve"]);
+    }
+  });
+
+  it("should preserve deferred result metadata in parseDetailed()", () => {
+    const deferredKeys = new Map<PropertyKey, null>([["value", null]]);
+    const base = constant({ value: "placeholder" });
+    const parser = {
+      ...base,
+      complete() {
+        return {
+          success: true as const,
+          value: { value: "placeholder" },
+          deferred: true as const,
+          deferredKeys,
+        };
+      },
+    };
+
+    assert.deepEqual(parseDetailed(parser, []), {
+      success: true,
+      value: { value: "placeholder" },
+      deferred: true,
+      deferredKeys,
+    });
+  });
+
+  it("should use claimed progress when a parser stalls", () => {
+    const parser: Parser<"sync", string, undefined> = {
+      mode: "sync",
+      $valueType: [],
+      $stateType: [],
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(),
+      acceptingAnyToken: true,
+      initialState: undefined,
+      parse(context) {
+        return {
+          success: true,
+          consumed: [context.buffer[0] ?? ""],
+          next: {
+            ...context,
+            exec: context.exec == null
+              ? undefined
+              : { ...context.exec, commandPath: ["canonical"] },
+          },
+        };
+      },
+      complete() {
+        return { success: true, value: "unreachable" };
+      },
+      *suggest() {},
+      getDocFragments() {
+        return { fragments: [] };
+      },
+    };
+
+    const result = parseDetailed(parser, ["first", "second"]);
+    assert.ok(!result.success);
+    if (!result.success) {
+      assert.deepEqual(result.remainingArgs, ["second"]);
+      assert.deepEqual(result.commandPath, ["canonical"]);
+    }
+  });
+
   it("should parse simple option successfully", () => {
     const parser = option("-v");
     const result = parse(parser, ["-v"]);

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -1,6 +1,7 @@
 export type { ParseOptions } from "./annotations.ts";
 export type {
   CombineModes,
+  DetailedParseResult,
   DocState,
   EffectfulCompletionSession,
   ExecutionContext,
@@ -24,6 +25,7 @@ export {
   getDocPageSync,
   parse,
   parseAsync,
+  parseDetailed,
   parseSync,
   suggest,
   suggestAsync,

--- a/packages/core/src/public-api.test.ts
+++ b/packages/core/src/public-api.test.ts
@@ -141,6 +141,7 @@ test("parser module hides constructs and parser-internal helpers", () => {
     "getDocPageSync",
     "parse",
     "parseAsync",
+    "parseDetailed",
     "parseSync",
     "suggest",
     "suggestAsync",
@@ -154,6 +155,7 @@ test("root module keeps user-facing APIs but not internal machinery", () => {
   assert.equal(typeof root.option, "function");
   assert.equal(typeof root.negatableFlag, "function");
   assert.equal(typeof root.parse, "function");
+  assert.equal(typeof root.parseDetailed, "function");
   assert.equal(typeof root.dependency, "function");
   assert.equal(typeof root.fluent, "function");
   assert.ok(!Object.hasOwn(root, "annotationKey"));

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -18,6 +18,23 @@ visible from its import:
 The package root holds only the contracts that mean the same thing at more than
 one boundary.  It depends on no test framework and no assertion library.
 
+The parser layer is available through `parseArgs()` and `parseArgsSync()`:
+
+~~~~ typescript
+import { option } from "@optique/core/primitives";
+import { parseArgsSync } from "@optique/testing/parser";
+
+const result = parseArgsSync(option("--verbose"), ["--verbose"]);
+if (result.success) {
+  console.log(result.value);
+} else {
+  console.error(result.error, result.remainingArgs, result.commandPath);
+}
+~~~~
+
+The runner, discovery, and child-process entry points remain reserved while
+their helpers are developed.
+
 [Optique]: https://optique.dev/
 
 

--- a/packages/testing/deno.json
+++ b/packages/testing/deno.json
@@ -9,9 +9,6 @@
     "./parser": "./src/parser.ts",
     "./run": "./src/run.ts"
   },
-  "imports": {
-    "@optique/core/parser": "../core/src/parser.ts"
-  },
   "exclude": [
     "dist/",
     "node_modules",

--- a/packages/testing/deno.json
+++ b/packages/testing/deno.json
@@ -9,6 +9,9 @@
     "./parser": "./src/parser.ts",
     "./run": "./src/run.ts"
   },
+  "imports": {
+    "@optique/core/parser": "../core/src/parser.ts"
+  },
   "exclude": [
     "dist/",
     "node_modules",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -85,6 +85,9 @@
     }
   },
   "sideEffects": false,
+  "dependencies": {
+    "@optique/core": "workspace:*"
+  },
   "devDependencies": {
     "@types/node": "catalog:",
     "tsdown": "catalog:",

--- a/packages/testing/src/parser.test.ts
+++ b/packages/testing/src/parser.test.ts
@@ -1,0 +1,219 @@
+import { getAnnotations } from "@optique/core/annotations";
+import { message } from "@optique/core/message";
+import type { Parser } from "@optique/core/parser";
+import { command, constant, option } from "@optique/core/primitives";
+import type { ValueParser } from "@optique/core/valueparser";
+import { parseArgs, parseArgsSync } from "@optique/testing/parser";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+const asyncString: ValueParser<"async", string> = {
+  mode: "async",
+  metavar: "VALUE",
+  placeholder: "",
+  parse(input) {
+    return Promise.resolve({
+      success: true as const,
+      value: input.toUpperCase(),
+    });
+  },
+  format(value) {
+    return value;
+  },
+  async *suggest() {},
+};
+
+describe("parseArgsSync()", () => {
+  it("should preserve the inferred parser value", () => {
+    const result = parseArgsSync(option("--verbose"), ["--verbose"]);
+
+    assert.ok(result.success);
+    if (result.success) {
+      const value: boolean = result.value;
+      assert.ok(value);
+    }
+  });
+
+  it("should report remaining arguments and the canonical command path", () => {
+    const parser = command(
+      "serve",
+      command("http", option("--port"), { aliases: ["web"] }),
+    );
+    const result = parseArgsSync(parser, ["serve", "web", "--unknown"]);
+
+    assert.ok(!result.success);
+    if (!result.success) {
+      assert.deepEqual(result.remainingArgs, ["--unknown"]);
+      assert.deepEqual(result.commandPath, ["serve", "http"]);
+    }
+  });
+
+  it("should report no remaining arguments when completion fails", () => {
+    const result = parseArgsSync(option("--required"), []);
+
+    assert.ok(!result.success);
+    if (!result.success) {
+      assert.deepEqual(result.remainingArgs, []);
+      assert.deepEqual(result.commandPath, []);
+    }
+  });
+
+  it("should pass annotations through ParseOptions", () => {
+    const key = Symbol.for("@optique/testing/parser-test");
+    const base = constant("ok");
+    const parser = {
+      ...base,
+      complete(state: typeof base.initialState) {
+        assert.equal(getAnnotations(state)?.[key], "value");
+        return base.complete(state);
+      },
+    };
+
+    const result = parseArgsSync(parser, [], {
+      annotations: { [key]: "value" },
+    });
+    assert.deepEqual(result, { success: true, value: "ok" });
+  });
+
+  it("should use frozen parser instances without wrapping them", () => {
+    class FrozenParser {
+      readonly mode = "sync" as const;
+      readonly $valueType = [] as readonly number[];
+      readonly $stateType = [] as readonly number[];
+      readonly priority = 0;
+      readonly usage = [];
+      readonly leadingNames = new Set<string>();
+      readonly acceptingAnyToken = true;
+      readonly initialState = 0;
+      #parseCalls = 0;
+
+      parse(context: Parameters<Parser<"sync", number, number>["parse"]>[0]) {
+        this.#parseCalls++;
+        return {
+          success: true as const,
+          consumed: [context.buffer[0] ?? ""],
+          next: {
+            ...context,
+            buffer: context.buffer.slice(1),
+            state: context.state + 1,
+          },
+        };
+      }
+
+      complete(state: number) {
+        return { success: true as const, value: state + this.#parseCalls };
+      }
+
+      *suggest() {}
+
+      getDocFragments() {
+        return { fragments: [] };
+      }
+    }
+
+    const parser = Object.freeze(new FrozenParser());
+    assert.deepEqual(parseArgsSync(parser, ["one"]), {
+      success: true,
+      value: 2,
+    });
+  });
+
+  it("should reject async parsers before invoking them", () => {
+    let invoked = false;
+    const parser: Parser<"async", string, undefined> = {
+      mode: "async",
+      $valueType: [],
+      $stateType: [],
+      priority: 0,
+      usage: [],
+      leadingNames: new Set(),
+      acceptingAnyToken: false,
+      initialState: undefined,
+      parse() {
+        invoked = true;
+        return Promise.resolve({
+          success: false as const,
+          consumed: 0,
+          error: message`unused`,
+        });
+      },
+      complete() {
+        invoked = true;
+        return Promise.resolve({ success: true as const, value: "unused" });
+      },
+      async *suggest() {},
+      getDocFragments() {
+        return { fragments: [] };
+      },
+    };
+
+    assert.throws(
+      // @ts-expect-error An async parser is invalid for parseArgsSync().
+      () => parseArgsSync(parser, []),
+      {
+        name: "TypeError",
+        message:
+          "Cannot use an async parser with parseArgsSync(). Use parseArgs() instead.",
+      },
+    );
+    assert.ok(!invoked);
+  });
+});
+
+describe("parseArgs()", () => {
+  it("should always return a promise for sync parsers", async () => {
+    const promise = parseArgs(constant("ok"), []);
+
+    assert.ok(promise instanceof Promise);
+    assert.deepEqual(await promise, { success: true, value: "ok" });
+  });
+
+  it("should isolate concurrent calls", async () => {
+    const parser = command("show", option("--json"));
+    const [success, failure] = await Promise.all([
+      parseArgs(parser, ["show", "--json"]),
+      parseArgs(parser, ["show", "--unknown"]),
+    ]);
+
+    assert.deepEqual(success, { success: true, value: true });
+    assert.ok(!failure.success);
+    if (!failure.success) {
+      assert.deepEqual(failure.remainingArgs, ["--unknown"]);
+      assert.deepEqual(failure.commandPath, ["show"]);
+    }
+  });
+
+  it("should run asynchronous parsers", async () => {
+    const result = await parseArgs(option("--value", asyncString), [
+      "--value",
+      "hello",
+    ]);
+    assert.deepEqual(result, { success: true, value: "HELLO" });
+  });
+
+  it("should preserve failure progress for asynchronous parsers", async () => {
+    const parser = command("show", option("--value", asyncString));
+    const result = await parseArgs(parser, ["show", "--unknown"]);
+
+    assert.ok(!result.success);
+    if (!result.success) {
+      assert.deepEqual(result.remainingArgs, ["--unknown"]);
+      assert.deepEqual(result.commandPath, ["show"]);
+    }
+  });
+
+  it("should turn synchronous exceptions into promise rejections", async () => {
+    const base = constant("ok");
+    const parser = {
+      ...base,
+      complete(): ReturnType<typeof base.complete> {
+        throw new RangeError("Completion failed.");
+      },
+    };
+
+    await assert.rejects(parseArgs(parser, []), {
+      name: "RangeError",
+      message: "Completion failed.",
+    });
+  });
+});

--- a/packages/testing/src/parser.ts
+++ b/packages/testing/src/parser.ts
@@ -1,15 +1,76 @@
 /**
- * Reserved for helpers that exercise a parser on its own.
- *
- * This layer will drive Optique's parsing protocol over a complete argument
- * list and report the parsed value or a structured parse error.  It renders no
- * help, writes to no stream, dispatches no command handler, and never exits,
- * so it observes neither standard output nor standard error.
- *
- * The helpers themselves are still landing; see
- * {@link https://github.com/dahlia/optique/issues/890}.
+ * Helpers that exercise a parser without runner or process integration.
  *
  * @module
  * @since 1.3.0
  */
-export {};
+import {
+  type DetailedParseResult,
+  type InferValue,
+  type Mode,
+  parseDetailed,
+  type ParseOptions,
+  type Parser,
+} from "@optique/core/parser";
+
+/**
+ * The result of parsing a complete argument list in a parser-layer test.
+ *
+ * @template T The inferred parser value type.
+ * @since 1.3.0
+ */
+export type ParseArgsResult<T> = DetailedParseResult<T>;
+
+/**
+ * Parses a complete argument list and always returns a promise.
+ *
+ * Parser failures are returned as structured values.  Exceptions thrown by a
+ * parser, or rejections from an asynchronous parser, reject the returned
+ * promise.
+ *
+ * @template TParser The parser type, including its inferred result value.
+ * @param parser The parser to exercise.
+ * @param args The complete argument list to parse.
+ * @param options Optional parser annotations.
+ * @returns A promise resolving to the parsed value or structured failure.
+ * @since 1.3.0
+ */
+export async function parseArgs<
+  TParser extends Parser<Mode, unknown, unknown>,
+>(
+  parser: TParser,
+  args: readonly string[],
+  options?: ParseOptions,
+): Promise<ParseArgsResult<InferValue<TParser>>> {
+  return await parseDetailed(parser, args, options);
+}
+
+/**
+ * Parses a complete argument list with a synchronous parser.
+ *
+ * Parser failures are returned as structured values.  Exceptions thrown by a
+ * parser propagate to the caller.
+ *
+ * @template TParser The synchronous parser type, including its inferred result
+ *                   value.
+ * @param parser The synchronous parser to exercise.
+ * @param args The complete argument list to parse.
+ * @param options Optional parser annotations.
+ * @returns The parsed value or structured failure.
+ * @throws {TypeError} When called with an asynchronous parser at runtime.
+ * @since 1.3.0
+ */
+export function parseArgsSync<
+  TParser extends Parser<"sync", unknown, unknown>,
+>(
+  parser: TParser,
+  args: readonly string[],
+  options?: ParseOptions,
+): ParseArgsResult<InferValue<TParser>> {
+  if (parser.mode !== "sync") {
+    throw new TypeError(
+      "Cannot use an async parser with parseArgsSync(). Use parseArgs() instead.",
+    );
+  }
+  return parseDetailed(parser, args, options);
+}

--- a/packages/testing/src/parser.ts
+++ b/packages/testing/src/parser.ts
@@ -42,7 +42,11 @@ export async function parseArgs<
   args: readonly string[],
   options?: ParseOptions,
 ): Promise<ParseArgsResult<InferValue<TParser>>> {
-  return await parseDetailed(parser, args, options);
+  return await parseDetailed<TParser["mode"], InferValue<TParser>>(
+    parser,
+    args,
+    options,
+  );
 }
 
 /**
@@ -72,5 +76,5 @@ export function parseArgsSync<
       "Cannot use an async parser with parseArgsSync(). Use parseArgs() instead.",
     );
   }
-  return parseDetailed(parser, args, options);
+  return parseDetailed<"sync", InferValue<TParser>>(parser, args, options);
 }

--- a/packages/testing/src/public-api.test.ts
+++ b/packages/testing/src/public-api.test.ts
@@ -124,18 +124,19 @@ describe("public surface", () => {
     assert.equal(captured.stderr, "");
   });
 
-  it("should resolve every reserved subpath without runtime exports", async () => {
-    // The root is limited to types shared across layers, and the four layer
-    // subpaths are reserved but not yet implemented, so none of them
-    // contributes a runtime export.  A subpath that starts exporting a helper
-    // has to say so here.
+  it("should expose only the implemented parser helpers", async () => {
+    // The root is limited to contracts shared across layers.  The remaining
+    // layer subpaths stay reserved until their helpers land.
     assert.deepEqual(Object.keys(await import("@optique/testing")), []);
     assert.deepEqual(Object.keys(await import("@optique/testing/cli")), []);
     assert.deepEqual(
       Object.keys(await import("@optique/testing/discover")),
       [],
     );
-    assert.deepEqual(Object.keys(await import("@optique/testing/parser")), []);
+    assert.deepEqual(
+      Object.keys(await import("@optique/testing/parser")).sort(),
+      ["parseArgs", "parseArgsSync"],
+    );
     assert.deepEqual(Object.keys(await import("@optique/testing/run")), []);
   });
 });
@@ -164,12 +165,14 @@ describe("npm build output", () => {
 
     const require = createRequire(import.meta.url);
 
-    // The CommonJS surface has to stay empty for the same reason the ESM one
-    // does, so that the two cannot drift apart unnoticed.
+    // Keep the CommonJS surface aligned with ESM.
     assert.deepEqual(Object.keys(require("@optique/testing")), []);
     assert.deepEqual(Object.keys(require("@optique/testing/cli")), []);
     assert.deepEqual(Object.keys(require("@optique/testing/discover")), []);
-    assert.deepEqual(Object.keys(require("@optique/testing/parser")), []);
+    assert.deepEqual(
+      Object.keys(require("@optique/testing/parser")).sort(),
+      ["parseArgs", "parseArgsSync"],
+    );
     assert.deepEqual(Object.keys(require("@optique/testing/run")), []);
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -523,6 +523,10 @@ importers:
         version: 5.8.3
 
   packages/testing:
+    dependencies:
+      '@optique/core':
+        specifier: workspace:*
+        version: link:../core
     devDependencies:
       '@types/node':
         specifier: 'catalog:'


### PR DESCRIPTION
Closes #892. Part of #890.


Why
---

Parser-only tests should not have to reproduce Optique's multi-step protocol or enter the runner layer.  The existing core APIs also discard the parse position on failure, which makes it hard to assert where parsing stopped.


How
---

The whole-argument loop now lives in one core driver instead of being copied into test code or hidden behind parser wrappers.  Existing `parse()`/`parseAsync()` results and facade behavior stay unchanged, while `parseDetailed()` retains failure progress.  `parseArgs()`/`parseArgsSync()` build on that boundary to preserve inferred values, remaining arguments, canonical command paths, annotations, and per-call isolation.
