### PR TITLE
Honor color preferences and validate terminal width

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -143,6 +143,8 @@ To be released.
 
     Invalid reported terminal widths now fall back to a positive decimal
     `COLUMNS` value, or leave output unwrapped when neither is valid.
+    Automatically detected widths too narrow for the output layout also
+    leave output unwrapped instead of failing.
     Explicit `maxWidth` keeps its existing validation. Deno ignores
     inaccessible environment variables without requesting permission.
     These defaults do not change the printer functions.  [[#903], [#955]]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -123,13 +123,32 @@ To be released.
  -  Added `termWidth` to the core and high-level runner options.  Automatic
     sizing measures the final help page after built-in help, version, and shell
     completion entries have been added.  [[#904], [#911]]
+
  -  Added `theme` and `messageFormatter` options to runners and printers,
     including themed error labels in `printError()`. Themed labels honor
     `colors.resetSuffix` so caller styling resumes after the label.
     [[#907], [#952]]
+
  -  Added `usageLine` to `RunOptions`.  `run()`, `runSync()`, and `runAsync()`
     can now replace the root synopsis in full help without changing parsing or
     subcommand help.  [[#879]]
+
+ -  Improved automatic color and width defaults for help, usage, and errors
+    from `run()`, `runSync()`, and `runAsync()`.
+
+    Any nonempty `FORCE_COLOR` enables colors, including `0`; otherwise a
+    nonempty `NO_COLOR` or any `NODE_DISABLE_COLORS` disables them. Empty
+    `FORCE_COLOR` and `NO_COLOR` values are ignored. Explicit `colors` still
+    takes precedence.
+
+    Invalid reported terminal widths now fall back to a positive decimal
+    `COLUMNS` value, or leave output unwrapped when neither is valid.
+    Explicit `maxWidth` keeps its existing validation. Deno ignores
+    inaccessible environment variables without requesting permission.
+    These defaults do not change the printer functions.  [[#903], [#955]]
+
+[#903]: https://github.com/dahlia/optique/issues/903
+[#955]: https://github.com/dahlia/optique/pull/955
 
 ### @optique/discover
 

--- a/changes.d/run/terminal-capabilities.md
+++ b/changes.d/run/terminal-capabilities.md
@@ -1,0 +1,18 @@
+---
+links:
+  '#903': https://github.com/dahlia/optique/issues/903
+  '#955': https://github.com/dahlia/optique/pull/955
+---
+ -  Improved automatic color and width defaults for help, usage, and errors
+    from `run()`, `runSync()`, and `runAsync()`.
+
+    Any nonempty `FORCE_COLOR` enables colors, including `0`; otherwise a
+    nonempty `NO_COLOR` or any `NODE_DISABLE_COLORS` disables them. Empty
+    `FORCE_COLOR` and `NO_COLOR` values are ignored. Explicit `colors` still
+    takes precedence.
+
+    Invalid reported terminal widths now fall back to a positive decimal
+    `COLUMNS` value, or leave output unwrapped when neither is valid.
+    Explicit `maxWidth` keeps its existing validation. Deno ignores
+    inaccessible environment variables without requesting permission.
+    These defaults do not change the printer functions.  [[#903], [#955]]

--- a/changes.d/run/terminal-capabilities.md
+++ b/changes.d/run/terminal-capabilities.md
@@ -13,6 +13,8 @@ links:
 
     Invalid reported terminal widths now fall back to a positive decimal
     `COLUMNS` value, or leave output unwrapped when neither is valid.
+    Automatically detected widths too narrow for the output layout also
+    leave output unwrapped instead of failing.
     Explicit `maxWidth` keeps its existing validation. Deno ignores
     inaccessible environment variables without requesting permission.
     These defaults do not change the printer functions.  [[#903], [#955]]

--- a/docs/concepts/runners.md
+++ b/docs/concepts/runners.md
@@ -556,12 +556,50 @@ The function automatically:
 
  -  *Extracts arguments* from `process.argv.slice(2)`
  -  *Uses program name* from `Program` metadata
- -  *Auto-detects colors* from `process.stdout.isTTY`
- -  *Auto-detects width* from `process.stdout.columns`
+ -  *Auto-detects colors* from environment preferences and
+    `process.stdout.isTTY`
+ -  *Auto-detects width* from `process.stdout.columns`, then `COLUMNS`
  -  *Exits on error* with code 1 by default
 
 When `help`, `version`, or `completion` is enabled, the same runner also
 handles those meta requests and exits with code 0.
+
+### Terminal defaults
+
+Since Optique 1.3, `run()`, `runSync()`, and `runAsync()` honor environment
+preferences when `colors` is omitted. A nonempty `FORCE_COLOR` enables colors,
+including when output is piped. Any nonempty value works, including `0`,
+`false`, or whitespace. Otherwise, a nonempty `NO_COLOR` or the presence of
+`NODE_DISABLE_COLORS` disables colors. If none applies, the runner uses
+`process.stdout.isTTY`.
+
+Empty `FORCE_COLOR` and `NO_COLOR` values are ignored, following the
+[`FORCE_COLOR`] and [`NO_COLOR`] conventions. An empty
+`NODE_DISABLE_COLORS` still disables colors. Explicit `colors: true` or
+`colors: false` overrides all of these defaults.
+
+When `maxWidth` is omitted, the runner uses `process.stdout.columns` if it is a
+positive finite integer. Otherwise, it tries `COLUMNS`, which must contain
+only decimal digits and represent a positive finite integer. Leading zeros
+are allowed; whitespace, fractions, and values such as `80px` are not. If
+neither source is valid, output remains unwrapped. An explicit `maxWidth`
+overrides detection and retains the formatter's validation, including errors
+for widths too narrow for the content.
+
+On Deno, `FORCE_COLOR` and `NO_COLOR` are readable without environment
+permissions. To use the other two variables, grant
+`--allow-env=COLUMNS,NODE_DISABLE_COLORS`. The runner ignores inaccessible
+variables without requesting permission.
+
+These defaults apply to runner-rendered help, usage, and errors, all using
+stdout as the detection source even when output callbacks are supplied.
+`print()`, `printError()`, and `createPrinter()` keep their stream-based
+defaults; pass their formatting options explicitly when they need to match
+your runner settings. For repeatable output assertions in tests, set both
+`colors` and `maxWidth` explicitly.
+
+[`FORCE_COLOR`]: https://force-color.org/
+[`NO_COLOR`]: https://no-color.org/
 
 ### Configuration options
 

--- a/docs/concepts/runners.md
+++ b/docs/concepts/runners.md
@@ -582,7 +582,9 @@ When `maxWidth` is omitted, the runner uses `process.stdout.columns` if it is a
 positive finite integer. Otherwise, it tries `COLUMNS`, which must contain
 only decimal digits and represent a positive finite integer. Leading zeros
 are allowed; whitespace, fractions, and values such as `80px` are not. If
-neither source is valid, output remains unwrapped. An explicit `maxWidth`
+neither source is valid, output remains unwrapped. An automatically detected
+width that cannot fit the help or error layout also leaves that output
+unwrapped. An explicit `maxWidth`
 overrides detection and retains the formatter's validation, including errors
 for widths too narrow for the content.
 

--- a/docs/concepts/testing.md
+++ b/docs/concepts/testing.md
@@ -147,8 +147,9 @@ an exit code of zero.  Help, version, completion, and parse errors produce an
 runner writers.
 
 The `colors` and `maxWidth` options keep `runAsync()`'s defaults, which depend
-on the test process's terminal.  Set both explicitly when asserting rendered
-text so the result is stable between local terminals and CI.
+on the test process's terminal and environment variables.  Set both explicitly
+when asserting rendered text so the result is stable between local terminals
+and CI.
 
 The capture helper supplies `stdout`, `stderr`, and `onExit`, so callers cannot
 override them.  Exceptions from parsers, contexts, option callbacks, or

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -1127,7 +1127,7 @@ const config = run(prog, {
 
 
   colors: true,           // Force colored output (auto-detected by default)
-  maxWidth: 100,          // Set help text width (terminal width by default)
+  maxWidth: 100,          // Set help text width (auto-detected by default)
   termWidth: "auto",      // Fit the term column to visible help entries
   errorExitCode: 2        // Custom exit code for errors (default: 1)
 });
@@ -1515,8 +1515,9 @@ assert.equal(result.stderr, "");
 ~~~~
 
 Setting `colors` and `maxWidth` explicitly matters here. Without them the
-runner keeps its usual defaults, which depend on the terminal the test happens
-to run in, and the rendered text differs between your machine and CI.
+runner keeps its usual defaults, which depend on the test process's terminal
+and environment variables, and the rendered text differs between your machine
+and CI.
 
 Command dispatch and full process behavior have their own layers, which the
 [testing guide](./concepts/testing.md) covers along with the one rule that

--- a/packages/core/skills/optique/SKILL.md
+++ b/packages/core/skills/optique/SKILL.md
@@ -27,7 +27,7 @@ Core rules
     for parser results, `captureRun()` from *@optique/testing/run* for runner
     output/exits, `captureProgramRun()` from *@optique/testing/discover* for
     dispatch, and `createCliRunner()` from *@optique/testing/cli* for real CLIs.
-    Pin `colors`/`maxWidth` for output assertions; defaults use the environment.
+    Pin `colors`/`maxWidth` in tests; defaults use terminal and environment.
  -  Compose parsers with `object()`, `tuple()`, `seq()`, `or()`, `merge()`, and
     modifiers. Do not hand-write argument scanners around Optique parsers.
  -  Let TypeScript infer the parsed value type from the parser. Do not

--- a/packages/core/skills/optique/SKILL.md
+++ b/packages/core/skills/optique/SKILL.md
@@ -18,8 +18,7 @@ combinatorial parser model and common pitfalls offline.
 Core rules
 ----------
 
- -  Use `run()` from *@optique/run* for applications; use `parse()` or
-    `runParser()` for embedded and custom runtimes.
+ -  Use `run()` from *@optique/run* for apps, `parse()`/`runParser()` to embed.
  -  With `runParser()`, `onError(exitCode, error)` supplies a structured
     `Message`; `help.onShow(exitCode, page)` supplies the final `DocPage`. Both
     follow output. Supply `stdout: () => {}` for custom help rendering. See
@@ -28,6 +27,7 @@ Core rules
     for parser results, `captureRun()` from *@optique/testing/run* for runner
     output/exits, `captureProgramRun()` from *@optique/testing/discover* for
     dispatch, and `createCliRunner()` from *@optique/testing/cli* for real CLIs.
+    Pin `colors`/`maxWidth` for output assertions; defaults use the environment.
  -  Compose parsers with `object()`, `tuple()`, `seq()`, `or()`, `merge()`, and
     modifiers. Do not hand-write argument scanners around Optique parsers.
  -  Let TypeScript infer the parsed value type from the parser. Do not

--- a/packages/core/skills/optique/SKILL.test.ts
+++ b/packages/core/skills/optique/SKILL.test.ts
@@ -59,6 +59,7 @@ declare module "node:process" {
 
   declare const process: {
     argv: string[];
+    readonly env: Readonly<Record<string, string | undefined>>;
     stdout: WritableStreamLike;
     stderr: WritableStreamLike;
     exit(code?: number): never;

--- a/packages/core/src/doc.ts
+++ b/packages/core/src/doc.ts
@@ -1,9 +1,12 @@
+import {
+  hasAutomaticWidth,
+  minimumUsageWidth,
+  reportAutomaticWidth,
+} from "./terminal-width.ts";
 import { messageRenderers } from "./message-registry.ts";
 import { resolveMessageFormatter } from "./message-renderer.ts";
 import {
   cacheTerminalTheme,
-  formatTerminalTerm,
-  fragmentTokens,
   renderTerminalTerm,
   styleCode,
 } from "./terminal-internal.ts";
@@ -832,30 +835,8 @@ export function formatDocPage(
     // long terms, the term width is capped at programNameWidth + 7;
     // the 7 matches the continuation indent, so terms fitting within
     // the first line's total width are guaranteed not to overflow.
-    const programNameWidth = page.usage != null && showUsage
-      ? Math.max(
-        0,
-        ...[
-          ...fragmentTokens(
-            formatTerminalTerm(
-              { type: "programName", programName },
-              options.theme,
-            ),
-          ),
-        ].map((token) => token.width),
-      )
-      : 0;
     const usageMin = page.usage != null && showUsage
-      ? Math.max(
-        measureText(usageLabel).maxLineWidth,
-        usageLabelWidth + Math.max(
-          programNameWidth,
-          Math.min(
-            maxVisibleAtomicWidth(page.usage, options.theme),
-            programNameWidth + usageLabelWidth,
-          ),
-        ),
-      )
+      ? minimumUsageWidth(programName, page.usage, usageLabel, options.theme)
       : 1;
     // Fixed labels cannot wrap. Examples/Author/Bugs also need two
     // indentation columns and at least one column for their content.
@@ -877,23 +858,32 @@ export function formatDocPage(
     // overflow. Including them here would make existing narrow --help fail.
     const minWidth = Math.max(entryMin, usageMin, sectionMin);
     if (options.maxWidth < minWidth) {
-      throw new RangeError(
-        `maxWidth must be at least ${minWidth}, got ${options.maxWidth}.`,
-      );
+      if (!hasAutomaticWidth(options)) {
+        throw new RangeError(
+          `maxWidth must be at least ${minWidth}, got ${options.maxWidth}.`,
+        );
+      }
+      options = { ...options, maxWidth: undefined };
+      effectiveTermWidth = termWidth;
     }
     // Second check: even if maxWidth passes the formula-based minimum,
     // the effective layout may leave too little room for fixed prefixes.
-    if (needsDescColumn && minDescWidth > 1) {
+    if (options.maxWidth != null && needsDescColumn && minDescWidth > 1) {
       const avail = options.maxWidth - termIndent - 2;
       const descW = avail - effectiveTermWidth;
       if (descW < minDescWidth) {
         const needed = termIndent + effectiveTermWidth + 2 + minDescWidth;
-        throw new RangeError(
-          `maxWidth must be at least ${needed}, got ${options.maxWidth}.`,
-        );
+        if (!hasAutomaticWidth(options)) {
+          throw new RangeError(
+            `maxWidth must be at least ${needed}, got ${options.maxWidth}.`,
+          );
+        }
+        options = { ...options, maxWidth: undefined };
+        effectiveTermWidth = termWidth;
       }
     }
   }
+  reportAutomaticWidth(options, options.maxWidth);
   let output = "";
   if (hasContent(page.brief)) {
     output += formatMessage(page.brief, {
@@ -1150,20 +1140,6 @@ export function formatDocPage(
 
 function indentLines(text: string, indent: number): string {
   return text.split("\n").join("\n" + " ".repeat(indent));
-}
-
-/**
- * Returns the width of the widest non-breakable segment among visible
- * (non-usage-hidden) terms in a usage tree.  Hidden terms are excluded
- * because they are filtered out before rendering, so they do not
- * contribute to the rendered width.
- */
-function maxVisibleAtomicWidth(usage: Usage, theme?: TerminalTheme): number {
-  return usage.reduce((widest, term) =>
-    Math.max(
-      widest,
-      measureText(formatUsageTerm(term, { theme, maxWidth: 1 })).maxLineWidth,
-    ), 0);
 }
 
 function ansiAwareRightPad(

--- a/packages/core/src/facade.ts
+++ b/packages/core/src/facade.ts
@@ -1,5 +1,10 @@
+import {
+  hasAutomaticWidth,
+  minimumUsageWidth,
+  withAutomaticWidth,
+} from "./terminal-width.ts";
 import { renderErrorMessage } from "./message-renderer.ts";
-import { renderTerminalTerm } from "./terminal-internal.ts";
+import { cacheTerminalTheme, renderTerminalTerm } from "./terminal-internal.ts";
 import type { TerminalTheme } from "./terminal.ts";
 import { measureText, spaceAfterLabel } from "./text-layout.ts";
 import {
@@ -19,6 +24,7 @@ import {
 import {
   type DocEntry,
   type DocPage,
+  type DocPageFormatOptions,
   type DocSection,
   formatDocPage,
   type ShowChoicesOptions,
@@ -1460,7 +1466,14 @@ function handleCompletion<M extends Mode, THelp, TError>(
   rootOptionSuggestions: readonly LiteralSuggestion[] = [],
   messageFormatter?: MessageFormatter,
   theme?: TerminalTheme,
+  automaticWidth = false,
 ): ModeValue<M, THelp | TError> {
+  const errorOptions = <T extends object>(format: T): T =>
+    automaticWidth
+      ? withAutomaticWidth(format, (width) => {
+        maxWidth = width;
+      })
+      : format;
   const shellName = completionArgs[0] || "";
   const args = completionArgs.slice(1);
 
@@ -1472,16 +1485,30 @@ function handleCompletion<M extends Mode, THelp, TError>(
   // Check if shell name is empty
   if (!shellName) {
     const error = message`Missing shell name for completion.`;
-    stderr(
-      renderErrorMessage(error, {
-        messageFormatter,
-        theme,
-        colors,
-        quotes: !colors,
-        maxWidth,
-      }) + "\n",
-    );
+    const writeError = () =>
+      stderr(
+        renderErrorMessage(
+          error,
+          errorOptions({
+            messageFormatter,
+            theme,
+            colors,
+            quotes: !colors,
+            maxWidth,
+          }),
+        ) + "\n",
+      );
 
+    if (!automaticWidth) writeError();
+    let wroteError = !automaticWidth;
+    const completionDocOptions = (format: DocPageFormatOptions) =>
+      automaticWidth
+        ? withAutomaticWidth(format, (width) => {
+          maxWidth = width;
+          writeError();
+          wroteError = true;
+        })
+        : format;
     // Show help for completion command if parser is available
     if (completionParser) {
       const displayName = isOptionMode
@@ -1490,18 +1517,24 @@ function handleCompletion<M extends Mode, THelp, TError>(
       const doc = getDocPage(completionParser, [displayName]);
       if (doc) {
         stderr(
-          formatDocPage(programName, doc, {
-            messageFormatter,
-            theme,
-            colors,
-            maxWidth,
-            termWidth,
-            sectionOrder,
-            showUsage,
-          }),
+          formatDocPage(
+            programName,
+            doc,
+            completionDocOptions({
+              messageFormatter,
+              theme,
+              colors,
+              maxWidth,
+              termWidth,
+              sectionOrder,
+              showUsage,
+            }),
+          ),
         );
       }
     }
+
+    if (!wroteError) writeError();
 
     return dispatchByMode(
       parser.mode,
@@ -1527,13 +1560,16 @@ function handleCompletion<M extends Mode, THelp, TError>(
     }
     const error =
       message`Unsupported shell ${shellName}. Available shells: ${available}.`;
-    stderr(renderErrorMessage(error, {
-      messageFormatter,
-      theme,
-      colors,
-      quotes: !colors,
-      maxWidth,
-    }));
+    stderr(renderErrorMessage(
+      error,
+      errorOptions({
+        messageFormatter,
+        theme,
+        colors,
+        quotes: !colors,
+        maxWidth,
+      }),
+    ));
     return dispatchByMode(
       parser.mode,
       () => {
@@ -2298,8 +2334,8 @@ export function runParser<
   const {
     colors,
     messageFormatter,
-    theme,
-    maxWidth,
+    theme: requestedTheme,
+    maxWidth: requestedMaxWidth,
     termWidth,
     showDefault,
     showChoices,
@@ -2321,6 +2357,25 @@ export function runParser<
     footer,
   } = options;
 
+  let maxWidth = requestedMaxWidth;
+  const automaticWidth = hasAutomaticWidth(options);
+  const theme = automaticWidth
+    ? cacheTerminalTheme(requestedTheme)
+    : requestedTheme;
+  const formatOptions = <T extends object>(format: T): T =>
+    automaticWidth
+      ? withAutomaticWidth(format, (width) => {
+        maxWidth = width;
+      })
+      : format;
+  const resolveUsageWidth = (usage: Usage) => {
+    if (
+      automaticWidth && maxWidth != null &&
+      maxWidth < minimumUsageWidth(programName, usage, usageLabel(), theme)
+    ) {
+      maxWidth = undefined;
+    }
+  };
   let usagePrefix: string | undefined;
   const usageLabel = () =>
     usagePrefix ??= spaceAfterLabel(renderTerminalTerm(
@@ -2638,6 +2693,7 @@ export function runParser<
           rootOptionSuggestions,
           messageFormatter,
           theme,
+          automaticWidth,
         ) as InferValue<TParser>;
 
       case "help": {
@@ -2691,6 +2747,7 @@ export function runParser<
         const reportInvalidHelpCommand = (
           validationError: Message,
         ): InferValue<TParser> => {
+          resolveUsageWidth(augmentedParser.usage);
           stderr(
             `${usageLabel()}${
               indentLines(
@@ -2706,13 +2763,16 @@ export function runParser<
               )
             }`,
           );
-          stderr(renderErrorMessage(validationError, {
-            messageFormatter,
-            theme,
-            colors,
-            quotes: !colors,
-            maxWidth,
-          }));
+          stderr(renderErrorMessage(
+            validationError,
+            formatOptions({
+              messageFormatter,
+              theme,
+              colors,
+              quotes: !colors,
+              maxWidth,
+            }),
+          ));
           return onError(1, validationError);
         };
 
@@ -2769,17 +2829,21 @@ export function runParser<
             const renderedDoc = isTopLevel && usageLine != null
               ? applyUsageLine(augmentedDoc, usageLine)
               : augmentedDoc;
-            stdout(formatDocPage(programName, renderedDoc, {
-              messageFormatter,
-              theme,
-              colors,
-              maxWidth,
-              termWidth,
-              showDefault,
-              showChoices,
-              sectionOrder,
-              showUsage,
-            }));
+            stdout(formatDocPage(
+              programName,
+              renderedDoc,
+              formatOptions({
+                messageFormatter,
+                theme,
+                colors,
+                maxWidth,
+                termWidth,
+                showDefault,
+                showChoices,
+                sectionOrder,
+                showUsage,
+              }),
+            ));
             return onHelp(0, renderedDoc);
           }
           throw new RunParserError("Failed to generate help page.");
@@ -2906,20 +2970,25 @@ export function runParser<
                   defaultRootUsage,
                 )
                 : augmentedDoc;
-              stderr(formatDocPage(programName, renderedDoc, {
-                messageFormatter,
-                theme,
-                colors,
-                maxWidth,
-                termWidth,
-                showDefault,
-                showChoices,
-                sectionOrder,
-                showUsage,
-              }));
+              stderr(formatDocPage(
+                programName,
+                renderedDoc,
+                formatOptions({
+                  messageFormatter,
+                  theme,
+                  colors,
+                  maxWidth,
+                  termWidth,
+                  showDefault,
+                  showChoices,
+                  sectionOrder,
+                  showUsage,
+                }),
+              ));
             }
           }
           if (effectiveAboveError === "usage") {
+            resolveUsageWidth(augmentedParser.usage);
             stderr(
               `${usageLabel()}${
                 indentLines(
@@ -2937,13 +3006,16 @@ export function runParser<
             );
           }
           // classified.error is now typed as Message
-          stderr(renderErrorMessage(classified.error, {
-            messageFormatter,
-            theme,
-            colors,
-            quotes: !colors,
-            maxWidth,
-          }));
+          stderr(renderErrorMessage(
+            classified.error,
+            formatOptions({
+              messageFormatter,
+              theme,
+              colors,
+              quotes: !colors,
+              maxWidth,
+            }),
+          ));
           return onError(1, classified.error);
         };
 

--- a/packages/core/src/internal/terminal.ts
+++ b/packages/core/src/internal/terminal.ts
@@ -6,3 +6,4 @@ export {
 } from "../message-renderer.ts";
 export { renderTerminalTerm } from "../terminal-internal.ts";
 export { measureText, placeText, spaceAfterLabel } from "../text-layout.ts";
+export { withAutomaticWidth } from "../terminal-width.ts";

--- a/packages/core/src/message-renderer.ts
+++ b/packages/core/src/message-renderer.ts
@@ -1,5 +1,6 @@
+import { hasAutomaticWidth, reportAutomaticWidth } from "./terminal-width.ts";
 import { renderTerminalTerm } from "./terminal-internal.ts";
-import { placeText, spaceAfterLabel } from "./text-layout.ts";
+import { measureText, placeText, spaceAfterLabel } from "./text-layout.ts";
 import {
   createMessageFormatter,
   formatMessage,
@@ -65,15 +66,26 @@ export function renderErrorMessage(
   }
   if (occupied < 0) throw new RangeError("Initial width must be nonnegative.");
   const colors = options.colors;
+  const label = spaceAfterLabel(renderTerminalTerm(
+    { type: "errorLabel", label: "Error:" },
+    options.theme,
+    typeof colors === "object" ? true : colors,
+    undefined,
+    undefined,
+    typeof colors === "object" ? colors.resetSuffix : undefined,
+  ));
+  if (hasAutomaticWidth(options) && options.maxWidth != null) {
+    const size = measureText(label);
+    if (
+      options.maxWidth <
+        Math.max(size.maxLineWidth, occupied + size.lastLineWidth + 1)
+    ) {
+      options = { ...options, maxWidth: undefined };
+    }
+  }
+  reportAutomaticWidth(options, options.maxWidth);
   const prefix = placeText(
-    spaceAfterLabel(renderTerminalTerm(
-      { type: "errorLabel", label: "Error:" },
-      options.theme,
-      typeof colors === "object" ? true : colors,
-      undefined,
-      undefined,
-      typeof colors === "object" ? colors.resetSuffix : undefined,
-    )),
+    label,
     { line: "", column: occupied },
     options.maxWidth,
   );

--- a/packages/core/src/terminal-width.test.ts
+++ b/packages/core/src/terminal-width.test.ts
@@ -1,0 +1,145 @@
+import { type DocPage, formatDocPage } from "#src/doc.ts";
+import { type RunOptions, runParser } from "#src/facade.ts";
+import { formatMessage, message, valueSet } from "#src/message.ts";
+import { option } from "#src/primitives.ts";
+import { withAutomaticWidth } from "#src/terminal-width.ts";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+describe("automatic runner width", () => {
+  const page: DocPage = {
+    usage: [{ type: "option", names: ["--value"], metavar: "VALUE" }],
+    brief:
+      message`A description long enough to wrap at a normal terminal width.`,
+    sections: [{
+      entries: [{
+        term: { type: "option", names: ["--value"], metavar: "VALUE" },
+        description: message`Select a value.`,
+        choices: valueSet(["first", "second"], { type: "unit", fallback: "" }),
+      }],
+    }],
+  };
+
+  it("should keep direct core API width constraints strict", () => {
+    assert.throws(
+      () => formatDocPage("test", page, { maxWidth: 1 }),
+      RangeError,
+    );
+    const options: RunOptions<void, void> = {
+      maxWidth: 1,
+      help: { option: true },
+      stdout: () => assert.fail("Invalid explicit width must not emit output."),
+    };
+    assert.throws(
+      () => runParser(option("--value"), "test", ["--help"], options),
+      RangeError,
+    );
+  });
+
+  it("should drop insufficient widths before calling message formatters", () => {
+    for (const termWidth of [1, 26, "auto"] as const) {
+      for (const maxWidth of [1, 10, 30]) {
+        const formatting = {
+          termWidth,
+          showChoices: { prefix: " (available choices: " },
+        };
+        let calls = 0;
+        let resolved = 0;
+        let effectiveWidth: number | undefined = maxWidth;
+        const original = {
+          ...formatting,
+          maxWidth,
+          messageFormatter: (
+            msg: Parameters<typeof formatMessage>[0],
+            opts?: Parameters<typeof formatMessage>[1],
+          ) => {
+            calls++;
+            return formatMessage(msg, opts);
+          },
+        };
+        // These widths cannot fit the choices prefix in the description column.
+        assert.throws(() => formatDocPage("test", page, original), RangeError);
+        assert.equal(calls, 0);
+        const actual = formatDocPage(
+          "test",
+          page,
+          withAutomaticWidth(original, (width) => {
+            resolved++;
+            effectiveWidth = width;
+            assert.equal(calls, 0);
+          }),
+        );
+        assert.equal(actual, formatDocPage("test", page, formatting));
+        assert.equal(effectiveWidth, undefined);
+        assert.equal(resolved, 1);
+        assert.equal(original.maxWidth, maxWidth);
+        assert.ok(calls > 0);
+      }
+    }
+  });
+
+  it("should share themed usage measurements with rendering", () => {
+    let calls = 0;
+    let exits = 0;
+    const output: string[] = [];
+    runParser(
+      option("--value"),
+      "test",
+      ["--invalid"],
+      withAutomaticWidth({
+        maxWidth: 1,
+        theme: {
+          programName: () => ({
+            type: "text" as const,
+            text: `name${++calls}`,
+          }),
+        },
+        stderr: (text: string) => output.push(text),
+        onError: () => {
+          exits++;
+        },
+      }),
+    );
+    assert.equal(calls, 1);
+    assert.equal(exits, 1);
+    assert.ok(output[0].startsWith("Usage: name1"));
+  });
+
+  it("should retain feasible widths and leave caller options reusable", () => {
+    const options = { maxWidth: 40 };
+    const expected = formatDocPage("test", page, options);
+    assert.equal(
+      formatDocPage("test", page, withAutomaticWidth(options)),
+      expected,
+    );
+    assert.equal(formatDocPage("test", page, options), expected);
+    assert.equal(options.maxWidth, 40);
+  });
+
+  it("should not suppress unrelated validation or formatter errors", () => {
+    assert.throws(() =>
+      formatDocPage(
+        "test",
+        page,
+        withAutomaticWidth({
+          maxWidth: 1,
+          showChoices: { maxItems: 0 },
+        }),
+      ), /showChoices.maxItems/);
+    const error = new RangeError("Custom formatter failed.");
+    let calls = 0;
+    assert.throws(() =>
+      formatDocPage(
+        "test",
+        page,
+        withAutomaticWidth({
+          maxWidth: 1,
+          messageFormatter: () => {
+            calls++;
+            throw error;
+          },
+        }),
+      ), (actual) => actual === error);
+    assert.equal(calls, 1);
+  });
+});

--- a/packages/core/src/terminal-width.ts
+++ b/packages/core/src/terminal-width.ts
@@ -1,0 +1,85 @@
+import { formatTerminalTerm, fragmentTokens } from "./terminal-internal.ts";
+import type { TerminalTheme } from "./terminal.ts";
+import { measureText } from "./text-layout.ts";
+import { formatUsageTerm, type Usage } from "./usage.ts";
+
+const automaticWidth = Symbol.for("@optique/core/automaticWidth");
+
+/**
+ * Marks runner options without changing their public type. The enumerable
+ * symbol survives the option copies made by Program and context runners.
+ * @param options The options whose width was automatically detected.
+ * @param onResolved Receives the effective width before message rendering.
+ * @returns A marked copy of the options.
+ * @internal
+ */
+export function withAutomaticWidth<T extends object>(
+  options: T,
+  onResolved: (width: number | undefined) => void = () => {},
+): T {
+  return { ...options, [automaticWidth]: onResolved };
+}
+
+/**
+ * Checks whether a width is a runner hint rather than an explicit constraint.
+ * @param options The formatting or runner options.
+ * @returns Whether automatic width fallback is enabled.
+ * @internal
+ */
+export function hasAutomaticWidth(options: object): boolean {
+  return automaticWidth in options &&
+    typeof options[automaticWidth] === "function";
+}
+
+/**
+ * Reports the resolved width before any opaque message formatter runs.
+ * @param options The marked formatting options.
+ * @param width The width selected by layout validation.
+ * @internal
+ */
+export function reportAutomaticWidth(
+  options: object,
+  width: number | undefined,
+): void {
+  if (
+    automaticWidth in options && typeof options[automaticWidth] === "function"
+  ) {
+    options[automaticWidth](width);
+  }
+}
+
+/**
+ * Measures the minimum usage layout, allowing long atomic terms to overflow.
+ * @param programName The program name shown in the usage line.
+ * @param usage The visible usage tree.
+ * @param label The rendered usage label, including its trailing space.
+ * @param theme The semantic terminal theme.
+ * @returns The minimum feasible width for the usage block.
+ * @internal
+ */
+export function minimumUsageWidth(
+  programName: string,
+  usage: Usage,
+  label: string,
+  theme?: TerminalTheme,
+): number {
+  const labelWidth = measureText(label).lastLineWidth;
+  const programWidth = Math.max(
+    0,
+    ...[
+      ...fragmentTokens(
+        formatTerminalTerm({ type: "programName", programName }, theme),
+      ),
+    ].map((token) => token.width),
+  );
+  const atomicWidth = usage.reduce((widest, term) =>
+    Math.max(
+      widest,
+      measureText(formatUsageTerm(term, { theme, maxWidth: 1 })).maxLineWidth,
+    ), 0);
+  return Math.max(
+    measureText(label).maxLineWidth,
+    labelWidth +
+      Math.max(programWidth, Math.min(atomicWidth, programWidth + labelWidth)),
+  );
+}

--- a/packages/run/deno.json
+++ b/packages/run/deno.json
@@ -14,9 +14,12 @@
     "dist/",
     "tsdown.config.ts"
   ],
+  "publish": {
+    "exclude": ["src/fixtures/terminal-capabilities.ts"]
+  },
   "tasks": {
     "build": "pnpm build",
-    "test": "deno test --allow-read --allow-write",
+    "test": "deno test --allow-read --allow-write --allow-env --allow-run",
     "test:node": {
       "dependencies": [
         "build"

--- a/packages/run/src/fixtures/terminal-capabilities.ts
+++ b/packages/run/src/fixtures/terminal-capabilities.ts
@@ -12,8 +12,16 @@ interface Scenario {
   readonly tty?: boolean;
   readonly colors?: boolean;
   readonly width?: string;
-  readonly request?: "help" | "error" | "success";
+  readonly request?:
+    | "help"
+    | "error"
+    | "error-only"
+    | "error-help"
+    | "unsupported-shell"
+    | "completion-error"
+    | "success";
   readonly distinguishColors?: boolean;
+  readonly formatterThrows?: boolean;
   readonly expectedError?: "RangeError" | "TypeError";
 }
 
@@ -39,6 +47,7 @@ const formatting: {
   readonly maxWidth: number | null;
 }[] = [];
 let exitCode: number | undefined;
+let exitCalls = 0;
 let failure: { readonly name: string; readonly message: string } | undefined;
 let value: unknown;
 const exit = new Error("Fixture runner exited.");
@@ -52,11 +61,22 @@ const context: SourceContext = {
 const options: RunOptions = {
   args: scenario.request === "success"
     ? ["--value", "ok"]
-    : scenario.request === "error"
+    : scenario.request === "unsupported-shell"
+    ? ["--completion", "unknown-shell"]
+    : scenario.request === "completion-error"
+    ? ["--completion"]
+    : scenario.request === "error" || scenario.request === "error-help" ||
+        scenario.request === "error-only"
     ? ["--invalid"]
     : ["--help"],
   programName: "test",
   help: "option",
+  completion: "option",
+  aboveError: scenario.request === "error-help"
+    ? "help"
+    : scenario.request === "error-only"
+    ? "none"
+    : "usage",
   brief:
     message`One two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty.`,
   colors: scenario.colors,
@@ -65,6 +85,7 @@ const options: RunOptions = {
   stdout: (text) => stdout.push(text),
   stderr: (text) => stderr.push(text),
   onExit(code) {
+    exitCalls++;
     exitCode = code;
     throw exit;
   },
@@ -73,6 +94,9 @@ const options: RunOptions = {
       colors: options?.colors ?? null,
       maxWidth: options?.maxWidth ?? null,
     });
+    if (scenario.formatterThrows) {
+      throw new RangeError("Custom formatter failed.");
+    }
     return scenario.distinguishColors
       ? options?.colors === undefined
         ? "UNSET"
@@ -135,6 +159,9 @@ process.stdout.write(
     stderr: stderr.join("\n"),
     formatting,
     exitCode,
+    exitCalls,
+    stdoutCalls: stdout.length,
+    stderrCalls: stderr.length,
     failure,
     value,
   }) + "\n",

--- a/packages/run/src/fixtures/terminal-capabilities.ts
+++ b/packages/run/src/fixtures/terminal-capabilities.ts
@@ -1,0 +1,141 @@
+import type { SourceContext } from "@optique/core/context";
+import { formatMessage, message } from "@optique/core/message";
+import { option } from "@optique/core/primitives";
+import { defineProgram } from "@optique/core/program";
+import { string } from "@optique/core/valueparser";
+import { run, runAsync, type RunOptions, runSync } from "@optique/run/run";
+import process from "node:process";
+
+interface Scenario {
+  readonly mode?: string;
+  readonly columns?: string;
+  readonly tty?: boolean;
+  readonly colors?: boolean;
+  readonly width?: string;
+  readonly request?: "help" | "error" | "success";
+  readonly distinguishColors?: boolean;
+  readonly expectedError?: "RangeError" | "TypeError";
+}
+
+const scenario: Scenario = JSON.parse(process.argv[2]);
+Object.defineProperty(process.stdout, "columns", {
+  configurable: true,
+  value: scenario.columns === undefined ? undefined : Number(scenario.columns),
+});
+Object.defineProperty(process.stdout, "isTTY", {
+  configurable: true,
+  value: scenario.tty,
+});
+// Deliberately disagree with stdout to check the runner's shared policy.
+Object.defineProperty(process.stderr, "isTTY", {
+  configurable: true,
+  value: !scenario.tty,
+});
+
+const stdout: string[] = [];
+const stderr: string[] = [];
+const formatting: {
+  readonly colors: boolean | null;
+  readonly maxWidth: number | null;
+}[] = [];
+let exitCode: number | undefined;
+let failure: { readonly name: string; readonly message: string } | undefined;
+let value: unknown;
+const exit = new Error("Fixture runner exited.");
+const context: SourceContext = {
+  id: Symbol.for("@test/terminal-capabilities"),
+  phase: "single-pass",
+  getAnnotations() {
+    return {};
+  },
+};
+const options: RunOptions = {
+  args: scenario.request === "success"
+    ? ["--value", "ok"]
+    : scenario.request === "error"
+    ? ["--invalid"]
+    : ["--help"],
+  programName: "test",
+  help: "option",
+  brief:
+    message`One two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty.`,
+  colors: scenario.colors,
+  maxWidth: scenario.width === undefined ? undefined : Number(scenario.width),
+  contexts: scenario.mode?.endsWith("-context") ? [context] : undefined,
+  stdout: (text) => stdout.push(text),
+  stderr: (text) => stderr.push(text),
+  onExit(code) {
+    exitCode = code;
+    throw exit;
+  },
+  messageFormatter(msg, options) {
+    formatting.push({
+      colors: options?.colors ?? null,
+      maxWidth: options?.maxWidth ?? null,
+    });
+    return scenario.distinguishColors
+      ? options?.colors === undefined
+        ? "UNSET"
+        : options.colors
+        ? "TRUE"
+        : "FALSE"
+      : formatMessage(msg, options);
+  },
+};
+const parser = option("--value", string());
+const asyncParser = option("--value", {
+  mode: "async",
+  metavar: "VALUE",
+  placeholder: "",
+  parse(input: string) {
+    return Promise.resolve({ success: true as const, value: input });
+  },
+  format(value: string) {
+    return value;
+  },
+});
+
+try {
+  switch (scenario.mode) {
+    case "runSync":
+    case "runSync-context":
+      value = runSync(parser, options);
+      break;
+    case "runAsync":
+      value = await runAsync(asyncParser, options);
+      break;
+    case "async-parser":
+      value = await run(asyncParser, options);
+      break;
+    case "program":
+      value = run(
+        defineProgram({ parser, metadata: { name: "test" } }),
+        options,
+      );
+      break;
+    default:
+      value = await run(parser, options);
+  }
+} catch (error) {
+  if (error !== exit) {
+    if (!(error instanceof Error) || error.name !== scenario.expectedError) {
+      throw error;
+    }
+    failure = { name: error.name, message: error.message };
+  }
+}
+
+process.stdout.write(
+  JSON.stringify({
+    observed: {
+      columns: String(process.stdout.columns),
+      tty: process.stdout.isTTY ?? null,
+    },
+    stdout: stdout.join("\n"),
+    stderr: stderr.join("\n"),
+    formatting,
+    exitCode,
+    failure,
+    value,
+  }) + "\n",
+);

--- a/packages/run/src/run.test.ts
+++ b/packages/run/src/run.test.ts
@@ -433,6 +433,8 @@ describe("run", () => {
         assert.throws(
           () => {
             run(parser, {
+              colors: false,
+              maxWidth: 80,
               help: "option",
             });
           },
@@ -513,6 +515,8 @@ describe("run", () => {
         assert.throws(
           () => {
             run(parser, {
+              colors: false,
+              maxWidth: 80,
               args: [],
               onExit: (code) => {
                 exitCode = code;
@@ -646,6 +650,8 @@ describe("run", () => {
       assert.throws(
         () => {
           run(parser, {
+            colors: false,
+            maxWidth: 80,
             args: ["--help"],
             programName: "tool",
             help: "option",
@@ -1790,6 +1796,8 @@ describe("runAsync", () => {
       assert.throws(
         () =>
           run(parser, {
+            colors: false,
+            maxWidth: 80,
             args: ["--help"],
             programName: "myapp",
             help: "option",
@@ -1815,6 +1823,8 @@ describe("runAsync", () => {
 
       try {
         run(parser, {
+          colors: false,
+          maxWidth: 80,
           args: ["--help"],
           commandList: "top-level",
           help: "option",

--- a/packages/run/src/run.ts
+++ b/packages/run/src/run.ts
@@ -27,6 +27,11 @@ import type { Message } from "@optique/core/message";
 import type { Usage } from "@optique/core/usage";
 import path from "node:path";
 import process from "node:process";
+import {
+  detectColorSupport,
+  detectTerminalWidth,
+  readEnvironmentVariable,
+} from "./terminal.ts";
 
 /**
  * Configuration options for the {@link run} function.
@@ -77,15 +82,23 @@ export interface RunOptions {
   /**
    * Whether to enable colored output in help and error messages.
    *
-   * @default `process.stdout.isTTY` (auto-detect based on terminal)
+   * Explicit values override environment variables and terminal detection.
+   * A nonempty `FORCE_COLOR` enables colors (including `0`); otherwise a
+   * nonempty `NO_COLOR` or any `NODE_DISABLE_COLORS` disables them.
+   * Inaccessible environment variables are ignored.
+   *
+   * @default Environment preferences, then `process.stdout.isTTY`
    */
   readonly colors?: boolean;
 
   /**
    * Maximum width for output formatting. Text will be wrapped to fit within
-   * this width. If not specified, uses the terminal width.
+   * this width. If not specified, uses a positive finite integer from the
+   * terminal width, then a positive decimal integer from `COLUMNS`. Invalid
+   * or inaccessible detected values are ignored; explicit values retain the
+   * formatter's validation.
    *
-   * @default `process.stdout.columns` (auto-detect terminal width)
+   * @default Valid `process.stdout.columns`, then `COLUMNS`, or no wrapping
    */
   readonly maxWidth?: number;
 
@@ -882,8 +895,10 @@ function buildCoreOptions(
   });
   const onExit = options.onExit ??
     ((exitCode: number) => process.exit(exitCode) as never);
-  const colors = options.colors ?? process.stdout.isTTY;
-  const maxWidth = options.maxWidth ?? process.stdout.columns;
+  const colors = options.colors ??
+    detectColorSupport(process.stdout, readEnvironmentVariable);
+  const maxWidth = options.maxWidth ??
+    detectTerminalWidth(process.stdout, readEnvironmentVariable);
   const termWidth = options.termWidth;
   const showDefault = options.showDefault;
   const showChoices = options.showChoices;

--- a/packages/run/src/run.ts
+++ b/packages/run/src/run.ts
@@ -1,3 +1,4 @@
+import { withAutomaticWidth } from "@optique/core/internal/terminal";
 import type { MessageFormatter } from "@optique/core/message";
 import type { TerminalTheme } from "@optique/core/terminal";
 import type { ShellCompletion } from "@optique/core/completion";
@@ -95,7 +96,8 @@ export interface RunOptions {
    * Maximum width for output formatting. Text will be wrapped to fit within
    * this width. If not specified, uses a positive finite integer from the
    * terminal width, then a positive decimal integer from `COLUMNS`. Invalid
-   * or inaccessible detected values are ignored; explicit values retain the
+   * or inaccessible detected values are ignored. Automatic widths too narrow
+   * for the output layout disable wrapping; explicit values retain the
    * formatter's validation.
    *
    * @default Valid `process.stdout.columns`, then `COLUMNS`, or no wrapping
@@ -991,7 +993,13 @@ function buildCoreOptions(
     },
   };
 
-  return { programName, args, coreOptions };
+  return {
+    programName,
+    args,
+    coreOptions: options.maxWidth == null
+      ? withAutomaticWidth(coreOptions)
+      : coreOptions,
+  };
 }
 
 /**

--- a/packages/run/src/terminal-integration.test.ts
+++ b/packages/run/src/terminal-integration.test.ts
@@ -149,6 +149,91 @@ describe("runner terminal detection", () => {
     });
   }
 
+  for (
+    const request of [
+      "help",
+      "error",
+      "error-help",
+      "error-only",
+      "unsupported-shell",
+      "completion-error",
+    ] as const
+  ) {
+    it(`should render ${request} once without wrapping when automatic widths are too narrow`, async () => {
+      const baseline = await invoke({ request, colors: false });
+      if (request === "completion-error") {
+        assert.ok(
+          baseline.stderr.startsWith(
+            "Error: Missing shell name for completion.",
+          ),
+        );
+      }
+      for (
+        const width
+          of request === "error-only" || request === "unsupported-shell"
+            ? ["1"]
+            : ["1", "10"]
+      ) {
+        for (const source of ["stream", "environment"]) {
+          const result = await invoke({
+            request,
+            colors: false,
+            columns: source === "stream" ? width : undefined,
+          }, { COLUMNS: source === "environment" ? width : "60" });
+          assert.equal(result.stdout, baseline.stdout);
+          assert.equal(result.stderr, baseline.stderr);
+          assert.equal(result.exitCode, request === "help" ? 0 : 1);
+          assert.equal(result.exitCalls, 1);
+          assert.equal(result.stdoutCalls, baseline.stdoutCalls);
+          assert.equal(result.stderrCalls, baseline.stderrCalls);
+          assert.deepEqual(result.formatting, baseline.formatting);
+        }
+      }
+    });
+  }
+
+  for (
+    const mode of [
+      "runSync",
+      "runAsync",
+      "async-parser",
+      "run-context",
+      "runSync-context",
+      "program",
+    ]
+  ) {
+    it(`should preserve automatic width provenance through ${mode}`, async () => {
+      const result = await invoke({ mode, colors: false }, { COLUMNS: "1" });
+      assert.equal(result.exitCode, 0);
+      assert.equal(result.exitCalls, 1);
+      assert.ok(result.formatting.every(({ maxWidth }) => maxWidth === null));
+    });
+  }
+
+  it("should preserve explicit narrow-width validation", async () => {
+    const result = await invoke({
+      width: "1",
+      colors: false,
+      expectedError: "RangeError",
+    });
+    assert.equal(result.failure?.name, "RangeError");
+    assert.equal(result.exitCalls, 0);
+  });
+
+  it("should propagate custom formatter errors without retrying", async () => {
+    for (const COLUMNS of ["1", "60"]) {
+      const result = await invoke({
+        colors: false,
+        formatterThrows: true,
+        expectedError: "RangeError",
+      }, { COLUMNS });
+      assert.equal(result.failure?.message, "Custom formatter failed.");
+      assert.equal(result.formatting.length, 1);
+      assert.equal(result.exitCalls, 0);
+      assert.equal(result.stdoutCalls, 0);
+    }
+  });
+
   it("should preserve explicit invalid-width errors", async () => {
     for (const width of ["0", "-1", "1.5", "NaN", "Infinity"]) {
       const expectedError = width === "0" || width === "-1"
@@ -217,8 +302,16 @@ interface Scenario {
   readonly tty?: boolean;
   readonly colors?: boolean;
   readonly width?: string;
-  readonly request?: "help" | "error" | "success";
+  readonly request?:
+    | "help"
+    | "error"
+    | "error-only"
+    | "error-help"
+    | "unsupported-shell"
+    | "completion-error"
+    | "success";
   readonly distinguishColors?: boolean;
+  readonly formatterThrows?: boolean;
   readonly expectedError?: "RangeError" | "TypeError";
 }
 
@@ -231,6 +324,9 @@ interface Result {
     readonly maxWidth: number | null;
   }[];
   readonly exitCode?: number;
+  readonly exitCalls: number;
+  readonly stdoutCalls: number;
+  readonly stderrCalls: number;
   readonly failure?: { readonly name: string; readonly message: string };
   readonly value?: unknown;
 }

--- a/packages/run/src/terminal-integration.test.ts
+++ b/packages/run/src/terminal-integration.test.ts
@@ -1,0 +1,271 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import process from "node:process";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+// deno-lint-ignore no-control-regex -- Check the actual ANSI escape prefix.
+const ansiSequence = /\x1b\[/u;
+
+describe("runner terminal detection", () => {
+  it("should force colored help on a pipe even with FORCE_COLOR=0", async () => {
+    const result = await invoke({}, { FORCE_COLOR: "0" });
+    assert.match(result.stdout, ansiSequence);
+    assert.equal(result.exitCode, 0);
+  });
+
+  it("should fall back from zero stream columns to COLUMNS", async () => {
+    const result = await invoke({ columns: "0", colors: false }, {
+      COLUMNS: "60",
+    });
+    assert.equal(result.exitCode, 0);
+    assert.ok(result.formatting.some((options) => options.maxWidth === 60));
+    assert.ok(result.stdout.split("\n").every((line) => line.length <= 60));
+  });
+
+  it("should leave output unwrapped when both detected widths are invalid", async () => {
+    const result = await invoke({ columns: "NaN", colors: false }, {
+      COLUMNS: "bad",
+    });
+    assert.equal(result.exitCode, 0);
+    assert.ok(result.formatting.every((options) => options.maxWidth === null));
+    assert.ok(result.stdout.split("\n").some((line) => line.length > 80));
+  });
+
+  it("should ignore empty color controls and retain the TTY fallback", async () => {
+    const variables = { FORCE_COLOR: "", NO_COLOR: "" };
+    assert.match((await invoke({ tty: true }, variables)).stdout, ansiSequence);
+    assert.doesNotMatch((await invoke({}, variables)).stdout, ansiSequence);
+  });
+
+  it("should disable TTY colors with nonempty NO_COLOR", async () => {
+    assert.doesNotMatch(
+      (await invoke({ tty: true }, { NO_COLOR: "0" })).stdout,
+      ansiSequence,
+    );
+  });
+
+  it("should honor an empty NODE_DISABLE_COLORS", async () => {
+    assert.doesNotMatch(
+      (await invoke({ tty: true }, { NODE_DISABLE_COLORS: "" })).stdout,
+      ansiSequence,
+    );
+  });
+
+  it("should let FORCE_COLOR override both disabling variables", async () => {
+    const result = await invoke({}, {
+      FORCE_COLOR: "false",
+      NO_COLOR: "1",
+      NODE_DISABLE_COLORS: "1",
+      COLUMNS: "60",
+    });
+    assert.match(result.stdout, ansiSequence);
+    assert.ok(
+      result.formatting.some(({ colors, maxWidth }) =>
+        colors && maxWidth === 60
+      ),
+    );
+  });
+
+  it("should prefer a valid stream width over COLUMNS", async () => {
+    const result = await invoke({ columns: "72", colors: false }, {
+      COLUMNS: "60",
+    });
+    assert.ok(result.formatting.some((options) => options.maxWidth === 72));
+    assert.ok(result.stdout.split("\n").some((line) => line.length > 60));
+  });
+
+  it("should preserve explicit colors and width over automatic values", async () => {
+    const plain = await invoke({
+      tty: true,
+      columns: "60",
+      colors: false,
+      width: "72",
+    }, {
+      FORCE_COLOR: "1",
+      COLUMNS: "60",
+    });
+    assert.doesNotMatch(plain.stdout, ansiSequence);
+    assert.ok(plain.formatting.some((options) => options.maxWidth === 72));
+    const colored = await invoke({ colors: true }, {
+      NO_COLOR: "1",
+      NODE_DISABLE_COLORS: "1",
+    });
+    assert.match(colored.stdout, ansiSequence);
+  });
+
+  it("should preserve missing TTY values for custom formatters", async () => {
+    for (const request of ["help", "error"] as const) {
+      const result = await invoke({ request, distinguishColors: true });
+      assert.match(result.stdout + result.stderr, /UNSET/u);
+      assert.ok(result.formatting.some((options) => options.colors === null));
+      const explicit = await invoke({
+        request,
+        distinguishColors: true,
+        colors: false,
+      });
+      assert.doesNotMatch(explicit.stdout + explicit.stderr, /UNSET/u);
+      assert.match(explicit.stdout + explicit.stderr, /FALSE/u);
+    }
+  });
+
+  it("should use stdout preferences for errors even when stderr disagrees", async () => {
+    const result = await invoke({ request: "error", tty: true }, {
+      NO_COLOR: "1",
+    });
+    assert.equal(result.exitCode, 1);
+    assert.match(result.stderr, /Error:/u);
+    assert.doesNotMatch(result.stderr, ansiSequence);
+    assert.equal(result.stdout, "");
+    const forced = await invoke({ request: "error", tty: false }, {
+      FORCE_COLOR: "0",
+    });
+    assert.match(forced.stderr, ansiSequence);
+  });
+
+  for (
+    const mode of [
+      "runSync",
+      "runAsync",
+      "async-parser",
+      "run-context",
+      "runSync-context",
+      "program",
+    ]
+  ) {
+    it(`should apply shared defaults through ${mode}`, async () => {
+      const result = await invoke({ mode, columns: "0" }, {
+        FORCE_COLOR: "0",
+        COLUMNS: "60",
+      });
+      assert.equal(result.exitCode, 0);
+      assert.match(result.stdout, ansiSequence);
+      assert.ok(
+        result.formatting.some(({ colors, maxWidth }) =>
+          colors && maxWidth === 60
+        ),
+      );
+    });
+  }
+
+  it("should preserve explicit invalid-width errors", async () => {
+    for (const width of ["0", "-1", "1.5", "NaN", "Infinity"]) {
+      const expectedError = width === "0" || width === "-1"
+        ? "RangeError"
+        : "TypeError";
+      const result = await invoke({ width, expectedError }, { COLUMNS: "60" });
+      assert.equal(result.failure?.name, expectedError);
+      assert.equal(result.exitCode, undefined);
+    }
+  });
+
+  for (const permissions of [[], ["--deny-env"], ["--allow-env=COLUMNS"]]) {
+    it(
+      `should tolerate restricted Deno environment access (${
+        permissions.join(",") || "no grants"
+      })`,
+      {
+        skip: !process.versions.deno,
+      },
+      async () => {
+        if (!process.versions.deno) return;
+        const expectedWidth = permissions.includes("--allow-env=COLUMNS")
+          ? 60
+          : null;
+        const result = await invoke({ tty: true, columns: "0" }, {
+          NODE_DISABLE_COLORS: "1",
+          COLUMNS: "60",
+        }, permissions);
+        assert.equal(result.exitCode, 0);
+        assert.match(result.stdout, ansiSequence);
+        assert.ok(
+          result.formatting.some((options) =>
+            options.maxWidth === expectedWidth
+          ),
+        );
+        const forced = await invoke({}, { FORCE_COLOR: "0" }, permissions);
+        assert.match(forced.stdout, ansiSequence);
+        const plain = await invoke(
+          { tty: true },
+          { NO_COLOR: "1" },
+          permissions,
+        );
+        assert.doesNotMatch(plain.stdout, ansiSequence);
+        const success = await invoke({ request: "success" }, {}, permissions);
+        assert.equal(success.value, "ok");
+        assert.equal(success.exitCode, undefined);
+        const explicit = await invoke({ colors: true, width: "72" }, {
+          NO_COLOR: "1",
+          COLUMNS: "60",
+        }, permissions);
+        assert.ok(
+          explicit.formatting.some(({ colors, maxWidth }) =>
+            colors && maxWidth === 72
+          ),
+        );
+      },
+    );
+  }
+});
+
+// Helpers
+
+interface Scenario {
+  readonly mode?: string;
+  readonly columns?: string;
+  readonly tty?: boolean;
+  readonly colors?: boolean;
+  readonly width?: string;
+  readonly request?: "help" | "error" | "success";
+  readonly distinguishColors?: boolean;
+  readonly expectedError?: "RangeError" | "TypeError";
+}
+
+interface Result {
+  readonly observed: { readonly columns: string; readonly tty: boolean | null };
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly formatting: readonly {
+    readonly colors: boolean | null;
+    readonly maxWidth: number | null;
+  }[];
+  readonly exitCode?: number;
+  readonly failure?: { readonly name: string; readonly message: string };
+  readonly value?: unknown;
+}
+
+async function invoke(
+  scenario: Scenario,
+  variables: Readonly<Record<string, string>> = {},
+  envPermissions: readonly string[] = ["--allow-env"],
+): Promise<Result> {
+  const env = { ...process.env };
+  for (
+    const key of ["FORCE_COLOR", "NO_COLOR", "NODE_DISABLE_COLORS", "COLUMNS"]
+  ) {
+    delete env[key];
+  }
+  Object.assign(env, variables);
+  const fixture = fileURLToPath(
+    new URL("./fixtures/terminal-capabilities.ts", import.meta.url),
+  );
+  const args = [fixture, JSON.stringify(scenario)];
+  // Deno spawnSync inherits omitted environment keys; execFile uses the
+  // asynchronous spawn path, which respects the complete supplied environment.
+  const child = await promisify(execFile)(
+    process.execPath,
+    process.versions.deno
+      ? ["run", "--allow-read", "--no-prompt", ...envPermissions, ...args]
+      : args,
+    { env, encoding: "utf8", timeout: 30_000, maxBuffer: 1024 * 1024 },
+  );
+  const result: Result = JSON.parse(child.stdout);
+  assert.deepEqual(result.observed, {
+    columns: scenario.columns === undefined
+      ? "undefined"
+      : String(Number(scenario.columns)),
+    tty: scenario.tty ?? null,
+  });
+  return result;
+}

--- a/packages/run/src/terminal.test.ts
+++ b/packages/run/src/terminal.test.ts
@@ -1,0 +1,165 @@
+import { detectColorSupport, detectTerminalWidth } from "#src/terminal.ts";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import * as fc from "fast-check";
+
+describe("detectColorSupport", () => {
+  it("should preserve each TTY fallback without color preferences", () => {
+    for (const isTTY of [true, false, undefined]) {
+      assert.equal(detectColorSupport({ isTTY }, () => undefined), isTTY);
+      assert.equal(
+        detectColorSupport(
+          { isTTY },
+          envReader({ FORCE_COLOR: "", NO_COLOR: "" }),
+        ),
+        isTTY,
+      );
+    }
+  });
+
+  it("should enable color for every nonempty FORCE_COLOR value", () => {
+    for (
+      const FORCE_COLOR of ["0", "1", "2", "3", "true", "false", "bad", " "]
+    ) {
+      for (const isTTY of [true, false, undefined]) {
+        assert.ok(detectColorSupport({ isTTY }, envReader({ FORCE_COLOR })));
+      }
+    }
+  });
+
+  it("should ignore empty NO_COLOR but honor every nonempty value", () => {
+    for (const NO_COLOR of ["0", "1", "false", " "]) {
+      assert.ok(!detectColorSupport({ isTTY: true }, envReader({ NO_COLOR })));
+    }
+    assert.ok(detectColorSupport({ isTTY: true }, envReader({ NO_COLOR: "" })));
+  });
+
+  it("should honor NODE_DISABLE_COLORS even when empty", () => {
+    for (const NODE_DISABLE_COLORS of ["", "0", "1", "false"]) {
+      assert.ok(
+        !detectColorSupport(
+          { isTTY: true },
+          envReader({
+            FORCE_COLOR: "",
+            NO_COLOR: "",
+            NODE_DISABLE_COLORS,
+          }),
+        ),
+      );
+    }
+  });
+
+  it("should stop reading after a decisive preference", () => {
+    assert.ok(detectColorSupport({}, (name) => {
+      assert.equal(name, "FORCE_COLOR");
+      return "0";
+    }));
+    assert.ok(
+      !detectColorSupport({ isTTY: true }, (name) => {
+        assert.notEqual(name, "NODE_DISABLE_COLORS");
+        return name === "NO_COLOR" ? "1" : "";
+      }),
+    );
+  });
+
+  it("should let nonempty FORCE_COLOR override other preferences", () => {
+    fc.assert(fc.property(
+      fc.string({ minLength: 1 }),
+      fc.option(fc.string(), { nil: undefined }),
+      fc.option(fc.string(), { nil: undefined }),
+      fc.option(fc.boolean(), { nil: undefined }),
+      (FORCE_COLOR, NO_COLOR, NODE_DISABLE_COLORS, isTTY) => {
+        assert.ok(detectColorSupport(
+          { isTTY },
+          envReader({
+            FORCE_COLOR,
+            NO_COLOR,
+            NODE_DISABLE_COLORS,
+          }),
+        ));
+      },
+    ));
+  });
+});
+
+describe("detectTerminalWidth", () => {
+  it("should accept positive stream widths without imposing a layout minimum", () => {
+    for (const columns of [1, 60, 120, Number.MAX_VALUE]) {
+      assert.equal(
+        detectTerminalWidth({ columns }, () => {
+          assert.fail("A valid stream width must not read COLUMNS.");
+        }),
+        columns,
+      );
+    }
+  });
+
+  it("should fall back from invalid stream widths to COLUMNS", () => {
+    for (const columns of [undefined, 0, -1, 1.5, NaN, Infinity, -Infinity]) {
+      assert.equal(
+        detectTerminalWidth({ columns }, envReader({ COLUMNS: "060" })),
+        60,
+      );
+      assert.equal(
+        detectTerminalWidth({ columns }, () => undefined),
+        undefined,
+      );
+    }
+  });
+
+  it("should accept only whole positive decimal widths from the environment", () => {
+    for (
+      const COLUMNS of [
+        "",
+        "0",
+        "000",
+        "-60",
+        "+60",
+        " 60",
+        "60 ",
+        "60\n",
+        "60\r\n",
+        "6\n0",
+        "60.0",
+        "1e2",
+        "0x40",
+        "60px",
+        "NaN",
+        "Infinity",
+        "６０",
+        "9".repeat(400),
+      ]
+    ) {
+      assert.equal(
+        detectTerminalWidth({}, envReader({ COLUMNS })),
+        undefined,
+        JSON.stringify(COLUMNS),
+      );
+    }
+    for (
+      const [COLUMNS, expected] of [["1", 1], ["0080", 80], [
+        "120",
+        120,
+      ]] as const
+    ) {
+      assert.equal(detectTerminalWidth({}, envReader({ COLUMNS })), expected);
+    }
+  });
+
+  it("should prefer a positive stream width over arbitrary COLUMNS", () => {
+    fc.assert(
+      fc.property(fc.integer({ min: 1 }), fc.string(), (columns, COLUMNS) => {
+        assert.equal(
+          detectTerminalWidth({ columns }, envReader({ COLUMNS })),
+          columns,
+        );
+      }),
+    );
+  });
+});
+
+// Helpers
+
+function envReader(env: Readonly<Record<string, string | undefined>>) {
+  return (name: string): string | undefined => env[name];
+}

--- a/packages/run/src/terminal.ts
+++ b/packages/run/src/terminal.ts
@@ -1,0 +1,87 @@
+import process from "node:process";
+
+type EnvironmentVariable =
+  | "FORCE_COLOR"
+  | "NO_COLOR"
+  | "NODE_DISABLE_COLORS"
+  | "COLUMNS";
+type EnvironmentReader = (name: EnvironmentVariable) => string | undefined;
+
+/**
+ * Resolves automatic color settings without changing the supplied environment.
+ * @param stream The output stream's TTY status.
+ * @param readEnv Reads one environment variable at a time.
+ * @returns The color preference, preserving an unspecified TTY fallback.
+ * @internal
+ */
+export function detectColorSupport(
+  stream: { readonly isTTY?: boolean },
+  readEnv: EnvironmentReader,
+): boolean | undefined {
+  const forceColor = readEnv("FORCE_COLOR");
+  if (forceColor != null && forceColor !== "") return true;
+  const noColor = readEnv("NO_COLOR");
+  if (noColor != null && noColor !== "") return false;
+  if (readEnv("NODE_DISABLE_COLORS") != null) return false;
+  return stream.isTTY;
+}
+
+/**
+ * Resolves a usable reported width, leaving unknown widths unwrapped.
+ * @param stream The output stream's reported width.
+ * @param readEnv Reads COLUMNS if the stream has no valid width.
+ * @returns A positive finite integer, or undefined when neither source is valid.
+ * @internal
+ */
+export function detectTerminalWidth(
+  stream: { readonly columns?: number },
+  readEnv: EnvironmentReader,
+): number | undefined {
+  const columns = stream.columns;
+  if (columns != null && Number.isInteger(columns) && columns > 0) {
+    return columns;
+  }
+  const value = readEnv("COLUMNS");
+  // Reject non-digits anywhere, including a final newline (which `$` can match).
+  if (value == null || value === "" || /[^0-9]/u.test(value)) return undefined;
+  const width = Number(value);
+  return Number.isInteger(width) && width > 0 ? width : undefined;
+}
+
+/**
+ * Reads an optional terminal setting without requesting runtime permissions.
+ * @param name The environment variable to read.
+ * @returns Its value, or undefined when absent or inaccessible.
+ * @internal
+ */
+export function readEnvironmentVariable(
+  name: EnvironmentVariable,
+): string | undefined {
+  try {
+    // Deno permits FORCE_COLOR and NO_COLOR even without --allow-env. Its
+    // permission query does not reflect that exemption, so only query the
+    // other variables. Reading a prompt-state variable could otherwise prompt.
+    if (name === "NODE_DISABLE_COLORS" || name === "COLUMNS") {
+      const deno = (globalThis as {
+        readonly Deno?: {
+          readonly permissions?: {
+            querySync?(descriptor: {
+              readonly name: "env";
+              readonly variable: string;
+            }): { readonly state: string };
+          };
+        };
+      }).Deno;
+      if (
+        deno != null &&
+        deno.permissions?.querySync?.({ name: "env", variable: name }).state !==
+          "granted"
+      ) return undefined;
+    }
+    return process.env[name];
+  } catch {
+    // Automatic formatting must still work when optional environment access
+    // is denied, including when permissions change after the query.
+    return undefined;
+  }
+}


### PR DESCRIPTION
TTY detection alone ignores color preferences on pipes, and invalid terminal widths can make help rendering fail. Resolve both defaults in the shared runner option builder so `run()`, `runSync()`, and `runAsync()` stay consistent.

Explicit options take precedence. Otherwise, nonempty `FORCE_COLOR` enables colors, including `0`, following the [`FORCE_COLOR`] convention. Otherwise, nonempty [`NO_COLOR`] or the presence of `NODE_DISABLE_COLORS` disables colors; TTY detection is the final fallback. Invalid stream widths fall back to a positive decimal `COLUMNS` value; unknown widths leave output unwrapped. Deno reads respect permissions without prompting, while retaining its exemptions for `FORCE_COLOR` and `NO_COLOR`.

Subprocess tests isolate environment settings across Deno, Node.js, and Bun, including restricted Deno permissions. `mise test` and the documentation production build pass.

Fixes #903.

[`FORCE_COLOR`]: https://force-color.org/
[`NO_COLOR`]: https://no-color.org/