### PR TITLE
Test complete CLIs in child processes

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -78,9 +78,32 @@ jobs:
         log_level: ${{ runner.debug == '1' && 'debug' || 'info' }}
     - run: mise run test:bun
 
+  test-cli-windows:
+    runs-on: windows-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        runtime: [deno, node, bun]
+    env:
+      MISE_NO_HOOKS: "1"
+      MISE_AUTO_INSTALL: "0"
+      MISE_TASK_RUN_AUTO_INSTALL: "false"
+    steps:
+    - uses: actions/checkout@v6
+    - uses: jdx/mise-action@v4
+      with:
+        experimental: true
+        install: true
+        install_args: node deno bun github:pnpm/pnpm
+        log_level: ${{ runner.debug == '1' && 'debug' || 'info' }}
+    - run: mise deps
+    - run: mise run --jobs 1 testing:cli:${{ matrix.runtime }}
+      timeout-minutes: 3
+
   publish:
     if: github.event_name == 'push'
-    needs: [test-node, test-deno, test-bun, check]
+    needs: [test-node, test-deno, test-bun, test-cli-windows, check]
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -79,6 +79,8 @@ jobs:
     - run: mise run test:bun
 
   test-cli-windows:
+    permissions:
+      contents: read
     runs-on: windows-latest
     timeout-minutes: 10
     strategy:
@@ -90,8 +92,10 @@ jobs:
       MISE_AUTO_INSTALL: "0"
       MISE_TASK_RUN_AUTO_INSTALL: "false"
     steps:
-    - uses: actions/checkout@v6
-    - uses: jdx/mise-action@v4
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      with:
+        persist-credentials: false
+    - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4
       with:
         experimental: true
         install: true

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /packages/*/dist/
 /packages/*/coverage/
 /packages/*/node_modules/
+/packages/tmp/
 /PLAN.md
 /coverage/
 /tmp/

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -179,15 +179,20 @@ To be released.
     exit codes without writing to process streams or running downstream
     application handlers.  The discovery entry point's `captureProgramRun()`
     captures output and exit codes while executing command discovery, hooks,
-    and handler dispatch in the test process.
-    [[#887], [#890], [#891], [#892], [#893], [#942], [#943], [#944], [#945]]
+    and handler dispatch in the test process.  The CLI entry point's
+    `createCliRunner()` runs a real process, capturing stdout, stderr, and exit
+    status with stdin, environment, timeout, cancellation, and optional
+    process-tree cleanup controls.
+    [[#887], [#890], [#891], [#892], [#893], [#894], [#942], [#943], [#944], [#945], [#946]]
 
 [#887]: https://github.com/dahlia/optique/issues/887
 [#891]: https://github.com/dahlia/optique/issues/891
 [#893]: https://github.com/dahlia/optique/issues/893
+[#894]: https://github.com/dahlia/optique/issues/894
 [#942]: https://github.com/dahlia/optique/pull/942
 [#944]: https://github.com/dahlia/optique/pull/944
 [#945]: https://github.com/dahlia/optique/pull/945
+[#946]: https://github.com/dahlia/optique/pull/946
 
 
 Version 1.2.5

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ The following is a list of the available packages:
 | [@optique/zod](/packages/zod/)                           | [JSR][jsr:@optique/zod]              | [npm][npm:@optique/zod]              | [Zod] schema integration for validation     |
 | [@optique/inquirer](/packages/inquirer/)                 | [JSR][jsr:@optique/inquirer]         | [npm][npm:@optique/inquirer]         | [Inquirer.js] prompt support                |
 | [@optique/prompt](/packages/prompt/)                     | [JSR][jsr:@optique/prompt]           | [npm][npm:@optique/prompt]           | Generic prompt adapter foundation           |
-| [@optique/testing](/packages/testing/)                   | [JSR][jsr:@optique/testing]          | [npm][npm:@optique/testing]          | Parser and runner testing for CLIs          |
+| [@optique/testing](/packages/testing/)                   | [JSR][jsr:@optique/testing]          | [npm][npm:@optique/testing]          | Parser, runner, and subprocess CLI tests    |
 
 [jsr:@optique/core]: https://jsr.io/@optique/core
 [npm:@optique/core]: https://www.npmjs.com/package/@optique/core

--- a/changes.d/testing/testing-package.md
+++ b/changes.d/testing/testing-package.md
@@ -5,10 +5,12 @@ links:
   '#891': https://github.com/dahlia/optique/issues/891
   '#892': https://github.com/dahlia/optique/issues/892
   '#893': https://github.com/dahlia/optique/issues/893
+  '#894': https://github.com/dahlia/optique/issues/894
   '#942': https://github.com/dahlia/optique/pull/942
   '#943': https://github.com/dahlia/optique/pull/943
   '#944': https://github.com/dahlia/optique/pull/944
   '#945': https://github.com/dahlia/optique/pull/945
+  '#946': https://github.com/dahlia/optique/pull/946
 ---
  -  Added the `@optique/testing` package with a shared `CapturedOutput` type
     and layered entry points for parser, runner, command discovery, and
@@ -19,5 +21,8 @@ links:
     exit codes without writing to process streams or running downstream
     application handlers.  The discovery entry point's `captureProgramRun()`
     captures output and exit codes while executing command discovery, hooks,
-    and handler dispatch in the test process.
-    [[#887], [#890], [#891], [#892], [#893], [#942], [#943], [#944], [#945]]
+    and handler dispatch in the test process.  The CLI entry point's
+    `createCliRunner()` runs a real process, capturing stdout, stderr, and exit
+    status with stdin, environment, timeout, cancellation, and optional
+    process-tree cleanup controls.
+    [[#887], [#890], [#891], [#892], [#893], [#894], [#942], [#943], [#944], [#945], [#946]]

--- a/docs/.vitepress/theme/components/PackageGrid.vue
+++ b/docs/.vitepress/theme/components/PackageGrid.vue
@@ -39,7 +39,7 @@ const groups = [
       { name: "@optique/discover", desc: "File-based command discovery and dispatch.", link: "/concepts/discover" },
       { name: "@optique/man", desc: "Unix man pages from parsers.", link: "/concepts/man" },
       { name: "@optique/logtape", desc: "Log-level options for LogTape.", link: "/integrations/logtape" },
-      { name: "@optique/testing", desc: "Shared contracts for layered CLI testing.", link: "/concepts/testing" },
+      { name: "@optique/testing", desc: "Test parsers, runners, dispatch, and real CLIs.", link: "/concepts/testing" },
     ],
   },
 ];

--- a/docs/concepts/testing.md
+++ b/docs/concepts/testing.md
@@ -23,11 +23,6 @@ import { /* ... */ } from "@optique/testing/discover";
 import { /* ... */ } from "@optique/testing/cli";
 ~~~~
 
