### PR TITLE
Capture discovered programs in tests

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -177,13 +177,17 @@ To be released.
     arguments and the matched command path.  The runner entry point can capture
     returned values, help, version, completion, parse errors, and intentional
     exit codes without writing to process streams or running downstream
-    application handlers.
-    [[#890], [#891], [#892], [#893], [#942], [#943], [#944]]
+    application handlers.  The discovery entry point's `captureProgramRun()`
+    captures output and exit codes while executing command discovery, hooks,
+    and handler dispatch in the test process.
+    [[#887], [#890], [#891], [#892], [#893], [#942], [#943], [#944], [#945]]
 
+[#887]: https://github.com/dahlia/optique/issues/887
 [#891]: https://github.com/dahlia/optique/issues/891
 [#893]: https://github.com/dahlia/optique/issues/893
 [#942]: https://github.com/dahlia/optique/pull/942
 [#944]: https://github.com/dahlia/optique/pull/944
+[#945]: https://github.com/dahlia/optique/pull/945
 
 
 Version 1.2.5

--- a/changes.d/testing/testing-package.md
+++ b/changes.d/testing/testing-package.md
@@ -1,5 +1,6 @@
 ---
 links:
+  '#887': https://github.com/dahlia/optique/issues/887
   '#890': https://github.com/dahlia/optique/issues/890
   '#891': https://github.com/dahlia/optique/issues/891
   '#892': https://github.com/dahlia/optique/issues/892
@@ -7,6 +8,7 @@ links:
   '#942': https://github.com/dahlia/optique/pull/942
   '#943': https://github.com/dahlia/optique/pull/943
   '#944': https://github.com/dahlia/optique/pull/944
+  '#945': https://github.com/dahlia/optique/pull/945
 ---
  -  Added the `@optique/testing` package with a shared `CapturedOutput` type
     and layered entry points for parser, runner, command discovery, and
@@ -15,5 +17,7 @@ links:
     arguments and the matched command path.  The runner entry point can capture
     returned values, help, version, completion, parse errors, and intentional
     exit codes without writing to process streams or running downstream
-    application handlers.
-    [[#890], [#891], [#892], [#893], [#942], [#943], [#944]]
+    application handlers.  The discovery entry point's `captureProgramRun()`
+    captures output and exit codes while executing command discovery, hooks,
+    and handler dispatch in the test process.
+    [[#887], [#890], [#891], [#892], [#893], [#942], [#943], [#944], [#945]]

--- a/docs/concepts/testing.md
+++ b/docs/concepts/testing.md
@@ -23,9 +23,8 @@ import { /* ... */ } from "@optique/testing/discover";
 import { /* ... */ } from "@optique/testing/cli";
 ~~~~
 
-The parser and runner helpers are available now.  The discovery and
-child-process helpers remain reserved while their respective parts of
-[issue #890] land.
+The parser, runner, and discovery helpers are available now.  The child-process
+helpers remain reserved while the remaining part of [issue #890] lands.
 
 [issue #890]: https://github.com/dahlia/optique/issues/890
 
@@ -162,6 +161,104 @@ resource disposal still reject the returned promise.  Output written directly
 through `console.log()`, `print()`, or a process stream bypasses these callbacks
 and is not captured.  Use the child-process layer when a test needs to observe
 that output or run the application code that consumes the parsed value.
+
+
+Testing command discovery and dispatch
+--------------------------------------
+
+Use `captureProgramRun()` to exercise `runProgram()`, including command loading,
+lifecycle hooks, and handler dispatch.  Pass either a `dir` to discover command
+modules or `commands` for a static registry, including entries returned by
+`commandsFromModules()`.
+
+This test checks both help and a parse error without running the handler:
+
+~~~~ typescript twoslash
+import assert from "node:assert/strict";
+import { argument } from "@optique/core/primitives";
+import { string } from "@optique/core/valueparser";
+import { defineCommand } from "@optique/discover/command";
+import { captureProgramRun } from "@optique/testing/discover";
+
+let calls = 0;
+const greet = defineCommand({
+  path: ["greet"],
+  parser: argument(string()),
+  handler() {
+    calls++;
+  },
+});
+
+const options = {
+  commands: [greet],
+  metadata: { name: "example" },
+  colors: false,
+  maxWidth: 80,
+};
+
+const help = await captureProgramRun({
+  ...options,
+  args: ["greet", "--help"],
+});
+assert.equal(help.exitCode, 0);
+assert.match(help.stdout, /Usage:/);
+assert.equal(help.stderr, "");
+
+const failure = await captureProgramRun({ ...options, args: ["greet"] });
+assert.equal(failure.exitCode, 1);
+assert.notEqual(failure.stderr, "");
+assert.equal(calls, 0);
+~~~~
+
+For dispatch, assert on an observable handler effect.  The helper waits for
+asynchronous handlers and lifecycle cleanup before resolving:
+
+~~~~ typescript twoslash
+import assert from "node:assert/strict";
+import { argument } from "@optique/core/primitives";
+import { string } from "@optique/core/valueparser";
+import { defineCommand } from "@optique/discover/command";
+import { captureProgramRun } from "@optique/testing/discover";
+
+const greeted: string[] = [];
+const greet = defineCommand({
+  path: ["greet"],
+  parser: argument(string()),
+  async handler(name) {
+    await Promise.resolve();
+    greeted.push(name);
+  },
+});
+
+const result = await captureProgramRun({
+  commands: [greet],
+  metadata: { name: "example" },
+  args: ["greet", "Ada"],
+  colors: false,
+  maxWidth: 80,
+});
+assert.equal(result.exitCode, 0);
+assert.deepEqual(greeted, ["Ada"]);
+~~~~
+
+`ProgramRunResult` contains `exitCode`, `stdout`, and `stderr`.  A normal
+completion has exit code zero; help, version, completion, and parse errors
+report the requested exit code.  It has no parsed value or `kind` field because
+`runProgram()` dispatches the value to the selected handler.
+
+`CaptureProgramRunOptions<R>` preserves `RunProgramOptions<R>`, including hook
+resource types, but reserves `stdout`, `stderr`, and `onExit` for capture.
+Each output callback appends its string followed by one newline, matching the
+default writers, even when the string is empty or already ends in a newline.
+The helper inherits argument, color, and width defaults from `runProgram()`;
+set `args`, `colors`, and `maxWidth` explicitly for repeatable tests.
+
+Errors from discovery, imports, handlers, hooks, and resource disposal reject
+the promise according to `runProgram()`'s error handling, including its
+`onError` rules.  They are not converted into exit results.  Commands and hooks
+run in the test process, so their side effects are real.  Direct writes through
+`console.log()`, `print()`, or process streams bypass capture; use a child
+process to assert on those writes.
 
 
 Shared contracts

--- a/packages/core/skills/optique/SKILL.md
+++ b/packages/core/skills/optique/SKILL.md
@@ -25,11 +25,11 @@ Core rules
  -  Use `run()` from *@optique/run* for applications; use `parse()` or
     `runParser()` for embedded and custom runtimes.
  -  In tests, use `parseArgs()`/`parseArgsSync()` from *@optique/testing/parser*
-    for structured parser results, or `captureRun()` from
-    *@optique/testing/run* for runner-rendered output and exits.
+    for parser results, `captureRun()` from *@optique/testing/run* for runner
+    output/exits, or `captureProgramRun()` from *@optique/testing/discover* for
+    dispatch/hooks. Direct console/process writes bypass capture.
  -  Compose parsers with `object()`, `tuple()`, `seq()`, `or()`, `merge()`, and
-    modifiers. Do not write imperative `if`/`else` argument scanners around
-    Optique parsers.
+    modifiers. Do not hand-write argument scanners around Optique parsers.
  -  Let TypeScript infer the parsed value type from the parser. Do not
     hand-maintain a separate interface for the result unless another API
     boundary requires it.

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -50,8 +50,27 @@ const result = await captureRun(argument(string()), {
 console.log(result.kind, result.exitCode, result.stdout, result.stderr);
 ~~~~
 
-The discovery and child-process entry points remain reserved while their
-helpers are developed.
+Use `captureProgramRun()` to include command discovery and handler dispatch:
+
+~~~~ typescript
+import { captureProgramRun } from "@optique/testing/discover";
+
+const result = await captureProgramRun({
+  dir: new URL("./commands/", import.meta.url),
+  metadata: { name: "example" },
+  args: ["--help"],
+  colors: false,
+  maxWidth: 80,
+});
+
+console.log(result.exitCode, result.stdout, result.stderr);
+~~~~
+
+The helper runs real command modules, hooks, and handlers.  It captures
+Optique's output callbacks; direct console or process-stream writes bypass
+capture.  Unexpected errors reject the promise.
+
+The child-process entry point remains reserved while its helpers are developed.
 
 [Optique]: https://optique.dev/
 

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -87,6 +87,7 @@
   "sideEffects": false,
   "dependencies": {
     "@optique/core": "workspace:*",
+    "@optique/discover": "workspace:*",
     "@optique/run": "workspace:*"
   },
   "devDependencies": {

--- a/packages/testing/src/discover.test.ts
+++ b/packages/testing/src/discover.test.ts
@@ -1,0 +1,515 @@
+import type { ShellCompletion } from "@optique/core/completion";
+import type { SourceContext } from "@optique/core/context";
+import { object } from "@optique/core/constructs";
+import { argument, constant } from "@optique/core/primitives";
+import { string } from "@optique/core/valueparser";
+import {
+  commandsFromModules,
+  defineCommand,
+  type ProgramHookContext,
+  type RunProgramOptions,
+} from "@optique/discover";
+import {
+  captureProgramRun,
+  type CaptureProgramRunOptions,
+  type ProgramRunResult,
+} from "@optique/testing/discover";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+const formatting = { colors: false, maxWidth: 80 } as const;
+
+describe("captureProgramRun()", () => {
+  it("should execute asynchronous parsers and forward context options", async () => {
+    const values: string[] = [];
+    const contextOptions = { label: "test context" };
+    const context: SourceContext = {
+      id: Symbol("forwarded-options"),
+      phase: "single-pass",
+      getAnnotations(_request, options) {
+        assert.deepEqual(options, contextOptions);
+        values.push("context");
+        return {};
+      },
+    };
+    const parser = argument({
+      mode: "async" as const,
+      metavar: string().metavar,
+      placeholder: "",
+      format: (value: string) => value,
+      parse: (value: string) =>
+        Promise.resolve({ success: true as const, value: value.toUpperCase() }),
+    });
+    const result = await captureProgramRun({
+      commands: [defineCommand({
+        path: [],
+        parser,
+        handler(value) {
+          values.push(value);
+        },
+      })],
+      metadata: { name: "tool" },
+      args: ["Ada"],
+      contexts: [context],
+      contextOptions,
+      ...formatting,
+    });
+    assert.deepEqual(result, { exitCode: 0, stdout: "", stderr: "" });
+    assert.deepEqual(values, ["context", "ADA"]);
+  });
+
+  it("should dispatch nested command entries and await handlers and hooks", async () => {
+    const events: string[] = [];
+    const commands = commandsFromModules<string>({
+      "./tasks/show.mjs": {
+        default: defineCommand({
+          parser: argument(string()),
+          hooks: {
+            beforeEach() {
+              events.push("command before");
+              return { resource: "command resource" };
+            },
+            async afterEach(context) {
+              await Promise.resolve();
+              events.push(`command after:${context.resource}`);
+            },
+          },
+          async handler(value, context) {
+            await Promise.resolve();
+            events.push(`handler:${value}:${context?.resource}`);
+          },
+        }),
+      },
+    }, { extensions: [".mjs"] });
+    const promise = captureProgramRun({
+      commands,
+      metadata: { name: "tool" },
+      args: ["tasks", "show", "Ada"],
+      ...formatting,
+      hooks: {
+        beforeEach(invocation) {
+          events.push(`program before:${invocation.path.join("/")}`);
+          return { resource: "program resource" };
+        },
+        async afterEach(context) {
+          await Promise.resolve();
+          events.push(`program after:${context.resource}`);
+        },
+      },
+    });
+    assert.ok(promise instanceof Promise);
+    assert.deepEqual(await promise, { exitCode: 0, stdout: "", stderr: "" });
+    assert.deepEqual(events, [
+      "program before:tasks/show",
+      "command before",
+      "handler:Ada:command resource",
+      "command after:command resource",
+      "program after:program resource",
+    ]);
+  });
+
+  it("should discover files and forward the entry file name and resource", async () => {
+    const events: string[] = [];
+    const result = await captureProgramRun({
+      dir: new URL("./fixtures/discover/valid/", import.meta.url),
+      extensions: [".mjs"],
+      entryFileName: "entry",
+      metadata: { name: "tool" },
+      args: ["tasks", "Ada"],
+      ...formatting,
+      hooks: { beforeEach: () => ({ resource: events }) },
+    });
+    assert.deepEqual(result, { exitCode: 0, stdout: "", stderr: "" });
+    assert.deepEqual(events, ["Ada"]);
+  });
+
+  it("should capture help, version, completion and errors without dispatch", async () => {
+    const events: string[] = [];
+    const shell: ShellCompletion = {
+      name: "custom",
+      generateScript: () => "script",
+      *encodeSuggestions() {
+        yield "";
+        yield "first\n";
+        yield "second";
+      },
+    };
+    const command = defineCommand({
+      path: ["show"],
+      parser: constant("unused"),
+      hooks: {
+        beforeEach() {
+          events.push("command before");
+        },
+        afterEach() {
+          events.push("command after");
+        },
+        onError() {
+          events.push("command error");
+        },
+      },
+      handler() {
+        events.push("handler");
+      },
+    });
+    const options = {
+      commands: [command],
+      metadata: { name: "tool", version: "1.2.3" },
+      ...formatting,
+      completion: { command: true as const, shells: { custom: shell } },
+      hooks: {
+        beforeEach() {
+          events.push("program before");
+        },
+        afterEach() {
+          events.push("program after");
+        },
+        onError() {
+          events.push("program error");
+        },
+      },
+    };
+    const help = await captureProgramRun({ ...options, args: ["--help"] });
+    assert.equal(help.exitCode, 0);
+    assert.match(help.stdout, /^Usage: tool /);
+    assert.ok(help.stdout.endsWith("\n\n"));
+    assert.equal(help.stderr, "");
+    assert.deepEqual(
+      await captureProgramRun({ ...options, args: ["--version"] }),
+      {
+        exitCode: 0,
+        stdout: "1.2.3\n",
+        stderr: "",
+      },
+    );
+    assert.deepEqual(
+      await captureProgramRun({ ...options, args: ["completion", "custom"] }),
+      {
+        exitCode: 0,
+        stdout: "script\n",
+        stderr: "",
+      },
+    );
+    assert.deepEqual(
+      await captureProgramRun({
+        ...options,
+        args: ["completion", "custom", "--"],
+      }),
+      {
+        exitCode: 0,
+        stdout: "\nfirst\n\nsecond\n",
+        stderr: "",
+      },
+    );
+    for (const errorExitCode of [undefined, 7]) {
+      const failure = await captureProgramRun({
+        ...options,
+        args: ["unknown"],
+        errorExitCode,
+      });
+      assert.equal(failure.exitCode, errorExitCode ?? 1);
+      assert.equal(failure.stdout, "");
+      assert.match(failure.stderr, /Error:/);
+      assert.ok(failure.stderr.endsWith("\n"));
+    }
+    assert.deepEqual(events, []);
+  });
+
+  it("should reject discovery and import failures even when requesting help", async () => {
+    for (const directory of ["invalid", "throwing"]) {
+      await assert.rejects(
+        captureProgramRun({
+          dir: new URL(`./fixtures/discover/${directory}/`, import.meta.url),
+          extensions: [".mjs"],
+          metadata: { name: "tool" },
+          args: ["--help"],
+          ...formatting,
+        }),
+        directory === "invalid" ? /default export/ : /Module failed\./,
+      );
+    }
+  });
+
+  it("should preserve handler and lifecycle failures including primitive values", async () => {
+    for (
+      const failure of [
+        new RangeError("Handler failed."),
+        { exitCode: 0 },
+        undefined,
+      ]
+    ) {
+      for (const phase of ["handler", "beforeEach", "afterEach"] as const) {
+        const observed: unknown[] = [];
+        const options = {
+          commands: [defineCommand({
+            path: [],
+            parser: constant("value"),
+            handler: () =>
+              phase === "handler" ? Promise.reject(failure) : undefined,
+          })],
+          metadata: { name: "tool" },
+          args: [],
+          ...formatting,
+          hooks: {
+            beforeEach() {
+              if (phase === "beforeEach") throw failure;
+            },
+            afterEach() {
+              if (phase === "afterEach") throw failure;
+            },
+            onError(_context: ProgramHookContext, error: unknown) {
+              observed.push(error);
+              throw new Error("Observer failed.");
+            },
+          },
+        };
+        await assert.rejects(captureProgramRun(options), (error) => {
+          assert.equal(error, failure);
+          return true;
+        });
+        assert.deepEqual(observed, [failure]);
+      }
+    }
+  });
+
+  it("should preserve parser, context and formatting callback failures", async () => {
+    const failure = new SyntaxError("Expected failure.");
+    const failingParser = argument({
+      metavar: string().metavar,
+      placeholder: "",
+      format: (value: string) => value,
+      mode: "async" as const,
+      parse: () => Promise.reject(failure),
+    });
+    const command = defineCommand({
+      path: [],
+      parser: failingParser,
+      handler() {},
+    });
+    const options = {
+      commands: [command],
+      metadata: { name: "tool" },
+      ...formatting,
+    };
+    const context: SourceContext = {
+      id: Symbol("failure"),
+      phase: "single-pass",
+      getAnnotations() {
+        throw failure;
+      },
+    };
+    for (
+      const overrides of [
+        { args: ["value"] },
+        { args: [], contexts: [context] },
+        {
+          args: ["--help"],
+          usageLine() {
+            throw failure;
+          },
+        },
+      ]
+    ) {
+      await assert.rejects(
+        captureProgramRun({ ...options, ...overrides }),
+        (error) => {
+          assert.equal(error, failure);
+          return true;
+        },
+      );
+    }
+  });
+
+  it("should await disposal and isolate overlapping executions", async () => {
+    const started = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const events: string[] = [];
+    const context: SourceContext = {
+      id: Symbol("disposal"),
+      phase: "single-pass",
+      getAnnotations: () => ({}),
+      async [Symbol.asyncDispose]() {
+        started.resolve();
+        await release.promise;
+        events.push("disposed");
+      },
+    };
+    const options = {
+      commands: [
+        defineCommand({
+          path: [],
+          parser: constant("value"),
+          handler() {
+            events.push("handler");
+          },
+        }),
+      ],
+      metadata: { name: "tool", version: "1.2.3" },
+      ...formatting,
+    };
+    const pending = captureProgramRun({
+      ...options,
+      args: [],
+      contexts: [context],
+    });
+    await started.promise;
+    assert.deepEqual(events, []);
+    assert.deepEqual(
+      await captureProgramRun({ ...options, args: ["--version"] }),
+      {
+        exitCode: 0,
+        stdout: "1.2.3\n",
+        stderr: "",
+      },
+    );
+    release.resolve();
+    assert.deepEqual(await pending, { exitCode: 0, stdout: "", stderr: "" });
+    assert.deepEqual(events, ["disposed", "handler"]);
+  });
+
+  it("should not capture an exit sentinel leaked by another invocation", async () => {
+    const failure = new Error("Disposal failed.");
+    const context: SourceContext = {
+      id: Symbol("leaked-exit"),
+      phase: "single-pass",
+      getAnnotations: () => ({}),
+      [Symbol.dispose]() {
+        throw failure;
+      },
+    };
+    let leaked: unknown;
+    await assert.rejects(
+      captureProgramRun({
+        commands: [
+          defineCommand({ path: [], parser: constant("value"), handler() {} }),
+        ],
+        metadata: { name: "tool" },
+        args: ["--help"],
+        contexts: [context],
+        ...formatting,
+      }),
+      (error) => {
+        assert.ok(error instanceof Error);
+        assert.equal(error.name, "SuppressedError");
+        assert.ok("error" in error);
+        assert.equal(error.error, failure);
+        assert.ok("suppressed" in error);
+        leaked = error.suppressed;
+        assert.ok(leaked instanceof Error);
+        return true;
+      },
+    );
+    await assert.rejects(
+      captureProgramRun({
+        commands: [
+          defineCommand({
+            path: [],
+            parser: constant("value"),
+            handler() {
+              throw leaked;
+            },
+          }),
+        ],
+        metadata: { name: "tool" },
+        args: [],
+        ...formatting,
+      }),
+      (error) => {
+        assert.equal(error, leaked);
+        return true;
+      },
+    );
+  });
+
+  it("should preserve option unions and resource typing", () => {
+    interface Resource {
+      readonly label: string;
+    }
+    const checkTypes = (original: RunProgramOptions<Resource>) => {
+      const good = defineCommand({
+        path: ["show"],
+        parser: object({}),
+        handler(_v, _c?: ProgramHookContext<Resource>) {},
+      });
+      const bad = defineCommand({
+        path: ["show"],
+        parser: object({}),
+        handler(_v, _c?: ProgramHookContext<number>) {},
+      });
+      const own = defineCommand({
+        path: ["own"],
+        parser: object({}),
+        hooks: { beforeEach: () => ({ resource: 1 }) },
+        handler(_v, context) {
+          const value: number | undefined = context?.resource;
+          void value;
+        },
+      });
+      const options: CaptureProgramRunOptions<Resource> = {
+        commands: [good, own],
+        metadata: { name: "tool" },
+      };
+      const result: Promise<ProgramRunResult> = captureProgramRun(options);
+      void result;
+      captureProgramRun({
+        commands: [good],
+        metadata: { name: "tool" },
+        hooks: {
+          beforeEach: () => ({ resource: { label: "value" } }),
+          afterEach(context) {
+            const label: string | undefined = context.resource?.label;
+            void label;
+            // @ts-expect-error Hook resources retain their inferred type.
+            void context.resource?.missing;
+          },
+        },
+      });
+      captureProgramRun({
+        dir: ".",
+        metadata: { name: "tool" },
+        hooks: {
+          beforeEach: () => ({ resource: { label: "value" } }),
+          afterEach(context) {
+            const label: string | undefined = context.resource?.label;
+            void label;
+            // @ts-expect-error Discovery options infer hook resources too.
+            void context.resource?.missing;
+          },
+        },
+      });
+      // @ts-expect-error Neither command source.
+      captureProgramRun({ metadata: { name: "tool" } });
+      // @ts-expect-error Both command sources.
+      captureProgramRun({ ...options, dir: "." });
+      // @ts-expect-error Static commands do not accept discovery settings.
+      captureProgramRun({ ...options, extensions: [".mjs"] });
+      // @ts-expect-error Static commands do not accept entryFileName.
+      captureProgramRun({ ...options, entryFileName: "entry" });
+      // @ts-expect-error A wider value may contain captured callbacks.
+      captureProgramRun(original);
+      // @ts-expect-error stdout is controlled by captureProgramRun.
+      captureProgramRun({ ...options, stdout() {} });
+      // @ts-expect-error stderr is controlled by captureProgramRun.
+      captureProgramRun({ ...options, stderr() {} });
+      captureProgramRun({
+        ...options,
+        // @ts-expect-error onExit is controlled by captureProgramRun.
+        onExit(): never {
+          throw new Error("Exit.");
+        },
+      });
+      captureProgramRun({
+        // @ts-expect-error Command resource is incompatible with program hooks.
+        commands: [bad],
+        metadata: { name: "tool" },
+        hooks: { beforeEach: () => ({ resource: { label: "x" } }) },
+      });
+      captureProgramRun<Resource>({
+        // @ts-expect-error Command entries preserve the resource contract.
+        commands: [{ path: ["show"], command: bad }],
+        metadata: { name: "tool" },
+      });
+    };
+    void checkTypes;
+  });
+});

--- a/packages/testing/src/discover.ts
+++ b/packages/testing/src/discover.ts
@@ -1,16 +1,101 @@
 /**
- * Reserved for helpers that capture `runProgram()` executions.
- *
- * This layer will add command discovery, lifecycle hooks, and handler dispatch
- * to what `@optique/testing/run` covers, so a test can assert on which command
- * ran.  Because a handler runs for real, output it writes outside Optique's
- * injected handlers still escapes capture, and an error it throws still
- * propagates to the caller.
- *
- * The helpers themselves are still landing; see
- * {@link https://github.com/dahlia/optique/issues/890}.
+ * Helpers that capture `runProgram()` executions, including command discovery,
+ * lifecycle hooks, and handler dispatch.
  *
  * @module
  * @since 1.3.0
  */
-export {};
+import { runProgram, type RunProgramOptions } from "@optique/discover";
+import type { CapturedOutput } from "./index.ts";
+
+type DistributiveOmit<T, K extends PropertyKey> = T extends unknown ? Omit<T, K>
+  : never;
+
+/**
+ * Options for {@link captureProgramRun}, preserving the command source union
+ * and program hook resource type of `RunProgramOptions`.
+ *
+ * Output and exit callbacks are controlled by the capture helper.
+ *
+ * @template R The resource made available by program-level lifecycle hooks.
+ * @since 1.3.0
+ */
+export type CaptureProgramRunOptions<R = unknown> =
+  & DistributiveOmit<RunProgramOptions<R>, "stdout" | "stderr" | "onExit">
+  & {
+    readonly stdout?: never;
+    readonly stderr?: never;
+    readonly onExit?: never;
+  };
+
+/**
+ * Captured output and exit code from a command program execution.
+ *
+ * @since 1.3.0
+ */
+export interface ProgramRunResult extends CapturedOutput {
+  /**
+   * Zero after normal completion, or the code requested by an intentional exit.
+   */
+  readonly exitCode: number;
+}
+
+/**
+ * Runs a command program in process and captures Optique-controlled output.
+ *
+ * Discovery, hooks, and command handlers execute normally.  Help, version,
+ * completion, and parse-error exits become results; other errors continue to
+ * reject as they do in `runProgram()`.  Writes through `console.log()`,
+ * `print()`, or process streams bypass the injected callbacks and are not
+ * captured.  Each callback write includes the default writer's trailing newline.
+ *
+ * Options retain `runProgram()`'s defaults, including process arguments and
+ * terminal-dependent colors and width.  Set `args`, `colors`, and `maxWidth`
+ * explicitly for deterministic tests.
+ *
+ * @template R The resource made available by program-level lifecycle hooks.
+ * @param options Program options other than the captured callbacks.
+ * @returns Captured output and the exit code after execution completes.
+ * @throws Any error propagated by `runProgram()`, including discovery, parser,
+ *         hook, handler, callback, and context disposal failures.
+ * @since 1.3.0
+ */
+export async function captureProgramRun<R = unknown>(
+  options: CaptureProgramRunOptions<R>,
+): Promise<ProgramRunResult> {
+  // A disposal failure can expose an exit through SuppressedError.suppressed.
+  // A separate class per call prevents a rethrown exit from another invocation
+  // from being mistaken for this invocation's intentional exit.
+  class ProgramExit extends Error {
+    readonly exitCode: number;
+
+    constructor(exitCode: number) {
+      super(`Program exited with code ${exitCode}.`);
+      this.name = "ProgramExit";
+      this.exitCode = exitCode;
+    }
+  }
+
+  let stdout = "";
+  let stderr = "";
+  const runOptions: RunProgramOptions<R> = {
+    ...options,
+    stdout(text) {
+      stdout += `${text}\n`;
+    },
+    stderr(text) {
+      stderr += `${text}\n`;
+    },
+    onExit(exitCode): never {
+      throw new ProgramExit(exitCode);
+    },
+  };
+
+  try {
+    await runProgram<R>(runOptions);
+    return { exitCode: 0, stdout, stderr };
+  } catch (error) {
+    if (!(error instanceof ProgramExit)) throw error;
+    return { exitCode: error.exitCode, stdout, stderr };
+  }
+}

--- a/packages/testing/src/fixtures/discover/invalid/entry.mjs
+++ b/packages/testing/src/fixtures/discover/invalid/entry.mjs
@@ -1,0 +1,1 @@
+export default {};

--- a/packages/testing/src/fixtures/discover/throwing/entry.mjs
+++ b/packages/testing/src/fixtures/discover/throwing/entry.mjs
@@ -1,0 +1,1 @@
+throw new Error("Module failed.");

--- a/packages/testing/src/fixtures/discover/valid/tasks/entry.mjs
+++ b/packages/testing/src/fixtures/discover/valid/tasks/entry.mjs
@@ -1,0 +1,10 @@
+import { argument } from "@optique/core/primitives";
+import { string } from "@optique/core/valueparser";
+import { defineCommand } from "@optique/discover";
+
+export default defineCommand({
+  parser: argument(string()),
+  handler(value, context) {
+    context.resource.push(value);
+  },
+});

--- a/packages/testing/src/public-api.test.ts
+++ b/packages/testing/src/public-api.test.ts
@@ -131,7 +131,7 @@ describe("public surface", () => {
     assert.deepEqual(Object.keys(await import("@optique/testing/cli")), []);
     assert.deepEqual(
       Object.keys(await import("@optique/testing/discover")),
-      [],
+      ["captureProgramRun"],
     );
     assert.deepEqual(
       Object.keys(await import("@optique/testing/parser")).sort(),
@@ -170,7 +170,9 @@ describe("npm build output", () => {
     // Keep the CommonJS surface aligned with ESM.
     assert.deepEqual(Object.keys(require("@optique/testing")), []);
     assert.deepEqual(Object.keys(require("@optique/testing/cli")), []);
-    assert.deepEqual(Object.keys(require("@optique/testing/discover")), []);
+    assert.deepEqual(Object.keys(require("@optique/testing/discover")), [
+      "captureProgramRun",
+    ]);
     assert.deepEqual(
       Object.keys(require("@optique/testing/parser")).sort(),
       ["parseArgs", "parseArgsSync"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -527,6 +527,9 @@ importers:
       '@optique/core':
         specifier: workspace:*
         version: link:../core
+      '@optique/discover':
+        specifier: workspace:*
+        version: link:../discover
       '@optique/run':
         specifier: workspace:*
         version: link:../run


### PR DESCRIPTION
`captureProgramRun()` in *@optique/testing/discover* delegates to `runProgram()` with per-call output buffers and an exit signal, so tests exercise real command discovery, hooks, and handlers without duplicating capture setup or terminating the test process.

Only deliberate exits from that invocation become results; other failures still propagate.  The wrapper preserves option constraints, hook resource inference, and output newlines.  Direct console/process writes remain outside capture.

Closes #887.  Part of #890.