### PR TITLE
Give Windows tree cleanup the full deadline

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -224,8 +224,10 @@ To be released.
     and handler dispatch in the test process.  The CLI entry point's
     `createCliRunner()` runs a real process, capturing stdout, stderr, and exit
     status with stdin, environment, timeout, cancellation, and optional
-    process-tree cleanup controls.
-    [[#887], [#890], [#891], [#892], [#893], [#894], [#942], [#943], [#944], [#945], [#946]]
+    process-tree cleanup controls.  On Windows, tree cleanup lets `taskkill`
+    use the shared cleanup deadline and preserves process and pipe errors
+    alongside the original invocation failure.
+    [[#887], [#890], [#891], [#892], [#893], [#894], [#942], [#943], [#944], [#945], [#946], [#953], [#954]]
 
 [#887]: https://github.com/dahlia/optique/issues/887
 [#891]: https://github.com/dahlia/optique/issues/891
@@ -235,6 +237,8 @@ To be released.
 [#944]: https://github.com/dahlia/optique/pull/944
 [#945]: https://github.com/dahlia/optique/pull/945
 [#946]: https://github.com/dahlia/optique/pull/946
+[#953]: https://github.com/dahlia/optique/issues/953
+[#954]: https://github.com/dahlia/optique/pull/954
 
 
 Version 1.2.6

--- a/changes.d/testing/testing-package.md
+++ b/changes.d/testing/testing-package.md
@@ -11,6 +11,8 @@ links:
   '#944': https://github.com/dahlia/optique/pull/944
   '#945': https://github.com/dahlia/optique/pull/945
   '#946': https://github.com/dahlia/optique/pull/946
+  '#953': https://github.com/dahlia/optique/issues/953
+  '#954': https://github.com/dahlia/optique/pull/954
 ---
  -  Added the `@optique/testing` package with a shared `CapturedOutput` type
     and layered entry points for parser, runner, command discovery, and
@@ -24,5 +26,7 @@ links:
     and handler dispatch in the test process.  The CLI entry point's
     `createCliRunner()` runs a real process, capturing stdout, stderr, and exit
     status with stdin, environment, timeout, cancellation, and optional
-    process-tree cleanup controls.
-    [[#887], [#890], [#891], [#892], [#893], [#894], [#942], [#943], [#944], [#945], [#946]]
+    process-tree cleanup controls.  On Windows, tree cleanup lets `taskkill`
+    use the shared cleanup deadline and preserves process and pipe errors
+    alongside the original invocation failure.
+    [[#887], [#890], [#891], [#892], [#893], [#894], [#942], [#943], [#944], [#945], [#946], [#953], [#954]]

--- a/docs/concepts/testing.md
+++ b/docs/concepts/testing.md
@@ -374,7 +374,8 @@ try {
 Invalid factory options throw `TypeError` or `RangeError`; invalid invocation
 options reject the promise.  If cleanup also fails, `reason` becomes
 `"cleanup"` and an `AggregateError` cause preserves the original failure and
-cleanup errors.
+cleanup errors, in that order.  Cleanup errors identify the failed stage and
+preserve underlying process or pipe errors as their own `cause`.
 
 `cleanup: "child"` is the default and terminates only the direct child on
 failure.  Choose `cleanup: "tree"` when the CLI starts other processes that
@@ -382,8 +383,9 @@ should also be terminated on failure.  On POSIX systems this creates a process
 group, sends `SIGTERM`, waits up to one second, and then sends `SIGKILL` if
 needed, allowing another second for final cleanup.  Windows terminates the
 child forcibly; tree cleanup uses the system `taskkill.exe /T /F` with a
-combined two-second bound for the tool and subsequent cleanup.  Cleanup time
-is additional to the invocation timeout.
+combined two-second bound for the tool and subsequent cleanup.  The tool can
+use the remaining cleanup time without a separate one-second cutoff.  Cleanup
+time is additional to the invocation timeout.
 
 Tree cleanup handles ordinary descendants, not processes that escape their
 group or become orphaned.  On Windows, if the direct child has already exited,

--- a/mise.toml
+++ b/mise.toml
@@ -124,19 +124,19 @@ run = 'pnpm --filter "@optique/testing..." -r build'
 description = "Test the CLI boundary using Deno"
 depends = ["testing:cli:build"]
 dir = "packages/testing"
-run = "deno test --allow-read --allow-write --allow-env --allow-run src/cli.test.ts src/public-api.test.ts"
+run = "deno test --allow-read --allow-write --allow-env --allow-run src/cli.test.ts src/cli-cleanup.test.ts src/public-api.test.ts"
 
 [tasks."testing:cli:node"]
 description = "Test the CLI boundary using Node.js"
 depends = ["testing:cli:build"]
 dir = "packages/testing"
-run = "node --test src/cli.test.ts src/public-api.test.ts"
+run = "node --test src/cli.test.ts src/cli-cleanup.test.ts src/public-api.test.ts"
 
 [tasks."testing:cli:bun"]
 description = "Test the CLI boundary using Bun"
 depends = ["testing:cli:build"]
 dir = "packages/testing"
-run = "bun test src/cli.test.ts src/public-api.test.ts"
+run = "bun test src/cli.test.ts src/cli-cleanup.test.ts src/public-api.test.ts"
 
 [tasks."testing:cli"]
 description = "Test the CLI boundary across all runtimes"

--- a/packages/testing/src/cli-cleanup.test.ts
+++ b/packages/testing/src/cli-cleanup.test.ts
@@ -1,0 +1,553 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawn } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { resolve, win32 } from "node:path";
+import { fileURLToPath } from "node:url";
+import { inspect } from "node:util";
+import { setTimeout as delay } from "node:timers/promises";
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import { setImmediate as nextTurn } from "node:timers/promises";
+import { describe, it } from "node:test";
+import {
+  cleanupCliProcess,
+  type CleanupClock,
+  type CleanupState,
+  createCleanupWaiter,
+} from "./cli-cleanup.ts";
+import { type CliProcess, spawnCliProcess } from "./cli-process.ts";
+
+describe("cleanupCliProcess", () => {
+  it("should allow tree termination beyond one second within the shared deadline", async () => {
+    // Arrange
+    const clock = new VirtualClock();
+    const waiter = createCleanupWaiter(clock);
+    const child = new TestProcess(101);
+    const helper = new TestProcess(102);
+    const getState = observe(child, waiter.notify);
+    const errors: unknown[] = [];
+    clock.schedule(() => {
+      child.finish();
+      helper.finish();
+    }, 1200);
+
+    // Act
+    await clock.run(cleanupCliProcess({
+      child,
+      mode: "tree",
+      getState,
+      waiter,
+      recordError: (error) => errors.push(error),
+    }, {
+      platform: "win32",
+      systemRoot: () => "C:\\Windows",
+      spawnHelper: () => helper,
+    }));
+    waiter.dispose();
+
+    // Assert
+    assert.deepEqual(errors, []);
+    assert.equal(clock.now(), 1200);
+    assert.ok(getState().closed);
+  });
+
+  it("should preserve a helper error and retire the failed helper promptly", async () => {
+    const clock = new VirtualClock();
+    const waiter = createCleanupWaiter(clock);
+    const child = new TestProcess(101);
+    const helper = new TestProcess(102);
+    const getState = observe(child, waiter.notify);
+    const errors: unknown[] = [];
+    const cause = new Error("Helper failed.");
+    clock.schedule(() => helper.emit("error", cause), 100);
+
+    await clock.run(cleanupCliProcess({
+      child,
+      mode: "tree",
+      getState,
+      waiter,
+      recordError: (error) => errors.push(error),
+    }, {
+      platform: "win32",
+      systemRoot: () => "C:\\Windows",
+      spawnHelper: () => helper,
+    }));
+    waiter.dispose();
+
+    assert.ok(
+      errors.some((error) => error instanceof Error && error.cause === cause),
+    );
+    assert.equal(clock.now(), 100);
+    assert.deepEqual(helper.signals, ["SIGKILL"]);
+    assert.ok(getState().closed);
+  });
+  it("should retain timeout failure even when forced termination closes the helper", async () => {
+    const clock = new VirtualClock();
+    const waiter = createCleanupWaiter(clock);
+    const child = new TestProcess(101);
+    const helper = new TestProcess(102);
+    const errors: unknown[] = [];
+    await clock.run(
+      cleanupCliProcess({
+        child,
+        mode: "tree",
+        getState: observe(child, waiter.notify),
+        waiter,
+        recordError: (error) => errors.push(error),
+      }, {
+        platform: "win32",
+        systemRoot: () => "C:\\Windows",
+        spawnHelper: () => helper,
+      }),
+    );
+    waiter.dispose();
+    assert.equal(clock.now(), 2000);
+    assert.deepEqual(helper.signals, ["SIGKILL"]);
+    assert.deepEqual(child.signals, ["SIGKILL"]);
+    assert.equal(errors.length, 1);
+    assert.match(String(errors[0]), /tree cleanup command timed out/);
+    const snapshot = [...errors];
+    helper.emit("error", new Error("Late process error."));
+    helper.stdout.emit("error", new Error("Late pipe error."));
+    assert.deepEqual(errors, snapshot);
+  });
+
+  it("should observe deferred pipe closure without extending an expired deadline", async () => {
+    const clock = new VirtualClock();
+    const waiter = createCleanupWaiter(clock);
+    const child = new TestProcess(101);
+    const helper = new TestProcess(102);
+    child.kill = (signal = "SIGTERM") => {
+      child.signals.push(signal);
+      child.emit("exit", 0, null);
+      clock.schedule(() => child.finish(), 0);
+      return true;
+    };
+    const errors: unknown[] = [];
+    await clock.run(
+      cleanupCliProcess({
+        child,
+        mode: "tree",
+        getState: observe(child, waiter.notify),
+        waiter,
+        recordError: (error) => errors.push(error),
+      }, {
+        platform: "win32",
+        systemRoot: () => "C:\\Windows",
+        spawnHelper: () => helper,
+      }),
+    );
+    waiter.dispose();
+    assert.equal(clock.now(), 2000);
+    assert.equal(errors.length, 1);
+    assert.match(String(errors[0]), /tree cleanup command timed out/);
+    assert.ok(!child.unreferenced);
+    assert.equal(clock.pendingCount, 0);
+  });
+
+  it("should keep output read errors while allowing taskkill to finish", async () => {
+    const clock = new VirtualClock();
+    const waiter = createCleanupWaiter(clock);
+    const child = new TestProcess(101);
+    const helper = new TestProcess(102);
+    const errors: unknown[] = [];
+    const cause = Object.assign(new Error("Read failed."), { code: "EPIPE" });
+    clock.schedule(() => helper.stdout.emit("error", cause), 100);
+    clock.schedule(() => {
+      child.finish();
+      helper.finish();
+    }, 1200);
+    await clock.run(
+      cleanupCliProcess({
+        child,
+        mode: "tree",
+        getState: observe(child, waiter.notify),
+        waiter,
+        recordError: (error) => errors.push(error),
+      }, {
+        platform: "win32",
+        systemRoot: () => "C:\\Windows",
+        spawnHelper: () => helper,
+      }),
+    );
+    waiter.dispose();
+    assert.equal(clock.now(), 1200);
+    assert.deepEqual(helper.signals, []);
+    assert.equal(errors.length, 1);
+    assert.ok(errors[0] instanceof Error);
+    assert.equal(errors[0].cause, cause);
+    assert.match(errors[0].message, /stdout/);
+  });
+
+  it("should report nonzero taskkill status with its diagnostic", async () => {
+    const clock = new VirtualClock();
+    const waiter = createCleanupWaiter(clock);
+    const child = new TestProcess(101);
+    const helper = new TestProcess(102);
+    const errors: unknown[] = [];
+    clock.schedule(() => {
+      helper.stderr.write("Access denied.");
+      helper.finish(5);
+    }, 100);
+    await clock.run(
+      cleanupCliProcess({
+        child,
+        mode: "tree",
+        getState: observe(child, waiter.notify),
+        waiter,
+        recordError: (error) => errors.push(error),
+      }, {
+        platform: "win32",
+        systemRoot: () => "C:\\Windows",
+        spawnHelper: () => helper,
+      }),
+    );
+    waiter.dispose();
+    assert.equal(clock.now(), 100);
+    assert.match(String(errors[0]), /code 5: Access denied/);
+    assert.deepEqual(child.signals, ["SIGKILL"]);
+  });
+
+  it("should avoid launching taskkill with an exited root PID", async () => {
+    const clock = new VirtualClock();
+    const waiter = createCleanupWaiter(clock);
+    const child = new TestProcess(101);
+    const getState = observe(child, waiter.notify);
+    child.finish();
+    const errors: unknown[] = [];
+    await clock.run(
+      cleanupCliProcess({
+        child,
+        mode: "tree",
+        getState,
+        waiter,
+        recordError: (error) => errors.push(error),
+      }, {
+        platform: "win32",
+        spawnHelper: () => {
+          assert.fail("Stale PID used.");
+        },
+      }),
+    );
+    waiter.dispose();
+    assert.match(String(errors[0]), /after its root exits/);
+    assert.deepEqual(child.signals, []);
+  });
+
+  it("should close other streams and unreference processes when operations throw", async () => {
+    const clock = new VirtualClock();
+    const waiter = createCleanupWaiter(clock);
+    const child = new TestProcess(101);
+    const helper = new TestProcess(102);
+    const errors: unknown[] = [];
+    const killError = new Error("Kill failed.");
+    const destroyError = new Error("Destroy failed.");
+    child.kill = helper.kill = () => {
+      throw killError;
+    };
+    helper.stdout.destroy = () => {
+      throw destroyError;
+    };
+    await clock.run(
+      cleanupCliProcess({
+        child,
+        mode: "tree",
+        getState: observe(child, waiter.notify),
+        waiter,
+        recordError: (error) => errors.push(error),
+      }, {
+        platform: "win32",
+        systemRoot: () => "C:\\Windows",
+        spawnHelper: () => helper,
+      }),
+    );
+    waiter.dispose();
+    assert.equal(clock.now(), 2000);
+    assert.ok(child.stdout.destroyed && child.stderr.destroyed);
+    assert.ok(helper.stdin.destroyed && helper.stderr.destroyed);
+    assert.ok(child.unreferenced && helper.unreferenced);
+    assert.ok(
+      errors.some((error) =>
+        error instanceof Error && error.cause === killError
+      ),
+    );
+    assert.ok(
+      errors.some((error) =>
+        error instanceof Error && error.cause === destroyError
+      ),
+    );
+    PassThrough.prototype.destroy.call(helper.stdout);
+  });
+
+  it("should retain the POSIX child termination grace period", async () => {
+    const clock = new VirtualClock();
+    const waiter = createCleanupWaiter(clock);
+    const child = new TestProcess(101);
+    child.kill = (signal = "SIGTERM") => {
+      child.signals.push(signal);
+      if (signal === "SIGKILL") child.finish();
+      return true;
+    };
+    const errors: unknown[] = [];
+    await clock.run(
+      cleanupCliProcess({
+        child,
+        mode: "child",
+        getState: observe(child, waiter.notify),
+        waiter,
+        recordError: (error) => errors.push(error),
+      }, { platform: "linux" }),
+    );
+    waiter.dispose();
+    assert.equal(clock.now(), 1000);
+    assert.deepEqual(child.signals, ["SIGTERM", "SIGKILL"]);
+    assert.deepEqual(errors, []);
+  });
+});
+
+describe("Windows tree cleanup integration", () => {
+  it("should let a delayed real taskkill terminate descendants", {
+    timeout: 20_000,
+    skip: process.platform !== "win32",
+  }, async () => {
+    if (process.platform !== "win32") return;
+    const root = process.env.SystemRoot ?? process.env.windir;
+    assert.ok(root !== undefined);
+    const taskkill = win32.join(root, "System32", "taskkill.exe");
+    const temporary = fileURLToPath(new URL("../../../tmp/", import.meta.url));
+    mkdirSync(temporary, { recursive: true });
+    const directory = mkdtempSync(resolve(temporary, "delayed-taskkill-"));
+    const ready = resolve(directory, "ready");
+    const prefix = "Deno" in globalThis ? ["run", "-A"] : [];
+    const env: Record<string, string> = {};
+    for (const [key, value] of Object.entries(process.env)) {
+      if (value !== undefined) env[key] = value;
+    }
+    const child = spawnCliProcess(process.execPath, [
+      ...prefix,
+      fileURLToPath(new URL("./fixtures/cli/program.mjs", import.meta.url)),
+      "tree",
+      ready,
+      "hang",
+    ], { cwd: process.cwd(), env, detached: false });
+    const waiter = createCleanupWaiter();
+    const getState = observe(child, waiter.notify);
+    const errors: unknown[] = [];
+    child.on("error", (error: unknown) => errors.push(error));
+    child.stdin.on("error", () => {});
+    child.stdout.on("error", (error: unknown) => errors.push(error));
+    child.stderr.on("error", (error: unknown) => errors.push(error));
+    child.stdout.resume();
+    child.stderr.resume();
+    let descendant: number | undefined;
+    try {
+      const deadline = performance.now() + 5000;
+      while (descendant === undefined && performance.now() < deadline) {
+        try {
+          const pid = Number(readFileSync(ready, "utf8"));
+          if (Number.isSafeInteger(pid) && pid > 0) descendant = pid;
+        } catch (error) {
+          if (
+            !(error instanceof Error) || !("code" in error) ||
+            error.code !== "ENOENT"
+          ) throw error;
+        }
+        if (descendant === undefined) await delay(10);
+      }
+      assert.ok(
+        descendant !== undefined,
+        "The descendant must report readiness.",
+      );
+      const started = performance.now();
+      await cleanupCliProcess({
+        child,
+        mode: "tree",
+        getState,
+        waiter,
+        recordError: (error) => errors.push(error),
+      }, {
+        budget: 4000,
+        spawnHelper: (command, args) =>
+          spawn(process.execPath, [
+            ...prefix,
+            fileURLToPath(
+              new URL("./fixtures/cli/delayed-taskkill.mjs", import.meta.url),
+            ),
+            command,
+            ...args,
+          ], { windowsHide: true, stdio: "pipe" }),
+      });
+      assert.deepEqual(errors, [], inspect(errors, { depth: null }));
+      assert.ok(performance.now() - started >= 1200);
+      assert.ok(getState().closed);
+      const descendantPid = descendant;
+      assert.throws(() => process.kill(descendantPid, 0), { code: "ESRCH" });
+    } finally {
+      waiter.dispose();
+      for (const pid of [child.pid, descendant]) {
+        if (pid === undefined) continue;
+        try {
+          process.kill(pid, 0);
+          execFileSync(taskkill, ["/PID", String(pid), "/T", "/F"], {
+            stdio: "ignore",
+            timeout: 4000,
+          });
+        } catch { /* Already stopped or bounded by the fixture watchdog. */ }
+      }
+      child.stdin.destroy();
+      child.stdout.destroy();
+      child.stderr.destroy();
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("createCleanupWaiter", () => {
+  it("should avoid scheduling ordinary waits at or beyond the deadline", async () => {
+    const clock = new VirtualClock();
+    const waiter = createCleanupWaiter(clock);
+    assert.ok(!await waiter.waitFor(() => false, 0));
+    assert.ok(!await waiter.waitFor(() => false, -1));
+    assert.ok(await waiter.waitFor(() => true, 0));
+    assert.equal(clock.pendingCount, 0);
+    waiter.dispose();
+  });
+
+  it("should cancel notification and disposal timers without leaving pending waits", async () => {
+    const clock = new VirtualClock();
+    const waiter = createCleanupWaiter(clock);
+    let complete = false;
+    const notified = waiter.waitFor(() => complete, 1000);
+    complete = true;
+    waiter.notify();
+    assert.ok(await notified);
+    assert.equal(clock.pendingCount, 0);
+    const disposed = waiter.waitFor(() => false, 1000);
+    waiter.dispose();
+    assert.ok(!await disposed);
+    assert.equal(clock.pendingCount, 0);
+  });
+
+  it("should observe one zero-delay turn after draining microtasks", async () => {
+    const clock = new VirtualClock();
+    const waiter = createCleanupWaiter(clock);
+    const order: string[] = [];
+    queueMicrotask(() => order.push("microtask"));
+    await clock.run(waiter.observeClose().then(() => order.push("observed")));
+    assert.deepEqual(order, ["microtask", "observed"]);
+    assert.equal(clock.now(), 0);
+    assert.equal(clock.pendingCount, 0);
+    waiter.dispose();
+  });
+});
+
+// Helpers
+
+class VirtualClock implements CleanupClock {
+  time = 0;
+  private sequence = 0;
+  private readonly tasks = new Map<number, {
+    readonly at: number;
+    readonly callback: () => void;
+  }>();
+
+  get pendingCount(): number {
+    return this.tasks.size;
+  }
+
+  now = (): number => this.time;
+
+  schedule = (callback: () => void, delay: number): () => void => {
+    const id = this.sequence++;
+    this.tasks.set(id, { at: this.time + delay, callback });
+    return () => {
+      this.tasks.delete(id);
+    };
+  };
+
+  async run<T>(promise: Promise<T>): Promise<T> {
+    let settled = false;
+    promise.then(() => settled = true, () => settled = true);
+    for (let steps = 0; !settled; steps++) {
+      assert.ok(steps < 100, "Cleanup must settle after bounded scheduling.");
+      // Flush real stream callbacks and promise continuations without advancing
+      // the injected cleanup clock.
+      await nextTurn();
+      if (settled) break;
+      const next = [...this.tasks.entries()].sort((a, b) =>
+        a[1].at - b[1].at || a[0] - b[0]
+      )[0];
+      assert.ok(next, "Cleanup must not wait without a notification or timer.");
+      const [id, task] = next;
+      this.tasks.delete(id);
+      this.time = task.at;
+      task.callback();
+    }
+    return await promise;
+  }
+}
+
+class TestProcess extends EventEmitter implements CliProcess {
+  readonly pid: number;
+  readonly stdin = new PassThrough();
+  readonly stdout = new PassThrough();
+  readonly stderr = new PassThrough();
+  readonly signals: NodeJS.Signals[] = [];
+  unreferenced = false;
+
+  constructor(pid: number) {
+    super();
+    this.pid = pid;
+  }
+
+  kill(signal: NodeJS.Signals = "SIGTERM"): boolean {
+    this.signals.push(signal);
+    this.finish();
+    return true;
+  }
+
+  unref(): void {
+    this.unreferenced = true;
+  }
+
+  finish(code = 0): void {
+    this.emit("exit", code, null);
+    for (const stream of [this.stdin, this.stdout, this.stderr]) {
+      stream.destroy();
+      stream.emit("close");
+    }
+    this.emit("close", code, null);
+  }
+}
+
+function observe(
+  child: CliProcess,
+  notify: () => void,
+): () => CleanupState {
+  let exited = false;
+  let closed = false;
+  let stdinClosed = false;
+  let stdoutClosed = false;
+  let stderrClosed = false;
+  child.on("exit", () => {
+    exited = true;
+    notify();
+  });
+  child.on("close", () => {
+    closed = true;
+    notify();
+  });
+  child.stdin.on("close", () => {
+    stdinClosed = true;
+    notify();
+  });
+  child.stdout.on("close", () => {
+    stdoutClosed = true;
+    notify();
+  });
+  child.stderr.on("close", () => {
+    stderrClosed = true;
+    notify();
+  });
+  return () => ({ exited, closed, stdinClosed, stdoutClosed, stderrClosed });
+}

--- a/packages/testing/src/cli-cleanup.ts
+++ b/packages/testing/src/cli-cleanup.ts
@@ -1,0 +1,366 @@
+/** Internal failure cleanup for real CLI processes. */
+import { spawn } from "node:child_process";
+import { win32 } from "node:path";
+import process from "node:process";
+import type { CliProcess } from "./cli-process.ts";
+
+/** A monotonic clock whose scheduled callbacks run after the current stack. */
+export interface CleanupClock {
+  readonly now: () => number;
+  readonly schedule: (callback: () => void, delay: number) => () => void;
+}
+
+/** Invocation-local waits, notified by process and stream lifecycle events. */
+export interface CleanupWaiter {
+  readonly now: () => number;
+  readonly notify: () => void;
+  readonly waitFor: (
+    predicate: () => boolean,
+    deadline: number,
+  ) => Promise<boolean>;
+  readonly observeClose: () => Promise<void>;
+  readonly dispose: () => void;
+}
+
+const systemClock: CleanupClock = {
+  now: () => performance.now(),
+  schedule(callback, delay) {
+    const timer = setTimeout(callback, delay);
+    return () => clearTimeout(timer);
+  },
+};
+
+/**
+ * Creates deadline waits driven by a monotonic clock and lifecycle notifications.
+ * @param clock The clock and cancellable timer scheduler.
+ * @returns A waiter that owns and disposes its outstanding timers.
+ */
+export function createCleanupWaiter(
+  clock: CleanupClock = systemClock,
+): CleanupWaiter {
+  const pending = new Set<{
+    readonly wake: () => void;
+    readonly finish: (value: boolean) => void;
+  }>();
+  let disposed = false;
+  return {
+    now: () => clock.now(),
+    notify() {
+      for (const wait of [...pending]) wait.wake();
+    },
+    waitFor(predicate, deadline) {
+      if (predicate()) return Promise.resolve(true);
+      if (disposed || deadline <= clock.now()) return Promise.resolve(false);
+      return new Promise((resolve) => {
+        let cancel = () => {};
+        let finished = false;
+        const wait = {
+          wake() {
+            if (predicate()) wait.finish(true);
+          },
+          finish(value: boolean) {
+            if (finished) return;
+            finished = true;
+            cancel();
+            pending.delete(wait);
+            resolve(value);
+          },
+        };
+        pending.add(wait);
+        cancel = clock.schedule(
+          () => wait.finish(false),
+          Math.max(0, deadline - clock.now()),
+        );
+      });
+    },
+    async observeClose() {
+      await Promise.resolve();
+      if (disposed) return;
+      await new Promise<void>((resolve) => {
+        let cancel = () => {};
+        const wait = {
+          wake() {},
+          finish() {
+            cancel();
+            pending.delete(wait);
+            resolve();
+          },
+        };
+        pending.add(wait);
+        cancel = clock.schedule(() => wait.finish(), 0);
+      });
+    },
+    dispose() {
+      disposed = true;
+      for (const wait of [...pending]) wait.finish(false);
+    },
+  };
+}
+
+/** Live target lifecycle state, read again for each wait and PID guard. */
+export interface CleanupState {
+  readonly exited: boolean;
+  readonly closed: boolean;
+  readonly stdinClosed: boolean;
+  readonly stdoutClosed: boolean;
+  readonly stderrClosed: boolean;
+}
+
+/** The invocation-owned state and ordered error collector used during cleanup. */
+export interface CleanupContext {
+  readonly child: CliProcess | undefined;
+  readonly mode: "child" | "tree";
+  readonly getState: () => CleanupState;
+  readonly waiter: CleanupWaiter;
+  readonly recordError: (error: unknown) => void;
+}
+
+/** Internal process operations; overrides belong to tests and measurements only. */
+export interface CleanupDependencies {
+  readonly platform?: NodeJS.Platform;
+  readonly systemRoot?: () => string | undefined;
+  readonly spawnHelper?: (
+    command: string,
+    args: readonly string[],
+  ) => CliProcess;
+  readonly signalGroup?: (pid: number, signal: NodeJS.Signals | 0) => void;
+  readonly budget?: number;
+}
+
+function errorCode(error: unknown): unknown {
+  return error !== null && typeof error === "object" && "code" in error
+    ? error.code
+    : undefined;
+}
+
+/**
+ * Terminates a failed invocation and closes its owned process streams.
+ * @param context Live invocation state and cleanup error sink.
+ * @param dependencies Internal platform operations and measurement overrides.
+ * @returns Completion after bounded cleanup attempts.
+ */
+export async function cleanupCliProcess(
+  context: CleanupContext,
+  dependencies: CleanupDependencies = {},
+): Promise<void> {
+  const { child, getState, waiter } = context;
+  if (child === undefined) return;
+  const platform = dependencies.platform ?? process.platform;
+  const deadline = waiter.now() + (dependencies.budget ?? 2000);
+  let active = true;
+  let helper: CliProcess | undefined;
+  let helperClosed = false;
+  let helperExited = false;
+  let helperFailed = false;
+  let helperSpawned = false;
+  let helperCode: number | null = null;
+  let diagnostic = "";
+
+  function record(stage: string, cause?: unknown) {
+    if (!active) return;
+    context.recordError(new Error(stage, { cause }));
+  }
+  function attempt(stage: string, action: () => void) {
+    try {
+      action();
+    } catch (error) {
+      record(stage, error);
+    }
+  }
+  function killChild(signal: NodeJS.Signals) {
+    if (child?.pid === undefined || getState().exited || getState().closed) {
+      return;
+    }
+    attempt("The CLI process could not be signaled during cleanup.", () => {
+      child.kill(signal);
+    });
+  }
+  function groupSignal(signal: NodeJS.Signals | 0): boolean {
+    if (child?.pid === undefined) return false;
+    try {
+      if (dependencies.signalGroup !== undefined) {
+        dependencies.signalGroup(-child.pid, signal);
+      } else process.kill(-child.pid, signal);
+      return true;
+    } catch (error) {
+      if (errorCode(error) !== "ESRCH") {
+        record(
+          "The CLI process group could not be signaled during cleanup.",
+          error,
+        );
+      }
+      return false;
+    }
+  }
+  function destroyStreams(target: CliProcess, name: string) {
+    for (const stream of ["stdin", "stdout", "stderr"] as const) {
+      attempt(`${name} ${stream} could not be closed during cleanup.`, () => {
+        target[stream].destroy();
+      });
+    }
+  }
+  function retireHelper() {
+    const target = helper;
+    if (target === undefined) return;
+    if (!helperExited && !helperClosed) {
+      attempt("The tree cleanup command could not be terminated.", () => {
+        target.kill("SIGKILL");
+      });
+    }
+    destroyStreams(target, "Tree cleanup command");
+  }
+  async function taskkill(pid: number) {
+    const root = dependencies.systemRoot?.() ??
+      (dependencies.systemRoot === undefined
+        ? process.env.SystemRoot ?? process.env.windir
+        : undefined);
+    if (root === undefined || !win32.isAbsolute(root)) {
+      record("Windows system directory is unavailable for tree cleanup.");
+      killChild("SIGKILL");
+      return;
+    }
+    try {
+      const command = win32.join(root, "System32", "taskkill.exe");
+      const args = ["/PID", String(pid), "/T", "/F"];
+      helper = dependencies.spawnHelper?.(command, args) ??
+        spawn(command, args, {
+          shell: false,
+          windowsHide: true,
+          stdio: "pipe",
+        });
+    } catch (error) {
+      record("The tree cleanup command could not be launched.", error);
+      killChild("SIGKILL");
+      return;
+    }
+    helper.on("spawn", () => {
+      helperSpawned = true;
+    });
+    helper.on("exit", () => {
+      helperExited = true;
+      waiter.notify();
+    });
+    helper.on("close", (code: number | null) => {
+      helperClosed = true;
+      helperCode = code;
+      waiter.notify();
+    });
+    helper.on("error", (error: unknown) => {
+      helperFailed = true;
+      record(
+        helperSpawned
+          ? "The tree cleanup command failed."
+          : "The tree cleanup command could not be launched.",
+        error,
+      );
+      waiter.notify();
+    });
+    // The helper receives no input.  Keep an error listener for a failed spawn.
+    helper.stdin.on("error", () => {});
+    helper.stdout.on("error", (error: unknown) => {
+      record("Tree cleanup command stdout could not be read.", error);
+    });
+    helper.stderr.on("error", (error: unknown) => {
+      record("Tree cleanup command stderr could not be read.", error);
+    });
+    helper.stderr.setEncoding("utf8");
+    helper.stderr.on("data", (text: string) => {
+      if (active) diagnostic += text;
+    });
+    helper.stdout.resume();
+    helper.stdin.end();
+    const completed = await waiter.waitFor(
+      () => helperClosed || helperFailed,
+      deadline,
+    );
+    if (!completed) {
+      // This verdict is permanent even if forced retirement later emits close.
+      record("The tree cleanup command timed out.");
+      retireHelper();
+      killChild("SIGKILL");
+    } else if (helperFailed) {
+      retireHelper();
+      killChild("SIGKILL");
+    } else if (helperCode !== 0) {
+      record(
+        `Tree cleanup command exited with code ${helperCode}: ${diagnostic}`,
+      );
+      killChild("SIGKILL");
+    }
+  }
+  const exited = () => getState().exited || getState().closed;
+  const targetClosed = () => {
+    const state = getState();
+    return state.closed && state.stdinClosed && state.stdoutClosed &&
+      state.stderrClosed;
+  };
+  const allClosed = () =>
+    targetClosed() &&
+    (helper === undefined || helperClosed);
+  try {
+    attempt("CLI stdin could not be closed during cleanup.", () => {
+      child.stdin.destroy();
+    });
+    if (child.pid !== undefined) {
+      if (platform === "win32") {
+        if (context.mode === "tree") {
+          if (exited()) {
+            record("Cannot trace a Windows process tree after its root exits.");
+          } else await taskkill(child.pid);
+        } else killChild("SIGKILL");
+      } else if (context.mode === "tree") {
+        const found = groupSignal("SIGTERM");
+        if (!found && !exited()) {
+          record("The child process group is unavailable.");
+        }
+        killChild("SIGTERM");
+        if (
+          found && !await waiter.waitFor(
+            () => exited() && !groupSignal(0),
+            Math.min(deadline, waiter.now() + 1000),
+          )
+        ) groupSignal("SIGKILL");
+        killChild("SIGKILL");
+      } else {
+        killChild("SIGTERM");
+        if (
+          !await waiter.waitFor(exited, Math.min(deadline, waiter.now() + 1000))
+        ) {
+          killChild("SIGKILL");
+        }
+      }
+    }
+    if (!await waiter.waitFor(exited, deadline)) {
+      record("The CLI process did not exit during cleanup.");
+      killChild("SIGKILL");
+    }
+    // Exit can precede the last reads, or descendants can keep pipes open.
+    await waiter.waitFor(
+      () => getState().closed,
+      Math.min(deadline, waiter.now() + 250),
+    );
+  } catch (error) {
+    record("Process termination failed during cleanup.", error);
+    retireHelper();
+    killChild("SIGKILL");
+  }
+  destroyStreams(child, "CLI process");
+  if (!await waiter.waitFor(allClosed, deadline)) {
+    // destroy() can enqueue local close events after the deadline. Observe one
+    // turn collectively, without granting a new positive-duration grace period.
+    await waiter.observeClose();
+  }
+  if (helper !== undefined && !helperClosed) {
+    record("The tree cleanup command did not close.");
+    attempt("The tree cleanup command could not be unreferenced.", () => {
+      helper?.unref();
+    });
+  }
+  if (!targetClosed()) {
+    record("The CLI process streams did not close during cleanup.");
+    attempt("The CLI process could not be unreferenced during cleanup.", () => {
+      child.unref();
+    });
+  }
+  active = false;
+}

--- a/packages/testing/src/cli.test.ts
+++ b/packages/testing/src/cli.test.ts
@@ -13,6 +13,7 @@ import { resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { setTimeout as delay } from "node:timers/promises";
 import { describe, it } from "node:test";
+import { inspect } from "node:util";
 
 const fixture = new URL("./fixtures/cli/program.mjs", import.meta.url);
 const runtimeArgs = "Deno" in globalThis ? ["-A"] : [];
@@ -531,34 +532,42 @@ describe("CLI process cleanup", () => {
     }
   });
 
-  it("should stop descendants on Windows with tree cleanup", {
-    skip: process.platform !== "win32",
-  }, async () => {
-    if (process.platform !== "win32") return;
-    const directory = scratch();
-    const ready = resolve(directory, "ready");
-    const controller = new AbortController();
-    const settled = runner().invoke({
-      args: ["tree", ready, "hang"],
-      cleanup: "tree",
-      signal: controller.signal,
-    })
-      .then((value) => ({ value }), (error: unknown) => ({ error }));
-    try {
-      const pid = await waitReady(ready);
-      controller.abort();
-      const result = await settled;
-      assert.ok("error" in result);
-      assert.ok(result.error instanceof CliInvocationError);
-      assert.equal(result.error.reason, "aborted");
-      assert.ok(!alive(pid));
-    } finally {
-      controller.abort();
-      await settled;
-      killFixture(ready);
-      rmSync(directory, { recursive: true, force: true });
-    }
-  });
+  for (const reason of ["aborted", "timeout"] as const) {
+    it(`should stop descendants on Windows after ${reason}`, {
+      timeout: 20_000,
+      skip: process.platform !== "win32",
+    }, async () => {
+      if (process.platform !== "win32") return;
+      const directory = scratch();
+      const ready = resolve(directory, "ready");
+      const controller = new AbortController();
+      const settled = runner().invoke({
+        args: ["tree", ready, "hang"],
+        cleanup: "tree",
+        signal: controller.signal,
+        timeout: reason === "timeout" ? 6000 : 8000,
+      })
+        .then((value) => ({ value }), (error: unknown) => ({ error }));
+      try {
+        const pid = await waitReady(ready);
+        if (reason === "aborted") controller.abort();
+        const result = await settled;
+        assert.ok("error" in result);
+        assert.ok(result.error instanceof CliInvocationError);
+        assert.equal(
+          result.error.reason,
+          reason,
+          inspect(result.error, { depth: null, colors: false }),
+        );
+        assert.ok(!alive(pid));
+      } finally {
+        controller.abort();
+        await settled;
+        killFixture(ready);
+        rmSync(directory, { recursive: true, force: true });
+      }
+    });
+  }
 });
 
 describe("Optique CLI entrypoints", () => {
@@ -610,6 +619,7 @@ describe("Windows CLI failures", () => {
   });
 
   it("should report taskkill failures without losing the original timeout", {
+    timeout: 20_000,
     skip: process.platform !== "win32",
   }, async () => {
     if (process.platform !== "win32") return;
@@ -622,13 +632,16 @@ describe("Windows CLI failures", () => {
           import.meta.url,
         ),
         runtimeArgs,
-        timeout: 10_000,
+        timeout: 12_000,
       }).invoke(ready);
       assert.equal(result.exitCode, 0, result.stderr);
       assert.deepEqual(JSON.parse(result.stdout), {
         reason: "cleanup",
         stdout: "ready\n",
         aggregate: true,
+        primaryReason: "timeout",
+        primaryStdout: "ready\n",
+        cleanupCause: true,
       });
     } finally {
       killFixture(ready);

--- a/packages/testing/src/cli.ts
+++ b/packages/testing/src/cli.ts
@@ -4,11 +4,11 @@
  * @module
  * @since 1.3.0
  */
-import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
-import { isAbsolute, join, resolve } from "node:path";
+import { resolve } from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 import type { CapturedOutput } from "./index.ts";
+import { cleanupCliProcess, createCleanupWaiter } from "./cli-cleanup.ts";
 import { type CliProcess, spawnCliProcess } from "./cli-process.ts";
 
 interface ProcessOptions {
@@ -376,7 +376,7 @@ function runProcess(
     } | undefined;
     const cleanupErrors: unknown[] = [];
     let timer: ReturnType<typeof setTimeout> | undefined;
-    const waiters = new Set<() => void>();
+    const waiter = createCleanupWaiter();
     const snapshot = (): CliResult => ({
       stdout: stdout.join(""),
       stderr: stderr.join(""),
@@ -391,6 +391,7 @@ function runProcess(
     };
     function release() {
       clearInvocation();
+      if (settled) waiter.dispose();
       child?.stdout.removeListener("data", onOut);
       child?.stderr.removeListener("data", onErr);
       // Error listeners remain until close, including after a cleanup deadline.
@@ -400,7 +401,7 @@ function runProcess(
       if (inClose) child?.stdin.removeListener("error", onInputError);
     }
     function update() {
-      for (const wake of [...waiters]) wake();
+      waiter.notify();
       if (settled) {
         release();
         return;
@@ -413,27 +414,6 @@ function runProcess(
         release();
         resolveResult(snapshot());
       }
-    }
-    function waitFor(
-      predicate: () => boolean,
-      milliseconds: number,
-    ): Promise<boolean> {
-      if (predicate()) return Promise.resolve(true);
-      return new Promise((done) => {
-        const finish = (value: boolean) => {
-          clearTimeout(timeout);
-          waiters.delete(wake);
-          done(value);
-        };
-        const wake = () => {
-          if (predicate()) finish(true);
-        };
-        const timeout = setTimeout(
-          () => finish(false),
-          Math.max(0, milliseconds),
-        );
-        waiters.add(wake);
-      });
     }
     function fail(
       reason: CliInvocationError["reason"],
@@ -448,179 +428,22 @@ function runProcess(
         void cleanup();
       });
     }
-    function killChild(kind: NodeJS.Signals) {
-      if (!child?.pid || exited || closed) return;
-      try {
-        child.kill(kind);
-      } catch (error) {
-        cleanupErrors.push(error);
-      }
-    }
-    function groupSignal(kind: NodeJS.Signals | 0): boolean {
-      if (!child?.pid) return false;
-      try {
-        process.kill(-child.pid, kind);
-        return true;
-      } catch (error) {
-        if (errorCode(error) !== "ESRCH") cleanupErrors.push(error);
-        return false;
-      }
-    }
-    async function taskkill(deadline: number, pid: number) {
-      let helper: ChildProcessWithoutNullStreams;
-      const root = process.env.SystemRoot ?? process.env.windir;
-      if (root === undefined || !isAbsolute(root)) {
-        cleanupErrors.push(
-          new Error("Windows system directory is unavailable."),
-        );
-        killChild("SIGKILL");
-        return;
-      }
-      try {
-        helper = spawn(join(root, "System32", "taskkill.exe"), [
-          "/PID",
-          String(pid),
-          "/T",
-          "/F",
-        ], {
-          shell: false,
-          windowsHide: true,
-          stdio: "pipe",
-        });
-      } catch (error) {
-        cleanupErrors.push(error);
-        killChild("SIGKILL");
-        return;
-      }
-      let helperClosed = false;
-      let helperError: unknown;
-      let helperCode: number | null = null;
-      let diagnostic = "";
-      helper.stdout.resume();
-      helper.stderr.setEncoding("utf8");
-      helper.stderr.on("data", (text: string) => {
-        diagnostic += text;
-      });
-      helper.stdin.on("error", () => {});
-      helper.stdout.on("error", (error) => {
-        helperError = error;
-      });
-      helper.stderr.on("error", (error) => {
-        helperError = error;
-      });
-      helper.on("error", (error) => {
-        helperError = error;
-        killChild("SIGKILL");
-      });
-      helper.on("close", (code) => {
-        helperClosed = true;
-        helperCode = code;
-        update();
-      });
-      helper.stdin.end();
-      if (
-        !await waitFor(
-          () => helperClosed,
-          Math.min(1000, deadline - Date.now()),
-        )
-      ) {
-        cleanupErrors.push(new Error("Tree cleanup command timed out."));
-        try {
-          helper.kill("SIGKILL");
-        } catch (error) {
-          cleanupErrors.push(error);
-        }
-        killChild("SIGKILL");
-        helper.stdin.destroy();
-        helper.stdout.destroy();
-        helper.stderr.destroy();
-        if (!await waitFor(() => helperClosed, deadline - Date.now())) {
-          cleanupErrors.push(new Error("Tree cleanup command did not close."));
-          helper.unref();
-        }
-      } else if (helperError !== undefined || helperCode !== 0) {
-        cleanupErrors.push(
-          helperError ??
-            new Error(
-              `Tree cleanup exited with code ${helperCode}: ${diagnostic}`,
-            ),
-        );
-        killChild("SIGKILL");
-      }
-    }
     async function cleanup() {
-      const deadline = Date.now() + 2000;
-      try {
-        if (child !== undefined) {
-          child.stdin.destroy();
-          if (child.pid !== undefined) {
-            if (process.platform === "win32") {
-              if (options.cleanup === "tree") {
-                if (exited || closed) {
-                  cleanupErrors.push(
-                    new Error(
-                      "Cannot trace a Windows process tree after its root exits.",
-                    ),
-                  );
-                } else await taskkill(deadline, child.pid);
-              } else killChild("SIGKILL");
-            } else if (options.cleanup === "tree") {
-              const found = groupSignal("SIGTERM");
-              if (!found && !exited && !closed) {
-                cleanupErrors.push(
-                  new Error("The child process group is unavailable."),
-                );
-              }
-              killChild("SIGTERM");
-              if (
-                found &&
-                !await waitFor(
-                  () => (exited || closed) && !groupSignal(0),
-                  1000,
-                )
-              ) {
-                groupSignal("SIGKILL");
-              }
-              killChild("SIGKILL");
-            } else {
-              killChild("SIGTERM");
-              if (!await waitFor(() => exited || closed, 1000)) {
-                killChild("SIGKILL");
-              }
-            }
-          }
-          if (!await waitFor(() => exited || closed, deadline - Date.now())) {
-            cleanupErrors.push(
-              new Error("The CLI process did not exit during cleanup."),
-            );
-          }
-          // Exit can precede the last pipe reads.  Allow a bounded drain even
-          // when descendants still hold the descriptors, then close our ends.
-          await waitFor(() => closed, Math.min(250, deadline - Date.now()));
-          child.stdout.destroy();
-          child.stderr.destroy();
-          if (
-            !await waitFor(
-              () => closed && outClose && errClose && inClose,
-              deadline - Date.now(),
-            )
-          ) {
-            cleanupErrors.push(
-              new Error(
-                "The CLI process streams did not close during cleanup.",
-              ),
-            );
-            child.unref();
-          }
-        }
-      } catch (error) {
-        cleanupErrors.push(error);
-        killChild("SIGKILL");
-        child?.stdin.destroy();
-        child?.stdout.destroy();
-        child?.stderr.destroy();
-        child?.unref();
-      }
+      await cleanupCliProcess({
+        child,
+        mode: options.cleanup,
+        getState: () => ({
+          exited,
+          closed,
+          stdinClosed: inClose,
+          stdoutClosed: outClose,
+          stderrClosed: errClose,
+        }),
+        waiter,
+        recordError: (error) => {
+          if (!settled) cleanupErrors.push(error);
+        },
+      });
       if (failure === undefined || settled) return;
       const result = snapshot();
       const primary = new CliInvocationError(
@@ -652,10 +475,29 @@ function runProcess(
       stderr.push(text);
     }
     function onError(error: Error) {
-      if (failure) cleanupErrors.push(error);
-      else fail(spawned ? "io" : "spawn", "Could not execute the CLI.", error);
+      if (settled) return;
+      if (failure) {
+        cleanupErrors.push(
+          new Error("The CLI process failed during cleanup.", { cause: error }),
+        );
+      } else {
+        fail(
+          spawned ? "io" : "spawn",
+          "Could not execute the CLI.",
+          error,
+        );
+      }
     }
     function onIoError(error: Error) {
+      if (settled) return;
+      if (failure) {
+        cleanupErrors.push(
+          new Error("CLI output could not be read during cleanup.", {
+            cause: error,
+          }),
+        );
+        return;
+      }
       fail("io", "Could not capture CLI output.", error);
     }
     function onInputError(error: Error) {

--- a/packages/testing/src/fixtures/cli/delayed-taskkill.mjs
+++ b/packages/testing/src/fixtures/cli/delayed-taskkill.mjs
@@ -1,0 +1,19 @@
+import { spawn } from "node:child_process";
+
+// The delay deliberately exceeds the former one-second helper limit.
+const watchdog = setTimeout(() => process.exit(124), 10_000);
+setTimeout(() => {
+  const helper = spawn(process.argv[2], process.argv.slice(3), {
+    stdio: ["ignore", "inherit", "inherit"],
+    windowsHide: true,
+  });
+  helper.on("error", (error) => {
+    console.error(error);
+    clearTimeout(watchdog);
+    process.exitCode = 1;
+  });
+  helper.on("close", (code) => {
+    clearTimeout(watchdog);
+    process.exitCode = code ?? 1;
+  });
+}, 1200);

--- a/packages/testing/src/fixtures/cli/windows-cleanup.mjs
+++ b/packages/testing/src/fixtures/cli/windows-cleanup.mjs
@@ -24,10 +24,23 @@ try {
   throw new Error("Expected tree cleanup to fail.");
 } catch (error) {
   if (!(error instanceof CliInvocationError)) throw error;
+  const primary = error.cause instanceof AggregateError
+    ? error.cause.errors[0]
+    : undefined;
   console.log(JSON.stringify({
     reason: error.reason,
     stdout: error.stdout,
     aggregate: error.cause instanceof AggregateError,
+    primaryReason: primary instanceof CliInvocationError
+      ? primary.reason
+      : null,
+    primaryStdout: primary instanceof CliInvocationError
+      ? primary.stdout
+      : null,
+    cleanupCause: error.cause instanceof AggregateError &&
+      error.cause.errors.slice(1).some(
+        (failure) => failure instanceof Error && failure.cause instanceof Error,
+      ),
   }));
 } finally {
   try {


### PR DESCRIPTION
Windows tree cleanup could fail after one second even when its shared two-second deadline had time left. Let `taskkill` use the remaining time, with a monotonic clock keeping all cleanup steps within the same deadline.

Preserve cleanup errors and their causes alongside the original cancellation or timeout so failures remain diagnosable. Late close events cannot erase an already-recorded timeout. Controlled lifecycle tests cover these races, including a helper that takes longer than the former one-second limit.

Validated with `mise test`, the docs build, and Windows CLI tests on Node.js/Deno/Bun. Windows measurements support keeping the two-second budget.

Closes #953.