-The parser, runner, and discovery helpers are available now.  The child-process
-helpers remain reserved while the remaining part of [issue #890] lands.
-
-[issue #890]: https://github.com/dahlia/optique/issues/890
-
 
 Execution boundaries
 --------------------
@@ -259,6 +254,142 @@ the promise according to `runProgram()`'s error handling, including its
 run in the test process, so their side effects are real.  Direct writes through
 `console.log()`, `print()`, or process streams bypass capture; use a child
 process to assert on those writes.
+
+
+Testing a real CLI
+------------------
+
+Use `createCliRunner()` when the test needs to observe the complete application,
+including direct console output, stdin, and process exit status:
+
+~~~~ typescript twoslash
+import assert from "node:assert/strict";
+import { createCliRunner } from "@optique/testing/cli";
+
+const cli = createCliRunner({
+  entrypoint: new URL("./cli.mjs", import.meta.url),
+});
+const help = await cli.invoke("--help");
+assert.equal(help.exitCode, 0);
+assert.match(help.stdout, /Usage:/);
+
+const result = await cli.invoke({
+  args: ["greet"],
+  stdin: "Ada\n",
+  env: { GREETING: "Hello", DEBUG: undefined },
+  timeout: 10_000,
+});
+assert.equal(result.stdout, "Hello, Ada!\n");
+~~~~
+
+`CliResult` contains separate UTF-8 `stdout` and `stderr` strings,
+`exitCode: number | null`, and `signal: string | null`.  A nonzero exit code
+is a result, including a CLI's parse error or uncaught handler exception.
+A signal termination reports its signal instead of an exit code.  Output is
+preserved without trimming, including CRLF, ANSI escapes, and trailing newlines.
+The runner does not force color or terminal width settings; configure these in
+your CLI or environment when asserting rendered text.
+
+### Selecting a runtime
+
+With `entrypoint`, the child uses the current runtime's executable.  Deno
+receives `run` before the entry point; Node.js and Bun receive the entry point
+directly.  `runtimeArgs` goes before the entry point.  Parent runtime flags are
+not inherited, and the helper does not install dependencies, build TypeScript,
+or infer a loader.  Use runnable JavaScript on Node.js versions that cannot
+execute your TypeScript source directly, or supply an explicit loader.
+
+Deno permissions must be explicit:
+
+~~~~ typescript twoslash
+import { createCliRunner } from "@optique/testing/cli";
+
+const cli = createCliRunner({
+  entrypoint: new URL("./cli.ts", import.meta.url),
+  runtimeArgs: ["--allow-read", "--allow-env"],
+});
+~~~~
+
+To select a different executable, supply a nonempty `command` array instead of
+`entrypoint` and `runtimeArgs`:
+
+~~~~ typescript twoslash
+import { createCliRunner } from "@optique/testing/cli";
+
+const cli = createCliRunner({ command: ["node", "./dist/cli.js"] });
+await cli.invoke("--version");
+~~~~
+
+Commands and arguments are passed without a shell.  Spaces and shell
+metacharacters remain literal; no quoting, splitting, or expansion is applied.
+
+### Invocation settings
+
+`invoke(...args)` accepts individual string arguments.  `invoke({ args, ... })`
+adds per-call options; `args` defaults to an empty array.  `stdin` is a UTF-8
+string and the input pipe always receives EOF, even when stdin is omitted.
+The runner reads stdout and stderr concurrently while writing input.
+
+`cwd`, `env`, `timeout`, `signal`, and `cleanup` can be set on the factory and
+overridden on each invocation.  The factory fixes its working directory and
+entry point to absolute paths when created.  A relative invocation `cwd` is
+resolved against that factory directory and does not relocate the entry point.
+Factory arrays, environment settings, and URL paths are copied, so later edits
+to them do not change the runner.
+
+The child inherits the parent's environment at invocation time, then applies
+factory and per-call overrides in that order.  An `undefined` value removes a
+variable from the supplied environment, although the runtime or operating
+system may restore system variables such as `PATH`.  Environment names are
+case-insensitive on Windows.  Invocations do
+not change the parent process's environment or working directory and can run
+concurrently.
+
+The default `timeout` is 5,000 milliseconds; `0` disables it.  Values must be
+integers between `0` and `2147483647`.  The limit includes output collection,
+so an exited CLI whose descendants keep its pipes open can still time out.
+An invocation `signal` replaces the factory signal.  An already-aborted signal
+prevents the child from starting.
+
+### Failures and cleanup
+
+Execution failures, timeouts, cancellation, input/output failures, and cleanup
+failures reject with `CliInvocationError`.  Its `reason` is `"spawn"`,
+`"timeout"`, `"aborted"`, `"io"`, or `"cleanup"`, respectively.  The error
+contains partial `stdout` and `stderr`, observed `exitCode` and `signal`, and
+an underlying `cause` when available:
+
+~~~~ typescript twoslash
+import { CliInvocationError, createCliRunner } from "@optique/testing/cli";
+
+const cli = createCliRunner({ entrypoint: "./cli.mjs", timeout: 1_000 });
+try {
+  await cli.invoke("serve");
+} catch (error) {
+  if (!(error instanceof CliInvocationError)) throw error;
+  console.error(error.reason, error.stdout, error.stderr);
+}
+~~~~
+
+Invalid factory options throw `TypeError` or `RangeError`; invalid invocation
+options reject the promise.  If cleanup also fails, `reason` becomes
+`"cleanup"` and an `AggregateError` cause preserves the original failure and
+cleanup errors.
+
+`cleanup: "child"` is the default and terminates only the direct child on
+failure.  Choose `cleanup: "tree"` when the CLI starts other processes that
+should also be terminated on failure.  On POSIX systems this creates a process
+group, sends `SIGTERM`, waits up to one second, and then sends `SIGKILL` if
+needed, allowing another second for final cleanup.  Windows terminates the
+child forcibly; tree cleanup uses the system `taskkill.exe /T /F` with a
+combined two-second bound for the tool and subsequent cleanup.  Cleanup time
+is additional to the invocation timeout.
+
+Tree cleanup handles ordinary descendants, not processes that escape their
+group or become orphaned.  On Windows, if the direct child has already exited,
+the runner does not start a new `taskkill` using its old PID.  Normal completion
+does not trigger a process-tree sweep.  This helper is not a process sandbox;
+fixtures that deliberately detach descendants need their own cleanup.
 
 
 Shared contracts

--- a/mise.toml
+++ b/mise.toml
@@ -3,7 +3,7 @@ experimental = true
 
 [tools]
 "aqua:dahlia/hongdown" = "0.5.3"
-"aqua:fish-shell/fish-shell" = "latest"
+"aqua:fish-shell/fish-shell" = { version = "latest", os = ["linux", "macos"] }
 bun = "1.3"
 deno = "2.9"
 "github:dahlia/sacho" = "0.3.2"
@@ -115,6 +115,32 @@ depends = ["check", "test:*"]
 [tasks.build]
 description = "Build all packages for npm publishing"
 run = "pnpm run --filter '!{docs}' -r build"
+
+[tasks."testing:cli:build"]
+description = "Build the testing package and its dependencies"
+run = 'pnpm --filter "@optique/testing..." -r build'
+
+[tasks."testing:cli:deno"]
+description = "Test the CLI boundary using Deno"
+depends = ["testing:cli:build"]
+dir = "packages/testing"
+run = "deno test --allow-read --allow-write --allow-env --allow-run src/cli.test.ts src/public-api.test.ts"
+
+[tasks."testing:cli:node"]
+description = "Test the CLI boundary using Node.js"
+depends = ["testing:cli:build"]
+dir = "packages/testing"
+run = "node --test src/cli.test.ts src/public-api.test.ts"
+
+[tasks."testing:cli:bun"]
+description = "Test the CLI boundary using Bun"
+depends = ["testing:cli:build"]
+dir = "packages/testing"
+run = "bun test src/cli.test.ts src/public-api.test.ts"
+
+[tasks."testing:cli"]
+description = "Test the CLI boundary across all runtimes"
+depends = ["testing:cli:deno", "testing:cli:node", "testing:cli:bun"]
 
 [tasks.coverage]
 description = "Measure test coverage"

--- a/packages/core/skills/optique/SKILL.md
+++ b/packages/core/skills/optique/SKILL.md
@@ -26,8 +26,8 @@ Core rules
     `runParser()` for embedded and custom runtimes.
  -  In tests, use `parseArgs()`/`parseArgsSync()` from *@optique/testing/parser*
     for parser results, `captureRun()` from *@optique/testing/run* for runner
-    output/exits, or `captureProgramRun()` from *@optique/testing/discover* for
-    dispatch/hooks. Direct console/process writes bypass capture.
+    output/exits, `captureProgramRun()` from *@optique/testing/discover* for
+    dispatch, and `createCliRunner()` from *@optique/testing/cli* for real CLIs.
  -  Compose parsers with `object()`, `tuple()`, `seq()`, `or()`, `merge()`, and
     modifiers. Do not hand-write argument scanners around Optique parsers.
  -  Let TypeScript infer the parsed value type from the parser. Do not

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -70,9 +70,29 @@ The helper runs real command modules, hooks, and handlers.  It captures
 Optique's output callbacks; direct console or process-stream writes bypass
 capture.  Unexpected errors reject the promise.
 
-The child-process entry point remains reserved while its helpers are developed.
+Use `createCliRunner()` to capture the complete process, including direct
+console writes and application exit codes:
+
+~~~~ typescript
+import { createCliRunner } from "@optique/testing/cli";
+
+const cli = createCliRunner({
+  entrypoint: new URL("./cli.mjs", import.meta.url),
+});
+const result = await cli.invoke("--help");
+console.log(result.exitCode, result.signal, result.stdout, result.stderr);
+~~~~
+
+The runner uses the current runtime.  Set `runtimeArgs` for explicit runtime
+flags, including Deno permissions, or use `command: ["node", "./cli.mjs"]`
+for a specific executable.  Calls accept stdin, cwd, environment overrides,
+and cancellation.  The default timeout is five seconds; `timeout: 0` disables
+it.  Nonzero exits return results; execution failures, timeouts, and
+cancellation reject with `CliInvocationError`, including partial output.
+See the [testing guide] for process-tree cleanup and runtime details.
 
 [Optique]: https://optique.dev/
+[testing guide]: https://optique.dev/concepts/testing
 
 
 Installation
@@ -92,5 +112,3 @@ Documentation
 
 For full documentation, visit the [testing guide], which explains what each
 layer does and does not execute, and how to choose between them.
-
-[testing guide]: https://optique.dev/concepts/testing

--- a/packages/testing/deno.json
+++ b/packages/testing/deno.json
@@ -16,7 +16,7 @@
   ],
   "tasks": {
     "build": "pnpm build",
-    "test": "deno test --allow-read",
+    "test": "deno test --allow-read --allow-write --allow-env --allow-run",
     "test:node": {
       "dependencies": [
         "build"

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -101,7 +101,7 @@
     "prepublish": "tsdown",
     "test": "node --test",
     "test:bun": "bun test",
-    "test:deno": "deno test --allow-read",
-    "test-all": "tsdown && node --test && bun test && deno test --allow-read"
+    "test:deno": "deno test --allow-read --allow-write --allow-env --allow-run",
+    "test-all": "tsdown && node --test && bun test && deno test --allow-read --allow-write --allow-env --allow-run"
   }
 }

--- a/packages/testing/src/cli-process.test.ts
+++ b/packages/testing/src/cli-process.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import { once } from "node:events";
+import process from "node:process";
+import type { Readable } from "node:stream";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+import { spawnDenoProcess } from "./cli-process.ts";
+
+const isDeno = "Deno" in globalThis;
+const fixture = fileURLToPath(
+  new URL("./fixtures/cli/program.mjs", import.meta.url),
+);
+
+function start(mode: string) {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value !== undefined) env[key] = value;
+  }
+  const child = spawnDenoProcess(
+    process.execPath,
+    ["run", "-A", fixture, mode],
+    {
+      cwd: process.cwd(),
+      env,
+      detached: false,
+    },
+  );
+  assert.ok(child);
+  return child;
+}
+
+async function text(stream: Readable): Promise<string> {
+  stream.setEncoding("utf8");
+  let result = "";
+  for await (const chunk of stream) result += chunk;
+  return result;
+}
+
+describe("native Deno CLI pipes", () => {
+  for (const mode of ["stdin", "duplex"]) {
+    it(
+      `should complete large ${mode} transfers`,
+      { skip: !isDeno },
+      async () => {
+        if (!isDeno) return;
+        const child = start(mode);
+        const timer = setTimeout(() => child.kill("SIGKILL"), 5000);
+        try {
+          const closed = once(child, "close");
+          const output = text(child.stdout);
+          const errors = text(child.stderr);
+          const input = "한글🌻\r\n".repeat(30_000);
+          child.stdin.end(input);
+          const [stdout, stderr] = await Promise.all([output, errors, closed]);
+          assert.equal(
+            stdout,
+            mode === "stdin"
+              ? input
+              : "o".repeat(256 * 1024) + `\n${Buffer.byteLength(input)}`,
+          );
+          assert.equal(stderr, mode === "stdin" ? "" : "e".repeat(256 * 1024));
+        } finally {
+          clearTimeout(timer);
+        }
+      },
+    );
+  }
+
+  it(
+    "should keep timers responsive while input is blocked",
+    { skip: !isDeno },
+    async () => {
+      if (!isDeno) return;
+      const child = start("hang");
+      const closed = once(child, "close");
+      const output = text(child.stdout);
+      const errors = text(child.stderr);
+      child.stdin.on("error", () => {});
+      let timedOut = false;
+      const timer = setTimeout(() => {
+        timedOut = true;
+        child.kill("SIGKILL");
+      }, 500);
+      try {
+        child.stdin.end("x".repeat(1024 * 1024));
+        await Promise.all([output, errors, closed]);
+        assert.ok(timedOut);
+      } finally {
+        clearTimeout(timer);
+      }
+    },
+  );
+});

