### PR TITLE
Expose final help pages to custom renderers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,11 @@ To be released.
     after the widest visible term using terminal display width while reserving
     description space under `maxWidth`.  The existing default and explicit
     numeric widths remain unchanged.  [[#904], [#911]]
+ -  Added the final `DocPage` as the second argument to `help.onShow`, so
+    custom help renderers can use runner-provided entries and selected
+    command documentation without reconstructing them. Existing zero-argument
+    and one-argument handlers remain compatible. Wrappers that invoke the
+    callback must now pass the page after the exit code.  [[#899], [#950]]
  -  Added `usageLine` to the core runner `RunOptions`.  Top-level full help can
     now replace the generated root synopsis or derive one from a callback,
     while subcommand help and usage-only error output remain unchanged.
@@ -68,6 +73,7 @@ To be released.
 [#890]: https://github.com/dahlia/optique/issues/890
 [#892]: https://github.com/dahlia/optique/issues/892
 [#897]: https://github.com/dahlia/optique/issues/897
+[#899]: https://github.com/dahlia/optique/issues/899
 [#904]: https://github.com/dahlia/optique/issues/904
 [#906]: https://github.com/dahlia/optique/issues/906
 [#909]: https://github.com/dahlia/optique/pull/909
@@ -88,6 +94,7 @@ To be released.
 [#932]: https://github.com/dahlia/optique/pull/932
 [#943]: https://github.com/dahlia/optique/pull/943
 [#949]: https://github.com/dahlia/optique/pull/949
+[#950]: https://github.com/dahlia/optique/pull/950
 
 ### @optique/run
 

--- a/changes.d/core/help-doc-page-callbacks.md
+++ b/changes.d/core/help-doc-page-callbacks.md
@@ -1,0 +1,10 @@
+---
+links:
+  '#899': https://github.com/dahlia/optique/issues/899
+  '#950': https://github.com/dahlia/optique/pull/950
+---
+ -  Added the final `DocPage` as the second argument to `help.onShow`, so
+    custom help renderers can use runner-provided entries and selected
+    command documentation without reconstructing them. Existing zero-argument
+    and one-argument handlers remain compatible. Wrappers that invoke the
+    callback must now pass the page after the exit code.  [[#899], [#950]]

--- a/docs/concepts/runners.md
+++ b/docs/concepts/runners.md
@@ -365,6 +365,48 @@ width.  When `maxWidth` constrains the layout, automatic sizing reserves at
 least half of the available space for descriptions.  Numeric widths retain
 their existing fallback behavior.
 
+### Structured help callbacks
+
+*The page argument is available since Optique 1.3.0.*
+
+Core runners pass `help.onShow(exitCode, page)` the final `DocPage` used for
+help output. This includes runner-provided help, version, and completion
+entries, program metadata, and root `usageLine` and `commandList` changes.
+Subcommand and meta-command help receive the selected command's page, with
+its own brief and description and the run-level footer as a fallback.
+
+The runner writes its usual output before calling the callback. To render the
+page yourself, supply a no-op `stdout` function:
+
+~~~~ typescript twoslash
+import { formatDocPage } from "@optique/core/doc";
+import { runParser } from "@optique/core/facade";
+import { argument } from "@optique/core/primitives";
+import { string } from "@optique/core/valueparser";
+
+runParser(argument(string()), "myapp", ["--help"], {
+  stdout: () => {},
+  help: {
+    option: true,
+    onShow(exitCode, page) {
+      console.log(formatDocPage("myapp", page, { colors: false }));
+      process.exit(exitCode);
+    },
+  },
+});
+~~~~
+
+Treat the page as read-only. It is the formatter's input: colors, widths,
+section ordering, and settings such as `showUsage` still belong to
+`formatDocPage()`. Optional fields may be `undefined`.
+
+The callback works with `runParserSync()`, `runParserAsync()`, and the
+`runWith()` family. Existing handlers accepting only the exit code or no
+arguments still work. Wrappers that invoke the callback must forward both
+arguments. Help printed on an error path, including `aboveError: "help"`,
+does not invoke this callback. The higher-level *@optique/run* API continues
+to use `onExit(code)`.
+
 ### Structured error callbacks
 
 *The message argument is available since Optique 1.3.0.*

--- a/packages/core/skills/optique/SKILL.md
+++ b/packages/core/skills/optique/SKILL.md
@@ -11,19 +11,19 @@ description: >
 license: MIT
 ---
 
-Build CLI grammars by composing Optique parsers instead of walking `argv`.
-
-If online, start at <https://optique.dev/llms.txt> for maintained docs. These
-rules also cover common pitfalls when offline.
+Start at <https://optique.dev/llms.txt> when online. These rules cover the
+combinatorial parser model and common pitfalls offline.
 
 
 Core rules
 ----------
 
  -  Use `run()` from *@optique/run* for applications; use `parse()` or
-    `runParser()` for embedded and custom runtimes. With `runParser()`,
-    `onError(exitCode, error)` receives a structured `Message` after stderr
-    output; use that argument instead of parsing rendered error text.
+    `runParser()` for embedded and custom runtimes.
+ -  With `runParser()`, `onError(exitCode, error)` supplies a structured
+    `Message`; `help.onShow(exitCode, page)` supplies the final `DocPage`. Both
+    follow output. Supply `stdout: () => {}` for custom help rendering. See
+    <https://optique.dev/concepts/runners.md#structured-help-callbacks>.
  -  In tests, use `parseArgs()`/`parseArgsSync()` from *@optique/testing/parser*
     for parser results, `captureRun()` from *@optique/testing/run* for runner
     output/exits, `captureProgramRun()` from *@optique/testing/discover* for

--- a/packages/core/src/facade-types.test.ts
+++ b/packages/core/src/facade-types.test.ts
@@ -13,6 +13,7 @@ import {
   runWithSync,
 } from "#src/facade.ts";
 import { type Message, message } from "#src/message.ts";
+import type { DocPage } from "#src/doc.ts";
 import { argument } from "#src/primitives.ts";
 import { string } from "#src/valueparser.ts";
 
@@ -123,6 +124,97 @@ test("Structured error callbacks preserve runner return inference", async () => 
   const program = runParser(
     { parser, metadata: { name: "test" } },
     ["value"],
+    options,
+  );
+  type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends
+    (<T>() => T extends B ? 1 : 2) ? true : false;
+  const types: [
+    Equal<typeof inferred, string>,
+    Equal<typeof sync, string>,
+    Equal<typeof async, Promise<string>>,
+    Equal<typeof withContext, Promise<string>>,
+    Equal<typeof withSync, string>,
+    Equal<typeof withAsync, Promise<string>>,
+    Equal<typeof program, string>,
+  ] = [true, true, true, true, true, true, true];
+  void types;
+  assert.deepEqual(
+    await Promise.all([
+      inferred,
+      sync,
+      async,
+      withContext,
+      withSync,
+      withAsync,
+      program,
+    ]),
+    Array.from({ length: 7 }, () => "value"),
+  );
+});
+
+test("Help callbacks preserve assignability and infer the final page", () => {
+  const legacy: {
+    readonly option: true;
+    readonly onShow?: (() => string) | ((code: number) => string);
+  } = { option: true, onShow: (code) => String(code) };
+  const callbacks: readonly RunOptions<string, never>[] = [
+    { help: { option: true, onShow: () => "shown" } },
+    { help: { option: true, onShow: (code) => String(code) } },
+    { help: { option: true, onShow: (code?: number) => String(code) } },
+    { help: legacy },
+    { help: { option: true, onShow: process.exit } },
+  ];
+  const options: RunWithOptions<string, never> = {
+    help: {
+      option: true,
+      onShow(code, page) {
+        const exitCode: number = code;
+        const structured: DocPage = page;
+        function invalidAssignments() {
+          // @ts-expect-error The exit code is not any or a string.
+          const text: string = code;
+          // @ts-expect-error The page is structured, not any or a string.
+          const rendered: string = page;
+          // @ts-expect-error The page is read-only.
+          page.sections = [];
+          void [text, rendered];
+        }
+        void invalidAssignments;
+        return `${exitCode}:${structured.sections.length}`;
+      },
+    },
+  };
+  function invalidInvocations() {
+    // @ts-expect-error Forwarders must supply the final page.
+    options.help?.onShow?.(0);
+    // @ts-expect-error The page cannot be undefined.
+    options.help?.onShow?.(0, undefined);
+    // @ts-expect-error Rendered text is not a DocPage.
+    options.help?.onShow?.(0, "help");
+  }
+  void invalidInvocations;
+  void callbacks;
+  assert.equal(options.help?.onShow?.(0, { sections: [] }), "0:0");
+});
+
+test("Help page callbacks preserve runner return inference", async () => {
+  const parser = argument(string());
+  const options = {
+    args: ["value"],
+    help: {
+      option: true as const,
+      onShow: (_code: number, _page: DocPage) => 42,
+    },
+  };
+  const inferred = runParser(parser, "test", options.args, options);
+  const sync = runParserSync(parser, "test", options.args, options);
+  const async = runParserAsync(parser, "test", options.args, options);
+  const withContext = runWith(parser, "test", [], options);
+  const withSync = runWithSync(parser, "test", [], options);
+  const withAsync = runWithAsync(parser, "test", [], options);
+  const program = runParser(
+    { parser, metadata: { name: "test" } },
+    options.args,
     options,
   );
   type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends

--- a/packages/core/src/facade.test.ts
+++ b/packages/core/src/facade.test.ts
@@ -15,7 +15,11 @@ import type {
   SourceContextPhase2Request,
   SourceContextRequest,
 } from "@optique/core/context";
-import type { DocSection } from "@optique/core/doc";
+import {
+  type DocPage,
+  type DocSection,
+  formatDocPage,
+} from "@optique/core/doc";
 import { defineInheritedAnnotationParser } from "#src/internal/parser.ts";
 import {
   createParserContext,
@@ -16280,3 +16284,378 @@ function asyncStructuredFailureParser(
     getDocFragments: () => ({ fragments: [] }),
   };
 }
+
+describe("structured help callbacks", () => {
+  it("should pass the page after writing help", () => {
+    const chunks: string[] = [];
+    const result = runParser(argument(string()), "test", ["--help"], {
+      colors: false,
+      help: {
+        option: true,
+        onShow: (...args: unknown[]) => {
+          assert.equal(chunks.length, 1);
+          assert.equal(args.length, 2);
+          assert.equal(args[0], 0);
+          assert.ok(args[1]);
+          return "shown";
+        },
+      },
+      stdout: (chunk) => chunks.push(chunk),
+    });
+    assert.equal(result, "shown");
+    // Fixed output captured before adding the callback argument.
+    assert.deepEqual(chunks, [
+      "Usage: test STRING\n       test --help\n\n" +
+      "  STRING                    \n" +
+      "  --help                      Show help information.\n",
+    ]);
+  });
+});
+
+describe("final help pages", () => {
+  const syncString = string();
+  const asyncString: ValueParser<"async", string> = {
+    metavar: syncString.metavar,
+    placeholder: syncString.placeholder,
+    format: (value) => value,
+    mode: "async",
+    parse: (input) => Promise.resolve(syncString.parse(input)),
+  };
+  const formats = { colors: false, maxWidth: 80 } as const;
+  for (const valueParser of [syncString, asyncString]) {
+    const mode = valueParser.mode;
+    for (const args of [["--help"], ["help"]]) {
+      it(`should expose augmented root help for ${mode} ${args[0]}`, async () => {
+        const chunks: string[] = [];
+        const events: string[] = [];
+        let usageCalls = 0;
+        const program = {
+          metadata: {
+            name: "test",
+            brief: message`Program brief.`,
+            description: message`Program description.`,
+            examples: message`Program examples.`,
+            author: message`Program author.`,
+            bugs: message`Program bugs.`,
+            footer: message`Program footer.`,
+          },
+        };
+        const invoke = (options: RunOptions<string, never>) =>
+          valueParser.mode === "sync"
+            ? runParser(
+              { ...program, parser: option("--name", valueParser) },
+              args,
+              options,
+            )
+            : runParser(
+              { ...program, parser: option("--name", valueParser) },
+              args,
+              options,
+            );
+        const result = invoke({
+          ...formats,
+          showUsage: false,
+          brief: message`Overridden brief.`,
+          usageLine(defaultUsage) {
+            usageCalls++;
+            assert.match(JSON.stringify(defaultUsage), /--completion/);
+            return [{ type: "ellipsis" }];
+          },
+          help: {
+            command: true,
+            option: true,
+            onShow(code, page) {
+              events.push("help");
+              assert.equal(code, 0);
+              assert.deepEqual(page.usage, [{ type: "ellipsis" }]);
+              assert.deepEqual(page.brief, message`Overridden brief.`);
+              assert.deepEqual(page.description, message`Program description.`);
+              assert.deepEqual(page.examples, message`Program examples.`);
+              assert.deepEqual(page.author, message`Program author.`);
+              assert.deepEqual(page.bugs, message`Program bugs.`);
+              assert.deepEqual(page.footer, message`Program footer.`);
+              const terms = page.sections.flatMap((section) => section.entries)
+                .map((entry) => entry.term);
+              for (
+                const name of ["--help", "--version", "--completion"] as const
+              ) {
+                assert.ok(
+                  terms.some((term) =>
+                    term.type === "option" && term.names.includes(name)
+                  ),
+                );
+              }
+              for (const name of ["help", "version", "completion"]) {
+                assert.ok(
+                  terms.some((term) =>
+                    term.type === "command" && term.name === name
+                  ),
+                );
+              }
+              assert.deepEqual(chunks, [formatDocPage("test", page, {
+                ...formats,
+                showUsage: false,
+              })]);
+              return "shown";
+            },
+          },
+          version: { value: "1.0", option: true, command: true },
+          completion: { option: true, command: true },
+          stdout(chunk) {
+            events.push("stdout");
+            chunks.push(chunk);
+          },
+        });
+        if (mode === "sync") assert.ok(!(result instanceof Promise));
+        else assert.ok(result instanceof Promise);
+        assert.equal(await result, "shown");
+        assert.equal(usageCalls, 1);
+        assert.deepEqual(events, ["stdout", "help"]);
+      });
+    }
+
+    for (
+      const args of [
+        ["remote", "add", "--help"],
+        ["help", "remote", "add"],
+        ["assist", "remote", "add"],
+        ["help", "help"],
+        ["help", "version"],
+        ["help", "completion"],
+        ["help", "--help"],
+        ["ver", "--help"],
+        ["completion", "--help"],
+      ]
+    ) {
+      it(`should forward selected ${mode} help for ${args.join(" ")}`, async () => {
+        const parser = command(
+          "remote",
+          command("add", argument(valueParser), {
+            brief: message`Add brief.`,
+            description: message`Add a remote.`,
+          }),
+        );
+        const chunks: string[] = [];
+        let calls = 0;
+        const result = await runParser(parser, "test", args, {
+          ...formats,
+          brief: message`Root brief.`,
+          description: message`Root description.`,
+          examples: message`Root examples.`,
+          author: message`Root author.`,
+          bugs: message`Root bugs.`,
+          footer: message`Global footer.`,
+          usageLine: () => assert.fail("Root usage override on command help."),
+          help: {
+            command: { names: ["help", "assist"] },
+            option: true,
+            onShow(code, page) {
+              calls++;
+              assert.equal(code, 0);
+              assert.equal(page.examples, undefined);
+              assert.equal(page.author, undefined);
+              assert.equal(page.bugs, undefined);
+              if (args.includes("completion")) {
+                // The completion command's own footer takes precedence.
+                assert.match(
+                  JSON.stringify(page.footer),
+                  /test completion bash/,
+                );
+              } else {
+                assert.deepEqual(page.footer, message`Global footer.`);
+              }
+              assert.notDeepEqual(page.brief, message`Root brief.`);
+              assert.notDeepEqual(page.description, message`Root description.`);
+              assert.deepEqual(chunks, [formatDocPage("test", page, formats)]);
+              if (args.includes("remote")) {
+                assert.deepEqual(page.brief, message`Add brief.`);
+                assert.deepEqual(page.description, message`Add a remote.`);
+                assert.match(chunks[0], /Usage: test remote add STRING/);
+              } else {
+                const selected = args.includes("completion")
+                  ? "completion"
+                  : args.includes("version") || args.includes("ver")
+                  ? "version"
+                  : "help";
+                assert.match(
+                  chunks[0],
+                  new RegExp(`Usage: test ${selected}\\b`),
+                );
+              }
+              return "shown";
+            },
+          },
+          version: { value: "1.0", command: { names: ["version", "ver"] } },
+          completion: { command: true },
+          stdout: (chunk) => chunks.push(chunk),
+        });
+        assert.equal(result, "shown");
+        assert.equal(calls, 1);
+      });
+    }
+
+    for (const runner of [runWith, runWithAsync]) {
+      for (const phase of ["single-pass", "two-pass"] as const) {
+        it(`should forward ${mode} help through ${runner.name} with ${phase} sources`, async () => {
+          const events: string[] = [];
+          const context: SourceContext = {
+            id: Symbol("help-page"),
+            phase,
+            getAnnotations(request) {
+              assert.ok(isPhase1ContextRequest(request));
+              events.push("phase1");
+              return {};
+            },
+            [Symbol.dispose]() {
+              events.push("dispose");
+            },
+          };
+          const result = await runner(
+            argument(valueParser),
+            "test",
+            [context],
+            {
+              args: ["--help"],
+              help: {
+                option: true,
+                onShow(code, page) {
+                  assert.equal(code, 0);
+                  assert.ok(page.sections.length > 0);
+                  events.push("help");
+                  return "shown";
+                },
+              },
+              stdout: () => {
+                events.push("stdout");
+              },
+            },
+          );
+          assert.equal(result, "shown");
+          assert.deepEqual(events, ["phase1", "stdout", "help", "dispose"]);
+        });
+      }
+    }
+
+    for (
+      const args of [
+        ["--name", "value"],
+        ["--version"],
+        ["--completion", "bash"],
+        ["--completion"],
+        ["--completion", "unknown"],
+        [],
+      ]
+    ) {
+      it(`should not call help for ${mode} non-help input ${JSON.stringify(args)}`, async () => {
+        await runParser(
+          option("--name", valueParser),
+          "test",
+          args,
+          {
+            aboveError: "help",
+            help: {
+              option: true,
+              onShow: () => assert.fail("Unexpected help."),
+            },
+            version: { option: true, value: "1.0", onShow: () => "version" },
+            completion: { option: true, onShow: () => "completion" },
+            onError: () => "error",
+            stdout: () => {},
+            stderr: () => {},
+          },
+        );
+      });
+    }
+    for (const throwing of ["stdout", "callback"] as const) {
+      it(`should propagate ${mode} ${throwing} exceptions without retrying`, async () => {
+        const error = new TypeError("Help output failed.");
+        let calls = 0;
+        const invoke = () =>
+          runParser(argument(valueParser), "test", ["--help"], {
+            stdout: () => {
+              if (throwing === "stdout") throw error;
+            },
+            help: {
+              option: true,
+              onShow(_code, page) {
+                calls++;
+                assert.ok(page);
+                throw error;
+              },
+            },
+          });
+        if (mode === "sync") assert.throws(invoke, (e) => e === error);
+        else {await assert.rejects(async () =>
+            await invoke(), (e) =>
+            e === error);}
+        assert.equal(calls, throwing === "stdout" ? 0 : 1);
+      });
+    }
+  }
+
+  it("should pass collapsed command entries to the callback", () => {
+    runParser(createFlatCommandDocParser(), "test", ["--help"], {
+      commandList: "top-level",
+      help: {
+        option: true,
+        onShow(_code, page) {
+          const names = page.sections.flatMap((section) => section.entries)
+            .flatMap((entry) =>
+              entry.term.type === "command" ? [entry.term.name] : []
+            );
+          assert.deepEqual(names, ["remote", "config"]);
+        },
+      },
+      stdout: () => {},
+    });
+  });
+
+  it("should forward help through explicit runners", async () => {
+    const options = {
+      args: ["--help"],
+      help: {
+        option: true as const,
+        onShow(code: number, page: DocPage) {
+          assert.equal(code, 0);
+          assert.ok(page.usage);
+          return "shown";
+        },
+      },
+      stdout: () => {},
+    };
+    const parser = argument(string());
+    assert.equal(runParserSync(parser, "test", options.args, options), "shown");
+    assert.equal(
+      await runParserAsync(parser, "test", options.args, options),
+      "shown",
+    );
+    for (const phase of ["single-pass", "two-pass"] as const) {
+      const events: string[] = [];
+      const context: SourceContext = {
+        id: Symbol("sync-help"),
+        phase,
+        getAnnotations(request) {
+          assert.ok(isPhase1ContextRequest(request));
+          return {};
+        },
+        [Symbol.dispose]() {
+          events.push("dispose");
+        },
+      };
+      assert.equal(
+        runWithSync(parser, "test", [context], {
+          ...options,
+          help: {
+            ...options.help,
+            onShow(code, page) {
+              events.push("help");
+              return options.help.onShow(code, page);
+            },
+          },
+        }),
+        "shown",
+      );
+      assert.deepEqual(events, ["help", "dispose"]);
+    }
+  });
+});

--- a/packages/core/src/facade.ts
+++ b/packages/core/src/facade.ts
@@ -1256,8 +1256,19 @@ export interface RunOptions<THelp, TError> {
    */
   readonly help?:
     & {
-      /** Callback invoked when help is requested. */
-      readonly onShow?: (() => THelp) | ((exitCode: number) => THelp);
+      /**
+       * Callback invoked after help output, with the exit code and the final
+       * page passed to {@link formatDocPage}. Treat the page as read-only.
+       * It includes runner-provided entries and root usage customization.
+       * Subcommand and meta-command help use the selected command's docs,
+       * with the run-level footer as a fallback. Formatting options remain
+       * separate from the page.
+       *
+       * Handlers may ignore either argument. Wrappers that invoke this
+       * callback themselves must forward both arguments.
+       * @since 1.3.0 Added the `page` parameter.
+       */
+      readonly onShow?: (exitCode: number, page: DocPage) => THelp;
     }
     & (
       | {
@@ -2148,7 +2159,7 @@ function validateVersionValue(value: unknown): string {
  *          whitespace or control characters, or (for option names) lacks a
  *          valid prefix (`--`, `-`, `/`, or `+`).
  * @throws {RunParserError} When parsing fails and no `onError` callback is
- *          provided.
+ *          provided, or if the requested help page cannot be generated.
  * @since 0.10.0 Added support for {@link Program} objects.
  */
 // Overload: Program with sync parser
@@ -2714,8 +2725,9 @@ export function runParser<
               sectionOrder,
               showUsage,
             }));
+            return onHelp(0, renderedDoc);
           }
-          return onHelp(0);
+          throw new RunParserError("Failed to generate help page.");
         };
 
         // Validate that the commands before --help are actually valid

--- a/packages/run/src/run.test.ts
+++ b/packages/run/src/run.test.ts
@@ -3174,3 +3174,27 @@ describe("runSync async parser rejection", () => {
     );
   });
 });
+
+describe("help callback compatibility", () => {
+  it("should write help before the injected exit callback", () => {
+    const events: unknown[] = [];
+    const exit = new Error("Help exit.");
+    assert.throws(() =>
+      run(argument(string()), {
+        args: ["--help"],
+        programName: "test",
+        help: "option",
+        colors: false,
+        stdout: (chunk) => {
+          events.push(chunk);
+        },
+        onExit: (code) => {
+          events.push(code);
+          throw exit;
+        },
+      }), (error) => error === exit);
+    assert.equal(events.length, 2);
+    assert.equal(typeof events[0], "string");
+    assert.equal(events[1], 0);
+  });
+});


### PR DESCRIPTION
Custom renderers cannot recover runner-added help/version/completion entries from `getDocPage()` on the original parser. Pass the exact `DocPage` used for built-in output to `help.onShow(exitCode, page)`, so they can reuse the runner's metadata and usage adjustments without reconstructing the page.

The callback still runs after output. Existing handlers remain assignable; wrappers that invoke the callback must forward both arguments.

Fixes #899.