### PR TITLE
Expose structured errors to runner callbacks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,11 @@ To be released.
 
 ### @optique/core
 
+ -  Added a structured `Message` argument to core runner `onError` callbacks,
+    allowing applications to handle errors without parsing rendered stderr.
+    Existing zero-argument and one-argument handlers remain compatible.
+    Wrappers that invoke `onError` must now pass the message after the exit
+    code.  [[#897], [#949]]
  -  Added `parseDetailed()` to preserve remaining arguments and the matched
     command path on structured parse failures.  [[#890], [#892], [#943]]
  -  Added `regExp()` for compiling command-line values into `RegExp` objects
@@ -62,6 +67,7 @@ To be released.
 [#879]: https://github.com/dahlia/optique/issues/879
 [#890]: https://github.com/dahlia/optique/issues/890
 [#892]: https://github.com/dahlia/optique/issues/892
+[#897]: https://github.com/dahlia/optique/issues/897
 [#904]: https://github.com/dahlia/optique/issues/904
 [#906]: https://github.com/dahlia/optique/issues/906
 [#909]: https://github.com/dahlia/optique/pull/909
@@ -81,6 +87,7 @@ To be released.
 [#931]: https://github.com/dahlia/optique/pull/931
 [#932]: https://github.com/dahlia/optique/pull/932
 [#943]: https://github.com/dahlia/optique/pull/943
+[#949]: https://github.com/dahlia/optique/pull/949
 
 ### @optique/run
 

--- a/changes.d/core/structured-error-callbacks.md
+++ b/changes.d/core/structured-error-callbacks.md
@@ -1,0 +1,10 @@
+---
+links:
+  '#897': https://github.com/dahlia/optique/issues/897
+  '#949': https://github.com/dahlia/optique/pull/949
+---
+ -  Added a structured `Message` argument to core runner `onError` callbacks,
+    allowing applications to handle errors without parsing rendered stderr.
+    Existing zero-argument and one-argument handlers remain compatible.
+    Wrappers that invoke `onError` must now pass the message after the exit
+    code.  [[#897], [#949]]

--- a/docs/concepts/runners.md
+++ b/docs/concepts/runners.md
@@ -365,6 +365,44 @@ width.  When `maxWidth` constrains the layout, automatic sizing reserves at
 least half of the available space for descriptions.  Numeric widths retain
 their existing fallback behavior.
 
+### Structured error callbacks
+
+*The message argument is available since Optique 1.3.0.*
+
+Core runners pass `onError(exitCode, error)` the structured
+[`Message`](./messages.md) used to render an error.  This covers parse failures,
+invalid command paths before help, and missing or unsupported completion
+shells.  You can inspect the message terms or format them for your application
+without extracting a reason from rendered stderr text.
+
+The runner writes its usual output before calling `onError`.  The message
+argument contains the error itself; the runner's `Error: ` prefix, usage/help
+output, and output-framing newlines are added only when rendering.  If your
+application handles all error reporting, supply a `stderr` callback to suppress
+or redirect the default output:
+
+~~~~ typescript twoslash
+import { runParser } from "@optique/core/facade";
+import { formatMessage } from "@optique/core/message";
+import { option } from "@optique/core/primitives";
+import { integer } from "@optique/core/valueparser";
+
+const parser = option("--port", integer({ min: 1, max: 65535 }));
+
+runParser(parser, "myserver", ["--port", "invalid"], {
+  stderr: () => {},
+  onError(exitCode, error) {
+    console.error(`myserver: ${formatMessage(error, { colors: false })}`);
+    process.exit(exitCode);
+  },
+});
+~~~~
+
+The same callback works with `runParserSync()`, `runParserAsync()`, and the
+`runWith()` family.  Existing handlers that accept only the exit code, or no
+arguments, still work.  A wrapper that calls `onError` itself must pass both
+arguments.  The higher-level *@optique/run* API continues to use `onExit(code)`.
+
 ### Explicit sync/async variants
 
 *This API is available since Optique 0.9.0.*

--- a/packages/core/skills/optique/SKILL.md
+++ b/packages/core/skills/optique/SKILL.md
@@ -11,19 +11,19 @@ description: >
 license: MIT
 ---
 
-Optique is a type-safe combinatorial CLI parser. Use it by describing the CLI
-grammar with parsers and combinators, not by manually walking `argv`.
+Build CLI grammars by composing Optique parsers instead of walking `argv`.
 
-If web access is available, start from <https://optique.dev/llms.txt> for the
-maintained documentation index. Keep the rules below in mind even when offline;
-they cover the parts agents most often get wrong.
+If online, start at <https://optique.dev/llms.txt> for maintained docs. These
+rules also cover common pitfalls when offline.
 
 
 Core rules
 ----------
 
  -  Use `run()` from *@optique/run* for applications; use `parse()` or
-    `runParser()` for embedded and custom runtimes.
+    `runParser()` for embedded and custom runtimes. With `runParser()`,
+    `onError(exitCode, error)` receives a structured `Message` after stderr
+    output; use that argument instead of parsing rendered error text.
  -  In tests, use `parseArgs()`/`parseArgsSync()` from *@optique/testing/parser*
     for parser results, `captureRun()` from *@optique/testing/run* for runner
     output/exits, `captureProgramRun()` from *@optique/testing/discover* for

--- a/packages/core/src/facade-types.test.ts
+++ b/packages/core/src/facade-types.test.ts
@@ -1,7 +1,20 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import type { ParserValuePlaceholder, SourceContext } from "#src/context.ts";
-import type { ExtractRequiredOptions } from "#src/facade.ts";
+import {
+  type ExtractRequiredOptions,
+  type RunOptions,
+  runParser,
+  runParserAsync,
+  runParserSync,
+  runWith,
+  runWithAsync,
+  type RunWithOptions,
+  runWithSync,
+} from "#src/facade.ts";
+import { type Message, message } from "#src/message.ts";
+import { argument } from "#src/primitives.ts";
+import { string } from "#src/valueparser.ts";
 
 interface NoOptionsContext extends SourceContext {}
 
@@ -50,4 +63,90 @@ test("ExtractRequiredOptions intersects required option objects", () => {
 
   assert.equal(options.locale, "en-US");
   assert.equal(options.getConfigPath({ config: "app.json" }), "app.json");
+});
+
+test("RunOptions preserves handler assignability and types the error argument", () => {
+  const legacy: {
+    readonly onError?: (() => string) | ((code: number) => string);
+  } = {
+    onError: (code) => String(code),
+  };
+  const callbacks: readonly RunOptions<void, string>[] = [
+    { onError: () => "handled" },
+    { onError: (code) => String(code) },
+    { onError: (code?: number) => String(code) },
+    legacy,
+  ];
+  const exits: RunOptions<void, never> = { onError: process.exit };
+  const options: RunWithOptions<void, string> = {
+    onError(code, error) {
+      const exitCode: number = code;
+      const structured: Message = error;
+      // Keep intentionally invalid code out of Node.js/Bun execution.
+      function invalidAssignments() {
+        // @ts-expect-error The exit code is not any or a string.
+        const text: string = code;
+        // @ts-expect-error The error is structured, not any or a string.
+        const rendered: string = error;
+        void [text, rendered];
+      }
+      void invalidAssignments;
+      return `${exitCode}:${structured.length}`;
+    },
+  };
+  function invalidInvocations() {
+    // @ts-expect-error Forwarders must provide the structured message.
+    options.onError?.(1);
+    // @ts-expect-error Rendered text is not a Message.
+    options.onError?.(1, "error");
+  }
+  void invalidInvocations;
+  void exits;
+  for (const callback of callbacks) {
+    assert.equal(typeof callback.onError?.(1, message`Bad input.`), "string");
+  }
+  assert.equal(options.onError?.(1, message`Bad input.`), "1:1");
+});
+
+test("Structured error callbacks preserve runner return inference", async () => {
+  const parser = argument(string());
+  const options = {
+    args: ["value"],
+    onError: (_code: number, _error: Message) => 42,
+  };
+  const inferred = runParser(parser, "test", ["value"], options);
+  const sync = runParserSync(parser, "test", ["value"], options);
+  const async = runParserAsync(parser, "test", ["value"], options);
+  const withContext = runWith(parser, "test", [], options);
+  const withSync = runWithSync(parser, "test", [], options);
+  const withAsync = runWithAsync(parser, "test", [], options);
+  const program = runParser(
+    { parser, metadata: { name: "test" } },
+    ["value"],
+    options,
+  );
+  type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends
+    (<T>() => T extends B ? 1 : 2) ? true : false;
+  const types: [
+    Equal<typeof inferred, string>,
+    Equal<typeof sync, string>,
+    Equal<typeof async, Promise<string>>,
+    Equal<typeof withContext, Promise<string>>,
+    Equal<typeof withSync, string>,
+    Equal<typeof withAsync, Promise<string>>,
+    Equal<typeof program, string>,
+  ] = [true, true, true, true, true, true, true];
+  void types;
+  assert.deepEqual(
+    await Promise.all([
+      inferred,
+      sync,
+      async,
+      withContext,
+      withSync,
+      withAsync,
+      program,
+    ]),
+    Array.from({ length: 7 }, () => "value"),
+  );
 });

--- a/packages/core/src/facade.test.ts
+++ b/packages/core/src/facade.test.ts
@@ -1,3 +1,4 @@
+import { bash } from "@optique/core/completion";
 import {
   conditional,
   group,
@@ -24,13 +25,19 @@ import {
 import {
   type RunOptions,
   runParser,
+  runParserAsync,
   RunParserError,
   runParserSync,
   runWith,
   runWithAsync,
   runWithSync,
 } from "@optique/core/facade";
-import { message } from "@optique/core/message";
+import {
+  type Message,
+  message,
+  optionName,
+  optionNames,
+} from "@optique/core/message";
 import {
   map,
   multiple,
@@ -15819,3 +15826,457 @@ describe("options terminator (--) handling", () => {
     });
   });
 });
+
+describe("structured runner errors", () => {
+  // Fixed output captured before adding the structured callback argument.
+  for (
+    const { colors, args, chunks } of [
+      {
+        colors: false,
+        args: ["completion"],
+        chunks: [
+          [
+            "Error: Missing shell name for completion.",
+            "",
+          ].join("\n"),
+          [
+            "Generate shell completion script or provide completions.",
+            "Usage: test completion [SHELL] [ARG...]",
+            "",
+            "Generate shell completion script or provide completions.",
+            "",
+            '  SHELL                       Shell type ("bash", "fish", "nu", "pwsh", "zsh"). Generate completion script when used alone, or provide completions when followed by arguments.',
+            "  ARG                         Command line arguments for completion suggestions (used by shell integration; you usually don't need to provide this).",
+            "",
+            "Examples:",
+            '  Bash:       `eval "$(test completion bash)"`',
+            '  zsh:        `eval "$(test completion zsh)"`',
+            '  fish:       `eval "$(test completion fish)"`',
+            "  PowerShell: `test completion pwsh > test-completion.ps1; . ./test-completion.ps1`",
+            "  Nushell:    `test completion nu | save test-completion.nu; source ./test-completion.nu`",
+          ].join("\n"),
+        ],
+      },
+      {
+        colors: false,
+        args: ["--completion"],
+        chunks: [
+          [
+            "Error: Missing shell name for completion.",
+            "",
+          ].join("\n"),
+          [
+            "Usage: test --completion SHELL [[ARG...]]",
+            "",
+            "  --completion SHELL          Generate shell completion script.",
+            "  ARG                         Command line arguments for completion suggestions (used by shell integration; you usually don't need to provide this).",
+            "",
+          ].join("\n"),
+        ],
+      },
+      {
+        colors: true,
+        args: ["completion"],
+        chunks: [
+          [
+            "Error: Missing shell name for completion.",
+            "",
+          ].join("\n"),
+          [
+            "Generate shell completion script or provide completions.",
+            "\u001b[1;2mUsage:\u001b[0m \u001b[1mtest\u001b[0m \u001b[1mcompletion\u001b[0m \u001b[2m[\u001b[0m\u001b[4mSHELL\u001b[0m\u001b[2m]\u001b[0m \u001b[2m[\u001b[0m\u001b[4mARG\u001b[0m\u001b[2m...\u001b[0m\u001b[2m]\u001b[0m",
+            "",
+            "Generate shell completion script or provide completions.",
+            "",
+            "  \u001b[4mSHELL\u001b[0m                       Shell type (\u001b[32mbash\u001b[0m, \u001b[32mfish\u001b[0m, \u001b[32mnu\u001b[0m, \u001b[32mpwsh\u001b[0m, \u001b[32mzsh\u001b[0m). Generate completion script when used alone, or provide completions when followed by arguments.",
+            "  \u001b[4mARG\u001b[0m                         Command line arguments for completion suggestions (used by shell integration; you usually don't need to provide this).",
+            "",
+            "Examples:",
+            '  Bash:       \u001b[36meval "$(test completion bash)"\u001b[0m',
+            '  zsh:        \u001b[36meval "$(test completion zsh)"\u001b[0m',
+            '  fish:       \u001b[36meval "$(test completion fish)"\u001b[0m',
+            "  PowerShell: \u001b[36mtest completion pwsh > test-completion.ps1; . ./test-completion.ps1\u001b[0m",
+            "  Nushell:    \u001b[36mtest completion nu | save test-completion.nu; source ./test-completion.nu\u001b[0m",
+          ].join("\n"),
+        ],
+      },
+      {
+        colors: true,
+        args: ["--completion"],
+        chunks: [
+          [
+            "Error: Missing shell name for completion.",
+            "",
+          ].join("\n"),
+          [
+            "\u001b[1;2mUsage:\u001b[0m \u001b[1mtest\u001b[0m \u001b[3m--completion\u001b[0m \u001b[4m\u001b[2mSHELL\u001b[0m \u001b[2m[\u001b[0m\u001b[2m[\u001b[0m\u001b[4mARG\u001b[0m\u001b[2m...\u001b[0m\u001b[2m]\u001b[0m\u001b[2m]\u001b[0m",
+            "",
+            "  \u001b[3m--completion\u001b[0m \u001b[4m\u001b[2mSHELL\u001b[0m          Generate shell completion script.",
+            "  \u001b[4mARG\u001b[0m                         Command line arguments for completion suggestions (used by shell integration; you usually don't need to provide this).",
+            "",
+          ].join("\n"),
+        ],
+      },
+    ]
+  ) {
+    it(`should preserve completion help chunks for ${args[0]} colors=${colors}`, () => {
+      const events: unknown[] = [];
+      runParser(object({}), "test", args, {
+        colors,
+        completion: { command: true, option: true },
+        stdout: () => assert.fail("Unexpected stdout."),
+        stderr: (chunk) => events.push(chunk),
+        onError: (...args: unknown[]) => {
+          events.push(args);
+        },
+      });
+      assert.deepEqual(events, [...chunks, [
+        1,
+        message`Missing shell name for completion.`,
+      ]]);
+    });
+  }
+
+  const modes = [
+    { name: "sync", create: structuredFailureParser },
+    { name: "async", create: asyncStructuredFailureParser },
+  ] as const;
+
+  for (const { name, create } of modes) {
+    for (const consumed of [0, 1]) {
+      it(`should forward the original ${name} error with consumed=${consumed}`, async () => {
+        const error = message`Error: Invalid ${optionName("--port")}.`;
+        const events: unknown[] = [];
+        const result = runParser(create(error, consumed), "test", ["bad"], {
+          aboveError: "none",
+          stdout: (chunk) => events.push(["stdout", chunk]),
+          stderr: (chunk) => events.push(["stderr", chunk]),
+          onError: (...args: unknown[]) => {
+            events.push(["onError", ...args]);
+            assert.strictEqual(args[1], error);
+            return "handled";
+          },
+        });
+        if (name === "sync") assert.equal(result, "handled");
+        else assert.ok(result instanceof Promise);
+        assert.equal(await result, "handled");
+        assert.deepEqual(events, [
+          ["stderr", "Error: Error: Invalid `--port`."],
+          ["onError", 1, error],
+        ]);
+      });
+    }
+
+    for (const aboveError of ["usage", "help", "none"] as const) {
+      it(`should report a ${name} error after aboveError=${aboveError}`, async () => {
+        const error = message`Invalid input.`;
+        const events: unknown[] = [];
+        await runParser(create(error), "test", ["bad"], {
+          aboveError,
+          stdout: (chunk) => events.push(["stdout", chunk]),
+          stderr: (chunk) => events.push(["stderr", chunk]),
+          onError: (...args: unknown[]) => {
+            events.push(["onError", ...args]);
+            return "handled";
+          },
+        });
+        assert.deepEqual(events, [
+          ...(aboveError === "none" ? [] : [[
+            "stderr",
+            aboveError === "help" ? "Usage: test\n" : "Usage: test",
+          ]]),
+          ["stderr", "Error: Invalid input."],
+          ["onError", 1, error],
+        ]);
+      });
+    }
+
+    for (
+      const args of [
+        ["completion"],
+        ["--completion"],
+        ["--completion="],
+        ["completions"],
+        ["--complete"],
+        ["--complete="],
+      ]
+    ) {
+      it(`should pass the missing-shell message for ${name} ${args[0]}`, async () => {
+        const events: unknown[] = [];
+        const result = await runParser(
+          create(message`Unused failure.`),
+          "test",
+          args,
+          {
+            aboveError: "none",
+            completion: {
+              command: { names: ["completion", "completions"] },
+              option: { names: ["--completion", "--complete"] },
+            },
+            stdout: (chunk) => events.push(["stdout", chunk]),
+            stderr: (chunk) => events.push(["stderr", chunk]),
+            onError: (...received: unknown[]) => {
+              events.push(["onError", ...received]);
+              return "handled";
+            },
+          },
+        );
+        assert.equal(result, "handled");
+        assert.equal(events.length, 3);
+        assert.deepEqual(events[0], [
+          "stderr",
+          "Error: Missing shell name for completion.\n",
+        ]);
+        assert.deepEqual(events[2], [
+          "onError",
+          1,
+          message`Missing shell name for completion.`,
+        ]);
+        const helpEvent = events[1];
+        assert.ok(Array.isArray(helpEvent));
+        assert.equal(helpEvent[0], "stderr");
+        assert.equal(typeof helpEvent[1], "string");
+        assert.match(
+          helpEvent[1],
+          args[0].startsWith("--")
+            ? /Usage: test \(.*--completion SHELL/
+            : /Usage: test completion/,
+        );
+      });
+    }
+
+    for (const colors of [false, true]) {
+      for (
+        const args of [
+          ["completion", "unknown"],
+          ["--completion", "unknown"],
+          ["--completion=unknown"],
+          ["completions", "unknown"],
+          ["--complete=unknown"],
+        ]
+      ) {
+        it(`should preserve ${name} unsupported-shell output for ${args.join(" ")} colors=${colors}`, async () => {
+          const events: unknown[] = [];
+          await runParser(create(message`Unused failure.`), "test", args, {
+            colors,
+            completion: {
+              command: { names: ["completion", "completions"] },
+              option: { names: ["--completion", "--complete"] },
+              shells: { custom: bash },
+            },
+            stdout: (chunk) => events.push(["stdout", chunk]),
+            stderr: (chunk) => events.push(["stderr", chunk]),
+            onError: (...received: unknown[]) => {
+              events.push(["onError", ...received]);
+              return "handled";
+            },
+          });
+          assert.deepEqual(events, [
+            [
+              "stderr",
+              colors
+                ? "Error: Unsupported shell \x1b[32munknown\x1b[0m. Available shells: \x1b[32mbash\x1b[0m, \x1b[32mfish\x1b[0m, \x1b[32mnu\x1b[0m, \x1b[32mpwsh\x1b[0m, \x1b[32mzsh\x1b[0m, \x1b[32mcustom\x1b[0m."
+                : 'Error: Unsupported shell "unknown". Available shells: "bash", "fish", "nu", "pwsh", "zsh", "custom".',
+            ],
+            [
+              "onError",
+              1,
+              message`Unsupported shell ${"unknown"}. Available shells: ${message`${"bash"}, ${"fish"}, ${"nu"}, ${"pwsh"}, ${"zsh"}, ${"custom"}`}.`,
+            ],
+          ]);
+        });
+      }
+    }
+
+    it(`should pass ${name} errors through the context runners before disposal`, async () => {
+      const error = message`Missing context value.`;
+      for (const phase of ["single-pass", "two-pass"] as const) {
+        for (const runner of [runWith, runWithAsync]) {
+          const events: unknown[] = [];
+          const context: SourceContext = {
+            id: Symbol("structured-errors"),
+            phase,
+            getAnnotations: () => ({}),
+            [Symbol.dispose]: () => {
+              events.push("dispose");
+            },
+          };
+          const result = await runner(create(error), "test", [context], {
+            args: ["bad"],
+            aboveError: "none",
+            stderr: (chunk) => events.push(chunk),
+            onError: (...args: unknown[]) => {
+              events.push(args);
+              return "handled";
+            },
+          });
+          assert.equal(result, "handled");
+          assert.deepEqual(events, [
+            "Error: Missing context value.",
+            [1, error],
+            "dispose",
+          ]);
+        }
+      }
+    });
+
+    it(`should preserve exceptions thrown by the ${name} error callback`, async () => {
+      const error = message`Invalid input.`;
+      const thrown = new TypeError("Application error handler failed.");
+      const invoke = () =>
+        runParser(create(error), "test", ["bad"], {
+          stderr: () => {},
+          onError: (...args: unknown[]): never => {
+            assert.strictEqual(args[1], error);
+            throw thrown;
+          },
+        });
+      if (name === "sync") assert.throws(invoke, (e) => e === thrown);
+      else {await assert.rejects(async () =>
+          await invoke(), (e) =>
+          e === thrown);}
+    });
+  }
+
+  it("should pass structured value errors without changing the rendered text", () => {
+    const events: unknown[] = [];
+    runParser(option("--port", integer()), "test", ["--port", "bad"], {
+      aboveError: "none",
+      stderr: (chunk) => events.push(chunk),
+      onError: (...args: unknown[]) => {
+        events.push(args);
+      },
+    });
+    assert.deepEqual(events, [
+      'Error: `--port`: Expected a valid integer, but got "bad".',
+      [
+        1,
+        message`${
+          optionNames(["--port"])
+        }: ${message`Expected a valid integer, but got ${"bad"}.`}`,
+      ],
+    ]);
+  });
+
+  it("should pass errors through Program and explicit runner variants", async () => {
+    const error = message`Invalid input.`;
+    const parser = structuredFailureParser(error);
+    const received: unknown[] = [];
+    const options = {
+      aboveError: "none" as const,
+      stderr: () => {},
+      onError: (...args: unknown[]) => {
+        received.push(args);
+        return "handled";
+      },
+    };
+    assert.equal(
+      runParser({ parser, metadata: { name: "test" } }, ["bad"], options),
+      "handled",
+    );
+    assert.equal(runParserSync(parser, "test", ["bad"], options), "handled");
+    assert.equal(
+      await runParserAsync(parser, "test", ["bad"], options),
+      "handled",
+    );
+    for (const phase of ["single-pass", "two-pass"] as const) {
+      const events: string[] = [];
+      const context: SourceContext = {
+        id: Symbol("sync-error-context"),
+        phase,
+        getAnnotations: () => ({}),
+        [Symbol.dispose]: () => {
+          events.push("dispose");
+        },
+      };
+      assert.equal(
+        runWithSync(parser, "test", [context], { ...options, args: ["bad"] }),
+        "handled",
+      );
+      assert.deepEqual(events, ["dispose"]);
+    }
+    assert.deepEqual(received, Array.from({ length: 5 }, () => [1, error]));
+  });
+
+  for (
+    const parser of [
+      command("known", constant("ok")),
+      command("parent", command("known", constant("ok"))),
+      object({ maybe: optional(option("--ok")) }),
+      asyncStructuredFailureParser(message`Unknown command.`),
+    ]
+  ) {
+    it(`should pass help-validation errors for ${JSON.stringify(parser.usage)} (${parser.mode})`, async () => {
+      const events: unknown[] = [];
+      const nested = parser.usage.some((term) =>
+        term.type === "command" && term.name === "parent"
+      );
+      await runParser(
+        parser,
+        "test",
+        nested ? ["parent", "bad", "--help"] : ["bad", "--help"],
+        {
+          aboveError: "none",
+          help: {
+            option: true,
+            onShow: () => assert.fail("Unexpected help callback."),
+          },
+          stdout: () => assert.fail("Unexpected help output."),
+          stderr: (chunk) => events.push(chunk),
+          onError: (...args: unknown[]) => {
+            events.push(args);
+            return "handled";
+          },
+        },
+      );
+      assert.equal(events.length, 3);
+      assert.equal(typeof events[0], "string");
+      assert.match(String(events[0]), /^Usage: test/);
+      assert.deepEqual(events.slice(1), [
+        "Error: Unexpected option or subcommand: `bad`.",
+        [1, message`Unexpected option or subcommand: ${optionName("bad")}.`],
+      ]);
+    });
+  }
+});
+
+// Helpers for structured runner error tests.
+function structuredFailureParser(
+  error: Message,
+  consumed = 0,
+): Parser<"sync", string, undefined> {
+  return {
+    mode: "sync",
+    $valueType: [],
+    $stateType: [],
+    priority: 0,
+    usage: [],
+    leadingNames: new Set(),
+    acceptingAnyToken: false,
+    initialState: undefined,
+    parse: () => ({ success: false, error, consumed }),
+    complete: () => ({ success: false, error }),
+    *suggest() {},
+    getDocFragments: () => ({ fragments: [] }),
+  };
+}
+
+function asyncStructuredFailureParser(
+  error: Message,
+  consumed = 0,
+): Parser<"async", string, undefined> {
+  return {
+    mode: "async",
+    $valueType: [],
+    $stateType: [],
+    priority: 0,
+    usage: [],
+    leadingNames: new Set(),
+    acceptingAnyToken: false,
+    initialState: undefined,
+    parse: () => Promise.resolve({ success: false, error, consumed }),
+    complete: () => Promise.resolve({ success: false, error }),
+    async *suggest() {},
+    getDocFragments: () => ({ fragments: [] }),
+  };
+}

--- a/packages/core/src/facade.ts
+++ b/packages/core/src/facade.ts
@@ -1334,14 +1334,21 @@ export interface RunOptions<THelp, TError> {
   readonly aboveError?: "usage" | "help" | "none";
 
   /**
-   * Callback function invoked when parsing fails. The function can
-   * optionally receive an exit code parameter.
+   * Callback invoked after error output for a parse failure, an invalid
+   * command path before help, or a missing or unsupported completion shell.
+   * Receives the exit code and the structured error message used for output.
+   * The message does not include the runner's `Error: ` prefix or usage/help
+   * output.  The runner preserves any formatting terms in the original message.
+   *
+   * Handlers may ignore either argument.  Wrappers that invoke this callback
+   * themselves must forward both the exit code and the message.
    *
    * You usually want to pass `process.exit` on Node.js or Bun and `Deno.exit`
    * on Deno to this option.
    * @default Throws a {@link RunParserError}.
+   * @since 1.3.0 Added the `error` parameter.
    */
-  readonly onError?: (() => TError) | ((exitCode: number) => TError);
+  readonly onError?: (exitCode: number, error: Message) => TError;
 
   /**
    * Function used to output error messages.  Assumes it prints the ending
@@ -1414,7 +1421,7 @@ function handleCompletion<M extends Mode, THelp, TError>(
   stdout: (text: string) => void,
   stderr: (text: string) => void,
   onCompletion: (() => THelp) | ((exitCode: number) => THelp),
-  onError: (() => TError) | ((exitCode: number) => TError),
+  onError: (exitCode: number, error: Message) => TError,
   availableShells: Record<string, ShellCompletion>,
   colors?: boolean,
   maxWidth?: number,
@@ -1429,13 +1436,15 @@ function handleCompletion<M extends Mode, THelp, TError>(
   const shellName = completionArgs[0] || "";
   const args = completionArgs.slice(1);
 
-  const callOnError = (code: number): TError => onError(code);
+  const callOnError = (code: number, error: Message): TError =>
+    onError(code, error);
 
   const callOnCompletion = (code: number): THelp => onCompletion(code);
 
   // Check if shell name is empty
   if (!shellName) {
-    stderr("Error: Missing shell name for completion.\n");
+    const error = message`Missing shell name for completion.`;
+    stderr(`Error: ${formatMessage(error, { colors, quotes: !colors })}\n`);
 
     // Show help for completion command if parser is available
     if (completionParser) {
@@ -1459,14 +1468,14 @@ function handleCompletion<M extends Mode, THelp, TError>(
     return dispatchByMode(
       parser.mode,
       () => {
-        const result = callOnError(1);
+        const result = callOnError(1, error);
         if (result instanceof Promise) {
           throw new RunParserError("Synchronous parser returned async result.");
         }
         return result;
       },
       // deno-lint-ignore require-await -- async wraps synchronous throws as rejections
-      async () => callOnError(1),
+      async () => callOnError(1, error),
     );
   }
 
@@ -1478,23 +1487,20 @@ function handleCompletion<M extends Mode, THelp, TError>(
       if (available.length > 0) available.push(text(", "));
       available.push(value(name));
     }
-    stderr(
-      formatMessage(
-        message`Error: Unsupported shell ${shellName}. Available shells: ${available}.`,
-        { colors, quotes: !colors },
-      ),
-    );
+    const error =
+      message`Unsupported shell ${shellName}. Available shells: ${available}.`;
+    stderr(`Error: ${formatMessage(error, { colors, quotes: !colors })}`);
     return dispatchByMode(
       parser.mode,
       () => {
-        const result = callOnError(1);
+        const result = callOnError(1, error);
         if (result instanceof Promise) {
           throw new RunParserError("Synchronous parser returned async result.");
         }
         return result;
       },
       // deno-lint-ignore require-await -- async wraps synchronous throws as rejections
-      async () => callOnError(1),
+      async () => callOnError(1, error),
     );
   }
 
@@ -2294,8 +2300,8 @@ export function runParser<
   const onCompletion = options.completion?.onShow ?? (() => ({} as THelp));
   const onCompletionResult = (code: number): InferValue<TParser> =>
     onCompletion(code) as InferValue<TParser>;
-  const onErrorResult = (code: number): InferValue<TParser> =>
-    onError(code) as InferValue<TParser>;
+  const onErrorResult = (code: number, error: Message): InferValue<TParser> =>
+    onError(code, error) as InferValue<TParser>;
 
   // Validate meta names eagerly
   if (helpOptionConfig?.names) {
@@ -2643,7 +2649,7 @@ export function runParser<
             quotes: !colors,
           });
           stderr(`Error: ${errorMessage}`);
-          return onError(1);
+          return onError(1, validationError);
         };
 
         // Helper function to display help and return
@@ -2864,7 +2870,7 @@ export function runParser<
             quotes: !colors,
           });
           stderr(`Error: ${errorMessage}`);
-          return onError(1);
+          return onError(1, classified.error);
         };
 
         // Error handling


### PR DESCRIPTION
Core runner callbacks receive only an exit code, forcing applications to parse rendered stderr to inspect an error. Pass the original `Message` as the second argument to `onError`, including help-validation and completion failures, so callers can inspect its terms or render it themselves.

Invoke the callback after the existing output to preserve stderr and exit behavior. Keep runner-owned prefixes and usage text out of the message. Existing zero-argument and one-argument handlers remain compatible; wrappers that invoke `onError` must forward both arguments.

Regression and type tests cover message identity, output order, and callback compatibility across synchronous and asynchronous runners. `mise test` and the documentation build pass.

Fixes #897.