--- a/packages/testing/src/cli-process.ts
+++ b/packages/testing/src/cli-process.ts
@@ -1,0 +1,155 @@
+/** Internal process adapters for the CLI testing boundary. */
+import { spawn } from "node:child_process";
+import { EventEmitter } from "node:events";
+import process from "node:process";
+import { Readable, Writable } from "node:stream";
+import type { ReadableStream, WritableStream } from "node:stream/web";
+
+/** The process operations used by the invocation lifecycle. */
+export interface CliProcess extends EventEmitter {
+  readonly pid?: number;
+  readonly stdin: Writable;
+  readonly stdout: Readable;
+  readonly stderr: Readable;
+  kill(signal?: NodeJS.Signals): boolean;
+  unref(): void;
+}
+
+/** Launch settings shared by the Node and Deno adapters. */
+export interface CliSpawnOptions {
+  readonly cwd: string;
+  readonly env: Readonly<Record<string, string>>;
+  readonly detached: boolean;
+}
+
+interface DenoChild {
+  readonly pid: number;
+  readonly stdin: WritableStream<Uint8Array>;
+  readonly stdout: ReadableStream<Uint8Array>;
+  readonly stderr: ReadableStream<Uint8Array>;
+  readonly status: Promise<
+    { readonly code: number; readonly signal: string | null }
+  >;
+  kill(signal: string): void;
+  unref(): void;
+}
+
+interface DenoRuntime {
+  readonly Command: new (command: string, options: {
+    readonly args: readonly string[];
+    readonly cwd: string;
+    readonly env: Readonly<Record<string, string>>;
+    readonly clearEnv: boolean;
+    readonly stdin: "piped";
+    readonly stdout: "piped";
+    readonly stderr: "piped";
+    readonly windowsHide: boolean;
+  }) => { spawn(): DenoChild };
+}
+
+function isDenoRuntime(value: unknown): value is DenoRuntime {
+  return typeof value === "object" && value !== null && "Command" in value &&
+    typeof value.Command === "function";
+}
+
+/**
+ * Uses Deno's native asynchronous pipes when available.
+ * Kept separate so its real I/O can also be tested on non-Windows Deno hosts.
+ * @param command Executable path.
+ * @param args Literal command arguments.
+ * @param options Working directory and complete child environment.
+ * @returns A process adapter, or undefined outside Deno.
+ * @throws If Deno cannot start the requested executable.
+ */
+export function spawnDenoProcess(
+  command: string,
+  args: readonly string[],
+  options: CliSpawnOptions,
+): CliProcess | undefined {
+  const runtime: unknown = "Deno" in globalThis ? globalThis.Deno : undefined;
+  if (!isDenoRuntime(runtime)) return;
+  const native = new runtime.Command(command, {
+    args,
+    cwd: options.cwd,
+    env: options.env,
+    clearEnv: true,
+    stdin: "piped",
+    stdout: "piped",
+    stderr: "piped",
+    windowsHide: true,
+  }).spawn();
+  const stdin = Writable.fromWeb(native.stdin);
+  const stdout = Readable.fromWeb(native.stdout);
+  const stderr = Readable.fromWeb(native.stderr);
+  const child = Object.assign(new EventEmitter(), {
+    pid: native.pid,
+    stdin,
+    stdout,
+    stderr,
+    kill(signal: NodeJS.Signals = "SIGTERM"): boolean {
+      native.kill(signal);
+      return true;
+    },
+    unref(): void {
+      native.unref();
+    },
+  });
+  let exited = false;
+  let closed = false;
+  let closedStreams = 0;
+  const maybeClose = () => {
+    if (exited && closedStreams === 3 && !closed) {
+      closed = true;
+      child.emit("close");
+    }
+  };
+  for (const stream of [stdin, stdout, stderr]) {
+    stream.once("close", () => {
+      closedStreams++;
+      maybeClose();
+    });
+  }
+  queueMicrotask(() => child.emit("spawn"));
+  native.status.then((status) => {
+    exited = true;
+    child.emit(
+      "exit",
+      status.signal === null ? status.code : null,
+      status.signal,
+    );
+    stdin.destroy();
+    maybeClose();
+  }, (error: unknown) => {
+    exited = true;
+    child.emit("error", error);
+    maybeClose();
+  });
+  return child;
+}
+
+/**
+ * Launches a CLI with pipes that leave the host event loop responsive.
+ * @param command Executable path.
+ * @param args Literal command arguments.
+ * @param options Working directory, environment, and process group settings.
+ * @returns The launched process and its three streams.
+ * @throws If the runtime rejects the launch synchronously.
+ */
+export function spawnCliProcess(
+  command: string,
+  args: readonly string[],
+  options: CliSpawnOptions,
+): CliProcess {
+  // Deno's Node-compatible Windows pipes can block the JS thread during a
+  // large write. Native web streams keep reads, writes, and timers concurrent.
+  if (process.platform === "win32") {
+    const native = spawnDenoProcess(command, args, options);
+    if (native !== undefined) return native;
+  }
+  return spawn(command, [...args], {
+    ...options,
+    shell: false,
+    stdio: "pipe",
+    windowsHide: true,
+  });
+}

