### PR TITLE
Capture `run()` executions in tests

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -174,11 +174,16 @@ To be released.
     and layered entry points for parser, runner, command discovery, and
     subprocess testing.  The parser entry point can run a complete argument
     list and report an inferred value or a structured failure with remaining
-    arguments and the matched command path.
-    [[#890], [#891], [#892], [#942], [#943]]
+    arguments and the matched command path.  The runner entry point can capture
+    returned values, help, version, completion, parse errors, and intentional
+    exit codes without writing to process streams or running downstream
+    application handlers.
+    [[#890], [#891], [#892], [#893], [#942], [#943], [#944]]
 
 [#891]: https://github.com/dahlia/optique/issues/891
+[#893]: https://github.com/dahlia/optique/issues/893
 [#942]: https://github.com/dahlia/optique/pull/942
+[#944]: https://github.com/dahlia/optique/pull/944
 
 
 Version 1.2.5

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ The following is a list of the available packages:
 | [@optique/zod](/packages/zod/)                           | [JSR][jsr:@optique/zod]              | [npm][npm:@optique/zod]              | [Zod] schema integration for validation     |
 | [@optique/inquirer](/packages/inquirer/)                 | [JSR][jsr:@optique/inquirer]         | [npm][npm:@optique/inquirer]         | [Inquirer.js] prompt support                |
 | [@optique/prompt](/packages/prompt/)                     | [JSR][jsr:@optique/prompt]           | [npm][npm:@optique/prompt]           | Generic prompt adapter foundation           |
-| [@optique/testing](/packages/testing/)                   | [JSR][jsr:@optique/testing]          | [npm][npm:@optique/testing]          | Layered testing support for CLIs            |
+| [@optique/testing](/packages/testing/)                   | [JSR][jsr:@optique/testing]          | [npm][npm:@optique/testing]          | Parser and runner testing for CLIs          |
 
 [jsr:@optique/core]: https://jsr.io/@optique/core
 [npm:@optique/core]: https://www.npmjs.com/package/@optique/core

--- a/changes.d/testing/testing-package.md
+++ b/changes.d/testing/testing-package.md
@@ -3,12 +3,17 @@ links:
   '#890': https://github.com/dahlia/optique/issues/890
   '#891': https://github.com/dahlia/optique/issues/891
   '#892': https://github.com/dahlia/optique/issues/892
+  '#893': https://github.com/dahlia/optique/issues/893
   '#942': https://github.com/dahlia/optique/pull/942
   '#943': https://github.com/dahlia/optique/pull/943
+  '#944': https://github.com/dahlia/optique/pull/944
 ---
  -  Added the `@optique/testing` package with a shared `CapturedOutput` type
     and layered entry points for parser, runner, command discovery, and
     subprocess testing.  The parser entry point can run a complete argument
     list and report an inferred value or a structured failure with remaining
-    arguments and the matched command path.
-    [[#890], [#891], [#892], [#942], [#943]]
+    arguments and the matched command path.  The runner entry point can capture
+    returned values, help, version, completion, parse errors, and intentional
+    exit codes without writing to process streams or running downstream
+    application handlers.
+    [[#890], [#891], [#892], [#893], [#942], [#943], [#944]]

--- a/docs/concepts/testing.md
+++ b/docs/concepts/testing.md
@@ -23,8 +23,9 @@ import { /* ... */ } from "@optique/testing/discover";
 import { /* ... */ } from "@optique/testing/cli";
 ~~~~
 
-The parser helpers are available now.  The runner, discovery, and child-process
-helpers remain reserved while their respective parts of [issue #890] land.
+The parser and runner helpers are available now.  The discovery and
+child-process helpers remain reserved while their respective parts of
+[issue #890] land.
 
 [issue #890]: https://github.com/dahlia/optique/issues/890
 
@@ -115,6 +116,52 @@ annotations.  They return parser failures as values, but exceptions thrown by
 the parser still propagate.  `parseArgs()` likewise preserves promise
 rejections.  Neither helper renders help, interprets `--help`/`--version`,
 writes output, exits, or dispatches a command handler.
+
+
+Testing a run
+-------------
+
+Use `captureRun()` to exercise the same runner behavior as `runAsync()` without
+writing to process streams or terminating the test process.  It accepts either
+a parser or a `Program` and always returns a promise.
+
+~~~~ typescript twoslash
+import { argument } from "@optique/core/primitives";
+import { string } from "@optique/core/valueparser";
+import { captureRun } from "@optique/testing/run";
+
+const parser = argument(string());
+const result = await captureRun(parser, {
+  args: ["--help"],
+  programName: "greet",
+  help: "option",
+  colors: false,
+  maxWidth: 80,
+});
+
+if (result.kind === "returned") {
+  result.value; // string
+} else {
+  result.exitCode; // number
+}
+~~~~
+
+A normal parse produces a `returned` result with the inferred parser value and
+an exit code of zero.  Help, version, completion, and parse errors produce an
+`exited` result with the requested exit code.  Both variants include separate
+`stdout` and `stderr` strings with the same trailing newlines as the default
+runner writers.
+
+The `colors` and `maxWidth` options keep `runAsync()`'s defaults, which depend
+on the test process's terminal.  Set both explicitly when asserting rendered
+text so the result is stable between local terminals and CI.
+
+The capture helper supplies `stdout`, `stderr`, and `onExit`, so callers cannot
+override them.  Exceptions from parsers, contexts, option callbacks, or
+resource disposal still reject the returned promise.  Output written directly
+through `console.log()`, `print()`, or a process stream bypasses these callbacks
+and is not captured.  Use the child-process layer when a test needs to observe
+that output or run the application code that consumes the parsed value.
 
 
 Shared contracts

--- a/packages/core/skills/optique/SKILL.md
+++ b/packages/core/skills/optique/SKILL.md
@@ -24,9 +24,9 @@ Core rules
 
  -  Use `run()` from *@optique/run* for applications; use `parse()` or
     `runParser()` for embedded and custom runtimes.
- -  In parser-focused tests, use `parseArgs()` or `parseArgsSync()` from
-    *@optique/testing/parser* for inferred values and detailed failures without
-    running help, output, exits, or command handlers.
+ -  In tests, use `parseArgs()`/`parseArgsSync()` from *@optique/testing/parser*
+    for structured parser results, or `captureRun()` from
+    *@optique/testing/run* for runner-rendered output and exits.
  -  Compose parsers with `object()`, `tuple()`, `seq()`, `or()`, `merge()`, and
     modifiers. Do not write imperative `if`/`else` argument scanners around
     Optique parsers.

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -32,8 +32,26 @@ if (result.success) {
 }
 ~~~~
 
-The runner, discovery, and child-process entry points remain reserved while
-their helpers are developed.
+The runner layer is available through `captureRun()`:
+
+~~~~ typescript
+import { argument } from "@optique/core/primitives";
+import { string } from "@optique/core/valueparser";
+import { captureRun } from "@optique/testing/run";
+
+const result = await captureRun(argument(string()), {
+  args: ["--help"],
+  programName: "greet",
+  help: "option",
+  colors: false,
+  maxWidth: 80,
+});
+
+console.log(result.kind, result.exitCode, result.stdout, result.stderr);
+~~~~
+
+The discovery and child-process entry points remain reserved while their
+helpers are developed.
 
 [Optique]: https://optique.dev/
 

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -86,7 +86,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@optique/core": "workspace:*"
+    "@optique/core": "workspace:*",
+    "@optique/run": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "catalog:",

--- a/packages/testing/src/public-api.test.ts
+++ b/packages/testing/src/public-api.test.ts
@@ -124,7 +124,7 @@ describe("public surface", () => {
     assert.equal(captured.stderr, "");
   });
 
-  it("should expose only the implemented parser helpers", async () => {
+  it("should expose only the implemented helpers", async () => {
     // The root is limited to contracts shared across layers.  The remaining
     // layer subpaths stay reserved until their helpers land.
     assert.deepEqual(Object.keys(await import("@optique/testing")), []);
@@ -137,7 +137,9 @@ describe("public surface", () => {
       Object.keys(await import("@optique/testing/parser")).sort(),
       ["parseArgs", "parseArgsSync"],
     );
-    assert.deepEqual(Object.keys(await import("@optique/testing/run")), []);
+    assert.deepEqual(Object.keys(await import("@optique/testing/run")), [
+      "captureRun",
+    ]);
   });
 });
 
@@ -173,6 +175,8 @@ describe("npm build output", () => {
       Object.keys(require("@optique/testing/parser")).sort(),
       ["parseArgs", "parseArgsSync"],
     );
-    assert.deepEqual(Object.keys(require("@optique/testing/run")), []);
+    assert.deepEqual(Object.keys(require("@optique/testing/run")), [
+      "captureRun",
+    ]);
   });
 });

--- a/packages/testing/src/run.test.ts
+++ b/packages/testing/src/run.test.ts
@@ -1,0 +1,601 @@
+import type { ShellCompletion } from "@optique/core/completion";
+import type {
+  ParserValuePlaceholder,
+  SourceContext,
+} from "@optique/core/context";
+import { object } from "@optique/core/constructs";
+import type { Parser } from "@optique/core/parser";
+import type { Program } from "@optique/core/program";
+import { argument, constant, option } from "@optique/core/primitives";
+import type { ValueParser } from "@optique/core/valueparser";
+import { string } from "@optique/core/valueparser";
+import type { RunOptions } from "@optique/run";
+import {
+  type CapturedRunResult,
+  captureRun,
+  type CaptureRunOptions,
+} from "@optique/testing/run";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+describe("captureRun()", () => {
+  it("should capture a normal return with its inferred value", async () => {
+    // Arrange
+    const parser = constant("ready" as const);
+
+    // Act
+    const promise = captureRun(parser, { args: [] });
+    const result = await promise;
+
+    // Assert
+    assert.ok(promise instanceof Promise);
+    assert.equal(result.kind, "returned");
+    if (result.kind === "returned") {
+      const value: "ready" = result.value;
+      assert.equal(value, "ready");
+      assert.equal(result.exitCode, 0);
+    }
+    assert.equal(result.stdout, "");
+    assert.equal(result.stderr, "");
+  });
+
+  it("should accept a Program and preserve its inferred value", async () => {
+    // Arrange
+    const program: Program<"sync", { readonly name: string }> = {
+      parser: object({ name: argument(string()) }),
+      metadata: { name: "greeter" },
+    };
+
+    // Act
+    const result = await captureRun(program, { args: ["Ada"] });
+
+    // Assert
+    assert.deepEqual(result, {
+      kind: "returned",
+      value: { name: "Ada" },
+      exitCode: 0,
+      stdout: "",
+      stderr: "",
+    });
+  });
+
+  it("should run asynchronous parsers", async () => {
+    // Arrange
+    const parser = argument(asyncUppercase());
+
+    // Act
+    const result = await captureRun(parser, { args: ["hello"] });
+
+    // Assert
+    assert.equal(result.kind, "returned");
+    if (result.kind === "returned") {
+      const value: string = result.value;
+      assert.equal(value, "HELLO");
+    }
+  });
+
+  it("should capture help with the default writer newline", async () => {
+    // Arrange
+    const parser = constant("unused");
+
+    // Act
+    const result = await captureRun(parser, {
+      args: ["--help"],
+      programName: "tool",
+      help: "option",
+      colors: false,
+      maxWidth: 80,
+    });
+
+    // Assert
+    assert.deepEqual(result, {
+      kind: "exited",
+      exitCode: 0,
+      stdout: "Usage: tool --help\n\n" +
+        "  --help                      Show help information.\n\n",
+      stderr: "",
+    });
+  });
+
+  it("should capture version output exactly", async () => {
+    // Arrange
+    const parser = constant("unused");
+
+    // Act
+    const result = await captureRun(parser, {
+      args: ["--version"],
+      programName: "tool",
+      version: "vβ 2+build",
+      colors: false,
+      maxWidth: 80,
+    });
+
+    // Assert
+    assert.deepEqual(result, {
+      kind: "exited",
+      exitCode: 0,
+      stdout: "vβ 2+build\n",
+      stderr: "",
+    });
+  });
+
+  it("should capture completion scripts and each suggestion chunk", async () => {
+    // Arrange
+    const shell: ShellCompletion = {
+      name: "custom",
+      generateScript(programName, args = []) {
+        return `script:${programName}:${args.join(",")}`;
+      },
+      *encodeSuggestions() {
+        yield "first";
+        yield "second";
+      },
+    };
+    const completion = {
+      command: true as const,
+      shells: { custom: shell },
+    };
+
+    // Act
+    const script = await captureRun(constant("unused"), {
+      args: ["completion", "custom"],
+      programName: "tool",
+      completion,
+      colors: false,
+      maxWidth: 80,
+    });
+    const suggestions = await captureRun(option("--verbose"), {
+      args: ["completion", "custom", "--"],
+      programName: "tool",
+      completion,
+      colors: false,
+      maxWidth: 80,
+    });
+
+    // Assert
+    assert.deepEqual(script, {
+      kind: "exited",
+      exitCode: 0,
+      stdout: "script:tool:completion,custom\n",
+      stderr: "",
+    });
+    assert.deepEqual(suggestions, {
+      kind: "exited",
+      exitCode: 0,
+      stdout: "first\nsecond\n",
+      stderr: "",
+    });
+  });
+
+  it("should capture parse errors and custom exit codes", async () => {
+    // Arrange
+    const parser = argument(string());
+
+    // Act
+    const result = await captureRun(parser, {
+      args: [],
+      programName: "tool",
+      help: "option",
+      colors: false,
+      maxWidth: 80,
+      errorExitCode: 7,
+    });
+
+    // Assert
+    assert.deepEqual(result, {
+      kind: "exited",
+      exitCode: 7,
+      stdout: "",
+      stderr: "Usage: tool --help\n" +
+        "       tool STRING\n" +
+        "Error: Expected an argument, but got end of input.\n",
+    });
+  });
+
+  it("should rethrow parser errors by identity", async () => {
+    // Arrange
+    const failure = new RangeError("Parser failed.");
+    const base = constant("unused");
+    const parser: Parser<"sync", string, typeof base.initialState> = {
+      ...base,
+      complete() {
+        throw failure;
+      },
+    };
+
+    // Act and assert
+    await assert.rejects(
+      captureRun(parser, { args: [] }),
+      (error) => {
+        assert.equal(error, failure);
+        return true;
+      },
+    );
+  });
+
+  it("should rethrow asynchronous parser rejections by identity", async () => {
+    // Arrange
+    const failure = new SyntaxError("Value parsing failed.");
+    const parser = argument(rejectingString(failure));
+
+    // Act and assert
+    await assert.rejects(
+      captureRun(parser, { args: ["value"] }),
+      (error) => {
+        assert.equal(error, failure);
+        return true;
+      },
+    );
+  });
+
+  it("should rethrow option callback errors by identity", async () => {
+    // Arrange
+    const failure = new Error("Usage rendering failed.");
+
+    // Act and assert
+    await assert.rejects(
+      captureRun(constant("unused"), {
+        args: ["--help"],
+        help: "option",
+        usageLine() {
+          throw failure;
+        },
+      }),
+      (error) => {
+        assert.equal(error, failure);
+        return true;
+      },
+    );
+  });
+
+  it("should rethrow context errors by identity", async () => {
+    // Arrange
+    const failure = new Error("Context failed.");
+    const context: SourceContext = {
+      id: Symbol("failing-context"),
+      phase: "single-pass",
+      getAnnotations() {
+        throw failure;
+      },
+    };
+
+    // Act and assert
+    await assert.rejects(
+      captureRun(constant("unused"), { args: [], contexts: [context] }),
+      (error) => {
+        assert.equal(error, failure);
+        return true;
+      },
+    );
+  });
+
+  it("should forward context options", async () => {
+    // Arrange
+    let receivedOptions: unknown;
+    const context: SourceContext<{ readonly profile: string }> = {
+      id: Symbol("context-options"),
+      phase: "single-pass",
+      getAnnotations(_request, options) {
+        receivedOptions = options;
+        return {};
+      },
+    };
+
+    // Act
+    await captureRun(constant("unused"), {
+      args: [],
+      contexts: [context],
+      contextOptions: { profile: "test" },
+    });
+
+    // Assert
+    assert.deepEqual(receivedOptions, { profile: "test" });
+  });
+
+  it("should not mistake structurally similar thrown values for exits", async () => {
+    // Arrange
+    const failure = { exitCode: 17 };
+
+    // Act and assert
+    await assert.rejects(
+      captureRun(constant("unused"), {
+        args: ["--help"],
+        help: "option",
+        usageLine() {
+          throw failure;
+        },
+      }),
+      (error) => {
+        assert.equal(error, failure);
+        return true;
+      },
+    );
+  });
+
+  it("should wait for asynchronous context disposal", async () => {
+    // Arrange
+    const disposalStarted = createDeferred();
+    const releaseDisposal = createDeferred();
+    const context: SourceContext = {
+      id: Symbol("async-disposal"),
+      phase: "single-pass",
+      getAnnotations() {
+        return {};
+      },
+      async [Symbol.asyncDispose]() {
+        disposalStarted.resolve();
+        await releaseDisposal.promise;
+      },
+    };
+
+    // Act
+    const promise = captureRun(constant("done"), {
+      args: [],
+      contexts: [context],
+    });
+    await disposalStarted.promise;
+    let settled = false;
+    void promise.finally(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+
+    // Assert
+    assert.ok(!settled);
+    releaseDisposal.resolve();
+    assert.deepEqual(await promise, {
+      kind: "returned",
+      value: "done",
+      exitCode: 0,
+      stdout: "",
+      stderr: "",
+    });
+  });
+
+  it("should preserve SuppressedError when exit and disposal both fail", async () => {
+    // Arrange
+    const disposalFailure = new Error("Disposal failed.");
+    const context: SourceContext = {
+      id: Symbol("failing-disposal"),
+      phase: "single-pass",
+      getAnnotations() {
+        return {};
+      },
+      [Symbol.dispose]() {
+        throw disposalFailure;
+      },
+    };
+
+    // Act and assert
+    await assert.rejects(
+      captureRun(constant("unused"), {
+        args: ["--help"],
+        help: "option",
+        contexts: [context],
+      }),
+      (error) => {
+        assert.ok(error instanceof Error);
+        assert.equal(error.name, "SuppressedError");
+        assert.ok("error" in error);
+        assert.equal(error.error, disposalFailure);
+        assert.ok("suppressed" in error);
+        assert.ok(error.suppressed instanceof Error);
+        return true;
+      },
+    );
+  });
+
+  it("should isolate overlapping calls", async () => {
+    // Arrange
+    const returnStarted = createDeferred();
+    const exitStarted = createDeferred();
+    const releaseReturn = createDeferred();
+    const releaseExit = createDeferred();
+    const returnContext = createBlockingContext(
+      "return-context",
+      returnStarted,
+      releaseReturn,
+    );
+    const exitContext = createBlockingContext(
+      "exit-context",
+      exitStarted,
+      releaseExit,
+    );
+
+    // Act
+    const returnedPromise = captureRun(constant("returned"), {
+      args: [],
+      contexts: [returnContext],
+    });
+    const exitedPromise = captureRun(constant("unused"), {
+      args: ["--version"],
+      version: "overlap",
+      contexts: [exitContext],
+    });
+    await Promise.all([returnStarted.promise, exitStarted.promise]);
+    releaseExit.resolve();
+    const exited = await exitedPromise;
+    releaseReturn.resolve();
+    const returned = await returnedPromise;
+
+    // Assert
+    assert.deepEqual(exited, {
+      kind: "exited",
+      exitCode: 0,
+      stdout: "overlap\n",
+      stderr: "",
+    });
+    assert.deepEqual(returned, {
+      kind: "returned",
+      value: "returned",
+      exitCode: 0,
+      stdout: "",
+      stderr: "",
+    });
+  });
+
+  it("should preserve runAsync option and context typing", () => {
+    interface RequiredContext extends
+      SourceContext<{
+        readonly resolvePath: (parsed: ParserValuePlaceholder) => string;
+      }> {}
+
+    const context: RequiredContext = {
+      id: Symbol("required-context"),
+      phase: "single-pass",
+      getAnnotations() {
+        return {};
+      },
+    };
+    const parser = object({ name: argument(string()) });
+    const program: Program<"sync", { readonly name: string }> = {
+      parser,
+      metadata: { name: "typed-program" },
+    };
+
+    const assertTypes = (): void => {
+      const parserResult: Promise<
+        CapturedRunResult<{ readonly name: string }>
+      > = captureRun(parser, {
+        args: ["Ada"],
+        contexts: [context],
+        contextOptions: {
+          resolvePath(parsed) {
+            // @ts-expect-error The substituted parser value has no `missing`.
+            void parsed.missing;
+            return parsed.name;
+          },
+        },
+      });
+      void parserResult;
+
+      // @ts-expect-error The Program context requires `resolvePath`.
+      captureRun(program, { args: ["Ada"], contexts: [context] });
+
+      const dynamicContexts: readonly SourceContext<unknown>[] = [context];
+      const dynamic: Promise<
+        CapturedRunResult<{ readonly name: string }>
+      > = captureRun(program, {
+        args: ["Ada"],
+        contexts: dynamicContexts,
+      });
+      void dynamic;
+
+      const options: CaptureRunOptions = { args: ["Ada"] };
+      const exact: Promise<
+        CapturedRunResult<{ readonly name: string }>
+      > = captureRun(program, options);
+      void exact;
+
+      const wrap = (forwarded?: CaptureRunOptions) =>
+        captureRun(program, forwarded);
+      const optional: Promise<
+        CapturedRunResult<{ readonly name: string }>
+      > = wrap(options);
+      void optional;
+
+      const extra: CaptureRunOptions & {
+        readonly argz: readonly string[];
+      } = { args: ["Ada"], argz: ["Ada"] };
+      // @ts-expect-error Wider option values must not bypass key checks.
+      captureRun(program, extra);
+
+      // @ts-expect-error Output callbacks are controlled by captureRun().
+      captureRun(parser, { stdout() {} });
+      // @ts-expect-error Error callbacks are controlled by captureRun().
+      captureRun(parser, { stderr() {} });
+      captureRun(parser, {
+        // @ts-expect-error Exit callbacks are controlled by captureRun().
+        onExit() {
+          throw new Error("Exit.");
+        },
+      });
+
+      const union: CapturedRunResult<string> = Math.random() > 0.5
+        ? {
+          kind: "returned",
+          value: "value",
+          exitCode: 0,
+          stdout: "",
+          stderr: "",
+        }
+        : { kind: "exited", exitCode: 2, stdout: "", stderr: "" };
+      if (union.kind === "returned") {
+        const value: string = union.value;
+        void value;
+      } else {
+        // @ts-expect-error Exited results do not have a parsed value.
+        void union.value;
+      }
+    };
+    void assertTypes;
+  });
+
+  it("should accept exact RunOptions-compatible values only after omission", () => {
+    const options: RunOptions = { args: [] };
+    const assertTypes = (): void => {
+      // @ts-expect-error RunOptions may contain captured callbacks.
+      captureRun(constant("unused"), options);
+    };
+    void assertTypes;
+  });
+});
+
+// Helpers
+
+function asyncUppercase(): ValueParser<"async", string> {
+  return {
+    mode: "async",
+    metavar: "STRING",
+    placeholder: "",
+    parse(input) {
+      return Promise.resolve({ success: true, value: input.toUpperCase() });
+    },
+    format(value) {
+      return value;
+    },
+  };
+}
+
+function rejectingString(error: unknown): ValueParser<"async", string> {
+  return {
+    mode: "async",
+    metavar: "STRING",
+    placeholder: "",
+    parse() {
+      return Promise.reject(error);
+    },
+    format(value) {
+      return value;
+    },
+  };
+}
+
+interface Deferred {
+  readonly promise: Promise<void>;
+  readonly resolve: () => void;
+}
+
+function createDeferred(): Deferred {
+  let resolve!: () => void;
+  const promise = new Promise<void>((accept) => {
+    resolve = accept;
+  });
+  return { promise, resolve };
+}
+
+function createBlockingContext(
+  description: string,
+  started: Deferred,
+  release: Deferred,
+): SourceContext {
+  return {
+    id: Symbol(description),
+    phase: "single-pass",
+    async getAnnotations() {
+      started.resolve();
+      await release.promise;
+      return {};
+    },
+  };
+}

--- a/packages/testing/src/run.ts
+++ b/packages/testing/src/run.ts
@@ -1,17 +1,222 @@
 /**
- * Reserved for helpers that capture `run()` and `runAsync()` executions.
- *
- * This layer will run a parser or `Program` through `@optique/run` with its
- * output and exit handlers injected, so help, version, completion, and
- * parse-error output become a captured result instead of process output.  It
- * does not run the application code that consumes the parsed value, and it
- * cannot see writes that bypass those handlers, such as `console.log()`,
- * `print()`, or direct writes to a process stream.
- *
- * The helpers themselves are still landing; see
- * {@link https://github.com/dahlia/optique/issues/890}.
+ * Helpers that capture `run()` and `runAsync()` executions.
  *
  * @module
  * @since 1.3.0
  */
-export {};
+import type { SourceContext } from "@optique/core/context";
+import type { ContextOptionsParam } from "@optique/core/facade";
+import type { InferValue, Mode, Parser } from "@optique/core/parser";
+import type { Program } from "@optique/core/program";
+import { runAsync, type RunOptions } from "@optique/run";
+import type { CapturedOutput } from "./index.ts";
+
+/**
+ * Options for {@link captureRun}.
+ *
+ * These are the options accepted by `runAsync()`, except for the output and
+ * exit callbacks controlled by the capture helper.
+ *
+ * @since 1.3.0
+ */
+export type CaptureRunOptions =
+  & Omit<RunOptions, "stdout" | "stderr" | "onExit">
+  & {
+    readonly stdout?: never;
+    readonly stderr?: never;
+    readonly onExit?: never;
+  };
+
+/**
+ * The result of an in-process runner execution.
+ *
+ * A normal parser return includes its inferred value.  Help, version,
+ * completion, and parse-error exits instead include the requested exit code.
+ * Both variants preserve the output written through the runner callbacks.
+ *
+ * @template T The inferred parser value type.
+ * @since 1.3.0
+ */
+export type CapturedRunResult<T> =
+  & CapturedOutput
+  & (
+    | {
+      readonly kind: "returned";
+      readonly value: T;
+      readonly exitCode: 0;
+    }
+    | {
+      readonly kind: "exited";
+      readonly exitCode: number;
+    }
+  );
+
+type RejectEmptyContexts<TContexts extends readonly SourceContext<unknown>[]> =
+  TContexts extends readonly [] ? never
+    : unknown;
+
+type ContextsFromOptions<TOptions> = [Exclude<TOptions, undefined>] extends
+  [never] ? undefined
+  : Exclude<TOptions, undefined> extends {
+    readonly contexts?: infer TContexts extends
+      | readonly SourceContext<unknown>[]
+      | undefined;
+  } ? TContexts
+  : undefined;
+
+type RejectContextfulOptions<TOptions> = [ContextsFromOptions<TOptions>] extends
+  [undefined | readonly []] ? unknown
+  : never;
+
+type RejectUnknownCaptureRunOptionKeys<TOptions> = [TOptions] extends
+  [undefined] ? unknown
+  : Exclude<keyof TOptions, keyof CaptureRunOptions> extends never ? unknown
+  : never;
+
+type AcceptExactCaptureRunOptions<TOptions> = [TOptions] extends
+  [CaptureRunOptions] ? [CaptureRunOptions] extends [TOptions] ? unknown
+  : never
+  : never;
+
+type AcceptExactOptionalCaptureRunOptions<TOptions> = [TOptions] extends
+  [CaptureRunOptions | undefined]
+  ? [CaptureRunOptions | undefined] extends [TOptions] ? unknown
+  : never
+  : never;
+
+/**
+ * Runs a parser or program in process and captures runner-controlled output.
+ *
+ * The helper always returns a promise.  Parser returns become `returned`
+ * results, while intentional help, version, completion, and parse-error exits
+ * become `exited` results.  Writes that bypass the injected callbacks, such as
+ * `console.log()` or direct process-stream writes, are not captured.
+ * `colors` and `maxWidth` retain `runAsync()`'s terminal-dependent defaults,
+ * so set both explicitly when asserting rendered text.
+ *
+ * @template T The parser or program result type.
+ * @param parser The parser or `Program` to execute.
+ * @param options Runner options other than the captured callbacks.
+ * @returns A promise resolving to the returned value or intentional exit,
+ *          together with captured standard output and standard error.
+ * @throws Any unexpected parser, context, callback, or disposal error.  Promise
+ *         rejections from asynchronous parsers and contexts also propagate.
+ * @since 1.3.0
+ */
+export function captureRun<
+  T extends Parser<Mode, unknown, unknown>,
+  TContexts extends readonly SourceContext<unknown>[],
+>(
+  parser: T,
+  options:
+    & CaptureRunOptions
+    & { readonly contexts: TContexts }
+    & ContextOptionsParam<TContexts, InferValue<T>>,
+): Promise<CapturedRunResult<InferValue<T>>>;
+
+export function captureRun<
+  M extends Mode,
+  T,
+  const TContexts extends readonly SourceContext<unknown>[],
+>(
+  program: Program<M, T>,
+  options:
+    & CaptureRunOptions
+    & { readonly contexts: TContexts }
+    & RejectEmptyContexts<TContexts>
+    & ContextOptionsParam<TContexts, T>,
+): Promise<CapturedRunResult<T>>;
+
+export function captureRun<
+  T,
+  const TOptions extends CaptureRunOptions | undefined,
+>(
+  program: Program<"sync", T>,
+  options?:
+    & TOptions
+    & RejectContextfulOptions<TOptions>
+    & RejectUnknownCaptureRunOptionKeys<TOptions>,
+): Promise<CapturedRunResult<T>>;
+
+export function captureRun<
+  T,
+  const TOptions extends CaptureRunOptions | undefined,
+>(
+  program: Program<"async", T>,
+  options?:
+    & TOptions
+    & RejectContextfulOptions<TOptions>
+    & RejectUnknownCaptureRunOptionKeys<TOptions>,
+): Promise<CapturedRunResult<T>>;
+
+export function captureRun<T, TOptions extends CaptureRunOptions>(
+  program: Program<Mode, T>,
+  options: TOptions & AcceptExactCaptureRunOptions<TOptions>,
+): Promise<CapturedRunResult<T>>;
+
+export function captureRun<
+  T,
+  TOptions extends CaptureRunOptions | undefined,
+>(
+  program: Program<Mode, T>,
+  options: TOptions & AcceptExactOptionalCaptureRunOptions<TOptions>,
+): Promise<CapturedRunResult<T>>;
+
+export function captureRun<T extends Parser<Mode, unknown, unknown>>(
+  parser: T,
+  options?: CaptureRunOptions,
+): Promise<CapturedRunResult<InferValue<T>>>;
+
+export async function captureRun(
+  parserOrProgram:
+    | Parser<Mode, unknown, unknown>
+    | Program<Mode, unknown>,
+  options: CaptureRunOptions = {},
+): Promise<CapturedRunResult<unknown>> {
+  let stdout = "";
+  let stderr = "";
+  const runOptions: RunOptions = {
+    ...options,
+    stdout(text) {
+      stdout += `${text}\n`;
+    },
+    stderr(text) {
+      stderr += `${text}\n`;
+    },
+    onExit(exitCode): never {
+      throw new CapturedExit(exitCode);
+    },
+  };
+
+  try {
+    const value = "parser" in parserOrProgram &&
+        "metadata" in parserOrProgram
+      ? await runAsync(parserOrProgram, runOptions)
+      : await runAsync(parserOrProgram, runOptions);
+    return {
+      kind: "returned",
+      value,
+      exitCode: 0,
+      stdout,
+      stderr,
+    };
+  } catch (error) {
+    if (!(error instanceof CapturedExit)) throw error;
+    return {
+      kind: "exited",
+      exitCode: error.exitCode,
+      stdout,
+      stderr,
+    };
+  }
+}
+
+class CapturedExit extends Error {
+  readonly exitCode: number;
+
+  constructor(exitCode: number) {
+    super(`Runner exited with code ${exitCode}.`);
+    this.name = "CapturedExit";
+    this.exitCode = exitCode;
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -527,6 +527,9 @@ importers:
       '@optique/core':
         specifier: workspace:*
         version: link:../core
+      '@optique/run':
+        specifier: workspace:*
+        version: link:../run
     devDependencies:
       '@types/node':
         specifier: 'catalog:'


### PR DESCRIPTION
Closes #893.


Why
---

Testing runner behavior currently means rebuilding buffers and a private exit sentinel for every program.  Intentional exits must be separated from thrown failures without changing the runner's output text.  Patching global streams would also make concurrent tests unsafe.


How
---

`captureRun()` delegates to `runAsync()` with per-call `stdout`, `stderr`, and `onExit` callbacks.  The private sentinel turns only deliberate runner exits into a discriminated result.  Parser, context, callback, and disposal failures continue to reject as they do at the runner boundary.

The `Parser`/`Program` overloads follow `runAsync()` so parsed values and context options remain inferred.  Direct console/process writes and application handlers stay outside this layer; later discovery and child-process helpers cover those boundaries.