### PR TITLE
Use @optique/testing in the docs and in-repo tests

### DIFF
--- a/docs/concepts/discover.md
+++ b/docs/concepts/discover.md
@@ -407,6 +407,17 @@ preflight, see the [program-level lifecycle hooks
 recipe](../cookbook.md#program-level-lifecycle-hooks) in the cookbook.
 
 
+Testing a discovered program
+----------------------------
+
+`captureProgramRun()` from *@optique/testing/discover* runs `runProgram()` with
+its output and exit code captured, covering discovery, lifecycle hooks, and
+handler dispatch without touching process streams.  Output that a handler
+writes directly through `console.log()` or `print()` bypasses that capture, so
+assert on it with the child-process layer instead: `createCliRunner()` from
+*@optique/testing/cli*.  See [*Testing*](./testing.md) for both helpers.
+
+
 File names and extensions
 -------------------------
 

--- a/docs/concepts/runners.md
+++ b/docs/concepts/runners.md
@@ -1045,6 +1045,11 @@ try {
 }
 ~~~~
 
+Tests rarely need to assemble those handlers by hand.  The `captureRun()`
+helper from *@optique/testing/run* packages exactly this pattern, returning the
+captured output and exit code instead of writing to process streams.  See
+[*Testing*](./testing.md) for the rest of the testing helpers.
+
 
 Async parser execution
 ----------------------
@@ -1371,7 +1376,9 @@ see [*Bundling parsers with metadata*](#bundling-parsers-with-metadata).
 
 ### Use `parse()` when:
 
- -  *Testing parsers*: You need to inspect parsing results in tests
+ -  *Testing parsers*: You need to inspect parsing results in tests, which the
+    `parseArgs()` and `parseArgsSync()` helpers from *@optique/testing/parser*
+    wrap for you
  -  *Complex integration*: Parsing is part of a larger application flow
  -  *Custom error handling*: You need application-specific error recovery
  -  *Multiple attempts*: You want to try different parsers or arguments

--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -384,6 +384,9 @@ inspect for success. The mid-level `runParser()` behaves more like `run()`: it
 returns the parsed value directly, invokes `onHelp` / `onError` callbacks, or
 throws a `RunParserError` by default, rather than returning a `Result`. During
 testing you can also pass an `onExit` callback to `run()` to intercept the exit.
+*@optique/testing* provides ready-made helpers for both routes: `captureRun()`
+runs `run()` with its output and exit code captured, and `parseArgs()` runs a
+parser without any runner behavior. See [*Testing*](./concepts/testing.md).
 
 
 Other sharp edges

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -1427,6 +1427,104 @@ See the [cookbook](./cookbook.md#combining-with-interactive-prompts) for a
 complete example.
 
 
+Testing your CLI
+----------------
+
+A CLI can be tested at more than one depth, and choosing the depth is most of
+the work. Checking that `--timeout 10000` becomes the number `10000` does not
+require rendering help text or starting a process, and checking what `--help`
+prints does not require running the code that consumes the parsed value. The
+*@optique/testing* package gives each of those boundaries its own entry point,
+so the scope of a test is visible from its import: *@optique/testing/parser*
+for a parser alone, *@optique/testing/run* for what the runner writes and how
+it exits, *@optique/testing/discover* for command dispatch, and
+*@optique/testing/cli* for a real entry point in a child process.
+
+The narrowest layer runs the parser over a complete argument list and hands the
+outcome back as a value. Nothing is rendered and nothing exits, so the
+assertions are about the data your parser produces. Here is the `test` command
+from the build tool above:
+
+~~~~ typescript twoslash
+import assert from "node:assert/strict";
+import { object } from "@optique/core/constructs";
+import { optional, withDefault } from "@optique/core/modifiers";
+import { command, constant, option } from "@optique/core/primitives";
+import { integer, string } from "@optique/core/valueparser";
+import { parseArgsSync } from "@optique/testing/parser";
+
+const testCommand = command("test", object({
+  action: constant("test"),
+  watch: optional(option("-w", "--watch")),
+  coverage: optional(option("--coverage")),
+  pattern: optional(option("--pattern", string())),
+  timeout: withDefault(option("--timeout", integer({ min: 1 })), 5000)
+}));
+
+const result = parseArgsSync(testCommand, [
+  "test",
+  "--coverage",
+  "--timeout",
+  "10000",
+]);
+
+if (result.success) {
+  assert.equal(result.value.timeout, 10000);
+  assert.ok(result.value.coverage);
+} else {
+  assert.fail(`Unexpected failure: ${result.remainingArgs.join(" ")}`);
+}
+~~~~
+
+Use `parseArgsSync()` for synchronous parsers and `parseArgs()` when a parser
+may be asynchronous. Both return failures as values instead of throwing, so a
+test can assert on the error the same way it asserts on a success.
+
+Once help text is what you care about, move one layer out. `captureRun()` runs
+what `run()` runs, but writes into strings and records the exit code instead of
+touching process streams:
+
+~~~~ typescript twoslash
+import { object } from "@optique/core/constructs";
+import { optional, withDefault } from "@optique/core/modifiers";
+import { command, constant, option } from "@optique/core/primitives";
+import { integer, string } from "@optique/core/valueparser";
+
+const testCommand = command("test", object({
+  action: constant("test"),
+  watch: optional(option("-w", "--watch")),
+  coverage: optional(option("--coverage")),
+  pattern: optional(option("--pattern", string())),
+  timeout: withDefault(option("--timeout", integer({ min: 1 })), 5000)
+}));
+// ---cut-before---
+import assert from "node:assert/strict";
+import { captureRun } from "@optique/testing/run";
+
+const result = await captureRun(testCommand, {
+  args: ["test", "--help"],
+  programName: "build-tool",
+  help: "option",
+  colors: false,
+  maxWidth: 80,
+});
+
+assert.equal(result.kind, "exited");
+assert.match(result.stdout, /--coverage/);
+assert.equal(result.stderr, "");
+~~~~
+
+Setting `colors` and `maxWidth` explicitly matters here. Without them the
+runner keeps its usual defaults, which depend on the terminal the test happens
+to run in, and the rendered text differs between your machine and CI.
+
+Command dispatch and full process behavior have their own layers, which the
+[testing guide](./concepts/testing.md) covers along with the one rule that
+catches people out: output written directly through `console.log()` or
+`print()` bypasses the in-process captures, so asserting on it needs a child
+process.
+
+
 Next steps
 ----------
 

--- a/examples/gitique/package.json
+++ b/examples/gitique/package.json
@@ -26,6 +26,7 @@
     "es-git": "^0.4.0"
   },
   "devDependencies": {
+    "@optique/testing": "workspace:",
     "@types/node": "catalog:",
     "tsdown": "catalog:",
     "typescript": "catalog:"

--- a/examples/gitique/src/index.test.ts
+++ b/examples/gitique/src/index.test.ts
@@ -1,56 +1,44 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { runParser } from "@optique/core/facade";
+import { type CapturedRunResult, captureRun } from "@optique/testing/run";
 import { program } from "./index.ts";
 
 function parseGitique(args: readonly string[]): unknown {
   return runParser(program, args);
 }
 
-interface CliRunResult {
-  readonly exitCode: number;
-  readonly stdout: string;
-  readonly stderr: string;
-}
-
-function runGitique(args: readonly string[]): CliRunResult {
-  const stdout: string[] = [];
-  const stderr: string[] = [];
-  const result = runParser(program, args, {
+function runGitique(
+  args: readonly string[],
+): Promise<CapturedRunResult<unknown>> {
+  return captureRun(program, {
+    args,
     help: {
       command: { group: "Meta commands" },
       option: { group: "Meta commands" },
-      onShow: (code) => code,
     },
     version: {
       value: program.metadata.version!,
       command: { group: "Meta commands" },
       option: { group: "Meta commands" },
-      onShow: (code) => code,
     },
     completion: {
       command: { group: "Meta commands" },
       option: { group: "Meta commands" },
-      onShow: (code) => code,
     },
     aboveError: "usage",
     showDefault: true,
     showChoices: true,
-    stdout: (line) => stdout.push(line),
-    stderr: (line) => stderr.push(line),
-    onError: (code) => code,
+    // Pin the rendering so assertions do not depend on the terminal that
+    // happens to run the tests.
+    colors: false,
+    maxWidth: 200,
   });
-
-  return {
-    exitCode: typeof result === "number" ? result : 0,
-    stdout: stdout.join("\n"),
-    stderr: stderr.join("\n"),
-  };
 }
 
 describe("gitique CLI", () => {
-  it("shows grouped top-level help", () => {
-    const result = runGitique(["--help"]);
+  it("shows grouped top-level help", async () => {
+    const result = await runGitique(["--help"]);
 
     assert.equal(result.exitCode, 0);
     assert.match(result.stdout, /Meta commands:/);
@@ -62,8 +50,8 @@ describe("gitique CLI", () => {
     assert.equal(result.stderr, "");
   });
 
-  it("reports invalid author input at parse time", () => {
-    const result = runGitique([
+  it("reports invalid author input at parse time", async () => {
+    const result = await runGitique([
       "commit",
       "--allow-empty",
       "--author",
@@ -79,15 +67,15 @@ describe("gitique CLI", () => {
     );
   });
 
-  it("shows AUTHOR metavar when --author is missing a value", () => {
-    const result = runGitique(["commit", "--author"]);
+  it("shows AUTHOR metavar when --author is missing a value", async () => {
+    const result = await runGitique(["commit", "--author"]);
 
     assert.equal(result.exitCode, 1);
     assert.match(result.stderr, /Error: `--author` requires `AUTHOR`\./);
   });
 
-  it("rejects impossible ISO dates before execution", () => {
-    const result = runGitique(["log", "--since", "2024-02-31"]);
+  it("rejects impossible ISO dates before execution", async () => {
+    const result = await runGitique(["log", "--since", "2024-02-31"]);
 
     assert.equal(result.exitCode, 1);
     assert.match(
@@ -96,8 +84,8 @@ describe("gitique CLI", () => {
     );
   });
 
-  it("uses custom choice errors for status format", () => {
-    const result = runGitique(["status", "--format", "weird"]);
+  it("uses custom choice errors for status format", async () => {
+    const result = await runGitique(["status", "--format", "weird"]);
 
     assert.equal(result.exitCode, 1);
     assert.match(
@@ -155,8 +143,8 @@ describe("gitique CLI", () => {
     });
   });
 
-  it("rejects blank commit messages", () => {
-    const result = runGitique(["commit", "-m", "   "]);
+  it("rejects blank commit messages", async () => {
+    const result = await runGitique(["commit", "-m", "   "]);
 
     assert.equal(result.exitCode, 1);
     assert.match(
@@ -199,8 +187,8 @@ describe("gitique CLI", () => {
     );
   });
 
-  it("rejects too many diff commit references", () => {
-    const result = runGitique(["diff", "HEAD~2", "HEAD~1", "HEAD"]);
+  it("rejects too many diff commit references", async () => {
+    const result = await runGitique(["diff", "HEAD~2", "HEAD~1", "HEAD"]);
 
     assert.equal(result.exitCode, 1);
     assert.match(
@@ -256,8 +244,8 @@ describe("gitique CLI", () => {
     );
   });
 
-  it("rejects malformed log dates", () => {
-    const result = runGitique(["log", "--until", "yesterday"]);
+  it("rejects malformed log dates", async () => {
+    const result = await runGitique(["log", "--until", "yesterday"]);
 
     assert.equal(result.exitCode, 1);
     assert.match(
@@ -325,8 +313,8 @@ describe("gitique CLI", () => {
     );
   });
 
-  it("rejects invalid reset mode choices", () => {
-    const result = runGitique(["reset", "--mode", "keep"]);
+  it("rejects invalid reset mode choices", async () => {
+    const result = await runGitique(["reset", "--mode", "keep"]);
 
     assert.equal(result.exitCode, 1);
     assert.match(

--- a/packages/discover/package.json
+++ b/packages/discover/package.json
@@ -87,6 +87,7 @@
     "@optique/run": "workspace:*"
   },
   "devDependencies": {
+    "@optique/testing": "workspace:*",
     "@types/node": "catalog:",
     "tsdown": "catalog:",
     "typescript": "catalog:"

--- a/packages/discover/src/cli.test.ts
+++ b/packages/discover/src/cli.test.ts
@@ -1,82 +1,55 @@
 import assert from "node:assert/strict";
-import { type ChildProcess, spawn, spawnSync } from "node:child_process";
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, it } from "node:test";
+import { createCliRunner } from "@optique/testing/cli";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const cliPathTs = join(__dirname, "cli.ts");
 const cliPathJs = join(__dirname, "..", "dist", "cli.js");
 
-interface RunResult {
-  readonly stdout: string;
-  readonly stderr: string;
-  readonly exitCode: number;
-}
-
-function isSubprocessReliable(): boolean {
+async function isSubprocessReliable(): Promise<boolean> {
   try {
-    const probe = spawnSync(
-      process.execPath,
-      ["-e", "process.stdout.write('ok')"],
-      {
-        encoding: "utf8",
-        timeout: 5000,
-      },
-    );
-    return probe.status === 0 && probe.stdout === "ok";
+    const probe = await createCliRunner({
+      command: [process.execPath, "-e", "process.stdout.write('ok')"],
+      cwd: __dirname,
+    }).invoke();
+    return probe.exitCode === 0 && probe.stdout === "ok";
   } catch {
     return false;
   }
 }
 
-const hasReliableSubprocess = isSubprocessReliable();
+const hasReliableSubprocess = await isSubprocessReliable();
 
-function runCli(args: readonly string[]): Promise<RunResult> {
-  return new Promise((resolve) => {
-    let child: ChildProcess;
-
-    if ("Deno" in globalThis) {
-      child = spawn("deno", [
-        "run",
-        "--allow-read",
-        "--allow-write",
-        "--allow-env",
-        cliPathTs,
-        ...args,
-      ], { cwd: __dirname });
-    } else if ("Bun" in globalThis) {
-      child = spawn("bun", [cliPathJs, ...args], { cwd: __dirname });
-    } else {
-      child = spawn("node", ["--no-warnings", cliPathJs, ...args], {
-        cwd: __dirname,
-      });
+// Deno runs the TypeScript source with explicit permissions, while Node.js and
+// Bun run the built JavaScript entry point.  The generous timeout leaves room
+// for a cold module cache.
+const cli = createCliRunner(
+  "Deno" in globalThis
+    ? {
+      entrypoint: cliPathTs,
+      runtimeArgs: ["--allow-read", "--allow-write", "--allow-env"],
+      cwd: __dirname,
+      timeout: 60_000,
     }
-
-    let stdout = "";
-    let stderr = "";
-    child.stdout?.on("data", (data) => {
-      stdout += data.toString();
-    });
-    child.stderr?.on("data", (data) => {
-      stderr += data.toString();
-    });
-    child.on("close", (code) => {
-      resolve({ stdout, stderr, exitCode: code ?? 0 });
-    });
-    child.on("error", (error) => {
-      resolve({ stdout, stderr: String(error), exitCode: 1 });
-    });
-  });
-}
+    : "Bun" in globalThis
+    ? { entrypoint: cliPathJs, cwd: __dirname, timeout: 60_000 }
+    : {
+      entrypoint: cliPathJs,
+      runtimeArgs: ["--no-warnings"],
+      cwd: __dirname,
+      timeout: 60_000,
+    },
+);
 
 describe("optique-discover CLI", { skip: !hasReliableSubprocess }, () => {
   it("should show help", async () => {
     if (!hasReliableSubprocess) return;
 
-    const result = await runCli(["--help"]);
+    const result = await cli.invoke("--help");
 
     assert.equal(result.exitCode, 0);
     assert.ok(result.stdout.includes("optique-discover"));
@@ -97,13 +70,13 @@ describe("optique-discover CLI", { skip: !hasReliableSubprocess }, () => {
       await writeText(join(commandsDir, "build.ts"), "");
       await writeText(join(commandsDir, "user", "add.ts"), "");
 
-      const result = await runCli([
+      const result = await cli.invoke(
         commandsDir,
         "--output",
         outputFile,
         "--extension",
         ".ts",
-      ]);
+      );
 
       assert.equal(result.exitCode, 0, result.stderr);
       assert.equal(result.stderr, "");
@@ -134,11 +107,7 @@ describe("optique-discover CLI", { skip: !hasReliableSubprocess }, () => {
       const commandsDir = join(dir, "commands");
       await writeText(join(commandsDir, "build.ts"), "");
 
-      const result = await runCli([
-        commandsDir,
-        "--extension",
-        ".ts",
-      ]);
+      const result = await cli.invoke(commandsDir, "--extension", ".ts");
 
       assert.equal(result.exitCode, 1);
       assert.equal(result.stdout, "");

--- a/packages/man/package.json
+++ b/packages/man/package.json
@@ -94,6 +94,7 @@
     "@optique/run": "workspace:"
   },
   "devDependencies": {
+    "@optique/testing": "workspace:",
     "@types/node": "catalog:",
     "tsdown": "catalog:",
     "tsx": "catalog:",

--- a/packages/man/src/cli.test.ts
+++ b/packages/man/src/cli.test.ts
@@ -18,11 +18,15 @@ const cliPathTs = join(__dirname, "cli.ts");
 const cliPathJs = join(__dirname, "..", "dist", "cli.js");
 
 async function isSubprocessReliable(): Promise<boolean> {
-  const probe = await createCliRunner({
-    command: [process.execPath, "-e", "process.stdout.write('ok')"],
-    cwd: __dirname,
-  }).invoke();
-  return probe.exitCode === 0 && probe.stdout === "ok";
+  try {
+    const probe = await createCliRunner({
+      command: [process.execPath, "-e", "process.stdout.write('ok')"],
+      cwd: __dirname,
+    }).invoke();
+    return probe.exitCode === 0 && probe.stdout === "ok";
+  } catch {
+    return false;
+  }
 }
 
 const hasReliableSubprocess = await isSubprocessReliable();

--- a/packages/man/src/cli.test.ts
+++ b/packages/man/src/cli.test.ts
@@ -3,12 +3,12 @@
  */
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { type ChildProcess, spawn, spawnSync } from "node:child_process";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import process from "node:process";
+import { createCliRunner } from "@optique/testing/cli";
 import { formatDateForMan } from "#src/man.ts";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -17,78 +17,47 @@ const fixturesDir = join(__dirname, "..", "test", "fixtures");
 const cliPathTs = join(__dirname, "cli.ts");
 const cliPathJs = join(__dirname, "..", "dist", "cli.js");
 
-interface RunResult {
-  readonly stdout: string;
-  readonly stderr: string;
-  readonly exitCode: number;
+async function isSubprocessReliable(): Promise<boolean> {
+  const probe = await createCliRunner({
+    command: [process.execPath, "-e", "process.stdout.write('ok')"],
+    cwd: __dirname,
+  }).invoke();
+  return probe.exitCode === 0 && probe.stdout === "ok";
 }
 
-function isSubprocessReliable(): boolean {
-  const probe = spawnSync(
-    process.execPath,
-    ["-e", "process.stdout.write('ok')"],
-    {
-      encoding: "utf8",
-      timeout: 5000,
-    },
-  );
-  return probe.status === 0 && probe.stdout === "ok";
-}
+const hasReliableSubprocess = await isSubprocessReliable();
 
-const hasReliableSubprocess = isSubprocessReliable();
-
-/**
- * Runs the CLI with the given arguments and returns the result.
- */
-function runCli(args: readonly string[]): Promise<RunResult> {
-  return new Promise((resolve) => {
-    // Determine which runtime to use
-    let child: ChildProcess;
-
-    if ("Deno" in globalThis) {
-      // Deno: use TypeScript source directly
-      child = spawn("deno", [
-        "run",
+// Deno runs the TypeScript source with explicit permissions, while Node.js and
+// Bun run the built JavaScript entry point.  Bun still loads the TypeScript
+// fixtures by itself.  The generous timeout leaves room for a cold module
+// cache and for the on-the-fly fixture transpilation the CLI performs.
+const cli = createCliRunner(
+  "Deno" in globalThis
+    ? {
+      entrypoint: cliPathTs,
+      runtimeArgs: [
         "--allow-read",
         "--allow-write",
         "--allow-env",
         "--allow-sys",
-        cliPathTs,
-        ...args,
-      ], { cwd: __dirname });
-    } else if ("Bun" in globalThis) {
-      // Bun: use built JS file (fixtures are still TS, Bun handles them)
-      child = spawn("bun", [cliPathJs, ...args], { cwd: __dirname });
-    } else {
-      // Node.js: use built JS file
-      child = spawn("node", [
-        "--no-warnings",
-        cliPathJs,
-        ...args,
-      ], { cwd: __dirname });
+      ],
+      cwd: __dirname,
+      timeout: 60_000,
     }
-
-    let stdout = "";
-    let stderr = "";
-
-    child.stdout?.on("data", (data) => {
-      stdout += data.toString();
-    });
-
-    child.stderr?.on("data", (data) => {
-      stderr += data.toString();
-    });
-
-    child.on("close", (code) => {
-      resolve({ stdout, stderr, exitCode: code ?? 0 });
-    });
-  });
-}
+    : "Bun" in globalThis
+    ? { entrypoint: cliPathJs, cwd: __dirname, timeout: 60_000 }
+    : {
+      entrypoint: cliPathJs,
+      runtimeArgs: ["--no-warnings"],
+      cwd: __dirname,
+      timeout: 60_000,
+    },
+);
 
 describe("optique-man CLI", { skip: !hasReliableSubprocess }, () => {
   describe("help and version", () => {
     it("shows help with --help", async () => {
-      const result = await runCli(["--help"]);
+      const result = await cli.invoke("--help");
 
       assert.equal(result.exitCode, 0);
       assert.ok(result.stdout.includes("optique-man"));
@@ -97,7 +66,7 @@ describe("optique-man CLI", { skip: !hasReliableSubprocess }, () => {
     });
 
     it("shows version with --version", async () => {
-      const result = await runCli(["--version"]);
+      const result = await cli.invoke("--version");
 
       assert.equal(result.exitCode, 0);
       assert.ok(/\d+\.\d+\.\d+/.test(result.stdout));
@@ -107,7 +76,7 @@ describe("optique-man CLI", { skip: !hasReliableSubprocess }, () => {
   describe("man page generation", () => {
     it("generates man page from Program export", async () => {
       const programFile = join(fixturesDir, "program.ts");
-      const result = await runCli([programFile, "-s", "1"]);
+      const result = await cli.invoke(programFile, "-s", "1");
 
       assert.equal(result.exitCode, 0);
       assert.ok(result.stdout.includes('.TH "GREET" 1'));
@@ -118,13 +87,13 @@ describe("optique-man CLI", { skip: !hasReliableSubprocess }, () => {
 
     it("generates man page from Parser export", async () => {
       const parserFile = join(fixturesDir, "parser.ts");
-      const result = await runCli([
+      const result = await cli.invoke(
         parserFile,
         "-s",
         "1",
         "--name",
         "myparser",
-      ]);
+      );
 
       assert.equal(result.exitCode, 0);
       assert.ok(result.stdout.includes('.TH "MYPARSER" 1'));
@@ -133,7 +102,7 @@ describe("optique-man CLI", { skip: !hasReliableSubprocess }, () => {
 
     it("generates man page from .tsx input", async () => {
       const tsxFile = join(fixturesDir, "program.tsx");
-      const result = await runCli([tsxFile, "-s", "1"]);
+      const result = await cli.invoke(tsxFile, "-s", "1");
 
       assert.equal(result.exitCode, 0);
       assert.ok(result.stdout.includes('.TH "GREET" 1'));
@@ -142,7 +111,7 @@ describe("optique-man CLI", { skip: !hasReliableSubprocess }, () => {
 
     it("generates man page from .jsx input", async () => {
       const jsxFile = join(fixturesDir, "program.jsx");
-      const result = await runCli([jsxFile, "-s", "1"]);
+      const result = await cli.invoke(jsxFile, "-s", "1");
 
       assert.equal(result.exitCode, 0);
       assert.ok(result.stdout.includes('.TH "GREET" 1'));
@@ -151,7 +120,7 @@ describe("optique-man CLI", { skip: !hasReliableSubprocess }, () => {
 
     it("generates man page from .ts entry that imports .tsx", async () => {
       const tsFile = join(fixturesDir, "imports-tsx.ts");
-      const result = await runCli([tsFile, "-s", "1"]);
+      const result = await cli.invoke(tsFile, "-s", "1");
 
       assert.equal(result.exitCode, 0);
       assert.ok(result.stdout.includes('.TH "GREET" 1'));
@@ -168,13 +137,13 @@ describe("optique-man CLI", { skip: !hasReliableSubprocess }, () => {
       try {
         await writeFile(parserFile, await readFile(sourceFile, "utf-8"));
 
-        const result = await runCli([
+        const result = await cli.invoke(
           parserFile,
           "-s",
           "1",
           "--name",
           "hashparser",
-        ]);
+        );
 
         assert.equal(result.exitCode, 0);
         assert.ok(result.stdout.includes('.TH "HASHPARSER" 1'));
@@ -193,11 +162,11 @@ describe("optique-man CLI", { skip: !hasReliableSubprocess }, () => {
       try {
         await writeFile(parserFile, await readFile(sourceFile, "utf-8"));
 
-        const result = await runCli([
+        const result = await cli.invoke(
           parserFile,
           "-s",
           "1",
-        ]);
+        );
 
         assert.equal(result.exitCode, 0);
         assert.ok(result.stdout.includes('.TH "MYAPP" 1'));
@@ -208,7 +177,7 @@ describe("optique-man CLI", { skip: !hasReliableSubprocess }, () => {
 
     it("generates man page from named export", async () => {
       const namedFile = join(fixturesDir, "named-export.ts");
-      const result = await runCli([namedFile, "-s", "1", "-e", "myProgram"]);
+      const result = await cli.invoke(namedFile, "-s", "1", "-e", "myProgram");
 
       assert.equal(result.exitCode, 0);
       assert.ok(result.stdout.includes('.TH "NAMED\\-APP" 1'));
@@ -221,13 +190,13 @@ describe("optique-man CLI", { skip: !hasReliableSubprocess }, () => {
       const outputFile = join(tempDir, "greet.1");
 
       try {
-        const result = await runCli([
+        const result = await cli.invoke(
           programFile,
           "-s",
           "1",
           "-o",
           outputFile,
-        ]);
+        );
 
         assert.equal(result.exitCode, 0);
 
@@ -241,11 +210,11 @@ describe("optique-man CLI", { skip: !hasReliableSubprocess }, () => {
     it("defaults --date to the current date", async () => {
       const programFile = join(fixturesDir, "program.ts");
       const before = new Date();
-      const result = await runCli([
+      const result = await cli.invoke(
         programFile,
         "-s",
         "1",
-      ]);
+      );
       const after = new Date();
 
       assert.equal(result.exitCode, 0);
@@ -272,13 +241,13 @@ describe("optique-man CLI", { skip: !hasReliableSubprocess }, () => {
     it("defaults --date to the current date for Parser export", async () => {
       const parserFile = join(fixturesDir, "parser.ts");
       const before = new Date();
-      const result = await runCli([
+      const result = await cli.invoke(
         parserFile,
         "-s",
         "1",
         "--name",
         "myapp",
-      ]);
+      );
       const after = new Date();
 
       assert.equal(result.exitCode, 0);
@@ -302,13 +271,13 @@ describe("optique-man CLI", { skip: !hasReliableSubprocess }, () => {
 
     it("accepts --date option", async () => {
       const programFile = join(fixturesDir, "program.ts");
-      const result = await runCli([
+      const result = await cli.invoke(
         programFile,
         "-s",
         "1",
         "--date",
         "January 2026",
-      ]);
+      );
 
       assert.equal(result.exitCode, 0);
       assert.ok(result.stdout.includes('"January 2026"'));
@@ -316,7 +285,7 @@ describe("optique-man CLI", { skip: !hasReliableSubprocess }, () => {
 
     it("accepts --version-string option", async () => {
       const parserFile = join(fixturesDir, "parser.ts");
-      const result = await runCli([
+      const result = await cli.invoke(
         parserFile,
         "-s",
         "1",
@@ -324,7 +293,7 @@ describe("optique-man CLI", { skip: !hasReliableSubprocess }, () => {
         "myapp",
         "--version-string",
         "2.0.0-beta",
-      ]);
+      );
 
       assert.equal(result.exitCode, 0);
       assert.ok(result.stdout.includes('"myapp 2.0.0-beta"'));
@@ -332,13 +301,13 @@ describe("optique-man CLI", { skip: !hasReliableSubprocess }, () => {
 
     it("accepts --manual option", async () => {
       const programFile = join(fixturesDir, "program.ts");
-      const result = await runCli([
+      const result = await cli.invoke(
         programFile,
         "-s",
         "1",
         "--manual",
         "User Commands",
-      ]);
+      );
 
       assert.equal(result.exitCode, 0);
       assert.ok(result.stdout.includes('"User Commands"'));
@@ -347,7 +316,7 @@ describe("optique-man CLI", { skip: !hasReliableSubprocess }, () => {
 
   describe("error handling", () => {
     it("fails with exit code 1 for non-existent file", async () => {
-      const result = await runCli(["nonexistent.ts", "-s", "1"]);
+      const result = await cli.invoke("nonexistent.ts", "-s", "1");
 
       assert.equal(result.exitCode, 1);
       assert.ok(result.stderr.includes("not found"));
@@ -355,7 +324,13 @@ describe("optique-man CLI", { skip: !hasReliableSubprocess }, () => {
 
     it("fails with exit code 2 for missing export", async () => {
       const namedFile = join(fixturesDir, "named-export.ts");
-      const result = await runCli([namedFile, "-s", "1", "-e", "nonexistent"]);
+      const result = await cli.invoke(
+        namedFile,
+        "-s",
+        "1",
+        "-e",
+        "nonexistent",
+      );
 
       assert.equal(result.exitCode, 2);
       assert.ok(result.stderr.includes("No"));
@@ -368,7 +343,7 @@ describe("optique-man CLI", { skip: !hasReliableSubprocess }, () => {
 
     it("fails with exit code 2 for missing default export", async () => {
       const noDefaultFile = join(fixturesDir, "no-default.ts");
-      const result = await runCli([noDefaultFile, "-s", "1"]);
+      const result = await cli.invoke(noDefaultFile, "-s", "1");
 
       assert.equal(result.exitCode, 2);
       assert.ok(result.stderr.includes("default export"));
@@ -376,7 +351,7 @@ describe("optique-man CLI", { skip: !hasReliableSubprocess }, () => {
 
     it("fails with exit code 3 for invalid export type", async () => {
       const invalidFile = join(fixturesDir, "invalid-export.ts");
-      const result = await runCli([invalidFile, "-s", "1"]);
+      const result = await cli.invoke(invalidFile, "-s", "1");
 
       assert.equal(result.exitCode, 3);
       assert.ok(result.stderr.includes("not a Program or Parser"));
@@ -384,7 +359,7 @@ describe("optique-man CLI", { skip: !hasReliableSubprocess }, () => {
 
     it("fails with exit code 3 for malformed parser-like export", async () => {
       const malformedFile = join(fixturesDir, "malformed-parser.ts");
-      const result = await runCli([malformedFile, "-s", "1"]);
+      const result = await cli.invoke(malformedFile, "-s", "1");
 
       assert.equal(result.exitCode, 3);
       assert.ok(result.stderr.includes("not a Program or Parser"));
@@ -392,7 +367,7 @@ describe("optique-man CLI", { skip: !hasReliableSubprocess }, () => {
 
     it("fails with exit code 3 for malformed program with bad parser", async () => {
       const malformedFile = join(fixturesDir, "malformed-program.ts");
-      const result = await runCli([malformedFile, "-s", "1"]);
+      const result = await cli.invoke(malformedFile, "-s", "1");
 
       assert.equal(result.exitCode, 3);
       assert.ok(result.stderr.includes("not a Program or Parser"));
@@ -403,7 +378,7 @@ describe("optique-man CLI", { skip: !hasReliableSubprocess }, () => {
         fixturesDir,
         "malformed-program-metadata.ts",
       );
-      const result = await runCli([malformedFile, "-s", "1"]);
+      const result = await cli.invoke(malformedFile, "-s", "1");
 
       assert.equal(result.exitCode, 3);
       assert.ok(result.stderr.includes("not a Program or Parser"));
@@ -414,7 +389,7 @@ describe("optique-man CLI", { skip: !hasReliableSubprocess }, () => {
         fixturesDir,
         "throwing-getter-parser.ts",
       );
-      const result = await runCli([malformedFile, "-s", "1"]);
+      const result = await cli.invoke(malformedFile, "-s", "1");
 
       assert.equal(result.exitCode, 3);
       assert.ok(result.stderr.includes("not a Program or Parser"));
@@ -425,7 +400,7 @@ describe("optique-man CLI", { skip: !hasReliableSubprocess }, () => {
         fixturesDir,
         "throwing-getter-program.ts",
       );
-      const result = await runCli([malformedFile, "-s", "1"]);
+      const result = await cli.invoke(malformedFile, "-s", "1");
 
       assert.equal(result.exitCode, 3);
       assert.ok(result.stderr.includes("not a Program or Parser"));
@@ -433,7 +408,7 @@ describe("optique-man CLI", { skip: !hasReliableSubprocess }, () => {
 
     it("rejects empty --name", async () => {
       const programFile = join(fixturesDir, "program.ts");
-      const result = await runCli([programFile, "-s", "1", "--name", ""]);
+      const result = await cli.invoke(programFile, "-s", "1", "--name", "");
 
       assert.notEqual(result.exitCode, 0);
       assert.ok(result.stderr.includes("Program name must not be empty"));
@@ -441,7 +416,7 @@ describe("optique-man CLI", { skip: !hasReliableSubprocess }, () => {
 
     it("rejects empty --date", async () => {
       const programFile = join(fixturesDir, "program.ts");
-      const result = await runCli([programFile, "-s", "1", "--date", ""]);
+      const result = await cli.invoke(programFile, "-s", "1", "--date", "");
 
       assert.notEqual(result.exitCode, 0);
       assert.ok(result.stderr.includes("Date must not be empty"));
@@ -449,13 +424,13 @@ describe("optique-man CLI", { skip: !hasReliableSubprocess }, () => {
 
     it("rejects empty --version-string", async () => {
       const programFile = join(fixturesDir, "program.ts");
-      const result = await runCli([
+      const result = await cli.invoke(
         programFile,
         "-s",
         "1",
         "--version-string",
         "",
-      ]);
+      );
 
       assert.notEqual(result.exitCode, 0);
       assert.ok(
@@ -465,7 +440,7 @@ describe("optique-man CLI", { skip: !hasReliableSubprocess }, () => {
 
     it("rejects empty --manual", async () => {
       const programFile = join(fixturesDir, "program.ts");
-      const result = await runCli([programFile, "-s", "1", "--manual", ""]);
+      const result = await cli.invoke(programFile, "-s", "1", "--manual", "");
 
       assert.notEqual(result.exitCode, 0);
       assert.ok(result.stderr.includes("Manual name must not be empty"));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -421,6 +421,9 @@ importers:
         specifier: 'workspace:'
         version: link:../run
     devDependencies:
+      '@optique/testing':
+        specifier: 'workspace:'
+        version: link:../testing
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -299,6 +299,9 @@ importers:
         specifier: workspace:*
         version: link:../run
     devDependencies:
+      '@optique/testing':
+        specifier: workspace:*
+        version: link:../testing
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,6 +175,9 @@ importers:
         specifier: ^0.4.0
         version: 0.4.0
     devDependencies:
+      '@optique/testing':
+        specifier: 'workspace:'
+        version: link:../../packages/testing
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.4


### PR DESCRIPTION
The package shipped under #890, but the guides and Optique's own tests still use the manual workarounds it replaces.

The runner and pitfalls guides keep their `onExit` examples and add a pointer to `captureRun()`, so readers who arrive through those pages still reach the helpers. The discovery guide, which said nothing about testing, gains a short section on `captureProgramRun()`. The tutorial introduces testing once the CLI is complete, reusing its own `test` command parser instead of a fresh example.

The CLI tests for *@optique/discover* and *@optique/man* now use `createCliRunner()` to remove the subprocess duplication cited in #894, keeping their per-runtime executables, flags, and skip conditions. The gitique example's hand-rolled capture becomes `captureRun()`, with `colors` and `maxWidth` pinned to keep the output independent of the terminal. Its assertions on parsed values keep `runParser()` to avoid branching on a captured result. pnpm supports the resulting devDependency cycle with *@optique/discover*, as it already does between *@optique/config* and *@optique/env*.

Documentation and tests only, so no changelog entry. Verified with `mise test` on Deno/Node.js/Bun and the documentation build.

Closes #890.