--- a/packages/testing/src/cli.test.ts
+++ b/packages/testing/src/cli.test.ts
@@ -1,0 +1,638 @@
+import { CliInvocationError, createCliRunner } from "@optique/testing/cli";
+import { Buffer } from "node:buffer";
+import { execFileSync } from "node:child_process";
+import assert from "node:assert/strict";
+import {
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+} from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { setTimeout as delay } from "node:timers/promises";
+import { describe, it } from "node:test";
+
+const fixture = new URL("./fixtures/cli/program.mjs", import.meta.url);
+const runtimeArgs = "Deno" in globalThis ? ["-A"] : [];
+
+describe("createCliRunner", () => {
+  it("should capture both process streams and the exit code", async () => {
+    const result = await createCliRunner({ entrypoint: fixture, runtimeArgs })
+      .invoke("output");
+    assert.deepEqual(result, {
+      stdout: "hello\r\n한글🌻\n",
+      stderr: "warning\n",
+      exitCode: 0,
+      signal: null,
+    });
+  });
+
+  it("should classify synchronous spawn exceptions as startup failures", async () => {
+    await assert.rejects(
+      runner().invoke("args", "invalid\0argument"),
+      (error: unknown) => {
+        assert.ok(error instanceof CliInvocationError);
+        assert.equal(error.reason, "spawn");
+        assert.equal(error.stdout, "");
+        assert.equal(error.stderr, "");
+        assert.ok(error.cause instanceof TypeError);
+        return true;
+      },
+    );
+  });
+
+  it("should reject missing executables with an invocation error", async () => {
+    await assert.rejects(
+      createCliRunner({ command: ["optique-nonexistent-executable-894"] })
+        .invoke(),
+      (error: unknown) => {
+        assert.ok(error instanceof CliInvocationError);
+        assert.equal(error.reason, "spawn");
+        return true;
+      },
+    );
+  });
+});
+
+describe("CLI invocation", () => {
+  it("should preserve argument boundaries without shell expansion", async () => {
+    const args = [
+      "",
+      "with spaces",
+      "'quoted'",
+      "$HOME",
+      "a;b",
+      "🌻",
+      "--flag",
+    ];
+    const result = await runner().invoke("args", ...args);
+    assert.deepEqual(JSON.parse(result.stdout), args);
+  });
+
+  it("should support commands with fixed arguments", async () => {
+    const prefix = "Deno" in globalThis ? ["run", "-A"] : [];
+    const result = await createCliRunner({
+      command: [
+        process.execPath,
+        ...prefix,
+        fileURLToPath(fixture),
+        "args",
+        "fixed",
+      ],
+    }).invoke({ args: ["variable"] });
+    assert.deepEqual(JSON.parse(result.stdout), ["fixed", "variable"]);
+  });
+
+  it("should resolve file URLs with spaces and snapshot command arrays", async () => {
+    const directory = scratch();
+    try {
+      const path = resolve(directory, "program with spaces.mjs");
+      copyFileSync(fixture, path);
+      const prefix = "Deno" in globalThis ? ["run", "-A"] : [];
+      const command: [string, ...string[]] = [
+        process.execPath,
+        ...prefix,
+        path,
+        "args",
+        "original",
+      ];
+      const cli = createCliRunner({ command });
+      command[command.length - 1] = "mutated";
+      assert.deepEqual(JSON.parse((await cli.invoke("value")).stdout), [
+        "original",
+        "value",
+      ]);
+      const result = await createCliRunner({
+        entrypoint: pathToFileURL(path),
+        runtimeArgs,
+      }).invoke("output");
+      assert.equal(result.exitCode, 0);
+      assert.equal(result.stdout, "hello\r\n한글🌻\n");
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("should send EOF for absent and empty input", async () => {
+    for (const stdin of [undefined, ""]) {
+      const result = await runner().invoke({ args: ["stdin"], stdin });
+      assert.equal(result.stdout, "");
+      assert.equal(result.exitCode, 0);
+    }
+  });
+
+  it("should preserve large UTF-8 input", async () => {
+    const input = "한글🌻\r\n".repeat(30_000);
+    assert.equal(
+      (await runner().invoke({ args: ["stdin"], stdin: input })).stdout,
+      input,
+    );
+  });
+
+  it("should collect both large streams while writing input", async () => {
+    const input = "한글🌻\r\n".repeat(30_000);
+    const result = await runner().invoke({ args: ["duplex"], stdin: input });
+    assert.equal(
+      result.stdout,
+      "o".repeat(256 * 1024) + `\n${Buffer.byteLength(input)}`,
+    );
+    assert.equal(result.stderr, "e".repeat(256 * 1024));
+  });
+
+  it("should time out even when the child does not read large input", async () => {
+    await assert.rejects(
+      runner().invoke({
+        args: ["hang"],
+        stdin: "x".repeat(1024 * 1024),
+        timeout: 1000,
+      }),
+      (error: unknown) => {
+        assert.ok(error instanceof CliInvocationError);
+        assert.equal(error.reason, "timeout");
+        return true;
+      },
+    );
+  });
+
+  it("should preserve an early exit while input is still being written", async () => {
+    const result = await runner().invoke({
+      args: ["early"],
+      stdin: "x".repeat(1024 * 1024),
+    });
+    assert.equal(result.exitCode, 7);
+  });
+
+  it("should return nonzero exit codes and uncaught exceptions", async () => {
+    assert.equal((await runner().invoke("exit", "42")).exitCode, 42);
+    const result = await runner().invoke("throw");
+    assert.notEqual(result.exitCode, 0);
+    assert.match(result.stderr, /Fixture handler failed/);
+  });
+
+  it("should report a terminating signal", {
+    skip: process.platform === "win32",
+  }, async () => {
+    if (process.platform === "win32") return;
+    const result = await runner().invoke("signal");
+    assert.equal(result.exitCode, null);
+    assert.equal(result.signal, "SIGTERM");
+  });
+
+  it("should snapshot factory options and resolve invocation cwd against the factory cwd", async () => {
+    const directory = scratch();
+    try {
+      mkdirSync(resolve(directory, "nested"));
+      const env = {
+        OPTIQUE_CLI_FIRST: "factory",
+        OPTIQUE_CLI_SECOND: "remove",
+      };
+      const entrypoint = new URL(fixture);
+      const cli = createCliRunner({
+        entrypoint,
+        runtimeArgs,
+        cwd: directory,
+        env,
+      });
+      env.OPTIQUE_CLI_FIRST = "mutated";
+      entrypoint.pathname = "/missing-file.mjs";
+      const [first, second] = await Promise.all([
+        cli.invoke({
+          args: ["context"],
+          cwd: "nested",
+          env: { OPTIQUE_CLI_SECOND: undefined },
+        }),
+        cli.invoke({ args: ["context"], env: { OPTIQUE_CLI_FIRST: "call" } }),
+      ]);
+      assert.deepEqual(JSON.parse(first.stdout), {
+        cwd: resolve(directory, "nested"),
+        first: "factory",
+        second: null,
+        inherited: process.env.PATH ?? process.env.Path ?? null,
+      });
+      assert.deepEqual(JSON.parse(second.stdout), {
+        cwd: directory,
+        first: "call",
+        second: "remove",
+        inherited: process.env.PATH ?? process.env.Path ?? null,
+      });
+      assert.equal(process.env.OPTIQUE_CLI_FIRST, undefined);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("should reject invalid timeout values", async () => {
+    for (const timeout of [-1, 0.5, NaN, Infinity, 2147483648]) {
+      assert.throws(
+        () => createCliRunner({ entrypoint: fixture, timeout }),
+        RangeError,
+      );
+      await assert.rejects(runner().invoke({ timeout }), RangeError);
+    }
+  });
+
+  it("should remove variables inherited from the parent environment", async () => {
+    const previous = process.env.OPTIQUE_CLI_SECOND;
+    process.env.OPTIQUE_CLI_SECOND = "inherited";
+    try {
+      const result = await runner().invoke({
+        args: ["context"],
+        env: { OPTIQUE_CLI_SECOND: undefined },
+      });
+      assert.equal(JSON.parse(result.stdout).second, null);
+      assert.equal(process.env.OPTIQUE_CLI_SECOND, "inherited");
+    } finally {
+      if (previous === undefined) delete process.env.OPTIQUE_CLI_SECOND;
+      else process.env.OPTIQUE_CLI_SECOND = previous;
+    }
+  });
+
+  it("should reject invalid execution forms", () => {
+    // @ts-expect-error An execution target is required.
+    assert.throws(() => createCliRunner({}), TypeError);
+    // @ts-expect-error Commands require an executable.
+    assert.throws(() => createCliRunner({ command: [] }), TypeError);
+    assert.throws(
+      // @ts-expect-error Execution targets are mutually exclusive.
+      () => createCliRunner({ entrypoint: fixture, command: ["node"] }),
+      TypeError,
+    );
+    assert.throws(
+      // @ts-expect-error runtimeArgs is only for entrypoints.
+      () => createCliRunner({ command: ["node"], runtimeArgs: [] }),
+      TypeError,
+    );
+  });
+
+  it("should reject malformed invocation options asynchronously", async () => {
+    // @ts-expect-error Invocation options must be an object or strings.
+    const promise = runner().invoke(42);
+    assert.ok(promise instanceof Promise);
+    await assert.rejects(promise, TypeError);
+    // @ts-expect-error Cleanup policies are a closed set.
+    await assert.rejects(runner().invoke({ cleanup: "all" }), TypeError);
+    await assert.rejects(
+      // @ts-expect-error Standard input is a UTF-8 string.
+      runner().invoke({ stdin: new Uint8Array() }),
+      TypeError,
+    );
+  });
+
+  it("should classify a nonexistent working directory as a spawn failure", async () => {
+    await assert.rejects(
+      runner().invoke({
+        cwd: fileURLToPath(new URL("./missing-894/", fixture)),
+      }),
+      (error: unknown) => {
+        assert.ok(error instanceof CliInvocationError);
+        assert.equal(error.reason, "spawn");
+        assert.equal(error.stdout, "");
+        assert.ok(error.cause);
+        return true;
+      },
+    );
+  });
+
+  it("should reject pre-aborted calls without starting a process", async () => {
+    await assert.rejects(
+      createCliRunner({
+        command: ["missing-894"],
+        signal: AbortSignal.abort("cancelled"),
+      }).invoke(),
+      (error: unknown) => {
+        assert.ok(error instanceof CliInvocationError);
+        assert.equal(error.reason, "aborted");
+        assert.equal(error.stdout, "");
+        return true;
+      },
+    );
+  });
+
+  it("should let invocation signals and timeout replace factory defaults", async () => {
+    const cli = createCliRunner({
+      entrypoint: fixture,
+      runtimeArgs,
+      timeout: 1,
+      signal: AbortSignal.abort(),
+    });
+    const result = await cli.invoke({
+      args: ["output"],
+      signal: new AbortController().signal,
+      timeout: 0,
+    });
+    assert.equal(result.exitCode, 0);
+  });
+
+  it("should abort an active process and retain its output", async () => {
+    const directory = scratch();
+    const ready = resolve(directory, "ready");
+    const controller = new AbortController();
+    const invocation = runner().invoke({
+      args: ["hang", ready],
+      signal: controller.signal,
+    });
+    const settled = invocation.then(
+      (value) => ({ value }),
+      (error: unknown) => ({ error }),
+    );
+    try {
+      const pid = await waitReady(ready);
+      controller.abort("test cancellation");
+      const result = await settled;
+      assert.ok("error" in result);
+      assert.ok(result.error instanceof CliInvocationError);
+      assert.equal(result.error.reason, "aborted");
+      assert.equal(result.error.stdout, "ready\n");
+      assert.equal(result.error.stderr, "waiting\n");
+      assert.ok(!alive(pid));
+    } finally {
+      controller.abort();
+      await settled;
+      killFixture(ready);
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("should time out a child and retain its partial output", async () => {
+    await assert.rejects(
+      runner().invoke({ args: ["hang"], timeout: 1000 }),
+      (error: unknown) => {
+        assert.ok(error instanceof CliInvocationError);
+        assert.equal(error.reason, "timeout");
+        assert.equal(error.stdout, "ready\n");
+        assert.equal(error.stderr, "waiting\n");
+        return true;
+      },
+    );
+  });
+});
+
+function runner() {
+  return createCliRunner({ entrypoint: fixture, runtimeArgs });
+}
+
+function scratch(): string {
+  const directory = fileURLToPath(new URL("../../../../tmp/", import.meta.url));
+  mkdirSync(directory, { recursive: true });
+  return mkdtempSync(resolve(directory, "cli-"));
+}
+
+async function waitReady(path: string): Promise<number> {
+  const deadline = Date.now() + 5000;
+  while (Date.now() < deadline) {
+    try {
+      const pid = Number(readFileSync(path, "utf8"));
+      if (Number.isInteger(pid) && pid > 0) return pid;
+    } catch { /* The fixture has not announced readiness yet. */ }
+    await delay(10);
+  }
+  throw new Error("CLI fixture did not become ready.");
+}
+
+function alive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ESRCH") {
+      return false;
+    }
+    throw error;
+  }
+  if (process.platform === "linux") {
+    // Deno protects /proc even with --allow-read.  Query ps through the already
+    // required --allow-run permission, and distinguish unreaped zombies from
+    // executing processes without silently swallowing permission failures.
+    try {
+      const status = execFileSync("ps", ["-o", "stat=", "-p", String(pid)], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      }).trim();
+      return status !== "" && !status.startsWith("Z");
+    } catch (error) {
+      if (error instanceof Error && "status" in error && error.status === 1) {
+        return false;
+      }
+      throw error;
+    }
+  }
+  return true;
+}
+
+function killFixture(path: string): void {
+  try {
+    process.kill(Number(readFileSync(path, "utf8")), "SIGKILL");
+  } catch { /* The runner may already have stopped the fixture. */ }
+}
+
+describe("CLI process cleanup", () => {
+  it("should drain output written while responding to cancellation", {
+    skip: process.platform === "win32",
+  }, async () => {
+    if (process.platform === "win32") return;
+    const directory = scratch();
+    const ready = resolve(directory, "ready");
+    const controller = new AbortController();
+    const settled = runner().invoke({
+      args: ["graceful", ready],
+      signal: controller.signal,
+    }).then((value) => ({ value }), (error: unknown) => ({ error }));
+    try {
+      await waitReady(ready);
+      controller.abort();
+      const result = await settled;
+      assert.ok("error" in result);
+      assert.ok(result.error instanceof CliInvocationError);
+      assert.equal(result.error.reason, "aborted");
+      assert.equal(result.error.stderr, "waiting\n" + "final\n".repeat(10_000));
+    } finally {
+      controller.abort();
+      await settled;
+      killFixture(ready);
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  for (const parent of ["hang", "exit"]) {
+    it(`should stop stubborn descendants when the parent will ${parent}`, {
+      skip: process.platform === "win32",
+    }, async () => {
+      if (process.platform === "win32") return;
+      const directory = scratch();
+      const ready = resolve(directory, "ready");
+      const controller = new AbortController();
+      const invocation = runner().invoke({
+        args: ["tree", ready, parent, resolve(directory, "parent")],
+        cleanup: "tree",
+        signal: controller.signal,
+        timeout: 8000,
+      });
+      const settled = invocation.then(
+        (value) => ({ value }),
+        (error: unknown) => ({ error }),
+      );
+      try {
+        const pid = await waitReady(ready);
+        if (parent === "exit") {
+          const parentPid = await waitReady(resolve(directory, "parent"));
+          const deadline = Date.now() + 5000;
+          while (alive(parentPid) && Date.now() < deadline) await delay(10);
+          assert.ok(
+            !alive(parentPid),
+            "The root must exit before cancellation.",
+          );
+        }
+        controller.abort();
+        const result = await settled;
+        assert.ok("error" in result);
+        assert.ok(result.error instanceof CliInvocationError);
+        assert.equal(result.error.reason, "aborted");
+        assert.equal(result.error.stdout, "ready\n");
+        // SIGKILL delivery may finish just after the direct child's streams
+        // close; allow the operating system to complete that transition.
+        const deadline = Date.now() + 1000;
+        while (alive(pid) && Date.now() < deadline) await delay(10);
+        assert.ok(!alive(pid), "The stubborn descendant must no longer run.");
+      } finally {
+        controller.abort();
+        await settled;
+        killFixture(ready);
+        rmSync(directory, { recursive: true, force: true });
+      }
+    });
+  }
+
+  it("should leave descendants alive with the default child-only cleanup", {
+    skip: process.platform === "win32",
+  }, async () => {
+    if (process.platform === "win32") return;
+    const directory = scratch();
+    const ready = resolve(directory, "ready");
+    const controller = new AbortController();
+    const settled = runner().invoke({
+      args: ["tree", ready, "hang"],
+      signal: controller.signal,
+    })
+      .then((value) => ({ value }), (error: unknown) => ({ error }));
+    try {
+      const pid = await waitReady(ready);
+      controller.abort();
+      const result = await settled;
+      assert.ok("error" in result);
+      assert.ok(result.error instanceof CliInvocationError);
+      assert.equal(result.error.reason, "aborted");
+      assert.ok(alive(pid), "Child-only cleanup must not kill a descendant.");
+    } finally {
+      controller.abort();
+      await settled;
+      killFixture(ready);
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("should stop descendants on Windows with tree cleanup", {
+    skip: process.platform !== "win32",
+  }, async () => {
+    if (process.platform !== "win32") return;
+    const directory = scratch();
+    const ready = resolve(directory, "ready");
+    const controller = new AbortController();
+    const settled = runner().invoke({
+      args: ["tree", ready, "hang"],
+      cleanup: "tree",
+      signal: controller.signal,
+    })
+      .then((value) => ({ value }), (error: unknown) => ({ error }));
+    try {
+      const pid = await waitReady(ready);
+      controller.abort();
+      const result = await settled;
+      assert.ok("error" in result);
+      assert.ok(result.error instanceof CliInvocationError);
+      assert.equal(result.error.reason, "aborted");
+      assert.ok(!alive(pid));
+    } finally {
+      controller.abort();
+      await settled;
+      killFixture(ready);
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("Optique CLI entrypoints", () => {
+  const application = new URL(
+    "./fixtures/cli/application.mjs",
+    import.meta.url,
+  );
+  it("should capture help, version, and parsing failures without exiting the test", async () => {
+    const cli = createCliRunner({ entrypoint: application, runtimeArgs });
+    const help = await cli.invoke("--help");
+    assert.equal(help.exitCode, 0);
+    assert.match(help.stdout, /fixture-app/);
+    const version = await cli.invoke("--version");
+    assert.equal(version.exitCode, 0);
+    assert.equal(version.stdout, "1.2.3\n");
+    const failure = await cli.invoke();
+    assert.notEqual(failure.exitCode, 0);
+    assert.notEqual(failure.stderr, "");
+  });
+
+  it("should capture console, print, and raw process output", async () => {
+    const result = await createCliRunner({
+      entrypoint: application,
+      runtimeArgs,
+    }).invoke("Ada");
+    assert.equal(result.exitCode, 0);
+    assert.equal(result.stdout, 'console:Ada\nprint:"Ada"\nraw\n');
+    assert.equal(result.stderr, "");
+  });
+});
+
+describe("Windows CLI failures", () => {
+  it("should override and remove environment keys without case sensitivity", {
+    skip: process.platform !== "win32",
+  }, async () => {
+    if (process.platform !== "win32") return;
+    const cli = createCliRunner({
+      entrypoint: fixture,
+      runtimeArgs,
+      env: { OPTIQUE_CLI_FIRST: "factory", OPTIQUE_CLI_SECOND: "factory" },
+    });
+    const result = await cli.invoke({
+      args: ["context"],
+      env: { optique_cli_first: "call", optique_cli_second: undefined },
+    });
+    const context = JSON.parse(result.stdout);
+    assert.equal(context.first, "call");
+    assert.equal(context.second, null);
+  });
+
+  it("should report taskkill failures without losing the original timeout", {
+    skip: process.platform !== "win32",
+  }, async () => {
+    if (process.platform !== "win32") return;
+    const directory = scratch();
+    const ready = resolve(directory, "ready");
+    try {
+      const result = await createCliRunner({
+        entrypoint: new URL(
+          "./fixtures/cli/windows-cleanup.mjs",
+          import.meta.url,
+        ),
+        runtimeArgs,
+        timeout: 10_000,
+      }).invoke(ready);
+      assert.equal(result.exitCode, 0, result.stderr);
+      assert.deepEqual(JSON.parse(result.stdout), {
+        reason: "cleanup",
+        stdout: "ready\n",
+        aggregate: true,
+      });
+    } finally {
+      killFixture(ready);
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/testing/src/cli.test.ts
+++ b/packages/testing/src/cli.test.ts
@@ -374,7 +374,7 @@ function runner() {
 }
 
 function scratch(): string {
-  const directory = fileURLToPath(new URL("../../../../tmp/", import.meta.url));
+  const directory = fileURLToPath(new URL("../../../tmp/", import.meta.url));
   mkdirSync(directory, { recursive: true });
   return mkdtempSync(resolve(directory, "cli-"));
 }

--- a/packages/testing/src/cli.ts
+++ b/packages/testing/src/cli.ts
@@ -1,16 +1,742 @@
 /**
- * Reserved for helpers that invoke a CLI entry point in a child process.
- *
- * This layer will execute the whole application, so it observes everything the
- * process writes—including output the in-process layers cannot see—plus its
- * exit code or terminating signal.  In exchange it needs a runnable entry
- * point, permission to start a process, and whatever build step that entry
- * point depends on.
- *
- * The helpers themselves are still landing; see
- * {@link https://github.com/dahlia/optique/issues/890}.
+ * Helpers that invoke real CLI entry points in child processes.
  *
  * @module
  * @since 1.3.0
  */
-export {};
+import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
+import { isAbsolute, join, resolve } from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+import type { CapturedOutput } from "./index.ts";
+import { type CliProcess, spawnCliProcess } from "./cli-process.ts";
+
+interface ProcessOptions {
+  /** Working directory, relative to the runner's original base directory. */
+  readonly cwd?: string | URL;
+  /**
+   * Environment overrides.  Undefined omits the variable from the supplied
+   * environment; the runtime or operating system may restore system variables.
+   */
+  readonly env?: Readonly<Record<string, string | undefined>>;
+  /** Milliseconds including output collection; defaults to 5000.  Zero disables. */
+  readonly timeout?: number;
+  /** Cancellation signal, replacing the runner's default when supplied. */
+  readonly signal?: AbortSignal;
+  /** Failure cleanup target; defaults to the directly launched child. */
+  readonly cleanup?: "child" | "tree";
+}
+
+/**
+ * A current-runtime entry point or an explicit executable and fixed arguments.
+ * Relative entry points are resolved once against the factory's working
+ * directory.  Runtime arguments and permissions are never inherited implicitly.
+ *
+ * @since 1.3.0
+ */
+export type CliRunnerOptions =
+  & ProcessOptions
+  & (
+    | {
+      /** File path or file URL to execute with the current runtime. */
+      readonly entrypoint: string | URL;
+      /** Runtime flags before the entry point; Deno flags follow `run`. */
+      readonly runtimeArgs?: readonly string[];
+      readonly command?: never;
+    }
+    | {
+      /** Executable followed by fixed arguments, passed without a shell. */
+      readonly command: readonly [string, ...string[]];
+      readonly entrypoint?: never;
+      readonly runtimeArgs?: never;
+    }
+  );
+
+/**
+ * Inputs and default overrides for one CLI invocation.
+ *
+ * @since 1.3.0
+ */
+export interface CliInvocationOptions extends ProcessOptions {
+  /** Arguments appended verbatim to the runner's command. */
+  readonly args?: readonly string[];
+  /** UTF-8 input.  The input pipe is closed even when this is omitted. */
+  readonly stdin?: string;
+}
+
+/**
+ * Complete captured output and the runtime's reported process status.
+ * Nonzero exit codes and external signal termination are results, not errors.
+ *
+ * @since 1.3.0
+ */
+export interface CliResult extends CapturedOutput {
+  /** Exit code, or null when the process terminated through a signal. */
+  readonly exitCode: number | null;
+  /** Terminating signal, or null; reporting depends on the OS and runtime. */
+  readonly signal: string | null;
+}
+
+/**
+ * A failure of the invocation harness, with partial output and observed status.
+ * Cleanup failures retain the original failure and cleanup errors in an
+ * `AggregateError` cause.  A status can be null when no exit was observed.
+ *
+ * @since 1.3.0
+ */
+export class CliInvocationError extends Error implements CliResult {
+  /** Whether launching, waiting, cancellation, I/O, or cleanup failed. */
+  readonly reason: "spawn" | "timeout" | "aborted" | "io" | "cleanup";
+  /** Standard output collected before the invocation finished cleaning up. */
+  readonly stdout: string;
+  /** Standard error collected before the invocation finished cleaning up. */
+  readonly stderr: string;
+  /** Observed exit code, including during cleanup, or null. */
+  readonly exitCode: number | null;
+  /** Observed terminating signal, including during cleanup, or null. */
+  readonly signal: string | null;
+
+  /**
+   * Constructs a harness failure from its captured state.
+   * @param reason The stage that failed.
+   * @param message A description of the failure.
+   * @param result Captured text and observed process status.
+   * @param options The underlying cause, if any.
+   */
+  constructor(
+    reason: CliInvocationError["reason"],
+    message: string,
+    result: CliResult,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = "CliInvocationError";
+    this.reason = reason;
+    this.stdout = result.stdout;
+    this.stderr = result.stderr;
+    this.exitCode = result.exitCode;
+    this.signal = result.signal;
+  }
+}
+
+/**
+ * A reusable runner whose invocations have independent process state.
+ *
+ * @since 1.3.0
+ */
+export interface CliRunner {
+  /**
+   * Invokes the CLI with positional arguments or explicit process inputs.
+   * @param args Arguments to append, or invocation options.
+   * @returns Exact output and process status after all output has been read.
+   * @throws {TypeError} If invocation options have an invalid shape.
+   * @throws {RangeError} If the timeout is outside its supported range.
+   * @throws {CliInvocationError} If starting, capturing, or cleaning up fails.
+   */
+  readonly invoke: {
+    (...args: readonly string[]): Promise<CliResult>;
+    (options: CliInvocationOptions): Promise<CliResult>;
+  };
+}
+
+const emptyResult: CliResult = {
+  stdout: "",
+  stderr: "",
+  exitCode: null,
+  signal: null,
+};
+
+function filePath(value: string | URL): string {
+  if (value instanceof URL) return fileURLToPath(value);
+  if (typeof value !== "string") {
+    throw new TypeError("Expected a file path or URL.");
+  }
+  return value;
+}
+
+function strings(value: readonly string[]): readonly string[] {
+  if (!Array.isArray(value) || value.some((item) => typeof item !== "string")) {
+    throw new TypeError("Expected an array of strings.");
+  }
+  return [...value];
+}
+
+function validate(options: ProcessOptions): void {
+  if (
+    options == null || typeof options !== "object" || Array.isArray(options)
+  ) {
+    throw new TypeError("Expected process options.");
+  }
+  if (
+    options.timeout !== undefined &&
+    (!Number.isInteger(options.timeout) || options.timeout < 0 ||
+      options.timeout > 2_147_483_647)
+  ) {
+    throw new RangeError(
+      "Timeout must be an integer between 0 and 2147483647.",
+    );
+  }
+  if (
+    options.cleanup !== undefined && options.cleanup !== "child" &&
+    options.cleanup !== "tree"
+  ) {
+    throw new TypeError("Cleanup must be child or tree.");
+  }
+  if (options.cwd !== undefined) filePath(options.cwd);
+  if (
+    options.env !== undefined && (options.env === null ||
+      typeof options.env !== "object" || Array.isArray(options.env) ||
+      Object.values(options.env).some((v) =>
+        v !== undefined && typeof v !== "string"
+      ))
+  ) {
+    throw new TypeError("Environment values must be strings or undefined.");
+  }
+  if (
+    options.signal !== undefined && (options.signal == null ||
+      typeof options.signal.aborted !== "boolean" ||
+      typeof options.signal.addEventListener !== "function" ||
+      typeof options.signal.removeEventListener !== "function")
+  ) {
+    throw new TypeError("Expected an AbortSignal.");
+  }
+}
+
+function environment(
+  ...layers:
+    readonly (Readonly<Record<string, string | undefined>> | undefined)[]
+): Record<string, string> {
+  const result: Record<string, string> = Object.create(null);
+  const names = new Map<string, string>();
+  for (const layer of layers) {
+    if (layer === undefined) continue;
+    for (const [name, value] of Object.entries(layer)) {
+      const key = process.platform === "win32" ? name.toUpperCase() : name;
+      const previous = names.get(key);
+      if (previous !== undefined) delete result[previous];
+      names.set(key, name);
+      if (value !== undefined) result[name] = value;
+    }
+  }
+  return result;
+}
+
+/**
+ * Creates a runner for a real CLI without building or installing its target.
+ *
+ * Output is UTF-8 text, kept separate and unmodified.  The default timeout is
+ * five seconds, including output collection; zero waits indefinitely unless
+ * aborted.  Failure cleanup targets the child by default, or its ordinary
+ * process tree when requested.  Tree cleanup uses POSIX groups or Windows
+ * taskkill and cannot contain escaped or already-orphaned descendants.  Normal
+ * completion does not sweep descendants.  Abrupt termination of the test
+ * process itself is outside this cleanup contract.
+ *
+ * Deno callers must grant the harness read, environment, and subprocess
+ * permissions.  Child permissions belong in `runtimeArgs`.  No color settings,
+ * runtime flags, or parent `execArgv` are injected.
+ *
+ * @param options An entry point or command and invocation defaults.
+ * @returns A reusable runner with isolated invocations.
+ * @throws {TypeError} If the command, paths, or options are invalid.
+ * @throws {RangeError} If the timeout is outside its supported range.
+ * @throws If reading the factory's working directory is not permitted.
+ * @since 1.3.0
+ */
+export function createCliRunner(options: CliRunnerOptions): CliRunner {
+  validate(options);
+  const hasCommand = options.command !== undefined;
+  if (
+    hasCommand === (options.entrypoint !== undefined) ||
+    (hasCommand && options.runtimeArgs !== undefined)
+  ) {
+    throw new TypeError("Specify either an entrypoint or a command.");
+  }
+  const base = resolve(
+    options.cwd === undefined ? process.cwd() : filePath(options.cwd),
+  );
+  let fixed: readonly string[] | undefined;
+  let entrypoint: string | undefined;
+  if (options.command !== undefined) {
+    fixed = strings(options.command);
+    if (fixed.length === 0 || fixed[0].length === 0) {
+      throw new TypeError("Command must contain a nonempty executable.");
+    }
+  } else {
+    entrypoint = resolve(base, filePath(options.entrypoint));
+  }
+  const runtimeArgs = strings(options.runtimeArgs ?? []);
+  const defaults = {
+    timeout: options.timeout ?? 5000,
+    signal: options.signal,
+    cleanup: options.cleanup ?? "child",
+    env: options.env === undefined ? undefined : { ...options.env },
+  };
+
+  async function invoke(...args: readonly string[]): Promise<CliResult>;
+  async function invoke(options: CliInvocationOptions): Promise<CliResult>;
+  async function invoke(
+    ...input: readonly (string | CliInvocationOptions)[]
+  ): Promise<CliResult> {
+    let call: CliInvocationOptions;
+    if (input.length === 1 && typeof input[0] === "object") {
+      call = input[0];
+    } else {
+      const args: string[] = [];
+      for (const item of input) {
+        if (typeof item !== "string") {
+          throw new TypeError("Arguments must be strings.");
+        }
+        args.push(item);
+      }
+      call = { args };
+    }
+    validate(call);
+    const args = strings(call.args ?? []);
+    if (call.stdin !== undefined && typeof call.stdin !== "string") {
+      throw new TypeError("Stdin must be a string.");
+    }
+    const signal = call.signal ?? defaults.signal;
+    if (signal?.aborted) {
+      throw new CliInvocationError(
+        "aborted",
+        "CLI invocation was aborted.",
+        emptyResult,
+        { cause: signal.reason },
+      );
+    }
+    try {
+      const command = fixed ?? [
+        process.execPath,
+        ...("Deno" in globalThis ? ["run"] : []),
+        ...runtimeArgs,
+        // The exclusive factory union guarantees an entry point here.
+        ...(entrypoint === undefined ? [] : [entrypoint]),
+      ];
+      return await runProcess(command[0], [...command.slice(1), ...args], {
+        cwd: call.cwd === undefined ? base : resolve(base, filePath(call.cwd)),
+        env: environment(process.env, defaults.env, call.env),
+        timeout: call.timeout ?? defaults.timeout,
+        cleanup: call.cleanup ?? defaults.cleanup,
+        signal,
+        stdin: call.stdin ?? "",
+      });
+    } catch (cause) {
+      if (cause instanceof CliInvocationError) throw cause;
+      throw new CliInvocationError(
+        "spawn",
+        "Could not start the CLI.",
+        emptyResult,
+        { cause },
+      );
+    }
+  }
+  return Object.freeze({ invoke });
+}
+
+interface ExecutionOptions {
+  readonly cwd: string;
+  readonly env: Record<string, string>;
+  readonly timeout: number;
+  readonly cleanup: "child" | "tree";
+  readonly signal: AbortSignal | undefined;
+  readonly stdin: string;
+}
+
+function errorCode(error: unknown): unknown {
+  return error !== null && typeof error === "object" && "code" in error
+    ? error.code
+    : undefined;
+}
+
+function runProcess(
+  command: string,
+  args: readonly string[],
+  options: ExecutionOptions,
+): Promise<CliResult> {
+  return new Promise((resolveResult, reject) => {
+    let child: CliProcess | undefined;
+    let spawned = false;
+    let exited = false;
+    let closed = false;
+    let outEnd = false;
+    let errEnd = false;
+    let outClose = false;
+    let errClose = false;
+    let inClose = false;
+    let exitCode: number | null = null;
+    let signal: string | null = null;
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    let settled = false;
+    let failure: {
+      readonly reason: CliInvocationError["reason"];
+      readonly message: string;
+      readonly cause?: unknown;
+    } | undefined;
+    const cleanupErrors: unknown[] = [];
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const waiters = new Set<() => void>();
+    const snapshot = (): CliResult => ({
+      stdout: stdout.join(""),
+      stderr: stderr.join(""),
+      exitCode,
+      signal,
+    });
+    const onAbort = () =>
+      fail("aborted", "CLI invocation was aborted.", options.signal?.reason);
+    const clearInvocation = () => {
+      clearTimeout(timer);
+      options.signal?.removeEventListener("abort", onAbort);
+    };
+    function release() {
+      clearInvocation();
+      child?.stdout.removeListener("data", onOut);
+      child?.stderr.removeListener("data", onErr);
+      // Error listeners remain until close, including after a cleanup deadline.
+      if (closed) child?.removeListener("error", onError);
+      if (outClose) child?.stdout.removeListener("error", onIoError);
+      if (errClose) child?.stderr.removeListener("error", onIoError);
+      if (inClose) child?.stdin.removeListener("error", onInputError);
+    }
+    function update() {
+      for (const wake of [...waiters]) wake();
+      if (settled) {
+        release();
+        return;
+      }
+      if (
+        !failure && exited && closed && outEnd && errEnd && outClose &&
+        errClose && inClose
+      ) {
+        settled = true;
+        release();
+        resolveResult(snapshot());
+      }
+    }
+    function waitFor(
+      predicate: () => boolean,
+      milliseconds: number,
+    ): Promise<boolean> {
+      if (predicate()) return Promise.resolve(true);
+      return new Promise((done) => {
+        const finish = (value: boolean) => {
+          clearTimeout(timeout);
+          waiters.delete(wake);
+          done(value);
+        };
+        const wake = () => {
+          if (predicate()) finish(true);
+        };
+        const timeout = setTimeout(
+          () => finish(false),
+          Math.max(0, milliseconds),
+        );
+        waiters.add(wake);
+      });
+    }
+    function fail(
+      reason: CliInvocationError["reason"],
+      message: string,
+      cause?: unknown,
+    ) {
+      if (failure || settled) return;
+      failure = { reason, message, cause };
+      clearInvocation();
+      // Let spawn finish assigning its handle before starting cleanup.
+      queueMicrotask(() => {
+        void cleanup();
+      });
+    }
+    function killChild(kind: NodeJS.Signals) {
+      if (!child?.pid || exited || closed) return;
+      try {
+        child.kill(kind);
+      } catch (error) {
+        cleanupErrors.push(error);
+      }
+    }
+    function groupSignal(kind: NodeJS.Signals | 0): boolean {
+      if (!child?.pid) return false;
+      try {
+        process.kill(-child.pid, kind);
+        return true;
+      } catch (error) {
+        if (errorCode(error) !== "ESRCH") cleanupErrors.push(error);
+        return false;
+      }
+    }
+    async function taskkill(deadline: number) {
+      let helper: ChildProcessWithoutNullStreams;
+      const root = process.env.SystemRoot ?? process.env.windir;
+      if (root === undefined || !isAbsolute(root)) {
+        cleanupErrors.push(
+          new Error("Windows system directory is unavailable."),
+        );
+        killChild("SIGKILL");
+        return;
+      }
+      try {
+        helper = spawn(join(root, "System32", "taskkill.exe"), [
+          "/PID",
+          String(child?.pid),
+          "/T",
+          "/F",
+        ], {
+          shell: false,
+          windowsHide: true,
+          stdio: "pipe",
+        });
+      } catch (error) {
+        cleanupErrors.push(error);
+        killChild("SIGKILL");
+        return;
+      }
+      let helperClosed = false;
+      let helperError: unknown;
+      let helperCode: number | null = null;
+      let diagnostic = "";
+      helper.stdout.resume();
+      helper.stderr.setEncoding("utf8");
+      helper.stderr.on("data", (text: string) => {
+        diagnostic += text;
+      });
+      helper.stdin.on("error", () => {});
+      helper.stdout.on("error", (error) => {
+        helperError = error;
+      });
+      helper.stderr.on("error", (error) => {
+        helperError = error;
+      });
+      helper.on("error", (error) => {
+        helperError = error;
+        killChild("SIGKILL");
+      });
+      helper.on("close", (code) => {
+        helperClosed = true;
+        helperCode = code;
+        update();
+      });
+      helper.stdin.end();
+      if (
+        !await waitFor(
+          () => helperClosed,
+          Math.min(1000, deadline - Date.now()),
+        )
+      ) {
+        cleanupErrors.push(new Error("Tree cleanup command timed out."));
+        try {
+          helper.kill("SIGKILL");
+        } catch (error) {
+          cleanupErrors.push(error);
+        }
+        killChild("SIGKILL");
+        helper.stdin.destroy();
+        helper.stdout.destroy();
+        helper.stderr.destroy();
+        if (!await waitFor(() => helperClosed, deadline - Date.now())) {
+          cleanupErrors.push(new Error("Tree cleanup command did not close."));
+          helper.unref();
+        }
+      } else if (helperError !== undefined || helperCode !== 0) {
+        cleanupErrors.push(
+          helperError ??
+            new Error(
+              `Tree cleanup exited with code ${helperCode}: ${diagnostic}`,
+            ),
+        );
+        killChild("SIGKILL");
+      }
+    }
+    async function cleanup() {
+      const deadline = Date.now() + 2000;
+      try {
+        if (child !== undefined) {
+          child.stdin.destroy();
+          if (child.pid !== undefined) {
+            if (process.platform === "win32") {
+              if (options.cleanup === "tree") {
+                if (exited || closed) {
+                  cleanupErrors.push(
+                    new Error(
+                      "Cannot trace a Windows process tree after its root exits.",
+                    ),
+                  );
+                } else await taskkill(deadline);
+              } else killChild("SIGKILL");
+            } else if (options.cleanup === "tree") {
+              const found = groupSignal("SIGTERM");
+              if (!found && !exited && !closed) {
+                cleanupErrors.push(
+                  new Error("The child process group is unavailable."),
+                );
+              }
+              killChild("SIGTERM");
+              if (
+                found &&
+                !await waitFor(
+                  () => (exited || closed) && !groupSignal(0),
+                  1000,
+                )
+              ) {
+                groupSignal("SIGKILL");
+              }
+              killChild("SIGKILL");
+            } else {
+              killChild("SIGTERM");
+              if (!await waitFor(() => exited || closed, 1000)) {
+                killChild("SIGKILL");
+              }
+            }
+          }
+          if (!await waitFor(() => exited || closed, deadline - Date.now())) {
+            cleanupErrors.push(
+              new Error("The CLI process did not exit during cleanup."),
+            );
+          }
+          // Exit can precede the last pipe reads.  Allow a bounded drain even
+          // when descendants still hold the descriptors, then close our ends.
+          await waitFor(() => closed, Math.min(250, deadline - Date.now()));
+          child.stdout.destroy();
+          child.stderr.destroy();
+          if (
+            !await waitFor(
+              () => closed && outClose && errClose && inClose,
+              deadline - Date.now(),
+            )
+          ) {
+            cleanupErrors.push(
+              new Error(
+                "The CLI process streams did not close during cleanup.",
+              ),
+            );
+            child.unref();
+          }
+        }
+      } catch (error) {
+        cleanupErrors.push(error);
+        killChild("SIGKILL");
+        child?.stdin.destroy();
+        child?.stdout.destroy();
+        child?.stderr.destroy();
+        child?.unref();
+      }
+      if (failure === undefined || settled) return;
+      const result = snapshot();
+      const primary = new CliInvocationError(
+        failure.reason,
+        failure.message,
+        result,
+        { cause: failure.cause },
+      );
+      settled = true;
+      release();
+      reject(
+        cleanupErrors.length === 0 ? primary : new CliInvocationError(
+          "cleanup",
+          "CLI cleanup could not be completed.",
+          result,
+          {
+            cause: new AggregateError(
+              [primary, ...cleanupErrors],
+              "CLI invocation and cleanup failed.",
+            ),
+          },
+        ),
+      );
+    }
+    function onOut(text: string) {
+      stdout.push(text);
+    }
+    function onErr(text: string) {
+      stderr.push(text);
+    }
+    function onError(error: Error) {
+      if (failure) cleanupErrors.push(error);
+      else fail(spawned ? "io" : "spawn", "Could not execute the CLI.", error);
+    }
+    function onIoError(error: Error) {
+      fail("io", "Could not capture CLI output.", error);
+    }
+    function onInputError(error: Error) {
+      // Windows Node.js reports write EOF when the child exits before reading
+      // all input; other runtimes report EPIPE or ECONNRESET for that closure.
+      const code = errorCode(error);
+      if (code !== "EPIPE" && code !== "ECONNRESET" && code !== "EOF") {
+        fail("io", "Could not write CLI input.", error);
+      }
+    }
+    function checkOutput() {
+      if (spawned && ((outClose && !outEnd) || (errClose && !errEnd))) {
+        fail("io", "CLI output closed before it could be fully read.");
+      }
+      update();
+    }
+    options.signal?.addEventListener("abort", onAbort, { once: true });
+    if (options.signal?.aborted) {
+      onAbort();
+      return;
+    }
+    if (options.timeout > 0) {
+      timer = setTimeout(
+        () => fail("timeout", "CLI invocation timed out."),
+        options.timeout,
+      );
+    }
+    try {
+      child = spawnCliProcess(command, args, {
+        cwd: options.cwd,
+        env: options.env,
+        detached: process.platform !== "win32" && options.cleanup === "tree",
+      });
+      child.on("error", onError);
+      child.on("spawn", () => {
+        spawned = true;
+        checkOutput();
+      });
+      child.on(
+        "exit",
+        (code: number | null, terminatingSignal: string | null) => {
+          exited = true;
+          exitCode = code;
+          signal = terminatingSignal;
+          update();
+        },
+      );
+      child.on("close", () => {
+        closed = true;
+        update();
+      });
+      child.stdout.setEncoding("utf8");
+      child.stderr.setEncoding("utf8");
+      child.stdout.on("data", onOut);
+      child.stderr.on("data", onErr);
+      child.stdout.on("error", onIoError);
+      child.stderr.on("error", onIoError);
+      child.stdin.on("error", onInputError);
+      child.stdout.on("end", () => {
+        outEnd = true;
+        update();
+      });
+      child.stderr.on("end", () => {
+        errEnd = true;
+        update();
+      });
+      child.stdout.on("close", () => {
+        outClose = true;
+        checkOutput();
+      });
+      child.stderr.on("close", () => {
+        errClose = true;
+        checkOutput();
+      });
+      child.stdin.on("close", () => {
+        inClose = true;
+        update();
+      });
+      child.stdin.end(options.stdin, "utf8");
+    } catch (cause) {
+      fail("spawn", "Could not start the CLI.", cause);
+    }
+  });
+}

--- a/packages/testing/src/cli.ts
+++ b/packages/testing/src/cli.ts
@@ -466,7 +466,7 @@ function runProcess(
         return false;
       }
     }
-    async function taskkill(deadline: number) {
+    async function taskkill(deadline: number, pid: number) {
       let helper: ChildProcessWithoutNullStreams;
       const root = process.env.SystemRoot ?? process.env.windir;
       if (root === undefined || !isAbsolute(root)) {
@@ -479,7 +479,7 @@ function runProcess(
       try {
         helper = spawn(join(root, "System32", "taskkill.exe"), [
           "/PID",
-          String(child?.pid),
+          String(pid),
           "/T",
           "/F",
         ], {
@@ -562,7 +562,7 @@ function runProcess(
                       "Cannot trace a Windows process tree after its root exits.",
                     ),
                   );
-                } else await taskkill(deadline);
+                } else await taskkill(deadline, child.pid);
               } else killChild("SIGKILL");
             } else if (options.cleanup === "tree") {
               const found = groupSignal("SIGTERM");

--- a/packages/testing/src/fixtures/cli/application.mjs
+++ b/packages/testing/src/fixtures/cli/application.mjs
@@ -1,0 +1,14 @@
+import { object } from "@optique/core/constructs";
+import { argument } from "@optique/core/primitives";
+import { string } from "@optique/core/valueparser";
+import { message } from "@optique/core/message";
+import { print, run } from "@optique/run";
+
+const value = run(object({ name: argument(string()) }), {
+  programName: "fixture-app",
+  help: "option",
+  version: "1.2.3",
+});
+console.log(`console:${value.name}`);
+print(message`print:${value.name}`);
+process.stdout.write("raw\n");

--- a/packages/testing/src/fixtures/cli/program.mjs
+++ b/packages/testing/src/fixtures/cli/program.mjs
@@ -1,0 +1,93 @@
+import { Buffer } from "node:buffer";
+import { writeFileSync } from "node:fs";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+// Independent watchdog bounds orphan lifetime even if a test assertion fails.
+setTimeout(() => process.exit(124), 15_000).unref();
+
+const [mode, ...args] = process.argv.slice(2);
+switch (mode) {
+  case "output": {
+    const bytes = Buffer.from("hello\r\n한글🌻\n");
+    for (const byte of bytes) process.stdout.write(Buffer.from([byte]));
+    process.stderr.write("warning\n");
+    break;
+  }
+  case "args":
+    console.log(JSON.stringify(args));
+    break;
+  case "context":
+    console.log(JSON.stringify({
+      cwd: process.cwd(),
+      first: process.env.OPTIQUE_CLI_FIRST ?? null,
+      second: process.env.OPTIQUE_CLI_SECOND ?? null,
+      inherited: process.env.PATH ?? process.env.Path ?? null,
+    }));
+    break;
+  case "stdin": {
+    for await (const chunk of process.stdin) process.stdout.write(chunk);
+    break;
+  }
+  case "duplex": {
+    process.stdout.write("o".repeat(256 * 1024));
+    process.stderr.write("e".repeat(256 * 1024));
+    let count = 0;
+    for await (const chunk of process.stdin) count += chunk.length;
+    process.stdout.write(`\n${count}`);
+    break;
+  }
+  case "early":
+    process.exit(7);
+    break;
+  case "exit":
+    process.exitCode = Number(args[0]);
+    break;
+  case "throw":
+    throw new TypeError("Fixture handler failed.");
+  case "signal":
+    process.kill(process.pid, "SIGTERM");
+    break;
+  case "graceful":
+    process.on("SIGTERM", () => {
+      const runtimeArgs = "Deno" in globalThis ? ["run", "-A"] : [];
+      const tail = spawn(process.execPath, [
+        ...runtimeArgs,
+        fileURLToPath(import.meta.url),
+        "tail",
+      ], { stdio: ["ignore", "inherit", "inherit"] });
+      tail.unref();
+      process.exit(0);
+    });
+    // Falls through to the ordinary readiness handshake.
+  case "hang":
+  case "stubborn":
+    if (mode === "stubborn") process.on("SIGTERM", () => {});
+    process.stdout.write("ready\n");
+    process.stderr.write("waiting\n");
+    if (args[0]) writeFileSync(args[0], String(process.pid));
+    setInterval(() => {}, 1000);
+    break;
+  case "tail":
+    setTimeout(() => process.stderr.write("final\n".repeat(10_000)), 20);
+    break;
+  case "tree": {
+    if (args[2]) writeFileSync(args[2], String(process.pid));
+    const runtimeArgs = "Deno" in globalThis ? ["run", "-A"] : [];
+    const child = spawn(process.execPath, [
+      ...runtimeArgs,
+      fileURLToPath(import.meta.url),
+      "stubborn",
+      args[0],
+    ], { stdio: ["ignore", "inherit", "inherit"] });
+    child.unref();
+    if (args[1] === "exit") {
+      process.exitCode = 0;
+    } else {
+      setInterval(() => {}, 1000);
+    }
+    break;
+  }
+  default:
+    throw new TypeError(`Unknown fixture mode: ${mode}`);
+}

--- a/packages/testing/src/fixtures/cli/windows-cleanup.mjs
+++ b/packages/testing/src/fixtures/cli/windows-cleanup.mjs
@@ -19,7 +19,7 @@ try {
     runtimeArgs: "Deno" in globalThis ? ["-A"] : [],
     env: { SystemRoot: systemRoot, windir },
     cleanup: "tree",
-    timeout: 1000,
+    timeout: 4000,
   }).invoke("tree", ready, "hang");
   throw new Error("Expected tree cleanup to fail.");
 } catch (error) {

--- a/packages/testing/src/fixtures/cli/windows-cleanup.mjs
+++ b/packages/testing/src/fixtures/cli/windows-cleanup.mjs
@@ -1,0 +1,36 @@
+import { CliInvocationError, createCliRunner } from "@optique/testing/cli";
+import { readFileSync } from "node:fs";
+
+const systemRoot = process.env.SystemRoot;
+const windir = process.env.windir;
+const ready = process.argv[2];
+// Isolate the broken cleanup environment from the test runner and restore the
+// actual Windows system paths in the target's environment so it can start.
+for (const key of Object.keys(process.env)) {
+  if (["systemroot", "windir"].includes(key.toLowerCase())) {
+    delete process.env[key];
+  }
+}
+process.env.SystemRoot = "Z:\\optique-missing-system-directory-894";
+process.env.windir = "Z:\\optique-missing-system-directory-894";
+try {
+  await createCliRunner({
+    entrypoint: new URL("./program.mjs", import.meta.url),
+    runtimeArgs: "Deno" in globalThis ? ["-A"] : [],
+    env: { SystemRoot: systemRoot, windir },
+    cleanup: "tree",
+    timeout: 1000,
+  }).invoke("tree", ready, "hang");
+  throw new Error("Expected tree cleanup to fail.");
+} catch (error) {
+  if (!(error instanceof CliInvocationError)) throw error;
+  console.log(JSON.stringify({
+    reason: error.reason,
+    stdout: error.stdout,
+    aggregate: error.cause instanceof AggregateError,
+  }));
+} finally {
+  try {
+    process.kill(Number(readFileSync(ready, "utf8")), "SIGKILL");
+  } catch { /* The descendant may already have exited. */ }
+}

--- a/packages/testing/src/public-api.test.ts
+++ b/packages/testing/src/public-api.test.ts
@@ -125,10 +125,13 @@ describe("public surface", () => {
   });
 
   it("should expose only the implemented helpers", async () => {
-    // The root is limited to contracts shared across layers.  The remaining
-    // layer subpaths stay reserved until their helpers land.
+    // The root is limited to contracts shared across layers; each execution
+    // boundary exposes its helpers through its own subpath.
     assert.deepEqual(Object.keys(await import("@optique/testing")), []);
-    assert.deepEqual(Object.keys(await import("@optique/testing/cli")), []);
+    assert.deepEqual(Object.keys(await import("@optique/testing/cli")).sort(), [
+      "CliInvocationError",
+      "createCliRunner",
+    ]);
     assert.deepEqual(
       Object.keys(await import("@optique/testing/discover")),
       ["captureProgramRun"],
@@ -169,7 +172,10 @@ describe("npm build output", () => {
 
     // Keep the CommonJS surface aligned with ESM.
     assert.deepEqual(Object.keys(require("@optique/testing")), []);
-    assert.deepEqual(Object.keys(require("@optique/testing/cli")), []);
+    assert.deepEqual(Object.keys(require("@optique/testing/cli")).sort(), [
+      "CliInvocationError",
+      "createCliRunner",
+    ]);
     assert.deepEqual(Object.keys(require("@optique/testing/discover")), [
       "captureProgramRun",
     ]);


### PR DESCRIPTION
In-process capture misses direct console and process-stream writes. `createCliRunner()` in *@optique/testing/cli* runs the application in a child process so tests can observe its output and exit status without patching global streams.

Invocations use the current runtime or an explicit command, passing arguments without a shell and leaving runtime permissions explicit.  Timeouts and cancellation bound execution and cleanup, with optional process-tree cleanup through POSIX groups or Windows `taskkill`.  Nonzero exits remain results; harness failures retain partial output for diagnosis.

Validated with `mise test` across Deno/Node.js/Bun and the documentation build on Linux.  Added Windows CI coverage; Windows was not tested locally.

Fixes #894. Part of #890.
